### PR TITLE
feat: reusable deploy workflow and configurable bot display name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,8 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_DISCORD__HEALTH_PORT=8081
 # When True (default), each Discord thread keeps a separate agent session per calling user, so no user inherits another user's session identity or permissions in a shared thread. When False, a single session is shared by every caller in the thread — a legacy fallback, not recommended for production.
 # DAIMON_DISCORD__PER_CALLER_THREAD_SESSIONS=True
+# The bot's presented name across user-facing Discord render sites (@mentions, setup messages, help text, privacy panel copy). Defaults to 'daimon' so unset deployments render byte-identical output. Set to a distinct name (e.g. 'daimon-staging') so a non-production deployment is visibly distinct in-channel.
+# DAIMON_DISCORD__BOT_DISPLAY_NAME=daimon
 
 # === Slack (optional) ===
 # Slack request-signing secret used to verify inbound HTTP requests. Required — keeps the whole Slack block None when no DAIMON_SLACK__* vars are set. (required to run the Slack adapter; secret)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,141 @@
+name: Deploy
+
+# Reusable deploy body: callable from other workflows (workflow_call) or
+# dispatched manually (workflow_dispatch). Deliberately no push trigger —
+# adding this file changes no existing deploy behavior.
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "GitHub Environment to deploy (staging or production)"
+        required: true
+        type: string
+      sha:
+        description: "Full commit SHA to deploy"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "GitHub Environment to deploy (staging or production)"
+        required: true
+        type: string
+      sha:
+        description: "Full commit SHA to deploy"
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    name: Deploy to GCP (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      group: deploy-gcp-${{ inputs.environment }}
+      cancel-in-progress: false
+    env:
+      REGION: ${{ vars.GCP_REGION }}
+      AR_HOST: ${{ vars.GCP_REGION }}-docker.pkg.dev
+      REPO: ${{ vars.GCP_AR_REPO }}
+      ZONE: ${{ vars.GCP_ZONE }}
+      NOTEBOOK_DOMAIN: ${{ vars.NOTEBOOK_DOMAIN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SA }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.AR_HOST }} --quiet
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          BASE=${{ env.AR_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ env.REPO }}
+          echo "daimon=$BASE/daimon:$SHA" >> "$GITHUB_OUTPUT"
+          echo "notebook=$BASE/notebook-host:$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Build + push daimon image
+        run: |
+          docker build -t "${{ steps.tags.outputs.daimon }}" -f Dockerfile .
+          docker push "${{ steps.tags.outputs.daimon }}"
+
+      - name: Build + push notebook-host image
+        run: |
+          docker build -t "${{ steps.tags.outputs.notebook }}" -f apps/notebook-host/Dockerfile .
+          docker push "${{ steps.tags.outputs.notebook }}"
+
+      - name: Run migrations (blocking gate)
+        run: |
+          gcloud run jobs update ${{ vars.GCP_AR_REPO }}-migrate --region "$REGION" \
+            --image "${{ steps.tags.outputs.daimon }}"
+          gcloud run jobs execute ${{ vars.GCP_AR_REPO }}-migrate --region "$REGION" --wait
+
+      - name: Deploy mcp revision
+        run: |
+          gcloud run services update ${{ vars.GCP_AR_REPO }}-mcp --region "$REGION" \
+            --image "${{ steps.tags.outputs.daimon }}"
+
+      - name: Refresh worker VM containers (recreate in place)
+        run: |
+          # Skip the refresh when the workers VM is stopped (nothing to recreate).
+          STATUS=$(gcloud compute instances describe ${{ vars.GCP_AR_REPO }}-workers \
+            --zone "$ZONE" --format='value(status)')
+          if [ "$STATUS" != "RUNNING" ]; then
+            echo "workers VM is $STATUS — skipping container refresh"
+            exit 0
+          fi
+          gcloud compute ssh ${{ vars.GCP_AR_REPO }}-workers --zone "$ZONE" \
+            --tunnel-through-iap --command '
+              export DAIMON_IMAGE="${{ steps.tags.outputs.daimon }}"
+              # sudo -E keeps the SSH user HOME, so docker would look for
+              # Artifact Registry credentials in ~/.docker (none there). Point
+              # at root docker config, where the boot startup script ran
+              # `gcloud auth configure-docker`.
+              export DOCKER_CONFIG=/root/.docker
+              cd /etc/daimon
+              sudo -E docker compose -f compose.worker.yml pull
+              sudo -E docker compose -f compose.worker.yml up -d --remove-orphans
+            '
+
+      - name: Refresh notebook-host VM container (recreate in place)
+        run: |
+          gcloud compute ssh ${{ vars.GCP_AR_REPO }}-notebook --zone "$ZONE" \
+            --tunnel-through-iap --command '
+              export NOTEBOOK_IMAGE="${{ steps.tags.outputs.notebook }}"
+              # Caddy fronts notebook-host with TLS on this domain; the compose
+              # file interpolates NOTEBOOK_DOMAIN + NOTEBOOK_PUBLIC_URL_BASE
+              # (the compose file and Caddyfile live in the operator private infra repo).
+              export NOTEBOOK_DOMAIN="${{ env.NOTEBOOK_DOMAIN }}"
+              export NOTEBOOK_PUBLIC_URL_BASE="https://${{ env.NOTEBOOK_DOMAIN }}"
+              # Same DOCKER_CONFIG redirect as the workers refresh: use root
+              # docker config (has the Artifact Registry credential helper).
+              export DOCKER_CONFIG=/root/.docker
+              cd /etc/daimon
+              sudo -E docker compose -f compose.notebook.yml pull
+              sudo -E docker compose -f compose.notebook.yml up -d --remove-orphans
+            '
+
+      - name: Health gate
+        run: |
+          URL=$(gcloud run services describe ${{ vars.GCP_AR_REPO }}-mcp --region "$REGION" \
+            --format='value(status.url)')
+          # /healthz is intercepted by Google Front End on run.app domains (404s
+          # before reaching the container); /readyz passes through and also
+          # verifies DB connectivity.
+          for i in $(seq 1 10); do
+            if curl -sfI "$URL/readyz" >/dev/null; then echo "healthy"; exit 0; fi
+            sleep 6
+          done
+          echo "mcp did not become healthy" >&2; exit 1

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -35,6 +35,7 @@ from daimon.adapters.discord.vision import (
     is_vision_image_attachment,
 )
 from daimon.core.billing import is_over_cap
