### PR TITLE
feat: deploy staging on push to main; promote workflow for production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
         run: docker build -t daimon:ci .
 
   deploy-gcp:
-    name: Deploy to GCP (production)
+    name: Deploy to GCP (staging)
     needs: [lint, pytest-core, pytest-mcp, pytest-discord, pytest-slack, pytest-notebook-host, docker-build]
     # vars.GCP_WIF_PROVIDER doubles as the deploy switch: repository variables
     # don't propagate to forks/clones, so a repo with no GCP config skips this
@@ -217,112 +217,14 @@ jobs:
     # enable push-to-main deploys by setting GCP_WIF_PROVIDER, GCP_DEPLOY_SA,
     # and GCP_PROJECT_ID in repo settings — no workflow edit needed. Partial
     # config (provider set, SA/project missing) fails loudly by design.
+    #
+    # A push to main deploys STAGING. Production deploys only through
+    # promote.yml (workflow_dispatch behind the production reviewer gate).
     if: github.ref == 'refs/heads/main' && github.event_name == 'push' && vars.GCP_WIF_PROVIDER != ''
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    concurrency:
-      group: deploy-gcp-production
-      cancel-in-progress: false
-    env:
-      REGION: ${{ vars.GCP_REGION }}
-      AR_HOST: ${{ vars.GCP_REGION }}-docker.pkg.dev
-      REPO: ${{ vars.GCP_AR_REPO }}
-      ZONE: ${{ vars.GCP_ZONE }}
-      NOTEBOOK_DOMAIN: ${{ vars.NOTEBOOK_DOMAIN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
-          service_account: ${{ vars.GCP_DEPLOY_SA }}
-
-      - uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ env.AR_HOST }} --quiet
-
-      - name: Compute image tags
-        id: tags
-        run: |
-          SHA=$(git rev-parse --short HEAD)
-          BASE=${{ env.AR_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ env.REPO }}
-          echo "daimon=$BASE/daimon:$SHA" >> "$GITHUB_OUTPUT"
-          echo "notebook=$BASE/notebook-host:$SHA" >> "$GITHUB_OUTPUT"
-
-      - name: Build + push daimon image
-        run: |
-          docker build -t "${{ steps.tags.outputs.daimon }}" -f Dockerfile .
-          docker push "${{ steps.tags.outputs.daimon }}"
-
-      - name: Build + push notebook-host image
-        run: |
-          docker build -t "${{ steps.tags.outputs.notebook }}" -f apps/notebook-host/Dockerfile .
-          docker push "${{ steps.tags.outputs.notebook }}"
-
-      - name: Run migrations (blocking gate)
-        run: |
-          gcloud run jobs update ${{ vars.GCP_AR_REPO }}-migrate --region "$REGION" \
-            --image "${{ steps.tags.outputs.daimon }}"
-          gcloud run jobs execute ${{ vars.GCP_AR_REPO }}-migrate --region "$REGION" --wait
-
-      - name: Deploy mcp revision
-        run: |
-          gcloud run services update ${{ vars.GCP_AR_REPO }}-mcp --region "$REGION" \
-            --image "${{ steps.tags.outputs.daimon }}"
-
-      - name: Refresh worker VM containers (recreate in place)
-        run: |
-          # Skip the refresh when the workers VM is stopped (nothing to recreate).
-          STATUS=$(gcloud compute instances describe ${{ vars.GCP_AR_REPO }}-workers \
-            --zone "$ZONE" --format='value(status)')
-          if [ "$STATUS" != "RUNNING" ]; then
-            echo "workers VM is $STATUS — skipping container refresh"
-            exit 0
-          fi
-          gcloud compute ssh ${{ vars.GCP_AR_REPO }}-workers --zone "$ZONE" \
-            --tunnel-through-iap --command '
-              export DAIMON_IMAGE="${{ steps.tags.outputs.daimon }}"
-              # sudo -E keeps the SSH user HOME, so docker would look for
-              # Artifact Registry credentials in ~/.docker (none there). Point
-              # at root docker config, where the boot startup script ran
-              # `gcloud auth configure-docker`.
-              export DOCKER_CONFIG=/root/.docker
-              cd /etc/daimon
-              sudo -E docker compose -f compose.worker.yml pull
-              sudo -E docker compose -f compose.worker.yml up -d --remove-orphans
-            '
-
-      - name: Refresh notebook-host VM container (recreate in place)
-        run: |
-          gcloud compute ssh ${{ vars.GCP_AR_REPO }}-notebook --zone "$ZONE" \
-            --tunnel-through-iap --command '
-              export NOTEBOOK_IMAGE="${{ steps.tags.outputs.notebook }}"
-              # Caddy fronts notebook-host with TLS on this domain; the compose
-              # file interpolates NOTEBOOK_DOMAIN + NOTEBOOK_PUBLIC_URL_BASE
-              # (the compose file and Caddyfile live in the operator private infra repo).
-              export NOTEBOOK_DOMAIN="${{ env.NOTEBOOK_DOMAIN }}"
-              export NOTEBOOK_PUBLIC_URL_BASE="https://${{ env.NOTEBOOK_DOMAIN }}"
-              # Same DOCKER_CONFIG redirect as the workers refresh: use root
-              # docker config (has the Artifact Registry credential helper).
-              export DOCKER_CONFIG=/root/.docker
-              cd /etc/daimon
-              sudo -E docker compose -f compose.notebook.yml pull
-              sudo -E docker compose -f compose.notebook.yml up -d --remove-orphans
-            '
-
-      - name: Health gate
-        run: |
-          URL=$(gcloud run services describe ${{ vars.GCP_AR_REPO }}-mcp --region "$REGION" \
-            --format='value(status.url)')
-          # /healthz is intercepted by Google Front End on run.app domains (404s
-          # before reaching the container); /readyz passes through and also
-          # verifies DB connectivity.
-          for i in $(seq 1 10); do
-            if curl -sfI "$URL/readyz" >/dev/null; then echo "healthy"; exit 0; fi
-            sleep 6
-          done
-          echo "mcp did not become healthy" >&2; exit 1
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: staging
+      sha: ${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,10 @@ jobs:
               cd /etc/daimon
               sudo -E docker compose -f compose.worker.yml pull
               sudo -E docker compose -f compose.worker.yml up -d --remove-orphans
+              # Prune superseded image tags after the new ones are in use —
+              # each deploy leaves a ~1GB tag behind, and a full root disk
+              # breaks IAP SSH key writes (breaking this very refresh step).
+              sudo docker image prune -af || true
             '
 
       - name: Refresh notebook-host VM container (recreate in place)
@@ -125,6 +129,8 @@ jobs:
               cd /etc/daimon
               sudo -E docker compose -f compose.notebook.yml pull
               sudo -E docker compose -f compose.notebook.yml up -d --remove-orphans
+              # Same prune as the workers refresh (see comment there).
+              sudo docker image prune -af || true
             '
 
       - name: Health gate

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,73 @@
+name: Promote
+
+# Production promote/rollback path. The ONLY way code reaches production:
+# an operator dispatches this workflow with a full commit SHA that has
+# already soaked on staging. Rollback is the same operation pointed at an
+# older SHA. The `production` GitHub Environment enforces the required
+# reviewers before any deploy authority is granted.
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Full 40-char commit SHA to promote to production"
+        required: true
+        type: string
+
+jobs:
+  validate:
+    name: Validate promote SHA
+    runs-on: ubuntu-latest
+    # Uses the STAGING Environment: after the CI flip, every main push builds
+    # images into staging's registry, so staging AR is where a soaked image
+    # lives (prod AR is only populated by the promote deploy itself). This
+    # also runs validation before the production reviewer gate — a bad SHA
+    # fails fast without paging reviewers.
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AR_HOST: ${{ vars.GCP_REGION }}-docker.pkg.dev
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Assert full 40-hex SHA
+        run: |
+          echo "${{ inputs.sha }}" | grep -Eq '^[0-9a-f]{40}$' \
+            || { echo "Input '${{ inputs.sha }}' is not a full 40-char lowercase hex SHA" >&2; exit 1; }
+
+      - name: Assert SHA is an ancestor of main
+        run: |
+          git merge-base --is-ancestor "${{ inputs.sha }}" origin/main \
+            || { echo "SHA ${{ inputs.sha }} is not an ancestor of origin/main — refusing to promote" >&2; exit 1; }
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SA }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Assert soaked image exists for this SHA
+        run: |
+          # ci.yml tags images with `git rev-parse --short HEAD` (7 chars);
+          # truncate the full input SHA to match that scheme. A missing image
+          # means the SHA never passed the test+build pipeline — fail closed.
+          SHORT=$(echo "${{ inputs.sha }}" | cut -c1-7)
+          IMAGE="${{ env.AR_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_AR_REPO }}/daimon:$SHORT"
+          gcloud artifacts docker images describe "$IMAGE" \
+            || { echo "No image at $IMAGE — SHA was never built by CI" >&2; exit 1; }
+
+  deploy:
+    name: Promote to production
+    needs: validate
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: production
+      sha: ${{ inputs.sha }}


### PR DESCRIPTION
## Summary

- `ci.yml`'s push-to-main deploy job is now a thin caller of the reusable `deploy.yml` with `environment: staging` — the inline deploy body is removed (single source of truth).
- New `promote.yml`: the only path to production. `workflow_dispatch` with a full 40-hex SHA, validated (hex format, ancestor-of-main, soaked staging image exists) before the reviewer-gated production deploy. Rollback is the same operation pointed at an older SHA.
- `deploy.yml` VM refresh steps prune superseded image tags after `up` (a full root disk silently breaks the IAP SSH refresh path).

After this merges, **push to main deploys staging**; production moves only via an approved promote.

Infra-side WIF provider renames and per-Environment variable updates were applied in the companion infra repo in the same window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Post-merge record (SPEC req 8)

- First production promote through `promote.yml`: https://github.com/pymc-labs/daimon/actions/runs/30221017984 — green end-to-end (validate → reviewer-approved deploy → /readyz), live client unaffected.
- Rollback direction proven: an older soaked SHA passed the validate job (run 30221061319, cancelled before deploy by design).