### PR TITLE
fix: harden deploy workflows and validate bot display name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,17 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "GitHub Environment to deploy (staging or production)"
+        description: "GitHub Environment to deploy"
         required: true
-        type: string
+        # choice, not string: a free-text typo (Production, prod) would create
+        # an implicit GitHub Environment with no protection rules that falls
+        # back to repo-level vars and deploys with no reviewer gate at all.
+        type: choice
+        options:
+          - staging
+          - production
       sha:
-        description: "Full commit SHA to deploy"
+        description: "Full 40-char commit SHA to deploy"
         required: true
         type: string
 
@@ -43,6 +49,17 @@ jobs:
       ZONE: ${{ vars.GCP_ZONE }}
       NOTEBOOK_DOMAIN: ${{ vars.NOTEBOOK_DOMAIN }}
     steps:
+      # Guard both entry points: ci.yml/promote.yml pass a full github.sha,
+      # but workflow_dispatch is free text — reject branch names, short SHAs,
+      # and anything else that isn't a pinned 40-hex commit. Passed via env so
+      # the input is data, never shell code.
+      - name: Assert full 40-hex SHA
+        env:
+          SHA: ${{ inputs.sha }}
+        run: |
+          echo "$SHA" | grep -Eq '^[0-9a-f]{40}$' \
+            || { echo "Input '$SHA' is not a full 40-char lowercase hex SHA" >&2; exit 1; }
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,11 @@ jobs:
       - name: Compute image tags
         id: tags
         run: |
-          SHA=$(git rev-parse --short HEAD)
+          # Deterministic 7-char truncation, NOT `git rev-parse --short`:
+          # --short honors core.abbrev=auto and grows with the object count,
+          # which would silently change the tag scheme and break promote.yml's
+          # image-exists check (it truncates the input SHA to 7 chars).
+          SHA=$(git rev-parse HEAD | cut -c1-7)
           BASE=${{ env.AR_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ env.REPO }}
           echo "daimon=$BASE/daimon:$SHA" >> "$GITHUB_OUTPUT"
           echo "notebook=$BASE/notebook-host:$SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -62,9 +62,10 @@ jobs:
         env:
           SHA: ${{ inputs.sha }}
         run: |
-          # ci.yml tags images with `git rev-parse --short HEAD` (7 chars);
-          # truncate the full input SHA to match that scheme. A missing image
-          # means the SHA never passed the test+build pipeline — fail closed.
+          # deploy.yml tags images with the first 7 chars of the full commit
+          # SHA (a fixed `cut -c1-7`, matching this truncation exactly). A
+          # missing image means the SHA never passed the test+build pipeline —
+          # fail closed.
           SHORT=$(echo "$SHA" | cut -c1-7)
           IMAGE="${{ env.AR_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_AR_REPO }}/daimon:$SHORT"
           gcloud artifacts docker images describe "$IMAGE" \

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -33,15 +33,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      # inputs.sha is free-text; always pass it through `env` so the shell
+      # sees it as data — inline `${{ }}` interpolation in `run:` would let a
+      # crafted input execute in a job holding id-token: write.
       - name: Assert full 40-hex SHA
+        env:
+          SHA: ${{ inputs.sha }}
         run: |
-          echo "${{ inputs.sha }}" | grep -Eq '^[0-9a-f]{40}$' \
-            || { echo "Input '${{ inputs.sha }}' is not a full 40-char lowercase hex SHA" >&2; exit 1; }
+          echo "$SHA" | grep -Eq '^[0-9a-f]{40}$' \
+            || { echo "Input '$SHA' is not a full 40-char lowercase hex SHA" >&2; exit 1; }
 
       - name: Assert SHA is an ancestor of main
+        env:
+          SHA: ${{ inputs.sha }}
         run: |
-          git merge-base --is-ancestor "${{ inputs.sha }}" origin/main \
-            || { echo "SHA ${{ inputs.sha }} is not an ancestor of origin/main — refusing to promote" >&2; exit 1; }
+          git merge-base --is-ancestor "$SHA" origin/main \
+            || { echo "SHA $SHA is not an ancestor of origin/main — refusing to promote" >&2; exit 1; }
 
       - id: auth
         uses: google-github-actions/auth@v2