+from daimon.core.config import Settings
 from daimon.core.defaults.provisioning import provision_tenant, reconcile_tenant_defaults
 from daimon.core.errors import DaimonError
 from daimon.core.github_credentials import build_multifernet
@@ -78,12 +79,30 @@ _EMBED_COLOR = theme.COLOR_BLURPLE  # Blurple — repo standard (help.py D-FORMA
 # mid-stream.
 _DRAIN_GRACE_S: float = 60.0
 
-# Distinct from the MAResolverMissError "no longer exists" message so a
-# still-provisioning state is never confused with a genuine misconfiguration.
-_SETTING_UP_MESSAGE = "Daimon is setting up this server — try again in a moment."
-
 # Bounded concurrency for the on_ready re-seed sweep.
 _SWEEP_CONCURRENCY = 4
+
+
+def _resolve_bot_display_name(settings: Settings) -> str:
+    """Read the operator-configured bot presented name (SPEC req 9).
+
+    Defaults to "daimon" when Discord settings are unset — the same default
+    ``DiscordSettings.bot_display_name`` carries, kept here too so callers
+    that only have a bare ``Settings`` (discord block optional) never crash.
+    """
+    return settings.discord.bot_display_name if settings.discord is not None else "daimon"
+
+
+def _setting_up_message(bot_display_name: str) -> str:
+    """Distinct from the MAResolverMissError "no longer exists" message so a
+    still-provisioning state is never confused with a genuine misconfiguration."""
+    return f"{bot_display_name.capitalize()} is setting up this server — try again in a moment."
+
+
+def _credit_depleted_message(bot_display_name: str) -> str:
+    return (
+        f"This server's {bot_display_name} credit is depleted. An admin can top up with `/billing`."
+    )
 
 
 def _is_dead_session(state: TurnState) -> bool:
@@ -126,7 +145,7 @@ def _log_bg_task_exception(task: asyncio.Task[None]) -> None:
         log.error("bg_task_failed", task_name=task.get_name(), exc_info=exc)
 
 
-def _build_welcome_embed() -> discord.Embed:
+def _build_welcome_embed(bot_display_name: str) -> discord.Embed:
     """Immediate "⏳ setting up…" welcome. Pure — no I/O."""
     embed = discord.Embed(
         title="⏳ Setting up…",
@@ -138,7 +157,10 @@ def _build_welcome_embed() -> discord.Embed:
     )
     embed.add_field(
         name="Once ready",
-        value=("Mention `@daimon` anywhere to chat, or run `/agent-setup` to manage your agents."),
+        value=(
+            f"Mention `@{bot_display_name}` anywhere to chat, or run `/agent-setup` "
+            "to manage your agents."
+        ),
         inline=False,
     )
     return embed
@@ -369,7 +391,9 @@ class DaimonBot(commands.Bot):
                 status="pending",
                 clear_archive=True,  # #132: rejoined guilds must not stay archived
             )
-            await self._post_to_guild(guild, _build_welcome_embed())
+            await self._post_to_guild(
+                guild, _build_welcome_embed(_resolve_bot_display_name(self.runtime.settings))
+            )
             self._spawn(_bounded_seed(tenant_id=result.tenant_id, guild=guild))
 
         # Re-seed any listed tenant stuck in pending/failed; per-guild permission
@@ -429,7 +453,9 @@ class DaimonBot(commands.Bot):
                 status="pending",
                 clear_archive=True,  # #132: rejoined guilds must not stay archived
             )
-            await self._post_to_guild(guild, _build_welcome_embed())
+            await self._post_to_guild(
+                guild, _build_welcome_embed(_resolve_bot_display_name(self.runtime.settings))
+            )
             try:
                 guild_obj = discord.Object(id=guild.id)
                 # Keep the guild command scope empty — global commands already
@@ -478,6 +504,7 @@ class DaimonBot(commands.Bot):
         assert message.guild is not None
         guild = message.guild
         guild_id = str(guild.id)
+        bot_display_name = _resolve_bot_display_name(self.runtime.settings)
 
         # --- Unified non-ready self-heal gate through turn completion,
         # guarded end-to-end. A DB hiccup or an unclassified bug
@@ -492,15 +519,15 @@ class DaimonBot(commands.Bot):
             if tr is None or tr.archived_at is not None:
                 # Unprovisioned OR archived → provision + un-archive + seed in background.
                 await self._ensure_provisioning(guild)
-                await message.channel.send(_SETTING_UP_MESSAGE)
+                await message.channel.send(_setting_up_message(bot_display_name))
                 return
             if tr.provision_status == "failed":
                 # Self-heal: re-seed if idle (in-flight guard). NEVER show "failed" to the user.
                 self._spawn(self._seed_tenant_defaults(tenant_id=tr.id, guild=guild))
-                await message.channel.send(_SETTING_UP_MESSAGE)
+                await message.channel.send(_setting_up_message(bot_display_name))
                 return
             if tr.provision_status == "pending":
-                await message.channel.send(_SETTING_UP_MESSAGE)
+                await message.channel.send(_setting_up_message(bot_display_name))
                 return
             # Only 'ready' proceeds.
 
@@ -883,7 +910,7 @@ class DaimonBot(commands.Bot):
             log.info("turn.skipped.over_balance", guild_id=guild_id, tenant_id=str(tenant_id))
             target = thread or message.channel
             await target.send(
-                "This server's daimon credit is depleted. An admin can top up with `/billing`."
+                _credit_depleted_message(_resolve_bot_display_name(self.runtime.settings))
             )
             return
 
@@ -1148,6 +1175,7 @@ class DaimonBot(commands.Bot):
                     trigger=message,
                     after_message_id=int(watermark),
                     bot_user_id=self.user.id if self.user else None,
+                    bot_display_name=discord_settings.bot_display_name,
                 )
             else:
                 user_message, _ = await build_context_xml(
@@ -1155,6 +1183,7 @@ class DaimonBot(commands.Bot):
                     trigger=message,
                     limit=100,
                     bot_user_id=self.user.id if self.user else None,
+                    bot_display_name=discord_settings.bot_display_name,
                 )
         else:
             if content_override is not None:
@@ -1164,6 +1193,7 @@ class DaimonBot(commands.Bot):
                     message.channel,
                     trigger=message,
                     bot_user_id=self.user.id if self.user else None,
+                    bot_display_name=discord_settings.bot_display_name,
                 )
             else:
                 # Forum/voice channels: fall back to raw message content
@@ -1278,6 +1308,7 @@ class DaimonBot(commands.Bot):
                 trigger=message,
                 limit=100,
                 bot_user_id=self.user.id if self.user else None,
+                bot_display_name=discord_settings.bot_display_name,
             )
             if synthetic_prefix:
                 user_message = synthetic_prefix + "\n" + user_message

--- a/packages/adapters/discord/daimon/adapters/discord/commands/help.py
+++ b/packages/adapters/discord/daimon/adapters/discord/commands/help.py
@@ -12,8 +12,11 @@ discord.py evaluates parameter annotations at import time to extract
 slash command parameter metadata.
 """
 
+from typing import cast
+
 from daimon.adapters.discord import layout
 from daimon.adapters.discord.checks import require_registered_guild
+from daimon.adapters.discord.runtime import DiscordRuntime
 
 import discord
 from discord import Interaction, app_commands
@@ -21,7 +24,9 @@ from discord.ext import commands
 
 BotInteraction = Interaction[commands.Bot]
 
-_BODY = """\
+
+def _body(bot_display_name: str) -> str:
+    return f"""\
 **Agent management**
 -# /agent-setup — Manage this server's agents
 
@@ -32,29 +37,35 @@ _BODY = """\
 -# /billing — Show your billing usage (admins see per-member breakdown)
 
 **Privacy**
--# /privacy — See, export, or delete what daimon stores about you
+-# /privacy — See, export, or delete what {bot_display_name} stores about you
 
 **Meta**
 -# /help — List commands and the @bot conversational entrypoint\
 """
 
-_CONVERSATIONAL = """\
+
+def _conversational(bot_display_name: str) -> str:
+    return f"""\
 💬 **Or just talk to your agent**
--# @daimon help me set up
--# @daimon make a routine that runs daily\
+-# @{bot_display_name} help me set up
+-# @{bot_display_name} make a routine that runs daily\
 """
 
 