@@ -52,11 +59,13 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v2
 
       - name: Assert soaked image exists for this SHA
+        env:
+          SHA: ${{ inputs.sha }}
         run: |
           # ci.yml tags images with `git rev-parse --short HEAD` (7 chars);
           # truncate the full input SHA to match that scheme. A missing image
           # means the SHA never passed the test+build pipeline — fail closed.
-          SHORT=$(echo "${{ inputs.sha }}" | cut -c1-7)
+          SHORT=$(echo "$SHA" | cut -c1-7)
           IMAGE="${{ env.AR_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_AR_REPO }}/daimon:$SHORT"
           gcloud artifacts docker images describe "$IMAGE" \
             || { echo "No image at $IMAGE — SHA was never built by CI" >&2; exit 1; }

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -5,6 +5,13 @@ name: Promote
 # already soaked on staging. Rollback is the same operation pointed at an
 # older SHA. The `production` GitHub Environment enforces the required
 # reviewers before any deploy authority is granted.
+#
+# Promotion is COMMIT-level, not artifact-level: the production deploy
+# rebuilds images from source at the promoted SHA (docker builds are not
+# reproducible — mutable base tags, network state at build time), so the
+# bytes that reach production are not the bytes that soaked on staging.
+# The validate job's image-exists check proves the commit passed the CI
+# test+build pipeline and had a staging image to soak — nothing more.
 on:
   workflow_dispatch:
     inputs:

--- a/packages/adapters/discord/daimon/adapters/discord/context.py
+++ b/packages/adapters/discord/daimon/adapters/discord/context.py
@@ -24,7 +24,10 @@ def _strip_bot_mention(
     """Replace ``<@bot_id>`` and ``<@!bot_id>`` with ``@{bot_display_name}``."""
     if bot_user_id is None:
         return content
-    return re.sub(rf"<@!?{bot_user_id}>", f"@{bot_display_name}", content)
+    # Callable repl, not a replacement string: a plain f-string here would let
+    # a backslash or \g<...> in the configured name raise re.error (or expand
+    # group refs) on every mention in every guild.
+    return re.sub(rf"<@!?{bot_user_id}>", lambda _: f"@{bot_display_name}", content)
 
 
 def _render_location(thread: discord.Thread) -> list[str]:

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -153,6 +153,14 @@ class DiscordSettings(BaseModel):
     )
     bot_display_name: str = Field(
         default="daimon",
+        # Constrained because the value flows into user-facing surfaces with
+        # hard limits: slash-command descriptions carry fixed copy around the
+        # name and must stay under Discord's 100-char cap (hence 32), and the
+        # excluded characters are regex-replacement / Discord-markdown /
+        # mention metacharacters that would corrupt those render sites.
+        min_length=1,
+        max_length=32,
+        pattern=r"^[^\\`@#:]+$",
         description=(
             "The bot's presented name across user-facing Discord render sites "
             "(@mentions, setup messages, help text, privacy panel copy). Defaults "


### PR DESCRIPTION
Follow-ups from a review of the deploy pipeline and the display-name branding change.

Workflow hardening:

- promote.yml now passes the dispatch SHA into run steps through `env` instead of inline `${{ }}` interpolation, so the input is data rather than shell code.
- deploy.yml's manual dispatch takes `environment` as a choice (staging or production) instead of free text, and asserts the SHA input is a full 40-hex commit before checkout.
- Image tags come from `git rev-parse HEAD | cut -c1-7` in both workflows. `rev-parse --short` grows with repo size, which would eventually make promote's tag-exists check look for a tag that was never pushed.
- promote.yml's header now says plainly that promotion is commit-level: the production deploy rebuilds from the validated commit, it does not copy the staging image digest.

Discord:

- `bot_display_name` is validated in settings (1 to 32 chars, rejects backslash, backtick, `@`, `#`, `:`). Previously a name containing a backslash would raise `re.error` inside `_strip_bot_mention` on every mention, and a long name could push the privacy command description past Discord's 100-char limit and silently break global command sync. The mention replacement also uses a callable now, so the name is never interpreted as a regex replacement template.

Companion infra repo has matching changes on the same branch (IAM scoping, WIF environment binding, secrets generator coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)