-def build_help_view() -> discord.ui.LayoutView:
-    """Build the static /help V2 LayoutView. Pure — no I/O, zero args."""
+def build_help_view(bot_display_name: str = "daimon") -> discord.ui.LayoutView:
+    """Build the static /help V2 LayoutView. Pure — no I/O."""
     container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container(
         layout.header("📖 Commands", subtext="only you can see this"),
         layout.hairline(),
-        discord.ui.TextDisplay(_BODY),
+        discord.ui.TextDisplay(_body(bot_display_name)),
         layout.hairline(),
-        discord.ui.TextDisplay(_CONVERSATIONAL),
+        discord.ui.TextDisplay(_conversational(bot_display_name)),
     )
     return layout.static_view(container)
+
+
+def _get_runtime(interaction: BotInteraction) -> DiscordRuntime:
+    return cast(DiscordRuntime, interaction.client.runtime)  # type: ignore[attr-defined]  # DaimonBot.runtime not on Bot type
 
 
 @app_commands.guild_only()
@@ -70,4 +81,12 @@ class HelpCog(commands.Cog):
     )
     @require_registered_guild
     async def help(self, interaction: BotInteraction) -> None:
-        await interaction.response.send_message(view=build_help_view(), ephemeral=True)
+        runtime = _get_runtime(interaction)
+        bot_display_name = (
+            runtime.settings.discord.bot_display_name
+            if runtime.settings.discord is not None
+            else "daimon"
+        )
+        await interaction.response.send_message(
+            view=build_help_view(bot_display_name), ephemeral=True
+        )

--- a/packages/adapters/discord/daimon/adapters/discord/commands/privacy.py
+++ b/packages/adapters/discord/daimon/adapters/discord/commands/privacy.py
@@ -46,6 +46,19 @@ class PrivacyCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         super().__init__()
         self.bot: commands.Bot = bot
+        # The slash-command description is Discord API metadata registered once at
+        # cog-init time (before tree.sync()) — not re-rendered per invocation like the
+        # panel body, so the operator-configured name is read here instead of at
+        # call-time (SPEC req 9).
+        runtime = cast(DiscordRuntime, bot.runtime)  # type: ignore[attr-defined]  # DaimonBot.runtime not on Bot type
+        bot_display_name = (
+            runtime.settings.discord.bot_display_name
+            if runtime.settings.discord is not None
+            else "daimon"
+        )
+        self.privacy.description = (
+            f"See, export, or delete what {bot_display_name} stores about you"
+        )
 
     @app_commands.command(
         name="privacy",

--- a/packages/adapters/discord/daimon/adapters/discord/context.py
+++ b/packages/adapters/discord/daimon/adapters/discord/context.py
@@ -18,11 +18,13 @@ import discord
 CHANNEL_BACKFILL_LIMIT = 25
 
 
-def _strip_bot_mention(content: str, bot_user_id: int | None) -> str:
-    """Replace ``<@bot_id>`` and ``<@!bot_id>`` with ``@daimon``."""
+def _strip_bot_mention(
+    content: str, bot_user_id: int | None, *, bot_display_name: str = "daimon"
+) -> str:
+    """Replace ``<@bot_id>`` and ``<@!bot_id>`` with ``@{bot_display_name}``."""
     if bot_user_id is None:
         return content
-    return re.sub(rf"<@!?{bot_user_id}>", "@daimon", content)
+    return re.sub(rf"<@!?{bot_user_id}>", f"@{bot_display_name}", content)
 
 
 def _render_location(thread: discord.Thread) -> list[str]:
@@ -40,7 +42,9 @@ def _render_location(thread: discord.Thread) -> list[str]:
     ]
 
 
-def _render_message(msg: discord.Message, bot_user_id: int | None) -> list[str]:
+def _render_message(
+    msg: discord.Message, bot_user_id: int | None, *, bot_display_name: str = "daimon"
+) -> list[str]:
     """Render a single message as XML lines."""
     attrs = (
         f" author_name={quoteattr(msg.author.display_name)}"
@@ -48,7 +52,9 @@ def _render_message(msg: discord.Message, bot_user_id: int | None) -> list[str]:
         f" is_bot={quoteattr(str(msg.author.bot).lower())}"
         f" timestamp={quoteattr(msg.created_at.isoformat())}"
     )
-    content = escape(_strip_bot_mention(msg.content, bot_user_id))
+    content = escape(
+        _strip_bot_mention(msg.content, bot_user_id, bot_display_name=bot_display_name)
+    )
 
     if not msg.attachments:
         return [f"<message{attrs}>{content}</message>"]
@@ -73,6 +79,7 @@ async def build_context_xml(
     *,
     limit: int = 100,
     bot_user_id: int | None = None,
+    bot_display_name: str = "daimon",
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context from thread history for the turn driver.
 
@@ -117,7 +124,7 @@ async def build_context_xml(
         "<thread_history>",
     ]
     for msg in messages:
-        lines.extend(_render_message(msg, bot_user_id))
+        lines.extend(_render_message(msg, bot_user_id, bot_display_name=bot_display_name))
     lines.append("</thread_history>")
     lines.append("</context>")
 
@@ -127,7 +134,9 @@ async def build_context_xml(
         f" user_id={quoteattr(str(trigger.author.id))}"
         f" timestamp={quoteattr(trigger.created_at.isoformat())}"
     )
-    trigger_content = escape(_strip_bot_mention(trigger.content, bot_user_id))
+    trigger_content = escape(
+        _strip_bot_mention(trigger.content, bot_user_id, bot_display_name=bot_display_name)
+    )
     lines.append("")
     lines.append(f"<user_query{trigger_attrs}>{trigger_content}</user_query>")
 
@@ -140,6 +149,7 @@ async def build_delta_xml(
     *,
     after_message_id: int | None,
     bot_user_id: int | None = None,
+    bot_display_name: str = "daimon",
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context for a continuation turn (delta since watermark).
 
@@ -166,7 +176,9 @@ async def build_delta_xml(
     snapshot.
     """
     if after_message_id is None:
-        return await build_context_xml(thread, trigger, bot_user_id=bot_user_id)
+        return await build_context_xml(
+            thread, trigger, bot_user_id=bot_user_id, bot_display_name=bot_display_name
+        )
 
     after_obj = discord.Object(id=after_message_id)
     messages = [m async for m in thread.history(after=after_obj, oldest_first=True)]
@@ -188,7 +200,7 @@ async def build_delta_xml(
         "<thread_delta>",
     ]
     for msg in messages:
-        lines.extend(_render_message(msg, bot_user_id))
+        lines.extend(_render_message(msg, bot_user_id, bot_display_name=bot_display_name))
     lines.append("</thread_delta>")
     lines.append("</context>")
 
@@ -197,7 +209,9 @@ async def build_delta_xml(
         f" user_id={quoteattr(str(trigger.author.id))}"
         f" timestamp={quoteattr(trigger.created_at.isoformat())}"
     )
-    trigger_content = escape(_strip_bot_mention(trigger.content, bot_user_id))
+    trigger_content = escape(
+        _strip_bot_mention(trigger.content, bot_user_id, bot_display_name=bot_display_name)
+    )
     lines.append("")
     lines.append(f"<user_query{trigger_attrs}>{trigger_content}</user_query>")
 
@@ -210,6 +224,7 @@ async def build_channel_context_xml(
     *,
     limit: int = CHANNEL_BACKFILL_LIMIT,
     bot_user_id: int | None = None,
+    bot_display_name: str = "daimon",
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context from parent channel history for a channel-mention turn.
 
@@ -233,7 +248,7 @@ async def build_channel_context_xml(
 
     lines: list[str] = [f'<channel_context count="{len(messages)}">']
     for msg in messages:
-        lines.extend(_render_message(msg, bot_user_id))
+        lines.extend(_render_message(msg, bot_user_id, bot_display_name=bot_display_name))
     lines.append("</channel_context>")
 
     trigger_attrs = (
@@ -241,7 +256,9 @@ async def build_channel_context_xml(
         f" user_id={quoteattr(str(trigger.author.id))}"
         f" timestamp={quoteattr(trigger.created_at.isoformat())}"
     )
-    trigger_content = escape(_strip_bot_mention(trigger.content, bot_user_id))
+    trigger_content = escape(
+        _strip_bot_mention(trigger.content, bot_user_id, bot_display_name=bot_display_name)
+    )
     lines.append("")
     lines.append(f"<user_query{trigger_attrs}>{trigger_content}</user_query>")
 

--- a/packages/adapters/discord/daimon/adapters/discord/privacy_panel/embeds.py
+++ b/packages/adapters/discord/daimon/adapters/discord/privacy_panel/embeds.py
@@ -13,7 +13,7 @@ import discord
 
 
 def build_post_delete_container(
-    result: AccountPurgeResult,
+    result: AccountPurgeResult, *, bot_display_name: str = "daimon"
 ) -> discord.ui.Container[discord.ui.LayoutView]:
     """Green-accent V2 container shown after a successful purge. Controls-less."""
     rows: list[str] = []
@@ -68,7 +68,9 @@ def build_post_delete_container(
     container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container(
         layout.header(
             "✅ Deleted",
-            subtext="Your daimon data has been deleted. Re-onboarding starts from scratch.",
+            subtext=(
+                f"Your {bot_display_name} data has been deleted. Re-onboarding starts from scratch."
+            ),
         ),
         layout.hairline(),
         discord.ui.TextDisplay(checklist),

--- a/packages/adapters/discord/daimon/adapters/discord/privacy_panel/modal.py
+++ b/packages/adapters/discord/daimon/adapters/discord/privacy_panel/modal.py
@@ -94,7 +94,14 @@ class DeleteConfirmModal(discord.ui.Modal, title="Confirm delete"):
             sessions_deleted=result.sessions.deleted,
             sessions_failed=result.sessions.failed,
         )
+        bot_display_name = (
+            self.runtime.settings.discord.bot_display_name
+            if self.runtime.settings.discord is not None
+            else "daimon"
+        )
         await interaction.edit_original_response(
-            view=layout.static_view(build_post_delete_container(result)),
+            view=layout.static_view(
+                build_post_delete_container(result, bot_display_name=bot_display_name)
+            ),
             allowed_mentions=discord.AllowedMentions.none(),
         )

--- a/packages/adapters/discord/daimon/adapters/discord/privacy_panel/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/privacy_panel/panel.py
@@ -37,8 +37,17 @@ def _summary_line(preview: PurgePreview) -> str:
     return ", ".join(parts) if parts else "nothing visible to you yet"
 
 
+def _export_placeholder_message(bot_display_name: str) -> str:
+    return (
+        "📤 **Export** is not yet implemented.\n\n"
+        f"When ready, this will produce a JSON dump of every {bot_display_name}-side row "
+        "tied to your identity and either attach it here or DM you a 7-day "
+        "signed URL."
+    )
+
+
 def build_privacy_main_container(
-    preview: PurgePreview, *, user_name: str
+    preview: PurgePreview, *, user_name: str, bot_display_name: str = "daimon"
 ) -> discord.ui.Container[discord.ui.LayoutView]:
     """Main panel V2 container — no accent, three trust-model groups.
 
@@ -67,7 +76,7 @@ def build_privacy_main_container(
     container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container(
         layout.header(
             "🔒 Privacy",
-            subtext=f"for **{user_name}** — daimon holds: {_summary_line(preview)}",
+            subtext=f"for **{user_name}** — {bot_display_name} holds: {_summary_line(preview)}",
         ),
         layout.hairline(),
         discord.ui.TextDisplay("\n".join(body_rows)),
@@ -91,6 +100,11 @@ class PrivacyPanelView(discord.ui.LayoutView):
         self.allowed_user_id = allowed_user_id
         self.user_name = user_name
         self._preview = preview
+        self._bot_display_name = (
+            runtime.settings.discord.bot_display_name
+            if runtime.settings.discord is not None
+            else "daimon"
+        )
 
         # Programmatic buttons — decorator pattern does not work on LayoutView subclasses
         policy_btn: discord.ui.Button[PrivacyPanelView] = discord.ui.Button(
@@ -119,17 +133,16 @@ class PrivacyPanelView(discord.ui.LayoutView):
         action_row: discord.ui.ActionRow[PrivacyPanelView] = discord.ui.ActionRow(
             policy_btn, export_btn, delete_btn, done_btn
         )
-        container = build_privacy_main_container(preview, user_name=user_name)
+        container = build_privacy_main_container(
+            preview, user_name=user_name, bot_display_name=self._bot_display_name
+        )
         container.add_item(layout.hairline())
         container.add_item(action_row)
         self.add_item(container)
 
     async def _on_export(self, interaction: discord.Interaction) -> None:
         await interaction.response.send_message(
-            "📤 **Export** is not yet implemented.\n\n"
-            "When ready, this will produce a JSON dump of every daimon-side row "
-            "tied to your identity and either attach it here or DM you a 7-day "
-            "signed URL.",
+            _export_placeholder_message(self._bot_display_name),
             ephemeral=True,
         )
 
@@ -158,7 +171,9 @@ class PrivacyPanelView(discord.ui.LayoutView):
         # Controls-less re-render (view=None empties a V2 message).
         await interaction.response.edit_message(
             view=layout.static_view(
-                build_privacy_main_container(self._preview, user_name=self.user_name)
+                build_privacy_main_container(
+                    self._preview, user_name=self.user_name, bot_display_name=self._bot_display_name
+                )
             ),
             allowed_mentions=discord.AllowedMentions.none(),
         )

--- a/packages/adapters/discord/tests/test_branding.py
+++ b/packages/adapters/discord/tests/test_branding.py
@@ -1,0 +1,239 @@
+"""Byte-identical-when-unset tests for ``DiscordSettings.bot_display_name`` (SPEC req 9).
+
+Every render function covered here must be BYTE-IDENTICAL to today's output when
+``bot_display_name`` is left unset (default "daimon"), and must change to reflect
+the configured name when it is set (e.g. "daimon-staging"). This is the safety
+net for the in-scope render-site sweep — anything not covered here is presumed
+out of scope per the plan's site list.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import discord
+import pytest
+from daimon.adapters.discord.bot import (
+    _build_welcome_embed,  # pyright: ignore[reportPrivateUsage]
+    _credit_depleted_message,  # pyright: ignore[reportPrivateUsage]
+    _setting_up_message,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.discord.commands.help import build_help_view
+from daimon.adapters.discord.commands.privacy import PrivacyCog
+from daimon.adapters.discord.context import build_context_xml
+from daimon.adapters.discord.privacy_panel.embeds import build_post_delete_container
+from daimon.adapters.discord.privacy_panel.panel import (
+    _export_placeholder_message,  # pyright: ignore[reportPrivateUsage]
+    build_privacy_main_container,
+)
+from daimon.adapters.discord.privacy_panel.state import PurgePreview, PurgePreviewRow
+from daimon.core.config import DiscordSettings
+from daimon.core.purge import AccountPurgeResult, PurgeReport
+from pydantic import SecretStr
+
+
+class _AsyncIter:
+    """Async iterator adapter for a mocked ``thread.history()``."""
+
+    def __init__(self, items: list[discord.Message]) -> None:
+        self._items = iter(items)
+
+    def __aiter__(self) -> _AsyncIter:
+        return self
+
+    async def __anext__(self) -> discord.Message:
+        try:
+            return next(self._items)
+        except StopIteration as err:
+            raise StopAsyncIteration from err
+
+
+def _make_message(*, msg_id: int, content: str) -> discord.Message:
+    msg = MagicMock(spec=discord.Message)
+    msg.id = msg_id
+    msg.content = content
+    msg.author = MagicMock()
+    msg.author.display_name = "Alice"
+    msg.author.id = 100
+    msg.author.bot = False
+    msg.created_at = datetime(2026, 4, 28, 12, 0, 0, tzinfo=UTC)
+    msg.attachments = []
+    return msg
+
+
+def _make_thread(messages: list[discord.Message]) -> discord.Thread:
+    thread = MagicMock(spec=discord.Thread)
+    thread.history = MagicMock(return_value=_AsyncIter(messages))
+    thread.id = 900
+    thread.parent_id = 800
+    thread.starter_message = None
+    thread.parent = None
+    return thread
+
+
+def _make_preview() -> PurgePreview:
+    zero = PurgePreviewRow(count=0, example=None)
+    return PurgePreview(
+        linked_principals=PurgePreviewRow(count=1, example="Discord:1234567890"),
+        principal_links=zero,
+        routines=zero,
+        user_configs=zero,
+        account=PurgePreviewRow(count=1, example=None),
+        user_skills=zero,
+        github_credentials=zero,
+        github_oauth_states=zero,
+        mcp_tokens=zero,
+        agent_github_binding=zero,
+    )
+
+
+def _collect_text(
+    view_or_container: discord.ui.LayoutView | discord.ui.Container[discord.ui.LayoutView],
+) -> str:
+    return "\n".join(
+        child.content
+        for child in view_or_container.walk_children()
+        if isinstance(child, discord.ui.TextDisplay)
+    )
+
+
+class TestDefaultBotDisplayName:
+    def test_default_is_daimon(self) -> None:
+        settings = DiscordSettings(bot_token=SecretStr("test-bot-token"))
+        assert settings.bot_display_name == "daimon", "default bot_display_name must be 'daimon'"
+
+
+class TestMentionReplacement:
+    @pytest.mark.asyncio
+    async def test_unset_renders_at_daimon(self) -> None:
+        trigger = _make_message(msg_id=10, content="<@999> help me")
+        thread = _make_thread([trigger])
+        result, _ = await build_context_xml(thread, trigger, bot_user_id=999)
+        assert "@daimon" in result, (
+            "unset bot_display_name must render '@daimon' (today's behavior)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_name_changes_mention(self) -> None:
+        trigger = _make_message(msg_id=10, content="<@999> help me")
+        thread = _make_thread([trigger])
+        result, _ = await build_context_xml(
+            thread, trigger, bot_user_id=999, bot_display_name="daimon-staging"
+        )
+        assert "<@999>" not in result, "raw bot mention should be replaced"
+        assert "@daimon-staging" in result, "set bot_display_name must change the @mention"
+
+
+class TestSettingUpMessage:
+    def test_unset_matches_todays_text(self) -> None:
+        assert _setting_up_message("daimon") == (
+            "Daimon is setting up this server — try again in a moment."
+        ), "unset bot_display_name must render byte-identical setting-up text"
+
+    def test_set_name_changes_text(self) -> None:
+        assert _setting_up_message("daimon-staging") == (
+            "Daimon-staging is setting up this server — try again in a moment."
+        )
+
+
+class TestWelcomeEmbedOnceReadyField:
+    def test_unset_matches_todays_text(self) -> None:
+        embed = _build_welcome_embed("daimon")
+        field = embed.fields[0]
+        assert field.value == (
+            "Mention `@daimon` anywhere to chat, or run `/agent-setup` to manage your agents."
+        ), "unset bot_display_name must render byte-identical welcome copy"
+
+    def test_set_name_changes_text(self) -> None:
+        embed = _build_welcome_embed("daimon-staging")
+        field = embed.fields[0]
+        assert field.value == (
+            "Mention `@daimon-staging` anywhere to chat, or run `/agent-setup` to manage your agents."
+        )
+
+
+class TestCreditDepletedMessage:
+    def test_unset_matches_todays_text(self) -> None:
+        assert _credit_depleted_message("daimon") == (
+            "This server's daimon credit is depleted. An admin can top up with `/billing`."
+        )
+
+    def test_set_name_changes_text(self) -> None:
+        assert _credit_depleted_message("daimon-staging") == (
+            "This server's daimon-staging credit is depleted. An admin can top up with `/billing`."
+        )
+
+
+class TestHelpViewConversationalExamples:
+    def test_unset_matches_todays_text(self) -> None:
+        texts = _collect_text(build_help_view("daimon"))
+        assert "See, export, or delete what daimon stores about you" in texts
+        assert "@daimon help me set up" in texts
+        assert "@daimon make a routine that runs daily" in texts
+
+    def test_set_name_changes_text(self) -> None:
+        texts = _collect_text(build_help_view("daimon-staging"))
+        assert "See, export, or delete what daimon-staging stores about you" in texts
+        assert "@daimon-staging help me set up" in texts
+        assert "@daimon-staging make a routine that runs daily" in texts
+
+
+class TestPrivacyCommandDescription:
+    def test_unset_matches_todays_text(self) -> None:
+        bot = MagicMock()
+        bot.runtime.settings.discord = DiscordSettings(bot_token=SecretStr("test-bot-token"))
+        cog = PrivacyCog(bot)
+        assert cog.privacy.description == "See, export, or delete what daimon stores about you"
+
+    def test_set_name_changes_text(self) -> None:
+        bot = MagicMock()
+        bot.runtime.settings.discord = DiscordSettings(
+            bot_token=SecretStr("test-bot-token"), bot_display_name="daimon-staging"
+        )
+        cog = PrivacyCog(bot)
+        assert (
+            cog.privacy.description == "See, export, or delete what daimon-staging stores about you"
+        )
+
+
+class TestPrivacyMainContainer:
+    def test_unset_matches_todays_text(self) -> None:
+        texts = _collect_text(build_privacy_main_container(_make_preview(), user_name="Alice"))
+        assert "daimon holds" in texts
+
+    def test_set_name_changes_text(self) -> None:
+        texts = _collect_text(
+            build_privacy_main_container(
+                _make_preview(), user_name="Alice", bot_display_name="daimon-staging"
+            )
+        )
+        assert "daimon-staging holds" in texts
+
+
+class TestExportPlaceholderMessage:
+    def test_unset_matches_todays_text(self) -> None:
+        assert _export_placeholder_message("daimon") == (
+            "📤 **Export** is not yet implemented.\n\n"
+            "When ready, this will produce a JSON dump of every daimon-side row "
+            "tied to your identity and either attach it here or DM you a 7-day "
+            "signed URL."
+        )
+
+    def test_set_name_changes_text(self) -> None:
+        result = _export_placeholder_message("daimon-staging")
+        assert "every daimon-staging-side row" in result
+
+
+class TestPostDeleteContainer:
+    def test_unset_matches_todays_text(self) -> None:
+        result = AccountPurgeResult(db=PurgeReport(accounts=1))
+        texts = _collect_text(build_post_delete_container(result))
+        assert "Your daimon data has been deleted." in texts
+
+    def test_set_name_changes_text(self) -> None:
+        result = AccountPurgeResult(db=PurgeReport(accounts=1))
+        texts = _collect_text(
+            build_post_delete_container(result, bot_display_name="daimon-staging")
+        )
+        assert "Your daimon-staging data has been deleted." in texts

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -151,6 +151,16 @@ class DiscordSettings(BaseModel):
             "legacy fallback, not recommended for production."
         ),
     )
+    bot_display_name: str = Field(
+        default="daimon",
+        description=(
+            "The bot's presented name across user-facing Discord render sites "
+            "(@mentions, setup messages, help text, privacy panel copy). Defaults "
+            "to 'daimon' so unset deployments render byte-identical output. Set "
+            "to a distinct name (e.g. 'daimon-staging') so a non-production "
+            "deployment is visibly distinct in-channel."
+        ),
+    )
 
 
 class SlackSettings(BaseModel):


### PR DESCRIPTION
Two independent changes that prepare for environment-parameterized deploys without altering current CI behavior.

**Reusable deploy workflow.** The deploy body from ci.yml, extracted into `deploy.yml` with `environment` and `sha` inputs. Per-environment config (project, registry, WIF provider, deploy service account, notebook domain) resolves from the GitHub Environment named by the input. It runs only via `workflow_call` or `workflow_dispatch`. There is no push trigger, so merging this changes nothing about how deploys happen today: ci.yml keeps its inline deploy job, untouched.

**Configurable bot display name.** `DiscordSettings.bot_display_name` (default `daimon`) now flows through the user-facing Discord render sites. With the field unset, rendered output is byte-identical to before, and a test locks that in. This lets a second deployment of the bot present itself under a different name so nobody mistakes it for the main one.

The motivation for both: we want to dispatch deploys to a non-production environment and prove the machinery end to end before pointing anything at production. Extracting the deploy body first, dormant, makes that possible while push-to-main keeps working exactly as it does now. Infrastructure for the second environment lives in the companion infra repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)