### PR TITLE
feat: give every agent a default GitHub credential, and let credentials be attached from chat

### DIFF
--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -69,14 +69,24 @@ system: |
        `attach_mcp_server(agent_name, server_name, url)`. Confirm with
        the user before invoking.
      - For servers that require an auth token: do NOT accept the token
-       in chat. Refuse and tell the user to open `/agent-setup` ->
-       MCPs, where the modal (Discord or Slack) keeps the token out of
-       channel history. This is a security policy, not a feature gap:
-       tokens sent in chat would land in channel history and MA's
-       tenant-wide session log. If the user pastes a token anyway,
-       acknowledge that you saw it, do NOT call any tool with it, and
-       repeat the redirect.
+       in chat. Refuse, then call
+       `request_mcp_credential(agent_name, server_name, url, channel_id)`
+       and tell the user to click the button it posts in this thread —
+       clicking it opens a private modal where they enter the token, so
+       it never enters channel history or your context.
   4. Confirm the final shape with the user before applying.
+
+  Credentials never travel through chat as plaintext — during this setup
+  flow or at any other time. If a task needs an environment secret you do
+  not already have, call
+  `request_env_credential(agent_name, key, purpose, channel_id)` rather
+  than asking the user to paste it: it posts the same kind of button. If a
+  user pastes a token or secret in chat anyway, acknowledge that you saw
+  it, call NO tool with it, and tell them to rotate it immediately since it is already in this channel's history and in MA's tenant-wide session log, which the bot cannot delete or scrub — then call
+  `request_mcp_credential` or `request_env_credential` (whichever
+  matches) so the replacement is entered privately via the button. Once
+  added via either tool, the credential becomes usable by everyone who
+  talks to this agent — say so when you post the button.
 
   You can also perform agent roster operations on your tenant via MCP:
 
@@ -87,8 +97,8 @@ system: |
     patch-updates an existing agent — omitted fields are preserved, `[]`
     clears a list field.
   - `attach_mcp_server(agent_name, server_name, url)` attaches a no-auth
-    MCP server to an agent. NO auth token parameter; do not use for
-    auth-required servers — redirect to `/agent-setup` -> MCPs modal.
+    MCP server to an agent. NO auth token parameter; for auth-required
+    servers call `request_mcp_credential` instead.
   - `list_agents` / `get_agent` for discovery.
 
   When a user asks for a roster operation in chat ("fork yourself into

--- a/packages/adapters/cli/daimon/adapters/cli/commands/skills.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/skills.py
@@ -175,6 +175,11 @@ async def sync_agent(
         )
         raise typer.Exit(code=3)
     fernet = build_multifernet(tuple(k.get_secret_value() for k in rt.settings.crypto.keys))
+    github_fallback_pat = (
+        rt.settings.github.fallback_pat.get_secret_value()
+        if rt.settings.github.fallback_pat is not None
+        else None
+    )
 
     async def _run(http: httpx.AsyncClient) -> SyncReport:
         return await sync_agent_skills(
@@ -186,6 +191,7 @@ async def sync_agent(
             fernet=fernet,
             http_client=http,
             anthropic_client=rt.anthropic,
+            github_fallback_pat=github_fallback_pat,
         )
 
     try:

--- a/packages/adapters/cli/tests/commands/test_skills_sync_agent.py
+++ b/packages/adapters/cli/tests/commands/test_skills_sync_agent.py
@@ -93,10 +93,15 @@ class _FakeCrypto:
         self.keys = keys
 
 
+class _FakeGithub:
+    fallback_pat: SecretStr | None = None
+
+
 class _FakeSettings:
     def __init__(self, fernet_key: bytes) -> None:
         self.cli = _FakeCli()
         self.crypto = _FakeCrypto(keys=(SecretStr(fernet_key.decode("utf-8")),))
+        self.github = _FakeGithub()
 
 
 def _make_rt(

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -324,7 +324,9 @@ class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
                         public = await is_public_repo(http_client, owner_repo=owner_repo)
                         if not public:
                             raise DaimonError(
-                                "This repo is private (or not found). Paste a PAT to bind it."
+                                "This repo isn't visible to the shared service account "
+                                "(it's private, or it doesn't exist) — paste a PAT or "
+                                "connect your GitHub to bind it."
                             )
                 # No inline PAT -> no per-agent credential is written. The resync
                 # path is agent-overlay-only and never consults a principal-default, so

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -195,11 +195,17 @@ def _build_body_text(state: PanelState) -> str:
         )
         groups.append(f"🔌 **MCPs**\n{mcp_lines}")
 
-    # Repo & auth group: only shown when at least one of repo/auth/secrets is set.
+    # Repo & auth group: only shown when at least one of repo/auth/secrets is set,
+    # or the shared service account is the agent's only source of GitHub access.
     has_repo = bool(state.bound_repo_url)
     has_auth = bool(state.github_login or state.pat_last4)
     has_secrets = state.secret_count > 0
-    if has_repo or has_auth or has_secrets:
+    # get_github_login never sees the operator fallback PAT, so an agent relying
+    # on it alone would otherwise read as "unlinked" here despite being able to
+    # clone public repos. Distinct from `wont_clone` below by construction: the
+    # two never fire together (wont_clone already requires fallback NOT configured).
+    uses_shared_service_account = not has_auth and state.fallback_pat_configured
+    if has_repo or has_auth or has_secrets or uses_shared_service_account:
         repo_line_parts: list[str] = []
         if state.bound_repo_url:
             # Masked-link text must NOT be a URL: Discord auto-links the inner
@@ -214,6 +220,11 @@ def _build_body_text(state: PanelState) -> str:
             repo_line_parts.append(login_label)
         elif state.pat_last4:
             repo_line_parts.append(f"PAT ••••{state.pat_last4}")
+        elif uses_shared_service_account:
+            repo_line_parts.append(
+                "🌐 public read-only via shared service account — "
+                "link your GitHub for private repos"
+            )
         if has_secrets:
             repo_line_parts.append(f"🔑 {state.secret_count} secrets")
         repo_line = " · ".join(repo_line_parts)

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
@@ -523,6 +523,11 @@ async def kick_off_skill_sync(
     """
     fernet = _build_runtime_fernet(runtime)
     repos = [SkillRepo(url=repo_url, branch="main", path="", split=True)]
+    github_fallback_pat = (
+        runtime.settings.github.fallback_pat.get_secret_value()
+        if runtime.settings.github.fallback_pat is not None
+        else None
+    )
     async with httpx.AsyncClient() as http_client:
         return await sync_agent_skills(
             principal_id=account_id,
@@ -533,4 +538,5 @@ async def kick_off_skill_sync(
             fernet=fernet,
             http_client=http_client,
             anthropic_client=runtime.anthropic,
+            github_fallback_pat=github_fallback_pat,
         )

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -265,6 +265,17 @@ class DaimonBot(commands.Bot):
         await self.add_cog(PrivacyCog(self))
         await self.add_cog(MemoryCog(self))
 
+        # One-time CLASS registration (not per-button) for the chat-initiated
+        # credential-request button. Imported here, not at module level, since
+        # credential_button.py imports DaimonBot at module level -- importing
+        # it up top here would be a cycle. Needed because a button posted by
+        # the separate MCP process still has to dispatch in THIS process:
+        # Discord routes interactions by bot application id, not by which
+        # process sent the message that carried the button.
+        from daimon.adapters.discord.credential_button import CredentialRequestButton
+
+        self.add_dynamic_items(CredentialRequestButton)
+
     async def _post_to_guild(self, guild: discord.Guild, embed: discord.Embed) -> None:
         """Post an embed via the fallback chain: text channel → DM owner → skip."""
         channel = _pick_post_channel(guild)

--- a/packages/adapters/discord/daimon/adapters/discord/credential_button.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_button.py
@@ -1,0 +1,182 @@
+"""CredentialRequestButton -- persistent, per-request credential button.
+
+The agent posts this button from the MCP process (Cloud Run); the click is
+dispatched to the Discord bot process (worker VM) — a different Python
+process entirely. Discord routes interactions by bot application id, not by
+which process sent the message, so both processes only need to authenticate
+with the same bot token; no other coordination is required.
+
+A per-request button cannot be served by a single long-lived View instance
+registered with `bot.add_view()` — that call only registers one already-built
+instance's fixed custom_id, and this button's custom_id is minted fresh per
+request. `discord.ui.DynamicItem` is the primitive that matches a *template*
+regex against an arbitrary future custom_id and reconstructs per-click state
+via `from_custom_id`, so this is the one place in the Discord adapter that
+carries a persistent, dispatchable custom_id — everywhere else stays
+non-persistent (see `views.py`'s module docstring for the documented
+exception).
+
+Authorization is requester-only: `interaction_check` compares the clicking
+user's id against the id the request was minted for. There is deliberately
+NO admin gate here — the setup panel's mutation buttons are admin-only, but
+this flow intentionally widens that to "whoever the agent was talking to"
+for one-click UX. That makes the requester comparison in `interaction_check`
+the ONLY authorization on this write path. Do not "restore" an admin check
+here without a deliberate decision to change that.
+
+discord.py's own dispatcher swallows every exception raised inside
+`from_custom_id`, `interaction_check`, and `callback` (logs internally and
+returns) — verified against the installed `discord/ui/view.py`. That makes
+those three methods a genuine adapter boundary: the ordinary
+let-failures-propagate rule does not apply here, because propagating would
+mean the exception vanishes into a dispatcher we don't control and the user
+sees nothing but a stuck interaction. Each method below catches narrowly (or,
+for the check/callback bodies, catches broadly with a structlog record and an
+ephemeral reply) specifically because this is the last point before that
+swallowing dispatcher.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any, Self, cast
+
+import structlog
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.credential_modals import EnvCredentialModal, McpCredentialModal
+from daimon.core.credential_requests import (
+    CUSTOM_ID_TEMPLATE,
+    CredentialRequestKind,
+    build_button_label,
+    build_custom_id,
+)
+from daimon.core.stores.credential_requests import peek_credential_request
+from daimon.core.stores.domain import CredentialRequestRow
+from sqlalchemy.exc import SQLAlchemyError
+
+import discord
+from discord.ext import commands
+
+_log = structlog.get_logger()
+
+# Shown when the lookup in from_custom_id found nothing (unknown token or a
+# DB failure) — the real label (naming the exact target) only exists once a
+# row is found, so this is the best available fallback for a dead button.
+_FALLBACK_LABEL = "Add credential"
+
+_NO_LONGER_VALID = "This request is no longer valid — ask again."
+_WRONG_REQUESTER = "This request was for someone else — ask again in your own thread."
+_EXPIRED = "This request expired — ask again."
+_ALREADY_USED = "This request was already used — ask again."
+_CHECK_FAILED = "Something went wrong checking this request — please try again."
+_CALLBACK_FAILED = "Something went wrong opening this form — please try again."
+
+
+class CredentialRequestButton(
+    discord.ui.DynamicItem[discord.ui.Button[discord.ui.View]], template=CUSTOM_ID_TEMPLATE
+):
+    """Persistent, per-request credential button reconstructed from its custom_id.
+
+    Registered ONCE as a class (not per-button) via `client.add_dynamic_items`
+    in `bot.py`'s `setup_hook`. See the module docstring for why authorization
+    here is requester-only with no admin gate, and why the three dispatched
+    methods below catch exceptions themselves rather than letting them
+    propagate.
+    """
+
+    def __init__(self, *, token: str, label: str, request_row: CredentialRequestRow | None) -> None:
+        button: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            style=discord.ButtonStyle.primary,
+            label=label,
+            custom_id=build_custom_id(token),
+        )
+        super().__init__(button)
+        self.token = token
+        self.request_row = request_row
+
+    @classmethod
+    async def from_custom_id(  # type: ignore[override]  # discord.py's ClientT is a free TypeVar; this adapter only ever runs DaimonBot
+        cls,
+        interaction: discord.Interaction[commands.Bot],
+        item: discord.ui.Item[Any],
+        match: re.Match[str],
+        /,
+    ) -> Self:
+        """Rebuild the item from its token. Runs before the 3s ack budget starts.
+
+        A single indexed primary-key read — no MA calls, no extra queries.
+        Never raises: discord.py logs and discards any exception from this
+        method, so a raised DB error here would leave the user with a
+        permanently stuck interaction and nothing in our own logs.
+        """
+        token = match["token"]
+        bot = cast(DaimonBot, interaction.client)
+        try:
+            async with bot.runtime.sessionmaker() as session:
+                request_row = await peek_credential_request(session, token=token)
+        except SQLAlchemyError:
+            _log.exception("credential_button.lookup_failed", token_tail=token[-4:])
+            request_row = None
+        if request_row is None:
+            return cls(token=token, label=_FALLBACK_LABEL, request_row=None)
+        # `CredentialRequestRow.kind` is a bare `str` at the store boundary (ORM ->
+        # Pydantic mapping); every row is inserted with a validated
+        # `CredentialRequestKind` (daimon.core.credential_requests.create_*), so this
+        # narrowing reflects a real invariant rather than papering over one.
+        kind = cast(CredentialRequestKind, request_row.kind)
+        label = build_button_label(kind, request_row.target)
+        return cls(token=token, label=label, request_row=request_row)
+
+    async def interaction_check(  # type: ignore[override]  # see from_custom_id
+        self, interaction: discord.Interaction[commands.Bot], /
+    ) -> bool:
+        """Requester-only authorization plus fast expiry/single-use feedback.
+
+        This is the ONLY authorization gate on the credential write — there is
+        no admin check. The authoritative single-use gate is the atomic
+        consume inside the modal's `on_submit`; rejecting an already-used or
+        expired row here is fast user feedback, not the security boundary.
+        """
+        try:
+            request_row = self.request_row
+            if request_row is None:
+                await interaction.response.send_message(_NO_LONGER_VALID, ephemeral=True)
+                return False
+            if str(interaction.user.id) != request_row.requester_platform_user_id:
+                await interaction.response.send_message(_WRONG_REQUESTER, ephemeral=True)
+                return False
+            if request_row.expires_at < datetime.now(UTC):
+                await interaction.response.send_message(_EXPIRED, ephemeral=True)
+                return False
+            if request_row.used_at is not None:
+                await interaction.response.send_message(_ALREADY_USED, ephemeral=True)
+                return False
+            return True
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception(
+                "credential_button.interaction_check_failed", err_type=type(err).__name__
+            )
+            await interaction.response.send_message(_CHECK_FAILED, ephemeral=True)
+            return False
+
+    async def callback(  # type: ignore[override]  # see from_custom_id
+        self, interaction: discord.Interaction[commands.Bot]
+    ) -> None:
+        """Open the env or MCP modal matching this request's kind."""
+        try:
+            request_row = self.request_row
+            if request_row is None:
+                return
+            bot = cast(DaimonBot, interaction.client)
+            if request_row.kind == "env":
+                await interaction.response.send_modal(
+                    EnvCredentialModal(runtime=bot.runtime, request_row=request_row)
+                )
+            else:
+                await interaction.response.send_modal(
+                    McpCredentialModal(runtime=bot.runtime, request_row=request_row)
+                )
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("credential_button.callback_failed", err_type=type(err).__name__)
+            await interaction.response.send_message(_CALLBACK_FAILED, ephemeral=True)

--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -1,0 +1,204 @@
+"""EnvCredentialModal / McpCredentialModal — the two credential-button modals.
+
+Two separate modals, not one type-dispatching modal: an env secret and an MCP
+auth token are different resources with different write paths
+(`put_agent_file` vs `add_external_mcp_credential`), mirroring the two modals
+that already exist for the same writes (`agent_setup/credentials.py`'s
+`PasteSecretModal`, `agent_setup/modals_mcp.py`'s `AddMcpModal`). Each modal
+here collects exactly ONE field — the secret value itself — because every
+routing field (agent, key/server name) is already fixed by the consumed
+`credential_requests` row; the user never retypes it.
+
+Secret hygiene, matching the structural guarantees `PasteSecretModal` already
+documents:
+- the value never reaches a log record (env logs the key name only; MCP logs
+  a masked tail only),
+- the value never reaches a `custom_id` (the button's custom_id carries only
+  the opaque request token, minted before either modal exists),
+- the value never reaches a container/embed (a Modal TextInput has no
+  render surface other than the ephemeral confirmation, which never echoes
+  the value back),
+- there is no URL-fetch path and no attachment path.
+
+The atomic single-use consume runs BEFORE either write, so a request can
+only ever produce one write no matter how many times its modal is
+(re)submitted — the loser of a race, or any resubmission, gets `None` back
+and writes nothing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from daimon.adapters.discord.agent_setup.credentials import (
+    _MAX_SECRET_VALUE_BYTES,  # pyright: ignore[reportPrivateUsage]  # reusing PasteSecretModal's byte cap rather than inventing a second number
+)
+from daimon.adapters.discord.agent_setup.write import mask_tail
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.mcp_vault import add_external_mcp_credential
+from daimon.core.stores import credential_requests
+from daimon.core.stores.agent_files import put_agent_file
+from daimon.core.stores.domain import CredentialRequestRow
+
+import discord
+
+_log = structlog.get_logger()
+
+_NO_LONGER_VALID = "This request is no longer valid — ask again."
+
+
+class EnvCredentialModal(discord.ui.Modal, title="Add secret"):
+    """Add secrets modal: one value, atomic consume, existing agent_files write."""
+
+    def __init__(self, *, runtime: DiscordRuntime, request_row: CredentialRequestRow) -> None:
+        super().__init__()
+        self._runtime = runtime
+        self._row = request_row
+        self.value_input: discord.ui.TextInput[EnvCredentialModal] = discord.ui.TextInput(
+            label="Secret value",
+            style=discord.TextStyle.paragraph,
+            required=True,
+            max_length=4000,
+            placeholder="usable by everyone who talks to this agent",
+        )
+        self.add_item(self.value_input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        raw_value = str(self.value_input.value or "")
+
+        if not raw_value.strip():
+            await interaction.followup.send(
+                "Secret value cannot be empty — try again.", ephemeral=True
+            )
+            return
+        if len(raw_value.encode()) > _MAX_SECRET_VALUE_BYTES:
+            await interaction.followup.send(
+                f"Secret value is too large. Max {_MAX_SECRET_VALUE_BYTES} bytes.",
+                ephemeral=True,
+            )
+            return
+
+        now = datetime.now(UTC)
+        try:
+            async with self._runtime.sessionmaker() as session, session.begin():
+                consumed_row = await credential_requests.consume_credential_request(
+                    session, token=self._row.token, now=now
+                )
+                if consumed_row is None:
+                    await interaction.followup.send(_NO_LONGER_VALID, ephemeral=True)
+                    return
+                await put_agent_file(
+                    session,
+                    tenant_id=consumed_row.tenant_id,
+                    agent_id=consumed_row.agent_id,
+                    key=consumed_row.target,
+                    content=raw_value,
+                )
+        except Exception:
+            _log.exception("credential_modal.env_write_failed", key=self._row.target)
+            await interaction.followup.send(
+                "Something went wrong — please try again.", ephemeral=True
+            )
+            return
+
+        # Log the key NAME only — never the value.
+        _log.info("credential_modal.env.submit", key=consumed_row.target)
+        await interaction.followup.send(
+            f"Added `{consumed_row.target}`. Takes effect on the next session — "
+            "anyone who talks to this agent can use it.",
+            ephemeral=True,
+        )
+
+
+class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
+    """Add MCP credential modal: one token, atomic consume, existing vault write."""
+
+    def __init__(self, *, runtime: DiscordRuntime, request_row: CredentialRequestRow) -> None:
+        super().__init__()
+        self._runtime = runtime
+        self._row = request_row
+        self.token_input: discord.ui.TextInput[McpCredentialModal] = discord.ui.TextInput(
+            label="Auth token",
+            required=True,
+            max_length=255,
+            placeholder="usable by everyone who talks to this agent",
+        )
+        self.add_item(self.token_input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        token_value = str(self.token_input.value or "")
+
+        if not token_value.strip():
+            await interaction.followup.send(
+                "Auth token cannot be empty — try again.", ephemeral=True
+            )
+            return
+
+        public_url_setting = self._runtime.settings.mcp.public_url
+        jwt_secret_setting = self._runtime.settings.mcp.jwt_secret
+        if public_url_setting is None or jwt_secret_setting is None:
+            await interaction.followup.send(
+                "daimon-mcp is not configured (public_url / jwt_secret missing) — "
+                "credential not written.",
+                ephemeral=True,
+            )
+            return
+
+        now = datetime.now(UTC)
+        async with self._runtime.sessionmaker() as session, session.begin():
+            consumed_row = await credential_requests.consume_credential_request(
+                session, token=self._row.token, now=now
+            )
+        if consumed_row is None:
+            await interaction.followup.send(_NO_LONGER_VALID, ephemeral=True)
+            return
+
+        mcp_server_url = consumed_row.mcp_server_url
+        if mcp_server_url is None:
+            _log.error("credential_modal.mcp_missing_server_url", token_tail=self._row.token[-4:])
+            await interaction.followup.send(
+                "This request is missing its server URL — please ask again.", ephemeral=True
+            )
+            return
+
+        _log.info(
+            "credential_modal.mcp.submit",
+            mcp_server_url=mcp_server_url,
+            token_masked=mask_tail(token_value),
+        )
+        try:
+            await add_external_mcp_credential(
+                self._runtime.anthropic,
+                account_id=consumed_row.account_id,
+                agent_id=consumed_row.agent_id,
+                jwt_secret=jwt_secret_setting.get_secret_value().encode(),
+                public_url=str(public_url_setting),
+                mcp_server_url=mcp_server_url,
+                token=token_value,
+                now=now,
+                session_factory=self._runtime.sessionmaker,
+            )
+        except Exception as err:
+            _log.exception(
+                "credential_modal.mcp_write_failed",
+                mcp_server_url=mcp_server_url,
+                err_type=type(err).__name__,
+            )
+            # Surface only the exception class name — never the stringified
+            # exception, which for SDK/network errors can carry the request
+            # envelope (a token-leak surface). Full traceback goes to structlog.
+            await interaction.followup.send(
+                "Credential request consumed, but storing the auth token failed "
+                f"(`{type(err).__name__}`). Ask for a new request to retry.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.followup.send(
+            f"MCP credential added for `{mcp_server_url}`. Anyone who talks to "
+            "this agent can use it.",
+            ephemeral=True,
+        )

--- a/packages/adapters/discord/daimon/adapters/discord/views.py
+++ b/packages/adapters/discord/daimon/adapters/discord/views.py
@@ -5,6 +5,15 @@ CancelView for interrupting running turns (no timeout -- lifecycle manages remov
 
 All Views are non-persistent (VIEW-04): no custom_id, no bot.add_view(). CancelView uses
 timeout=None -- lifecycle manages removal.
+
+The one documented exception: the chat-initiated credential-request button
+(`daimon.adapters.discord.credential_button.CredentialRequestButton`) IS
+persistent -- it carries a custom_id and is registered as a
+`discord.ui.DynamicItem` class in `setup_hook`. This is necessary because the
+process that posts that button (the MCP server) is not the process that
+dispatches its click (this bot) -- there is no live in-memory View instance
+to attach a non-persistent handler to. Every other interactive component in
+this adapter stays non-persistent.
 """
 
 from __future__ import annotations

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -1139,8 +1139,72 @@ async def test_anon_bind_rejected_when_repo_private(
     assert not set_binding_called, "private/404 repo must not write a binding"
     interaction.followup.send.assert_called_once()
     call_text = str(interaction.followup.send.call_args)
-    assert "private" in call_text.lower(), (
-        "user must see the 'repo is private — connect GitHub or paste a PAT' message"
+    assert "shared service account" in call_text, (
+        "user must see a refusal naming the shared service account, not GitHub's bare framing"
+    )
+
+
+@pytest.mark.asyncio
+async def test_anon_bind_rejected_when_repo_lookup_returns_404(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """A 404 repo lookup (GitHub's response for a private repo the shared service
+    account cannot see) must produce the same refusal as an explicitly-private
+    repo — not a "repo doesn't exist" message. Drives the real `is_public_repo`
+    mapping via a mocked transport, rather than stubbing the function itself."""
+    set_binding_called = False
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_binding_called
+        set_binding_called = True
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/repos/me/missing-repo", (
+            "the real is_public_repo must hit the GitHub repo-lookup endpoint"
+        )
+        return httpx.Response(404)
+
+    class _HttpxProxyWithMockedAsyncClient:
+        """Delegates to the real `httpx` module except for `AsyncClient`, which
+        gets the mocked transport. Patching `modals_mod.httpx` (the module's own
+        name binding) rather than the shared global `httpx.AsyncClient` attribute
+        keeps this test from breaking unrelated code (e.g. the anthropic SDK)
+        that also constructs `httpx.AsyncClient` instances during this test."""
+
+        def AsyncClient(self, *args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(httpx, name)
+
+    monkeypatch.setattr(modals_mod, "httpx", _HttpxProxyWithMockedAsyncClient())
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    # Default runtime has no App creds configured, so is_app_installed_for_repo
+    # returns False with zero HTTP calls, leaving is_public_repo as the only
+    # request the mocked transport needs to answer.
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/missing-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    assert not set_binding_called, "a 404 repo lookup must not write a binding"
+    interaction.followup.send.assert_called_once()
+    call_text = str(interaction.followup.send.call_args)
+    assert "shared service account" in call_text, (
+        "a 404 repo lookup must produce the same shared-service-account refusal as a private repo"
     )
 
 

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -266,10 +266,14 @@ def test_body_text_shows_pat_last4_masked(account_id: uuid.UUID) -> None:
         selected=selected,
         account_id=account_id,
         pat_last4="7890",
+        fallback_pat_configured=True,
     )
     container = build_panel_container(state, thumbnail_url=None)
     text = _container_text(container)
     assert "••••7890" in text, "pat_last4 must render as ••••7890 in body text"
+    assert "shared service account" not in text, (
+        "a masked PAT must suppress the shared-service-account line"
+    )
 
 
 def test_body_text_shows_github_login_when_hydrated(account_id: uuid.UUID) -> None:
@@ -280,10 +284,14 @@ def test_body_text_shows_github_login_when_hydrated(account_id: uuid.UUID) -> No
         selected=selected,
         account_id=account_id,
         github_login="octocat",
+        fallback_pat_configured=True,
     )
     container = build_panel_container(state, thumbnail_url=None)
     text = _container_text(container)
     assert "@octocat" in text, "hydrated GitHub login must render as @handle in body"
+    assert "shared service account" not in text, (
+        "a linked GitHub login must suppress the shared-service-account line"
+    )
 
 
 def test_body_text_labels_inline_pat_as_pat_not_handle(account_id: uuid.UUID) -> None:
@@ -398,10 +406,14 @@ def test_body_text_anon_binding_warns_without_fallback(account_id: uuid.UUID) ->
     assert "won't clone — no token" in text, (
         "anon: binding with no fallback PAT must warn it won't clone"
     )
+    assert "shared service account" not in text, (
+        "no fallback PAT configured must NOT show the shared-service-account line"
+    )
 
 
 def test_body_text_anon_binding_no_warning_with_fallback(account_id: uuid.UUID) -> None:
-    """An anon: binding clones via the operator fallback PAT — no warning."""
+    """An anon: binding clones via the operator fallback PAT — no warning, and the
+    shared-service-account line renders instead."""
     selected = _entry("my-agent")
     state = PanelState(
         roster=[selected],
@@ -417,6 +429,30 @@ def test_body_text_anon_binding_no_warning_with_fallback(account_id: uuid.UUID) 
     assert "won't clone" not in text, (
         "anon: binding must NOT warn when the operator fallback PAT is configured"
     )
+    assert "shared service account" in text, (
+        "an anon: binding backed by the fallback PAT must show the shared-service-account line"
+    )
+
+
+def test_body_text_shows_shared_service_account_line_with_no_repo_bound(
+    account_id: uuid.UUID,
+) -> None:
+    """With the fallback PAT configured but nothing bound yet, the Repo & auth group
+    renders with just the shared-service-account line — not the 'unconfigured' hint."""
+    selected = _entry("my-agent")
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        fallback_pat_configured=True,
+    )
+    container = build_panel_container(state, thumbnail_url=None)
+    text = _container_text(container)
+    assert "📦" in text, "fallback PAT configured must show the Repo & auth group even unbound"
+    assert "shared service account" in text, (
+        "fallback PAT configured with nothing bound must show the shared-service-account line"
+    )
+    assert "won't clone" not in text, "no repo is bound, so the clone warning must not appear"
 
 
 def test_body_text_inline_pat_binding_never_warns(account_id: uuid.UUID) -> None:

--- a/packages/adapters/discord/tests/privacy_panel/conftest.py
+++ b/packages/adapters/discord/tests/privacy_panel/conftest.py
@@ -34,6 +34,7 @@ def _make_preview(**overrides: Any) -> PurgePreview:
         "agent_github_binding": PurgePreviewRow(count=0, example=None),
         "slack_user_tokens": PurgePreviewRow(count=0, example=None),
         "slack_turn_contexts": PurgePreviewRow(count=0, example=None),
+        "credential_requests": PurgePreviewRow(count=0, example=None),
     }
     base.update(overrides)
     return PurgePreview(**base)

--- a/packages/adapters/discord/tests/test_bot.py
+++ b/packages/adapters/discord/tests/test_bot.py
@@ -1650,3 +1650,28 @@ class TestDrainLoopDeCoalescing:
             "second drain turn content must not contain author A's prefix — "
             f"it would be a mixed-author composite; got: {second_override!r}"
         )
+
+
+class TestCredentialButtonRegistration:
+    """setup_hook registers CredentialRequestButton as a dynamic item exactly once."""
+
+    async def test_setup_hook_registers_credential_request_button(
+        self, db_session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        from daimon.adapters.discord.credential_button import CredentialRequestButton
+
+        runtime = _make_runtime(db_session_factory)
+        bot = _make_bot(runtime)
+
+        await bot.setup_hook()
+
+        # The registry is private (ConnectionState._view_store._dynamic_items) --
+        # discord.py exposes no public read of the registration.
+        dynamic_items = (
+            bot._connection._view_store._dynamic_items  # pyright: ignore[reportPrivateUsage]  # discord.py exposes no public accessor
+        )
+        template = CredentialRequestButton.__discord_ui_compiled_template__
+        assert dynamic_items.get(template) is CredentialRequestButton, (
+            "CredentialRequestButton's compiled template must be registered as a "
+            "dynamic item after setup_hook runs"
+        )

--- a/packages/adapters/discord/tests/test_branding.py
+++ b/packages/adapters/discord/tests/test_branding.py
@@ -87,6 +87,7 @@ def _make_preview() -> PurgePreview:
         agent_github_binding=zero,
         slack_user_tokens=zero,
         slack_turn_contexts=zero,
+        credential_requests=zero,
     )
 
 

--- a/packages/adapters/discord/tests/test_credential_button.py
+++ b/packages/adapters/discord/tests/test_credential_button.py
@@ -1,0 +1,280 @@
+"""Tests for CredentialRequestButton -- from_custom_id / interaction_check / callback."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, Literal
+from unittest.mock import AsyncMock, MagicMock
+
+import daimon.adapters.discord.credential_button as credential_button_mod
+import structlog
+from daimon.adapters.discord.credential_button import CredentialRequestButton
+from daimon.adapters.discord.credential_modals import EnvCredentialModal, McpCredentialModal
+from daimon.core.credential_requests import build_button_label, build_custom_id, mint_request_token
+from daimon.core.stores.credential_requests import create_credential_request
+from daimon.core.stores.domain import CredentialRequestRow
+from daimon.testing.factories import make_tenant
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_REQUESTER_ID = "100000000000000001"
+_OTHER_USER_ID = "200000000000000002"
+
+
+def _fake_bot(sessionmaker: Any) -> Any:
+    """A minimal stand-in for DaimonBot -- only `.runtime.sessionmaker` is read."""
+    return SimpleNamespace(runtime=SimpleNamespace(sessionmaker=sessionmaker))
+
+
+def _interaction(*, user_id: str, client: Any) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user.id = int(user_id)
+    interaction.client = client
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    return interaction
+
+
+def _match(token: str) -> Any:
+    custom_id = build_custom_id(token)
+    matched = CredentialRequestButton.__discord_ui_compiled_template__.fullmatch(custom_id)
+    assert matched is not None, "test token must satisfy the button's own custom_id template"
+    return matched
+
+
+def _row(
+    *,
+    token: str,
+    kind: Literal["env", "mcp"] = "env",
+    target: str = "OPENAI_API_KEY",
+    mcp_server_url: str | None = None,
+    requester_platform_user_id: str = _REQUESTER_ID,
+    expires_at: datetime | None = None,
+    used_at: datetime | None = None,
+) -> CredentialRequestRow:
+    """Build a CredentialRequestRow in memory -- no DB needed for interaction_check/callback tests."""
+    now = datetime.now(UTC)
+    return CredentialRequestRow(
+        token=token,
+        kind=kind,
+        tenant_id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        account_id=uuid.uuid4(),
+        target=target,
+        mcp_server_url=mcp_server_url,
+        requester_platform_user_id=requester_platform_user_id,
+        channel_id="chan-1",
+        created_at=now,
+        expires_at=expires_at or (now + timedelta(minutes=30)),
+        used_at=used_at,
+    )
+
+
+async def _seed_request(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    kind: Literal["env", "mcp"] = "env",
+    target: str = "OPENAI_API_KEY",
+    mcp_server_url: str | None = None,
+    requester_platform_user_id: str = _REQUESTER_ID,
+) -> str:
+    """Seed a real credential_requests row and return its token."""
+    token = mint_request_token()
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=f"guild-{token[:8]}")
+        await create_credential_request(
+            session,
+            token=token,
+            kind=kind,
+            tenant_id=tenant.id,
+            agent_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            target=target,
+            mcp_server_url=mcp_server_url,
+            requester_platform_user_id=requester_platform_user_id,
+            channel_id="chan-1",
+            expires_at=datetime.now(UTC) + timedelta(minutes=30),
+        )
+    return token
+
+
+# --- from_custom_id (real DB) -----------------------------------------------
+
+
+async def test_from_custom_id_known_token_builds_button_with_target_label(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    token = await _seed_request(db_session_factory, kind="env", target="OPENAI_API_KEY")
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await CredentialRequestButton.from_custom_id(interaction, MagicMock(), _match(token))
+
+    assert item.request_row is not None, "a known token must resolve its row"
+    assert item.item.label == build_button_label("env", "OPENAI_API_KEY"), (
+        "the reconstructed button must name the exact target"
+    )
+
+
+async def test_from_custom_id_unknown_token_returns_item_with_no_row_and_fallback_label(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+    token = "never-minted-token-abcdef123456"
+
+    item = await CredentialRequestButton.from_custom_id(interaction, MagicMock(), _match(token))
+
+    assert item.request_row is None, "an unknown token must yield no row rather than raising"
+    assert item.item.label == "Add credential", "fallback label is used when no row is found"
+
+
+async def test_from_custom_id_db_failure_is_logged_and_interaction_check_rejects_gracefully(
+    monkeypatch: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A DB failure during the lookup must be logged and must not raise -- the
+    exception does not escape into discord.py's swallowing dispatcher."""
+
+    async def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise SQLAlchemyError("connection reset")
+
+    monkeypatch.setattr(credential_button_mod, "peek_credential_request", _boom)
+
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+    token = "db-failure-simulated-token-000001"
+
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        item = await CredentialRequestButton.from_custom_id(interaction, MagicMock(), _match(token))
+    finally:
+        structlog.reset_defaults()
+
+    assert item.request_row is None, "a DB failure must not raise -- it degrades to no row"
+    assert any(entry.get("event") == "credential_button.lookup_failed" for entry in cap.entries), (
+        "the failure must be logged for observability, since discord.py's own logger "
+        "would otherwise be the only trace of it"
+    )
+
+    check_interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+    allowed = await item.interaction_check(check_interaction)
+
+    assert allowed is False, "an item built from a failed lookup must reject the click"
+    check_interaction.response.send_message.assert_awaited_once()
+
+
+# --- interaction_check (in-memory row, no DB) -------------------------------
+
+
+async def test_interaction_check_unknown_row_sends_ephemeral_and_rejects() -> None:
+    item = CredentialRequestButton(
+        token="unknown12345678901234", label="Add credential", request_row=None
+    )
+    interaction = _interaction(user_id=_REQUESTER_ID, client=None)
+
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "no row means the click must be rejected"
+    interaction.response.send_message.assert_awaited_once()
+    message = interaction.response.send_message.call_args.args[0]
+    assert "no longer valid" in message, "unknown-row rejection must tell the user to ask again"
+
+
+async def test_interaction_check_wrong_requester_sends_ephemeral_and_rejects() -> None:
+    row = _row(token="wrongrequester12345678", requester_platform_user_id=_REQUESTER_ID)
+    item = CredentialRequestButton(token=row.token, label="Add credential", request_row=row)
+    interaction = _interaction(user_id=_OTHER_USER_ID, client=None)
+
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "a non-requester click must be rejected"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "someone else" in message, "rejection must indicate the request targeted another user"
+
+
+async def test_interaction_check_expired_sends_ephemeral_and_rejects() -> None:
+    row = _row(
+        token="expiredrow123456789012",
+        expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+    item = CredentialRequestButton(token=row.token, label="Add credential", request_row=row)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=None)
+
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "an expired row must be rejected"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "expired" in message, "rejection must say the request expired"
+
+
+async def test_interaction_check_already_used_sends_ephemeral_and_rejects() -> None:
+    row = _row(token="usedrow1234567890123456", used_at=datetime.now(UTC))
+    item = CredentialRequestButton(token=row.token, label="Add credential", request_row=row)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=None)
+
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "an already-used row must be rejected"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "already used" in message, "rejection must say the request was already used"
+
+
+async def test_interaction_check_allows_requester_with_valid_row_and_sends_nothing() -> None:
+    row = _row(token="validrow123456789012345", requester_platform_user_id=_REQUESTER_ID)
+    item = CredentialRequestButton(token=row.token, label="Add credential", request_row=row)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=None)
+
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is True, "the requester with a fresh, unused row must be allowed through"
+    interaction.response.send_message.assert_not_awaited()
+
+
+# --- callback ----------------------------------------------------------------
+
+
+async def test_callback_dispatches_env_modal_for_env_kind() -> None:
+    row = _row(token="envcallback1234567890123", kind="env")
+    item = CredentialRequestButton(token=row.token, label="Add credential", request_row=row)
+    bot = _fake_bot(MagicMock())
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    await item.callback(interaction)
+
+    interaction.response.send_modal.assert_awaited_once()
+    sent_modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(sent_modal, EnvCredentialModal), "env-kind rows must open EnvCredentialModal"
+
+
+async def test_callback_dispatches_mcp_modal_for_mcp_kind() -> None:
+    row = _row(
+        token="mcpcallback1234567890123",
+        kind="mcp",
+        mcp_server_url="https://ext.example.com/mcp",
+    )
+    item = CredentialRequestButton(token=row.token, label="Add credential", request_row=row)
+    bot = _fake_bot(MagicMock())
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    await item.callback(interaction)
+
+    interaction.response.send_modal.assert_awaited_once()
+    sent_modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(sent_modal, McpCredentialModal), "mcp-kind rows must open McpCredentialModal"
+
+
+# --- dispatch matching (no DB) -----------------------------------------------
+
+
+def test_custom_id_that_does_not_fullmatch_template_never_dispatches() -> None:
+    pattern = CredentialRequestButton.__discord_ui_compiled_template__
+    assert pattern.fullmatch("not-a-credential-button-id") is None, (
+        "an unrelated custom_id must never match this button's dispatch template"
+    )
+    assert pattern.fullmatch(build_custom_id("a" * 20)) is not None, (
+        "a well-formed minted custom_id must match the dispatch template"
+    )

--- a/packages/adapters/discord/tests/test_credential_modals.py
+++ b/packages/adapters/discord/tests/test_credential_modals.py
@@ -1,0 +1,439 @@
+"""Tests for EnvCredentialModal / McpCredentialModal -- atomic consume then
+the existing write paths, with secret-hygiene assertions."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import structlog
+from daimon.adapters.discord.credential_modals import EnvCredentialModal, McpCredentialModal
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.credential_requests import mint_request_token
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.agent_files import list_agent_files
+from daimon.core.stores.credential_requests import create_credential_request
+from daimon.core.stores.domain import CredentialRequestRow
+from daimon.testing.factories import make_tenant
+from daimon.testing.ma import build_stub_anthropic
+from pydantic import HttpUrl
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_SECRET_VALUE = "super-secret-env-value-do-not-leak"
+_MCP_TOKEN = "super-secret-mcp-token-do-not-leak"
+
+
+def _runtime(
+    *,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    anthropic: Any = None,
+    public_url: HttpUrl | None = None,
+    jwt_secret: str | None = None,
+) -> DiscordRuntime:
+    settings = MagicMock()
+    settings.mcp.public_url = public_url
+    if jwt_secret is not None:
+        secret_mock = MagicMock()
+        secret_mock.get_secret_value.return_value = jwt_secret
+        settings.mcp.jwt_secret = secret_mock
+    else:
+        settings.mcp.jwt_secret = None
+    return DiscordRuntime(
+        settings=settings,
+        anthropic=anthropic if anthropic is not None else build_stub_anthropic(),
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+    )
+
+
+async def _seed_env_request(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    target: str = "OPENAI_API_KEY",
+    expires_at: datetime | None = None,
+) -> CredentialRequestRow:
+    token = mint_request_token()
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=f"g-{token[:8]}")
+        row = await create_credential_request(
+            session,
+            token=token,
+            kind="env",
+            tenant_id=tenant.id,
+            agent_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            target=target,
+            mcp_server_url=None,
+            requester_platform_user_id="100000000000000001",
+            channel_id="chan-1",
+            expires_at=expires_at or (datetime.now(UTC) + timedelta(minutes=30)),
+        )
+    return row
+
+
+async def _seed_mcp_request(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    mcp_server_url: str = "https://ext.example.com/mcp",
+) -> CredentialRequestRow:
+    token = mint_request_token()
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=f"g-{token[:8]}")
+        row = await create_credential_request(
+            session,
+            token=token,
+            kind="mcp",
+            tenant_id=tenant.id,
+            agent_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            target="linear",
+            mcp_server_url=mcp_server_url,
+            requester_platform_user_id="100000000000000001",
+            channel_id="chan-1",
+            expires_at=datetime.now(UTC) + timedelta(minutes=30),
+        )
+    return row
+
+
+def _interaction() -> MagicMock:
+    interaction = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# --- EnvCredentialModal ------------------------------------------------------
+
+
+async def test_env_modal_submit_consumes_token_and_writes_agent_file(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="OPENAI_API_KEY")
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = _SECRET_VALUE  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    rows = await list_agent_files(db_session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert len(rows) == 1, "exactly one agent_files row must be written"
+    assert rows[0].key == "OPENAI_API_KEY", "the key must come from the consumed row's target"
+    assert rows[0].content == _SECRET_VALUE, "the value comes from the modal's TextInput"
+
+    toast = interaction.followup.send.call_args.args[0]
+    assert "OPENAI_API_KEY" in toast, "confirmation names the key"
+    assert _SECRET_VALUE not in toast, "confirmation never echoes the secret value"
+
+
+async def test_env_modal_double_submit_writes_exactly_one_row(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="TOGGL_TOKEN")
+    runtime = _runtime(sessionmaker=db_session_factory)
+
+    first_modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    first_modal.value_input._value = "first-value"  # pyright: ignore[reportPrivateUsage]
+    await first_modal.on_submit(_interaction())
+
+    second_modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    second_modal.value_input._value = "second-value"  # pyright: ignore[reportPrivateUsage]
+    second_interaction = _interaction()
+    await second_modal.on_submit(second_interaction)
+
+    rows = await list_agent_files(db_session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert len(rows) == 1, "a resubmission on an already-consumed token must write nothing new"
+    assert rows[0].content == "first-value", "only the first submission's value is stored"
+
+    message = second_interaction.followup.send.call_args.args[0]
+    assert "no longer valid" in message, "the second submission must report the request is dead"
+
+
+async def test_env_modal_expired_row_consumes_nothing_and_writes_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(
+        db_session_factory,
+        target="EXPIRED_KEY",
+        expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = _SECRET_VALUE  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    rows = await list_agent_files(db_session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert rows == [], "an expired row must never produce a write"
+
+
+async def test_env_modal_empty_value_writes_nothing_and_does_not_consume(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="EMPTY_KEY")
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = "   "  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    rows = await list_agent_files(db_session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert rows == [], "a blank value must never produce a write"
+    message = interaction.followup.send.call_args.args[0]
+    assert "empty" in message.lower(), "the toast must ask the user to try again"
+
+    # The token must still be usable -- a fail-fast rejection did not consume it.
+    retry_modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    retry_modal.value_input._value = _SECRET_VALUE  # pyright: ignore[reportPrivateUsage]
+    await retry_modal.on_submit(_interaction())
+    retry_rows = await list_agent_files(db_session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert len(retry_rows) == 1, "the token must still be consumable after a validation rejection"
+
+
+async def test_env_modal_value_over_byte_cap_writes_nothing_and_does_not_consume(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="TOO_BIG_KEY")
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = "x" * 5000  # pyright: ignore[reportPrivateUsage]  # over the 4096-byte cap
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    rows = await list_agent_files(db_session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert rows == [], "an over-cap value must never produce a write"
+    message = interaction.followup.send.call_args.args[0]
+    assert "too large" in message.lower(), "the toast must report the size cap"
+
+    retry_modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    retry_modal.value_input._value = _SECRET_VALUE  # pyright: ignore[reportPrivateUsage]
+    await retry_modal.on_submit(_interaction())
+    retry_rows = await list_agent_files(db_session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert len(retry_rows) == 1, "the token must still be consumable after a cap rejection"
+
+
+async def test_env_modal_confirmation_states_shared_agent_exposure(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="SHARED_KEY")
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = _SECRET_VALUE  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    toast = interaction.followup.send.call_args.args[0]
+    assert "anyone who talks to this agent" in toast, (
+        "confirmation must disclose the credential is usable by every caller of the agent"
+    )
+
+
+async def test_env_modal_never_logs_the_secret_value(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="LOGGED_KEY")
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = _SECRET_VALUE  # pyright: ignore[reportPrivateUsage]
+
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        await modal.on_submit(_interaction())
+    finally:
+        structlog.reset_defaults()
+
+    for entry in cap.entries:
+        assert _SECRET_VALUE not in repr(entry), "no log line may contain the secret value"
+
+
+# --- McpCredentialModal ------------------------------------------------------
+
+
+def _vault_handler(
+    vault_id: str, per_agent_display: str, creds_created: list[dict[str, Any]]
+) -> Any:
+    def _handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "GET" and req.url.path == "/v1/vaults":
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": vault_id,
+                            "type": "vault",
+                            "display_name": per_agent_display,
+                            "metadata": None,
+                            "archived_at": None,
+                            "created_at": "2026-04-01T00:00:00Z",
+                        }
+                    ],
+                    "has_more": False,
+                },
+            )
+        if req.method == "GET" and req.url.path == f"/v1/vaults/{vault_id}/credentials":
+            return httpx.Response(200, json={"data": [], "has_more": False})
+        if req.method == "POST" and req.url.path == f"/v1/vaults/{vault_id}/credentials":
+            body = json.loads(req.content)
+            creds_created.append(body)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "vcrd_1",
+                    "type": "credential",
+                    "vault_id": vault_id,
+                    "auth": {
+                        "type": "static_bearer",
+                        "mcp_server_url": body["auth"]["mcp_server_url"],
+                    },
+                },
+            )
+        raise AssertionError(f"unexpected: {req.method} {req.url.path}")
+
+    return _handler
+
+
+async def test_mcp_modal_submit_consumes_token_and_writes_vault_credential(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_mcp_request(db_session_factory, mcp_server_url="https://ext.example.com/mcp")
+    vault_id = "vlt_credmodal"
+    per_agent_display = f"daimon-mcp:{row.account_id}:{row.agent_id}"
+    creds_created: list[dict[str, Any]] = []
+
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(_vault_handler(vault_id, per_agent_display, creds_created)),
+        public_url=HttpUrl("https://mcp.example.com/mcp"),
+        jwt_secret="x" * 32,
+    )
+    modal = McpCredentialModal(runtime=runtime, request_row=row)
+    modal.token_input._value = _MCP_TOKEN  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    assert len(creds_created) == 1, "exactly one credential must be POSTed to the per-agent vault"
+    assert creds_created[0]["auth"]["mcp_server_url"] == "https://ext.example.com/mcp", (
+        "the mcp_server_url must come from the consumed row, never user input"
+    )
+    assert creds_created[0]["auth"]["token"] == _MCP_TOKEN
+
+    toast = interaction.followup.send.call_args.args[0]
+    assert "anyone who talks to this agent" in toast.lower(), (
+        "confirmation must disclose the credential is usable by every caller of the agent"
+    )
+
+
+async def test_mcp_modal_unconfigured_mcp_reports_misconfiguration_no_consume_no_vault_write(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    def _no_http(req: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"no vault HTTP calls expected: {req.method} {req.url}")
+
+    row = await _seed_mcp_request(db_session_factory)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(_no_http),
+        public_url=None,
+        jwt_secret=None,
+    )
+    modal = McpCredentialModal(runtime=runtime, request_row=row)
+    modal.token_input._value = _MCP_TOKEN  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    message = interaction.followup.send.call_args.args[0]
+    assert "not configured" in message, "must report the daimon-mcp misconfiguration"
+
+    # The token must still be unconsumed -- retry with configured settings must succeed.
+    retry_runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(
+            _vault_handler("vlt_retry", f"daimon-mcp:{row.account_id}:{row.agent_id}", [])
+        ),
+        public_url=HttpUrl("https://mcp.example.com/mcp"),
+        jwt_secret="x" * 32,
+    )
+    retry_modal = McpCredentialModal(runtime=retry_runtime, request_row=row)
+    retry_modal.token_input._value = _MCP_TOKEN  # pyright: ignore[reportPrivateUsage]
+    retry_interaction = _interaction()
+    await retry_modal.on_submit(retry_interaction)
+    retry_message = retry_interaction.followup.send.call_args.args[0]
+    assert "not configured" not in retry_message, (
+        "the request must still be consumable once daimon-mcp is configured"
+    )
+
+
+async def test_mcp_modal_vault_write_failure_surfaces_only_exception_class_name(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    def _failing_vault(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("upstream reset by peer -- request envelope: secret=abc123")
+
+    row = await _seed_mcp_request(db_session_factory)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(_failing_vault),
+        public_url=HttpUrl("https://mcp.example.com/mcp"),
+        jwt_secret="x" * 32,
+    )
+    modal = McpCredentialModal(runtime=runtime, request_row=row)
+    modal.token_input._value = _MCP_TOKEN  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    message = interaction.followup.send.call_args.args[0]
+    assert "APIConnectionError" in message, "only the exception class name is surfaced"
+    assert "secret=abc123" not in message, (
+        "the stringified exception (which can carry the request envelope) must never reach the user"
+    )
+
+
+async def test_mcp_modal_never_logs_the_raw_token(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_mcp_request(db_session_factory)
+    vault_id = "vlt_hygiene"
+    per_agent_display = f"daimon-mcp:{row.account_id}:{row.agent_id}"
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(_vault_handler(vault_id, per_agent_display, [])),
+        public_url=HttpUrl("https://mcp.example.com/mcp"),
+        jwt_secret="x" * 32,
+    )
+    modal = McpCredentialModal(runtime=runtime, request_row=row)
+    modal.token_input._value = _MCP_TOKEN  # pyright: ignore[reportPrivateUsage]
+
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        await modal.on_submit(_interaction())
+    finally:
+        structlog.reset_defaults()
+
+    for entry in cap.entries:
+        assert _MCP_TOKEN not in repr(entry), "no log line may contain the raw token"

--- a/packages/adapters/mcp/daimon/adapters/mcp/server.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/server.py
@@ -48,6 +48,7 @@ from daimon.adapters.mcp.tools import (
 )
 from daimon.adapters.mcp.tools.channels import register_channel_tools
 from daimon.adapters.mcp.tools.cli_token import register_cli_token_tool
+from daimon.adapters.mcp.tools.credential_requests import register_credential_request_tools
 from daimon.adapters.mcp.tools.media import register_media_tools
 from daimon.adapters.mcp.tools.notebook import register_notebook_tools
 from daimon.adapters.mcp.tools.propagation import register_propagation_tools
@@ -257,6 +258,7 @@ def create_mcp_app(
     agents.register_agent_tools(mcp, runtime)
     environments.register_environment_tools(mcp, runtime)
     vault.register_vault_tools(mcp, runtime)
+    register_credential_request_tools(mcp, runtime)
     skills.register_skill_tools(mcp, runtime)
     sessions.register_sessions_tools(mcp, runtime)
     agent_chat.register_agent_chat_tools(mcp, runtime)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -377,6 +377,11 @@ async def _create_agent_impl(
                 for r in spec.skill_repos
             ]
         else:
+            github_fallback_pat = (
+                runtime.settings.github.fallback_pat.get_secret_value()
+                if runtime.settings.github.fallback_pat is not None
+                else None
+            )
             async with httpx.AsyncClient() as http_client:
                 report = await sync_agent_skills(
                     principal_id=auth.account_id,  # NOT auth.principal_id (no such field)
@@ -387,6 +392,7 @@ async def _create_agent_impl(
                     fernet=fernet,
                     http_client=http_client,
                     anthropic_client=runtime.client,  # McpRuntime field is client
+                    github_fallback_pat=github_fallback_pat,
                 )
             warnings = sync_report_failures(report) or None
     return await _build_agent_info(

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/cli_token.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/cli_token.py
@@ -44,12 +44,16 @@ async def _get_cli_token_impl(
     """
     auth = await _auth(ctx)
     try:
+        # This token is handed to the agent's shell for transient gh/clone use
+        # and is never persisted, so opting into the operator service default
+        # is safe here.
         token = await dispatch_mint_token(
             service=service,
             account_id=auth.account_id,
             agent_id=auth.agent_id,
             sessionmaker=runtime.session_factory,
             settings=runtime.settings,
+            allow_service_default=True,
         )
     except NoBindingError as e:
         logger.warning(

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -1,0 +1,245 @@
+"""Credential-request tools: request_env_credential, request_mcp_credential.
+
+These two tools replace the "go open /agent-setup" redirect for a task that
+needs an env secret or an auth-required MCP server: the agent mints a
+single-use, TTL-bounded ``credential_requests`` row and posts a
+target-naming button in the thread (``tools/discord/_credential_button.py``).
+Clicking the button opens a native Discord modal in a different process (the
+Discord bot, worker VM) — the secret itself never travels through either
+process's tool arguments, so neither tool below has a token/secret/value
+parameter, and none should ever be added.
+
+Deliberately NOT admin-gated — the chat-mutation admin check other tools call
+at the top of their impl is intentionally absent here. Authorization for the
+actual credential write happens at click time instead, when the Discord
+button's ``interaction_check`` compares the clicking user against
+``requester_platform_user_id`` on the minted row. This widens today's
+admin-only credential writes (``/agent-setup``'s mutation buttons are
+``is_admin``-only) in exchange for one-click UX — a deliberate, accepted
+trade documented here so a future reviewer does not "fix" the omission by
+adding that admin gate back.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools._ctx import _auth  # pyright: ignore[reportPrivateUsage]
+from daimon.adapters.mcp.tools.discord import (
+    _post_credential_button_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.credential_requests import (
+    DEFAULT_TTL,
+    CredentialRequestKind,
+    mint_request_token,
+)
+from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
+from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.stores.credential_requests import create_credential_request
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, ConfigDict
+
+# Mirrors packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py's
+# _POSIX_KEY_RE. Duplicated rather than imported: the Discord adapter and the
+# MCP adapter cannot import each other (import-linter's independence
+# contract), and this rule is small enough not to warrant a core lift.
+_POSIX_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class RequestCredentialResult(BaseModel):
+    """Result of minting and posting a credential-request button."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: CredentialRequestKind
+    target: str
+    expires_at: datetime
+    message_id: str
+
+
+async def _resolve_agent_uuid(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    agent_name: str,
+) -> uuid.UUID:
+    ma_agent = await find_agent_by_daimon_tag(
+        runtime.client, tenant_id=auth.tenant_id, name=agent_name
+    )
+    if ma_agent is None:
+        raise ToolError(f"agent '{agent_name}' not found in this tenant")
+    return derive_agent_uuid(tenant_id=auth.tenant_id, ma_agent_id=str(ma_agent.id))
+
+
+async def _mint_and_post(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    kind: CredentialRequestKind,
+    target: str,
+    mcp_server_url: str | None,
+    agent_id: uuid.UUID,
+    requester_platform_user_id: str,
+    agent_name: str,
+    purpose: str,
+    channel_id: str,
+) -> RequestCredentialResult:
+    token = mint_request_token()
+    expires_at = datetime.now(UTC) + DEFAULT_TTL
+    async with runtime.session_factory.begin() as session:
+        row = await create_credential_request(
+            session,
+            token=token,
+            kind=kind,
+            tenant_id=auth.tenant_id,
+            agent_id=agent_id,
+            account_id=auth.account_id,
+            target=target,
+            mcp_server_url=mcp_server_url,
+            requester_platform_user_id=requester_platform_user_id,
+            channel_id=channel_id,
+            expires_at=expires_at,
+        )
+    try:
+        message_id = await _post_credential_button_impl(
+            runtime,
+            auth,
+            channel_id=channel_id,
+            kind=kind,
+            target=target,
+            token=token,
+            agent_name=agent_name,
+            purpose=purpose,
+        )
+    except ToolError as exc:
+        # The row already exists (single-use + TTL bound it regardless), but
+        # with no live button it is silently unusable — say so rather than
+        # letting the caller believe the request succeeded.
+        raise ToolError(
+            f"credential request was created but posting the button failed: {exc}"
+        ) from exc
+    return RequestCredentialResult(
+        kind=kind, target=target, expires_at=row.expires_at, message_id=message_id
+    )
+
+
+async def _request_env_credential_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+    key: str,
+    purpose: str,
+    channel_id: str,
+) -> RequestCredentialResult:
+    if auth.platform == "slack":
+        raise ToolError("request_env_credential is not supported on Slack yet")
+    if auth.platform_user_id is None:
+        raise ToolError("credential requests require a platform-bound identity")
+    if not _POSIX_KEY_RE.match(key):
+        raise ToolError(
+            "env key must match [A-Za-z_][A-Za-z0-9_]* "
+            "(letters, digits, underscores; must not start with a digit)"
+        )
+    agent_id = await _resolve_agent_uuid(runtime, auth, agent_name)
+    return await _mint_and_post(
+        runtime,
+        auth,
+        kind="env",
+        target=key,
+        mcp_server_url=None,
+        agent_id=agent_id,
+        requester_platform_user_id=auth.platform_user_id,
+        agent_name=agent_name,
+        purpose=purpose,
+        channel_id=channel_id,
+    )
+
+
+async def _request_mcp_credential_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+    server_name: str,
+    url: str,
+    channel_id: str,
+) -> RequestCredentialResult:
+    if auth.platform == "slack":
+        raise ToolError("request_mcp_credential is not supported on Slack yet")
+    if auth.platform_user_id is None:
+        raise ToolError("credential requests require a platform-bound identity")
+    if urlparse(url).scheme not in ("http", "https"):
+        raise ToolError("mcp server url must be http or https")
+    agent_id = await _resolve_agent_uuid(runtime, auth, agent_name)
+    return await _mint_and_post(
+        runtime,
+        auth,
+        kind="mcp",
+        target=server_name,
+        mcp_server_url=url,
+        agent_id=agent_id,
+        requester_platform_user_id=auth.platform_user_id,
+        agent_name=agent_name,
+        purpose=f"connecting the MCP server '{server_name}'",
+        channel_id=channel_id,
+    )
+
+
+def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
+    @mcp.tool
+    async def request_env_credential(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        agent_name: str,
+        key: str,
+        purpose: str,
+        channel_id: str,
+    ) -> RequestCredentialResult:
+        """Request an environment secret from the user via a private modal.
+
+        Call this INSTEAD of ever accepting a secret value in chat. Posts a
+        button in the thread naming the exact env key; clicking it opens a
+        native Discord modal where the user enters the value privately — it
+        never appears in this channel or in your context. Once added, the
+        credential becomes usable by everyone who talks to ``agent_name``.
+        """
+        return await _request_env_credential_impl(
+            runtime,
+            await _auth(ctx),
+            agent_name=agent_name,
+            key=key,
+            purpose=purpose,
+            channel_id=channel_id,
+        )
+
+    @mcp.tool
+    async def request_mcp_credential(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        agent_name: str,
+        server_name: str,
+        url: str,
+        channel_id: str,
+    ) -> RequestCredentialResult:
+        """Request an auth-required MCP server's credential via a private modal.
+
+        Call this INSTEAD of ever accepting a token value in chat, and instead
+        of ``attach_mcp_server`` when the server requires authentication.
+        Posts a button in the thread naming the exact server; clicking it
+        opens a native Discord modal where the user enters the token
+        privately — it never appears in this channel or in your context.
+        Once added, the credential becomes usable by everyone who talks to
+        ``agent_name``.
+        """
+        return await _request_mcp_credential_impl(
+            runtime,
+            await _auth(ctx),
+            agent_name=agent_name,
+            server_name=server_name,
+            url=url,
+            channel_id=channel_id,
+        )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/__init__.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/__init__.py
@@ -25,6 +25,9 @@ from daimon.adapters.mcp.tools.discord._client import (
 from daimon.adapters.mcp.tools.discord._client import (
     rest_client as rest_client,  # pyright: ignore[reportPrivateUsage]
 )
+from daimon.adapters.mcp.tools.discord._credential_button import (
+    _post_credential_button_impl as _post_credential_button_impl,  # pyright: ignore[reportPrivateUsage]
+)
 from daimon.adapters.mcp.tools.discord._models import (
     AttachmentRow as AttachmentRow,  # pyright: ignore[reportPrivateUsage]
 )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_credential_button.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_credential_button.py
@@ -1,0 +1,117 @@
+"""Post the credential-request button to a Discord channel.
+
+Posted from the MCP process (Cloud Run); dispatched later by the Discord bot
+process (worker VM) via `CredentialRequestButton`, a `discord.ui.DynamicItem`
+matching `CUSTOM_ID_TEMPLATE`. The two processes cannot import each other
+(import-linter's independence contract), so this module imports only the
+core wire-contract builders (`build_custom_id`, `build_button_label`) — never
+the Discord adapter's dynamic-item class, and never a re-derived prefix or
+label format. A divergent copy here would silently stop the button from
+dispatching in the other process.
+
+Reuses `_send_message_impl`'s exact require/resolve/permission-check order
+(`tools/discord/_send.py`) rather than re-implementing any of it, so posting
+a credential button carries the same channel-visibility discipline as
+`send_message`.
+"""
+
+from __future__ import annotations
+
+import discord
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.discord._client import (
+    _require_bot_token,  # pyright: ignore[reportPrivateUsage]
+    _require_discord_identity,  # pyright: ignore[reportPrivateUsage]
+    _require_guild_channel,  # pyright: ignore[reportPrivateUsage]
+    _require_guild_id,  # pyright: ignore[reportPrivateUsage]
+    _resolve_channel,  # pyright: ignore[reportPrivateUsage]
+    _resolve_member,  # pyright: ignore[reportPrivateUsage]
+    rest_client,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.discord._visibility import (
+    _check_send_permission,  # pyright: ignore[reportPrivateUsage]
+    _ensure_thread_parent_cached,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.credential_requests import (
+    CredentialRequestKind,
+    build_button_label,
+    build_custom_id,
+)
+from fastmcp.exceptions import ToolError
+
+_KIND_NOUN: dict[CredentialRequestKind, str] = {
+    "env": "an environment secret",
+    "mcp": "an MCP server credential",
+}
+
+
+def _build_message_body(
+    *,
+    requester_platform_user_id: str,
+    agent_name: str,
+    kind: CredentialRequestKind,
+    target: str,
+    purpose: str,
+) -> str:
+    return (
+        f"<@{requester_platform_user_id}> **{agent_name}** needs {_KIND_NOUN[kind]} "
+        f"(`{target}`) — {purpose}\n"
+        "Click the button below to enter the value privately in a Discord modal; "
+        "it will never appear in this channel.\n"
+        f"Once added, this credential becomes usable by everyone who talks to "
+        f"**{agent_name}**."
+    )
+
+
+async def _post_credential_button_impl(  # pyright: ignore[reportUnusedFunction]
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    kind: CredentialRequestKind,
+    target: str,
+    token: str,
+    agent_name: str,
+    purpose: str,
+) -> str:
+    """Post a target-naming credential button. Returns the sent message id."""
+    requester_id = _require_discord_identity(auth)
+    guild_id = _require_guild_id(auth)
+    bot_token = _require_bot_token(runtime)
+
+    button: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+        style=discord.ButtonStyle.primary,
+        label=build_button_label(kind, target),
+        custom_id=build_custom_id(token),
+    )
+    view: discord.ui.View = discord.ui.View(timeout=None)
+    view.add_item(button)
+
+    content = _build_message_body(
+        requester_platform_user_id=requester_id,
+        agent_name=agent_name,
+        kind=kind,
+        target=target,
+        purpose=purpose,
+    )
+
+    async with rest_client(bot_token) as c:
+        _, member = await _resolve_member(c, guild_id, requester_id)
+        raw_channel = await _resolve_channel(c, channel_id)
+        channel = _require_guild_channel(raw_channel, guild_id)
+        if isinstance(channel, discord.Thread):
+            # Thread.permissions_for needs the parent in the guild cache;
+            # the per-call REST client starts with an empty one.
+            await _ensure_thread_parent_cached(channel)
+        _check_send_permission(channel, member)
+        if not isinstance(channel, discord.abc.Messageable):
+            raise ToolError("channel does not support sending messages")
+        sent = await channel.send(
+            content=content,
+            view=view,
+            allowed_mentions=discord.AllowedMentions(
+                users=True, everyone=False, roles=False, replied_user=False
+            ),
+        )
+        return str(sent.id)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/self_edit.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/self_edit.py
@@ -198,7 +198,11 @@ async def _set_repo_binding_impl(
     _require_admin(auth)
     agent_id = _require_agent_id(auth)
 
-    # 1. Mint plaintext PAT via the broker.
+    # 1. Mint plaintext PAT via the broker. Deliberately does NOT opt into the
+    # operator service default: the minted token is uploaded as a durable MA
+    # vault static_bearer credential below, so opting in would write the
+    # shared operator secret into a per-agent vault — the exact durable-copy
+    # failure mode this must avoid.
     try:
         token = await dispatch_mint_token(
             service=service,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
@@ -75,11 +75,20 @@ async def _resolve_sync_token(
 
     The session JWT carries no agent_id claim (SC-4), so the credential is
     resolved from the URL instead: the caller-tenant's ``agent_repo_binding``
-    for this repo → that agent's PAT overlay. Other tenants' bindings
-    for the same repo never resolve — no cross-tenant credential bleed.
+    for this repo → that agent's PAT overlay, else the operator service
+    default (opt-in). Other tenants' bindings for the same repo never
+    resolve — no cross-tenant credential bleed. Because the loop returns on
+    the first `token is not None`, a fallback resolved on the first
+    tenant-matching binding short-circuits the loop — correct, since every
+    binding would resolve the same fallback.
     """
     if runtime.fernet is None:
         return None
+    fallback_pat = (
+        runtime.settings.github.fallback_pat.get_secret_value()
+        if runtime.settings.github.fallback_pat is not None
+        else None
+    )
     async with runtime.session_factory() as session:
         bindings = await get_bindings_for_repo(session, repo_url=url)
     for binding in bindings:
@@ -90,6 +99,8 @@ async def _resolve_sync_token(
             agent_id=binding.agent_id,
             sessionmaker=runtime.session_factory,
             fernet=runtime.fernet,
+            allow_service_default=True,
+            fallback_pat=fallback_pat,
         )
         if token is not None:
             return token

--- a/packages/adapters/mcp/tests/tools/test_cli_token.py
+++ b/packages/adapters/mcp/tests/tools/test_cli_token.py
@@ -28,6 +28,7 @@ from daimon.core.config import (
     CredentialsSettings,
     CryptoSettings,
     DatabaseSettings,
+    GithubSettings,
     Settings,
 )
 from daimon.core.github_credentials import build_multifernet, upsert_credential_encrypted
@@ -45,7 +46,11 @@ async def _fixture_is_admin_resolver_false(_ctx: object) -> str | None:
     return None
 
 
-def _build_settings(*, fernet_key: SecretStr) -> Settings:
+def _build_settings(
+    *,
+    fernet_key: SecretStr,
+    github_fallback_pat: SecretStr | None = None,
+) -> Settings:
     return Settings(
         database=DatabaseSettings(
             url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon"),
@@ -56,6 +61,7 @@ def _build_settings(*, fernet_key: SecretStr) -> Settings:
         ),
         crypto=CryptoSettings(keys=(fernet_key,)),
         credentials=CredentialsSettings(google_sa_json=None),
+        github=GithubSettings(fallback_pat=github_fallback_pat),
     )
 
 
@@ -165,6 +171,62 @@ async def test_get_cli_token_no_binding_maps_to_tool_error(
     async with Client(mcp) as client:
         with pytest.raises(ToolError, match="agent-setup repo-auth panel"):
             await client.call_tool("get_cli_token", {"service": "github"})
+
+
+async def test_get_cli_token_github_resolves_operator_fallback_when_unbound(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """No credential bound + a configured operator fallback -> get_cli_token
+    resolves the shared service PAT instead of raising NoBindingError. This
+    token is handed to the agent's shell for transient gh/clone use, never
+    persisted, so it is a legitimate opt-in site."""
+    fernet_key = SecretStr(Fernet.generate_key().decode("ascii"))
+    settings = _build_settings(
+        fernet_key=fernet_key, github_fallback_pat=SecretStr("ghp_operator_fallback")
+    )
+    account_id = uuid.uuid4()
+    tenant_id = uuid.uuid4()
+
+    runtime = McpRuntime(
+        session_factory=db_session_factory,
+        client=MagicMock(spec=AsyncAnthropic),
+        settings=settings,
+        deployment_default=DeploymentDefault(),
+    )
+
+    async def fixture_subject_resolver(_ctx: object) -> str:
+        return str(account_id)
+
+    async def fixture_tenant_resolver(_ctx: object) -> str:
+        return str(tenant_id)
+
+    async def fixture_role_resolver(_ctx: object) -> str:
+        return "user"
+
+    async def fixture_agent_id_resolver(_ctx: object) -> str | None:
+        return None
+
+    mcp = FastMCP(name="test")
+    mcp.add_middleware(
+        IdentityMiddleware(
+            subject_resolver=fixture_subject_resolver,
+            tenant_resolver=fixture_tenant_resolver,
+            role_resolver=fixture_role_resolver,
+            agent_id_resolver=fixture_agent_id_resolver,
+            is_admin_resolver=_fixture_is_admin_resolver_false,
+            internal_resolver=_fixture_is_admin_resolver_false,
+            sessionmaker=db_session_factory,
+        )
+    )
+    register_cli_token_tool(mcp, runtime)
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_cli_token", {"service": "github"})
+
+    text = result.content[0].text  # type: ignore[union-attr]
+    assert text == "ghp_operator_fallback", (
+        "get_cli_token('github') must resolve the operator fallback when no credential is bound"
+    )
 
 
 async def test_get_cli_token_unknown_service_rejected_by_literal(

--- a/packages/adapters/mcp/tests/tools/test_credential_requests.py
+++ b/packages/adapters/mcp/tests/tools/test_credential_requests.py
@@ -1,0 +1,581 @@
+"""DB-backed unit tests for the credential-request MCP tools.
+
+Each test calls the private ``_*_impl`` functions directly with a real
+sessionmaker (real Postgres), a transport-level Anthropic fake (``MARouter``)
+for the agent-name resolution, and a transport-level patched Discord
+``HTTPClient`` (``patch_discord_http``, loaded from the sibling conftest.py by
+file path — see test_discord.py for the same pattern) for the button post.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import daimon.adapters.mcp.tools.credential_requests as _credential_requests_mod
+import discord.http
+import pytest
+from anthropic import AsyncAnthropic
+from anthropic.types.beta.beta_managed_agents_agent import BetaManagedAgentsAgent
+from anthropic.types.beta.beta_managed_agents_model_config import (
+    BetaManagedAgentsModelConfig,
+)
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    DiscordSettings,
+    Settings,
+)
+from daimon.core.credential_requests import CUSTOM_ID_PREFIX, DEFAULT_TTL
+from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.credential_requests import peek_credential_request
+from daimon.core.stores.domain import Role
+from daimon.testing.factories import make_tenant
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from pydantic import SecretStr
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+# Load patch_discord_http directly from the sibling conftest.py by file path —
+# same trick test_discord.py uses to dodge the "from conftest import ..."
+# collision with the parent tests/conftest.py.
+_conftest_path = Path(__file__).parent / "conftest.py"
+_spec = importlib.util.spec_from_file_location("_tools_conftest", _conftest_path)
+assert _spec is not None and _spec.loader is not None
+_tools_conftest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_tools_conftest)
+patch_discord_http = _tools_conftest.patch_discord_http
+
+_request_env_credential_impl = (
+    _credential_requests_mod._request_env_credential_impl  # pyright: ignore[reportPrivateUsage]
+)
+_request_mcp_credential_impl = (
+    _credential_requests_mod._request_mcp_credential_impl  # pyright: ignore[reportPrivateUsage]
+)
+register_credential_request_tools = _credential_requests_mod.register_credential_request_tools
+
+pytestmark = pytest.mark.asyncio
+
+_VIEW_CHANNEL = 1 << 10
+_SEND_MESSAGES = 1 << 11
+
+
+# ---------------------------------------------------------------------------
+# Helpers (small, intentional — mirrors test_routines.py / test_discord.py)
+# ---------------------------------------------------------------------------
+
+
+def _runtime(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    client: AsyncAnthropic | None = None,
+    with_discord: bool = True,
+) -> McpRuntime:
+    settings = Settings(
+        database=DatabaseSettings(url="postgresql+asyncpg://x/y"),  # pyright: ignore[reportArgumentType]
+        anthropic=AnthropicSettings(api_key=SecretStr("k")),
+        discord=DiscordSettings(bot_token=SecretStr("test-bot-token")) if with_discord else None,
+    )
+    return McpRuntime(
+        session_factory=sessionmaker,
+        client=client if client is not None else MagicMock(),  # type: ignore[arg-type]
+        settings=settings,
+        deployment_default=DeploymentDefault(),
+    )
+
+
+def _auth_identity(
+    *,
+    platform: str | None = "discord",
+    external_id: str | None = "111",
+    platform_user_id: str | None = "42",
+    tenant_id: uuid.UUID | None = None,
+    is_admin: bool = False,
+) -> AuthIdentity:
+    return AuthIdentity(
+        account_id=uuid.uuid4(),
+        tenant_id=tenant_id if tenant_id is not None else uuid.uuid4(),
+        role=Role.USER,
+        platform=platform,
+        external_id=external_id,
+        platform_user_id=platform_user_id,
+        is_admin=is_admin,
+    )
+
+
+def _ma_agent(*, agent_id: str, name: str, tenant_id: uuid.UUID) -> dict[str, object]:
+    agent = BetaManagedAgentsAgent(
+        id=agent_id,
+        type="agent",
+        name=name,
+        version=1,
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+        system=None,
+        metadata={
+            MA_METADATA_KEY_TENANT: str(tenant_id),
+            MA_METADATA_KEY_NAME: name,
+        },
+        mcp_servers=[],
+        tools=[],
+        skills=[],
+        created_at="2026-05-19T00:00:00Z",  # type: ignore[arg-type]
+        updated_at="2026-05-19T00:00:00Z",  # type: ignore[arg-type]
+        archived_at=None,
+        description=None,
+    )
+    return agent.model_dump(mode="json")
+
+
+def _ma_client_with_agents(agents: list[dict[str, object]]) -> AsyncAnthropic:
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda _req, _m: list_response(agents))
+    return build_fake_anthropic(router.dispatch)
+
+
+def _guild_payload(*, guild_id: str = "111") -> dict[str, Any]:
+    return {
+        "id": guild_id,
+        "name": "test-guild",
+        "owner_id": "1",
+        "afk_timeout": 0,
+        "verification_level": 0,
+        "default_message_notifications": 0,
+        "explicit_content_filter": 0,
+        "roles": [],
+        "emojis": [],
+        "features": [],
+        "mfa_level": 0,
+        "system_channel_flags": 0,
+        "premium_tier": 0,
+        "preferred_locale": "en-US",
+        "nsfw_level": 0,
+        "premium_progress_bar_enabled": False,
+        "stickers": [],
+        "region": "us-east",
+    }
+
+
+def _everyone_role(guild_id: str, perms: int) -> dict[str, Any]:
+    return {
+        "id": guild_id,
+        "name": "@everyone",
+        "permissions": str(perms),
+        "position": 0,
+        "color": 0,
+        "hoist": False,
+        "managed": False,
+        "mentionable": False,
+        "flags": 0,
+    }
+
+
+def _member_payload(user_id: str = "42") -> dict[str, Any]:
+    return {
+        "user": {
+            "id": user_id,
+            "username": "caller",
+            "discriminator": "0001",
+            "global_name": "caller",
+            "avatar": None,
+            "bot": False,
+            "flags": 0,
+        },
+        "roles": [],
+        "joined_at": "2024-01-01T00:00:00+00:00",
+        "deaf": False,
+        "mute": False,
+        "flags": 0,
+    }
+
+
+def _text_channel_payload(*, channel_id: str = "222", guild_id: str = "111") -> dict[str, Any]:
+    return {
+        "id": channel_id,
+        "type": 0,
+        "guild_id": guild_id,
+        "name": "general",
+        "position": 0,
+        "permission_overwrites": [],
+        "nsfw": False,
+        "rate_limit_per_user": 0,
+        "parent_id": None,
+    }
+
+
+def _message_payload(
+    *, message_id: str, channel_id: str = "222", content: str = "x"
+) -> dict[str, Any]:
+    return {
+        "id": message_id,
+        "channel_id": channel_id,
+        "author": {
+            "id": "1",
+            "username": "bot",
+            "discriminator": "0001",
+            "global_name": "bot",
+            "avatar": None,
+            "bot": True,
+            "flags": 0,
+        },
+        "content": content,
+        "timestamp": "2026-05-09T00:00:00+00:00",
+        "edited_timestamp": None,
+        "tts": False,
+        "mention_everyone": False,
+        "mentions": [],
+        "mention_roles": [],
+        "attachments": [],
+        "embeds": [],
+        "type": 0,
+        "pinned": False,
+        "flags": 0,
+    }
+
+
+def _patch_successful_post(
+    monkeypatch: pytest.MonkeyPatch, *, message_id: str, posted: dict[str, Any] | None = None
+) -> None:
+    """Patch a successful button post. When ``posted`` is given, the POSTed
+    kwargs are recorded into it so the caller can pull the minted token back
+    out of the button's custom_id (``ztc:{token}``) for a store-level
+    ``peek_credential_request`` field check — never via a raw ORM import."""
+
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            if posted is not None:
+                posted.update(kwargs)
+            return _message_payload(message_id=message_id)
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+
+
+def _token_from_posted(posted: dict[str, Any]) -> str:
+    custom_id: str = posted["json"]["components"][0]["components"][0]["custom_id"]
+    assert custom_id.startswith(CUSTOM_ID_PREFIX), f"unexpected custom_id shape: {custom_id!r}"
+    return custom_id[len(CUSTOM_ID_PREFIX) :]
+
+
+async def _row_count(db_session: AsyncSession) -> int:
+    result = await db_session.execute(text("SELECT COUNT(*) FROM credential_requests"))
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# 1. request_env_credential creates a row + posts a button
+# ---------------------------------------------------------------------------
+
+
+async def test_request_env_credential_creates_row_and_posts_button(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    client = _ma_client_with_agents(
+        [_ma_agent(agent_id="ag_env", name="daimon", tenant_id=tenant.id)]
+    )
+    runtime = _runtime(committing_sessionmaker, client=client)
+    auth = _auth_identity(tenant_id=tenant.id)
+    before = datetime.now(UTC)
+    posted: dict[str, Any] = {}
+    _patch_successful_post(monkeypatch, message_id="9201", posted=posted)
+
+    result = await _request_env_credential_impl(
+        runtime,
+        auth,
+        agent_name="daimon",
+        key="OPENAI_API_KEY",
+        purpose="calling the OpenAI API",
+        channel_id="222",
+    )
+
+    assert result.kind == "env", "result must report the env kind"
+    assert result.target == "OPENAI_API_KEY", "result must report the exact key"
+    assert result.message_id == "9201", "result must report the posted message id"
+    assert before + DEFAULT_TTL <= result.expires_at, "expires_at must be at least now + TTL"
+    assert await _row_count(db_session) == 1, "exactly one credential_requests row must be created"
+
+    row = await peek_credential_request(db_session, token=_token_from_posted(posted))
+    assert row is not None, "the minted token must resolve to the created row"
+    assert row.kind == "env"
+    assert row.mcp_server_url is None, "env rows must not carry an mcp_server_url"
+    assert row.account_id == auth.account_id, "row must stamp the caller's account_id"
+    assert row.requester_platform_user_id == auth.platform_user_id, (
+        "row must stamp the caller's platform_user_id"
+    )
+    assert row.tenant_id == tenant.id
+
+
+# ---------------------------------------------------------------------------
+# 2. request_mcp_credential creates a row + posts a button
+# ---------------------------------------------------------------------------
+
+
+async def test_request_mcp_credential_creates_row_and_posts_button(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    client = _ma_client_with_agents(
+        [_ma_agent(agent_id="ag_mcp", name="daimon", tenant_id=tenant.id)]
+    )
+    runtime = _runtime(committing_sessionmaker, client=client)
+    auth = _auth_identity(tenant_id=tenant.id)
+    posted: dict[str, Any] = {}
+    _patch_successful_post(monkeypatch, message_id="9202", posted=posted)
+
+    result = await _request_mcp_credential_impl(
+        runtime,
+        auth,
+        agent_name="daimon",
+        server_name="linear",
+        url="https://mcp.linear.app/sse",
+        channel_id="222",
+    )
+
+    assert result.kind == "mcp"
+    assert result.target == "linear"
+    assert result.message_id == "9202"
+    assert await _row_count(db_session) == 1, "exactly one credential_requests row must be created"
+
+    row = await peek_credential_request(db_session, token=_token_from_posted(posted))
+    assert row is not None, "the minted token must resolve to the created row"
+    assert row.kind == "mcp"
+    assert row.mcp_server_url == "https://mcp.linear.app/sse", "mcp rows must carry the server url"
+
+
+# ---------------------------------------------------------------------------
+# 3. Neither registered tool exposes a token/secret/value parameter
+# ---------------------------------------------------------------------------
+
+
+async def test_neither_tool_signature_exposes_a_secret_bearing_parameter() -> None:
+    mcp = FastMCP(name="test")
+    register_credential_request_tools(mcp, _runtime(MagicMock()))  # type: ignore[arg-type]
+    tools = await mcp.list_tools()
+    by_name = {t.name: t for t in tools}
+    assert {"request_env_credential", "request_mcp_credential"} <= by_name.keys(), (
+        "both tools must be registered"
+    )
+    for name in ("request_env_credential", "request_mcp_credential"):
+        param_names = set(by_name[name].parameters.get("properties", {}))
+        forbidden = {
+            p for p in param_names if any(w in p.lower() for w in ("token", "secret", "value"))
+        }
+        assert not forbidden, (
+            f"{name} must not expose a secret-bearing parameter, found {forbidden}"
+        )
+
+
+async def test_impl_signatures_have_no_token_secret_or_value_parameter() -> None:
+    """Belt-and-suspenders: the underlying impls' own signatures, not just the
+    FastMCP-registered schema, carry no token/secret/value parameter."""
+    for fn in (_request_env_credential_impl, _request_mcp_credential_impl):
+        params = set(inspect.signature(fn).parameters)
+        forbidden = {p for p in params if any(w in p.lower() for w in ("token", "secret", "value"))}
+        assert not forbidden, (
+            f"{fn.__name__} must not accept a secret-bearing parameter, found {forbidden}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. A non-admin caller succeeds — there is no admin gate
+# ---------------------------------------------------------------------------
+
+
+async def test_request_env_credential_succeeds_for_non_admin_caller(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    client = _ma_client_with_agents(
+        [_ma_agent(agent_id="ag_nonadmin", name="daimon", tenant_id=tenant.id)]
+    )
+    runtime = _runtime(committing_sessionmaker, client=client)
+    auth = _auth_identity(tenant_id=tenant.id, is_admin=False)
+    _patch_successful_post(monkeypatch, message_id="9203")
+
+    result = await _request_env_credential_impl(
+        runtime,
+        auth,
+        agent_name="daimon",
+        key="TOGGL_TOKEN",
+        purpose="tracking time",
+        channel_id="222",
+    )
+    assert result.target == "TOGGL_TOKEN", (
+        "a non-admin caller must succeed — there is no admin gate"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. A Slack caller gets a ToolError; no row created
+# ---------------------------------------------------------------------------
+
+
+async def test_request_env_credential_rejects_slack_caller(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    runtime = _runtime(committing_sessionmaker)
+    auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
+    with pytest.raises(ToolError, match="not supported on Slack"):
+        await _request_env_credential_impl(
+            runtime, auth, agent_name="daimon", key="OPENAI_API_KEY", purpose="x", channel_id="222"
+        )
+    assert await _row_count(db_session) == 0, "a rejected slack call must create no row"
+
+
+async def test_request_mcp_credential_rejects_slack_caller(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    runtime = _runtime(committing_sessionmaker)
+    auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
+    with pytest.raises(ToolError, match="not supported on Slack"):
+        await _request_mcp_credential_impl(
+            runtime,
+            auth,
+            agent_name="daimon",
+            server_name="linear",
+            url="https://mcp.linear.app/sse",
+            channel_id="222",
+        )
+    assert await _row_count(db_session) == 0, "a rejected slack call must create no row"
+
+
+# ---------------------------------------------------------------------------
+# 6. A caller with no platform_user_id gets a ToolError; no row created
+# ---------------------------------------------------------------------------
+
+
+async def test_request_env_credential_rejects_missing_platform_user_id(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    runtime = _runtime(committing_sessionmaker)
+    auth = _auth_identity(platform_user_id=None)
+    with pytest.raises(ToolError, match="platform-bound identity"):
+        await _request_env_credential_impl(
+            runtime, auth, agent_name="daimon", key="OPENAI_API_KEY", purpose="x", channel_id="222"
+        )
+    assert await _row_count(db_session) == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. An env key failing the POSIX rule gets a ToolError; no row created
+# ---------------------------------------------------------------------------
+
+
+async def test_request_env_credential_rejects_invalid_key(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    runtime = _runtime(committing_sessionmaker)
+    auth = _auth_identity()
+    with pytest.raises(ToolError, match=r"\[A-Za-z_\]\[A-Za-z0-9_\]\*"):
+        await _request_env_credential_impl(
+            runtime, auth, agent_name="daimon", key="1BAD-KEY", purpose="x", channel_id="222"
+        )
+    assert await _row_count(db_session) == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. An agent_name with no matching MA agent gets a ToolError; no row created
+# ---------------------------------------------------------------------------
+
+
+async def test_request_env_credential_rejects_unknown_agent(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    client = _ma_client_with_agents([])  # no agents in the tenant
+    runtime = _runtime(committing_sessionmaker, client=client)
+    auth = _auth_identity(tenant_id=tenant.id)
+    with pytest.raises(ToolError, match="not found in this tenant"):
+        await _request_env_credential_impl(
+            runtime, auth, agent_name="ghost", key="OPENAI_API_KEY", purpose="x", channel_id="222"
+        )
+    assert await _row_count(db_session) == 0
+
+
+# ---------------------------------------------------------------------------
+# 9. An mcp url that is not http(s) gets a ToolError; no row created
+# ---------------------------------------------------------------------------
+
+
+async def test_request_mcp_credential_rejects_non_http_url(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    runtime = _runtime(committing_sessionmaker)
+    auth = _auth_identity()
+    with pytest.raises(ToolError, match="must be http or https"):
+        await _request_mcp_credential_impl(
+            runtime,
+            auth,
+            agent_name="daimon",
+            server_name="linear",
+            url="ftp://mcp.linear.app/sse",
+            channel_id="222",
+        )
+    assert await _row_count(db_session) == 0
+
+
+# ---------------------------------------------------------------------------
+# 10. A failed button post raises a ToolError rather than silently succeeding
+# ---------------------------------------------------------------------------
+
+
+async def test_request_env_credential_raises_when_button_post_fails(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    client = _ma_client_with_agents(
+        [_ma_agent(agent_id="ag_fail", name="daimon", tenant_id=tenant.id)]
+    )
+    # No discord settings configured -> _post_credential_button_impl's
+    # _require_bot_token raises inside the post step, after the row is
+    # already minted.
+    runtime = _runtime(committing_sessionmaker, client=client, with_discord=False)
+    auth = _auth_identity(tenant_id=tenant.id)
+
+    with pytest.raises(ToolError, match="posting the button failed"):
+        await _request_env_credential_impl(
+            runtime, auth, agent_name="daimon", key="OPENAI_API_KEY", purpose="x", channel_id="222"
+        )
+
+    # The row is minted before the post is attempted — a failed post leaves it
+    # in place (single-use + TTL bound it regardless), it just never got a
+    # live button. This documents that reality rather than asserting it away.
+    assert await _row_count(db_session) == 1, (
+        "the credential request row is created before the button post is attempted"
+    )

--- a/packages/adapters/mcp/tests/tools/test_discord.py
+++ b/packages/adapters/mcp/tests/tools/test_discord.py
@@ -28,6 +28,7 @@ from daimon.core.config import (
     DiscordSettings,
     Settings,
 )
+from daimon.core.credential_requests import build_button_label, build_custom_id
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.domain import Role
 from fastmcp.exceptions import ToolError
@@ -46,6 +47,9 @@ _send_message_impl = _discord_mod._send_message_impl  # pyright: ignore[reportPr
 _fetch_attachment = _discord_mod._fetch_attachment  # pyright: ignore[reportPrivateUsage]
 _require_discord_identity = _discord_mod._require_discord_identity  # pyright: ignore[reportPrivateUsage]
 _require_guild_id = _discord_mod._require_guild_id  # pyright: ignore[reportPrivateUsage]
+_post_credential_button_impl = (
+    _discord_mod._post_credential_button_impl  # pyright: ignore[reportPrivateUsage]
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -637,3 +641,241 @@ async def test_require_guild_id_raises_with_exact_error_string_when_guild_id_mis
     assert str(exc_info.value) == _EXPECTED_GUILD_CONTEXT_ERROR, (
         "error message must remain stable for log-grep tooling and operator runbooks"
     )
+
+
+# ---------------------------------------------------------------------------
+# _post_credential_button_impl (08-06) — posting the credential-request button.
+# ---------------------------------------------------------------------------
+
+
+def _sent_component_button(kwargs: dict[str, Any]) -> dict[str, Any]:
+    components = kwargs["json"]["components"]
+    assert len(components) == 1, f"expected exactly one action row, got {components!r}"
+    row_children = components[0]["components"]
+    assert len(row_children) == 1, f"expected exactly one button, got {row_children!r}"
+    return row_children[0]  # type: ignore[no-any-return]
+
+
+async def test_post_credential_button_posts_one_button_with_the_core_custom_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The posted message carries exactly one button whose custom_id is
+    build_custom_id(token) and whose label is build_button_label(kind, target)."""
+    posted: dict[str, Any] = {}
+
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            posted.update(kwargs)
+            return _message_payload(message_id="9101", content=kwargs["json"]["content"])
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    message_id = await _post_credential_button_impl(
+        _runtime_with_discord_token(),
+        _auth(),
+        channel_id="222",
+        kind="env",
+        target="OPENAI_API_KEY",
+        token="tok-abc123",
+        agent_name="demo",
+        purpose="calling the OpenAI API",
+    )
+    assert message_id == "9101", "must return the sent message id"
+    button = _sent_component_button(posted)
+    assert button["custom_id"] == build_custom_id("tok-abc123"), (
+        "posted button custom_id must be the core-owned build_custom_id output"
+    )
+    assert button["label"] == build_button_label("env", "OPENAI_API_KEY"), (
+        "posted button label must be the core-owned build_button_label output"
+    )
+
+
+async def test_post_credential_button_body_mentions_requester_and_exposure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The message body pings the requester and states the credential becomes
+    usable by everyone who talks to the agent; allowed_mentions pings only
+    that user, never everyone or a role."""
+    posted: dict[str, Any] = {}
+
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            posted.update(kwargs)
+            return _message_payload(message_id="9102", content=kwargs["json"]["content"])
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    await _post_credential_button_impl(
+        _runtime_with_discord_token(),
+        _auth(platform_user_id="42"),
+        channel_id="222",
+        kind="mcp",
+        target="linear",
+        token="tok-xyz789",
+        agent_name="demo",
+        purpose="syncing Linear issues",
+    )
+    body = posted["json"]["content"]
+    assert "<@42>" in body, "body must mention the requester"
+    assert "demo" in body, "body must name the agent"
+    assert "linear" in body, "body must name the exact target"
+    assert "syncing Linear issues" in body, "body must include the caller-supplied purpose"
+    assert "usable by everyone who talks to" in body, (
+        "body must disclose that the credential becomes usable by everyone who talks to the agent"
+    )
+    allowed_mentions = posted["json"]["allowed_mentions"]
+    assert allowed_mentions["parse"] == ["users"], (
+        "allowed_mentions must ping only users (the requester), never everyone or roles"
+    )
+
+
+async def test_post_credential_button_hydrates_thread_parent_before_permission_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Posting to a thread hydrates the parent before the permission check, so
+    permissions_for does not raise on the REST-only client."""
+
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            if str(route.channel_id) == "999":
+                return _thread_payload()
+            if str(route.channel_id) == "222":
+                return _text_channel_payload()
+            raise AssertionError(f"unexpected channel fetch {route.channel_id}")
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            return _message_payload(
+                message_id="9103", channel_id="999", content=kwargs["json"]["content"]
+            )
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    message_id = await _post_credential_button_impl(
+        _runtime_with_discord_token(),
+        _auth(),
+        channel_id="999",
+        kind="env",
+        target="OPENAI_API_KEY",
+        token="tok-thread",
+        agent_name="demo",
+        purpose="calling the OpenAI API",
+    )
+    assert message_id == "9103", "posting into an uncached thread must succeed"
+
+
+async def test_post_credential_button_denies_without_send_permission_and_posts_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller lacking send_messages gets a ToolError and nothing is posted."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]  # no send_messages
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            raise AssertionError("must not POST when send permission denied")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="send_messages"):
+        await _post_credential_button_impl(
+            _runtime_with_discord_token(),
+            _auth(),
+            channel_id="222",
+            kind="env",
+            target="OPENAI_API_KEY",
+            token="tok-denied",
+            agent_name="demo",
+            purpose="x",
+        )
+
+
+async def test_post_credential_button_rejects_cross_guild_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A channel in a different guild than the caller's gets a ToolError and
+    nothing is posted."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload(guild_id="222")  # different guild than "111"
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            raise AssertionError("must not POST for a cross-guild channel")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="channel not in this guild"):
+        await _post_credential_button_impl(
+            _runtime_with_discord_token(),
+            _auth(),
+            channel_id="222",
+            kind="env",
+            target="OPENAI_API_KEY",
+            token="tok-cross-guild",
+            agent_name="demo",
+            purpose="x",
+        )
+
+
+async def test_post_credential_button_rejects_dm_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DM channel gets a ToolError and nothing is posted."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return {"id": "333", "type": 1, "recipients": [_author_payload()]}
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            raise AssertionError("must not POST to a DM channel")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="dm channels are not supported"):
+        await _post_credential_button_impl(
+            _runtime_with_discord_token(),
+            _auth(),
+            channel_id="333",
+            kind="env",
+            target="OPENAI_API_KEY",
+            token="tok-dm",
+            agent_name="demo",
+            purpose="x",
+        )

--- a/packages/adapters/mcp/tests/tools/test_skills_sync_token.py
+++ b/packages/adapters/mcp/tests/tools/test_skills_sync_token.py
@@ -17,11 +17,13 @@ from anthropic import AsyncAnthropic
 from daimon.adapters.mcp.auth.resolver import AuthIdentity, Role
 from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools.skills import _resolve_sync_token
+from daimon.core.config import AnthropicSettings, DatabaseSettings, GithubSettings, Settings
 from daimon.core.github_credentials import build_multifernet, upsert_credential_encrypted
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.agent_github_binding import set_agent_github_binding
 from daimon.core.stores.agent_repo_binding import set_binding
 from daimon.testing.factories import make_tenant
+from pydantic import HttpUrl, PostgresDsn, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 pytestmark = pytest.mark.asyncio
@@ -29,11 +31,15 @@ pytestmark = pytest.mark.asyncio
 FERNET_KEY = "x" * 43 + "="  # length-44 urlsafe base64 — valid Fernet key shape
 
 
-def _make_runtime(sessionmaker: async_sessionmaker[AsyncSession]) -> McpRuntime:
+def _make_runtime(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    settings: Settings | None = None,
+) -> McpRuntime:
     return McpRuntime(
         session_factory=sessionmaker,
         client=MagicMock(spec=AsyncAnthropic),
-        settings=MagicMock(),  # type: ignore[arg-type]
+        settings=settings if settings is not None else MagicMock(),  # type: ignore[arg-type]
         fernet=build_multifernet((FERNET_KEY,)),
         deployment_default=DeploymentDefault(),
     )
@@ -135,3 +141,45 @@ async def test_resolve_sync_token_returns_none_when_no_binding(
         "https://github.com/example-org/example-agent",
     )
     assert token is None, "no binding for the repo means anonymous fetch (public-repo path)"
+
+
+def _minimal_settings(*, fallback_pat: SecretStr | None) -> Settings:
+    return Settings(
+        database=DatabaseSettings(
+            url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon"),
+        ),
+        anthropic=AnthropicSettings(
+            api_key=SecretStr("sk-test"),
+            base_url=HttpUrl("https://api.anthropic.com"),
+        ),
+        github=GithubSettings(fallback_pat=fallback_pat),
+    )
+
+
+async def test_resolve_sync_token_returns_fallback_for_tenant_binding_with_no_overlay(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A tenant-matching binding whose agent has no overlay PAT still resolves
+    the configured operator fallback, so a fresh agent's public skill sync
+    isn't limited to the unauthenticated GitHub rate limit."""
+    async with sessionmaker.begin() as session:
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(uuid.uuid4()))
+    agent_id = uuid.uuid4()
+    url = "https://github.com/example-org/example-agent"
+    async with sessionmaker.begin() as session:
+        await set_binding(
+            session,
+            tenant_id=tenant.id,
+            agent_id=agent_id,
+            repo_url=url,
+            default_branch="main",
+            ma_secret_ref="anon:",
+        )
+
+    settings = _minimal_settings(fallback_pat=SecretStr("ghp_operator_fallback"))
+    token = await _resolve_sync_token(
+        _make_runtime(sessionmaker, settings=settings), _identity(tenant.id), url
+    )
+    assert token == "ghp_operator_fallback", (
+        "a tenant binding with no overlay PAT must resolve the configured operator fallback"
+    )

--- a/packages/adapters/slack/tests/test_privacy_panel.py
+++ b/packages/adapters/slack/tests/test_privacy_panel.py
@@ -307,6 +307,7 @@ def _make_preview(**overrides: Any) -> PurgePreview:
         "agent_github_binding": PurgePreviewRow(count=0, example=None),
         "slack_user_tokens": PurgePreviewRow(count=0, example=None),
         "slack_turn_contexts": PurgePreviewRow(count=0, example=None),
+        "credential_requests": PurgePreviewRow(count=0, example=None),
     }
     base.update(overrides)
     return PurgePreview(**base)

--- a/packages/core/alembic/versions/0003_credential_requests.py
+++ b/packages/core/alembic/versions/0003_credential_requests.py
@@ -1,0 +1,55 @@
+"""credential_requests — chat-initiated credential-button handshake.
+
+One row per credential-request button posted in a thread. `token` is the
+opaque value carried in the button's `custom_id`; `used_at` plus
+`expires_at` back the single-use, TTL-bounded consume in
+`daimon.core.stores.credential_requests`. No cleanup sweep this phase —
+expired rows accumulate deliberately, one row per credential request.
+
+downgrade: safe
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0003_credential_requests"
+down_revision: str | None = "0002_agent_memory_store"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "credential_requests",
+        sa.Column("token", sa.Text(), nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("tenant_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("account_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("target", sa.Text(), nullable=False),
+        sa.Column("mcp_server_url", sa.Text(), nullable=True),
+        sa.Column("requester_platform_user_id", sa.Text(), nullable=False),
+        sa.Column("channel_id", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("token", name="pk_credential_requests"),
+        sa.ForeignKeyConstraint(
+            ["tenant_id"],
+            ["tenants.id"],
+            ondelete="CASCADE",
+            name="fk_credential_requests_tenant_id",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("credential_requests")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -818,6 +818,42 @@ class SlackTurnContext(Base):
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
+class CredentialRequest(Base):
+    """Short-lived handshake row backing the chat-initiated credential button.
+
+    A row is minted when the agent posts a credential-request button in a
+    thread; `used_at` plus `expires_at` make a click single-use and
+    TTL-bounded — the atomic consume in `daimon.core.stores.credential_requests`
+    is the actual single-use gate, this column is just its durable marker.
+    `tenant_id` carries isolation and cascades on tenant teardown. `account_id`
+    intentionally has no FK to `accounts.id`: these rows are erased through the
+    platform-user-scoped erasure helper (mirroring how the OAuth handshake
+    table `github_oauth_states` is erased), not through an accounts.id
+    cascade.
+    """
+
+    __tablename__ = "credential_requests"
+
+    token: Mapped[str] = mapped_column(Text, primary_key=True)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)  # "env" | "mcp"
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    account_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    target: Mapped[str] = mapped_column(Text, nullable=False)
+    mcp_server_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    requester_platform_user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    channel_id: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
 class SlackEventDedup(Base):
     """Exactly-once gate for inbound Slack events.
 

--- a/packages/core/daimon/core/broker/__init__.py
+++ b/packages/core/daimon/core/broker/__init__.py
@@ -38,8 +38,16 @@ async def dispatch_mint_token(
     agent_id: uuid.UUID | None,
     sessionmaker: async_sessionmaker[AsyncSession],
     settings: Settings,
+    allow_service_default: bool = False,
 ) -> str:
-    """Mint a token for ``service``. Audit-logs metadata only — never the token."""
+    """Mint a token for ``service``. Audit-logs metadata only — never the token.
+
+    ``allow_service_default`` passes straight through to the provider — the
+    broker itself makes no opt-in decision. Each consumer of this function
+    decides whether its use of the token is transient (safe to opt in) or
+    durable (must stay at the default so it never inherits the shared
+    operator secret).
+    """
     provider = _REGISTRY.get(service)
     if provider is None:
         raise ProviderConfigError(f"unknown service: {service!r}")
@@ -49,6 +57,7 @@ async def dispatch_mint_token(
             agent_id=agent_id,
             sessionmaker=sessionmaker,
             settings=settings,
+            allow_service_default=allow_service_default,
         )
     except NoBindingError:
         logger.warning(

--- a/packages/core/daimon/core/broker/providers/__init__.py
+++ b/packages/core/daimon/core/broker/providers/__init__.py
@@ -22,4 +22,5 @@ class TokenProvider(Protocol):
         agent_id: uuid.UUID | None,
         sessionmaker: async_sessionmaker[AsyncSession],
         settings: Settings,
+        allow_service_default: bool = False,
     ) -> str: ...

--- a/packages/core/daimon/core/broker/providers/gcloud.py
+++ b/packages/core/daimon/core/broker/providers/gcloud.py
@@ -33,6 +33,9 @@ class GcloudTokenProvider:
         agent_id: uuid.UUID | None,
         sessionmaker: async_sessionmaker[AsyncSession],
         settings: Settings,
+        # Accepted for Protocol conformance; inert here — no service-wide
+        # gcloud identity exists to fall back to.
+        allow_service_default: bool = False,
     ) -> str:
         # Pitfall 2: config check FIRST, then binding check.
         if settings.credentials.google_sa_json is None:

--- a/packages/core/daimon/core/broker/providers/github.py
+++ b/packages/core/daimon/core/broker/providers/github.py
@@ -25,6 +25,7 @@ class GitHubTokenProvider:
         agent_id: uuid.UUID | None,
         sessionmaker: async_sessionmaker[AsyncSession],
         settings: Settings,
+        allow_service_default: bool = False,
     ) -> str:
         if not settings.crypto.keys:
             raise ProviderConfigError(
@@ -34,15 +35,24 @@ class GitHubTokenProvider:
         # NOTE: account_id IS principal_id today because
         # credentials are keyed on account_id-as-principal-id.
         # This may break if multi-principal accounts ship.
-        # when agent_id is given, get_pat is overlay-only — if the agent has
-        # no overlay row, None is returned and NoBindingError is raised here. This is
-        # correct: an agent with no per-agent credential bound must not silently inherit
-        # the principal-default PAT from another agent's Connect-GitHub action.
+        # when agent_id is given, get_pat is overlay-only — if the agent has no
+        # overlay row and (when allow_service_default is set) no configured
+        # operator fallback either, None is returned and NoBindingError is
+        # raised here. This is correct: an agent with no per-agent credential
+        # bound must not silently inherit the principal-default PAT from
+        # another agent's Connect-GitHub action. Three-tier resolution:
+        # overlay -> operator service default (opt-in, this caller only) -> raise.
         token = await get_pat(
             principal_id=account_id,
             agent_id=agent_id,
             sessionmaker=sessionmaker,
             fernet=fernet,
+            allow_service_default=allow_service_default,
+            fallback_pat=(
+                settings.github.fallback_pat.get_secret_value()
+                if settings.github.fallback_pat is not None
+                else None
+            ),
         )
         if token is None:
             raise NoBindingError(

--- a/packages/core/daimon/core/credential_requests.py
+++ b/packages/core/daimon/core/credential_requests.py
@@ -1,0 +1,77 @@
+"""Wire contract for the chat-initiated credential-request button.
+
+This module lives in `daimon.core`, not in either adapter, because the two
+processes that need it cannot import each other: the MCP server (Cloud Run)
+mints the button and posts it to a channel, while the Discord bot (worker VM)
+later receives the click and must decode the same `custom_id`. Import-linter's
+independence contract forbids `daimon.adapters.mcp` from importing
+`daimon.adapters.discord` (or vice versa), so the shared encode/decode logic
+has to sit one level up, in core.
+
+Discord caps `custom_id` at 100 characters, which rules out encoding the
+target fields (kind, agent, key/server name, requester, expiry) directly in
+the id — an MCP server name alone can blow that budget. Instead the
+`custom_id` carries only an opaque, single-use token; the actual target
+fields live in the `credential_requests` DB row keyed by that token (see
+`daimon.core.stores.credential_requests`). The button's *label* is what
+names the human-readable target, via `build_button_label`.
+
+`CUSTOM_ID_PATTERN` MUST fullmatch every minted custom_id: discord.py's
+`DynamicItem` dispatch matches incoming custom_ids with `pattern.fullmatch`,
+not a prefix search, so a template that merely starts with the right prefix
+would never dispatch (or could over-match unrelated ids).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+import secrets
+from typing import Final, Literal
+
+CUSTOM_ID_PREFIX: Final[str] = "ztc:"
+
+# secrets.token_urlsafe(16) yields a 22-character URL-safe string (~128 bits
+# of entropy) — the resulting custom_id ("ztc:" + 22 chars = 26 chars) sits
+# comfortably under Discord's 100-character custom_id cap.
+TOKEN_BYTES: Final[int] = 16
+
+CUSTOM_ID_TEMPLATE: Final[str] = r"ztc:(?P<token>[A-Za-z0-9_-]{16,64})"
+CUSTOM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(CUSTOM_ID_TEMPLATE)
+
+CredentialRequestKind = Literal["env", "mcp"]
+
+# TTL bounds the replay window for a never-clicked button sitting in channel
+# scrollback; combined with the store's single-use consume, this is the full
+# replay defense.
+DEFAULT_TTL: Final[dt.timedelta] = dt.timedelta(minutes=30)
+
+# Discord's documented Button.label limit.
+MAX_BUTTON_LABEL_CHARS: Final[int] = 80
+
+_KIND_DISPLAY: Final[dict[CredentialRequestKind, str]] = {"env": "env", "mcp": "MCP"}
+
+
+def mint_request_token() -> str:
+    """Return a fresh, URL-safe, single-use token. Two calls never collide."""
+    return secrets.token_urlsafe(TOKEN_BYTES)
+
+
+def build_custom_id(token: str) -> str:
+    """Return the wire `custom_id` for a minted token."""
+    return f"{CUSTOM_ID_PREFIX}{token}"
+
+
+def build_button_label(kind: CredentialRequestKind, target: str) -> str:
+    """Return the human-readable button label naming the exact target.
+
+    Truncates `target` (with a trailing "…") when it would overflow Discord's
+    80-character button label limit — the label, not the custom_id, is what
+    names the exact target, so it must fit on its own.
+    """
+    prefix = f"Add {_KIND_DISPLAY[kind]} credential: "
+    available = MAX_BUTTON_LABEL_CHARS - len(prefix)
+    if len(target) <= available:
+        return f"{prefix}{target}"
+    truncated = target[: available - 1] + "…"
+    return f"{prefix}{truncated}"

--- a/packages/core/daimon/core/github_credentials.py
+++ b/packages/core/daimon/core/github_credentials.py
@@ -1,12 +1,28 @@
-"""GitHub PAT encryption + two-tier resolver.
+"""GitHub PAT encryption + three-tier resolver.
 
 Encryption: MultiFernet wrapping a list of Fernet keys. v1 ships
 a length-1 tuple; rotation = prepend a new key.
 
 Resolver: get_pat(principal_id, agent_id=None) -> str | None. Cascade:
-- agent_id given: tier-1 overlay ONLY. If no overlay row -> None (no bleed).
+- agent_id given: tier-1 overlay ONLY. If no overlay row -> tier-3 (below).
   get_pat(agent_id=X) never falls back to the principal-default credential.
-- agent_id=None: principal-default credential -> token or None (unchanged).
+- agent_id=None: tier-2 principal-default credential -> tier-3 (below).
+- tier-3 (opt-in, both tiers above exhausted): the operator-wide service
+  default. Gated by two keyword-only parameters that both must be set —
+  `allow_service_default` is the authorization, `fallback_pat` is the
+  payload; neither alone does anything. This keeps the default behavior
+  (both params at their default) identical to the old two-tier cascade, so
+  no future caller can silently inherit the shared operator secret by
+  omission. A resolved real credential (tier-1 or tier-2) always returns
+  before this tier is reached, so the fallback can never shadow one.
+
+  Three callers must NEVER pass allow_service_default=True: the agent-fork
+  copy path (would persist the shared token as a per-agent DB row plus a
+  binding), the session Copilot vault mirror and clone-token resolver (the
+  shared token must never beat a short-lived per-repo GitHub App
+  installation token, nor land in a per-agent MA vault credential), and the
+  MCP self-edit repo-binding write (uploads the minted token as a durable MA
+  vault credential).
 
 No try/except — exceptions propagate. None means 'not found', NEVER
 'something broke'.
@@ -74,31 +90,38 @@ async def get_pat(
     agent_id: uuid.UUID | None = None,
     sessionmaker: async_sessionmaker[AsyncSession],
     fernet: MultiFernet,
+    allow_service_default: bool = False,
+    fallback_pat: str | None = None,
 ) -> str | None:
     """Per-agent credential resolver.
 
-    agent_id given -> overlay-only -> None (no principal-default bleed).
-    agent_id=None -> principal-default -> None (OAuth-callback / CLI path).
+    agent_id given -> overlay-only -> opt-in service default -> None (no
+    principal-default bleed).
+    agent_id=None -> principal-default -> opt-in service default -> None
+    (OAuth-callback / CLI path).
+
+    The opt-in tier only engages when BOTH `allow_service_default=True` AND
+    `fallback_pat` is not None — see the module docstring for the full
+    contract and the callers that must never opt in.
     """
     async with sessionmaker() as session:
         if agent_id is not None:
             # Agent path is overlay-only. No fallback to principal default.
             binding = await binding_store.get_agent_github_binding(session, agent_id=agent_id)
-            if binding is None:
-                return None
-            overlay_cred = await cred_store.get_credential_by_principal(
-                session, principal_id=binding.principal_id
-            )
-            if overlay_cred is None:
-                return None
-            return decrypt_token(fernet, overlay_cred.encrypted_token)
+            if binding is not None:
+                overlay_cred = await cred_store.get_credential_by_principal(
+                    session, principal_id=binding.principal_id
+                )
+                if overlay_cred is not None:
+                    return decrypt_token(fernet, overlay_cred.encrypted_token)
+            return fallback_pat if allow_service_default and fallback_pat is not None else None
 
         # agent_id=None: principal-default path (OAuth-callback / CLI flows).
         cred = await cred_store.get_credential_by_principal(session, principal_id=principal_id)
         if cred is not None:
             return decrypt_token(fernet, cred.encrypted_token)
 
-        return None
+        return fallback_pat if allow_service_default and fallback_pat is not None else None
 
 
 async def get_github_login(

--- a/packages/core/daimon/core/github_credentials.py
+++ b/packages/core/daimon/core/github_credentials.py
@@ -16,13 +16,13 @@ Resolver: get_pat(principal_id, agent_id=None) -> str | None. Cascade:
   omission. A resolved real credential (tier-1 or tier-2) always returns
   before this tier is reached, so the fallback can never shadow one.
 
-  Three callers must NEVER pass allow_service_default=True: the agent-fork
-  copy path (would persist the shared token as a per-agent DB row plus a
-  binding), the session Copilot vault mirror and clone-token resolver (the
-  shared token must never beat a short-lived per-repo GitHub App
-  installation token, nor land in a per-agent MA vault credential), and the
-  MCP self-edit repo-binding write (uploads the minted token as a durable MA
-  vault credential).
+  Three callers must NEVER opt into this tier: the agent-fork copy path
+  (would persist the shared token as a per-agent DB row plus a binding), the
+  session Copilot vault mirror and clone-token resolver (the shared token
+  must never beat a short-lived per-repo GitHub App installation token, nor
+  land in a per-agent MA vault credential), and the MCP self-edit
+  repo-binding write (uploads the minted token as a durable MA vault
+  credential).
 
 No try/except — exceptions propagate. None means 'not found', NEVER
 'something broke'.
@@ -100,8 +100,8 @@ async def get_pat(
     agent_id=None -> principal-default -> opt-in service default -> None
     (OAuth-callback / CLI path).
 
-    The opt-in tier only engages when BOTH `allow_service_default=True` AND
-    `fallback_pat` is not None — see the module docstring for the full
+    The opt-in tier only engages when `allow_service_default` is set to True
+    AND `fallback_pat` is not None — see the module docstring for the full
     contract and the callers that must never opt in.
     """
     async with sessionmaker() as session:

--- a/packages/core/daimon/core/privacy.py
+++ b/packages/core/daimon/core/privacy.py
@@ -17,6 +17,7 @@ import uuid
 
 from daimon.core.stores import accounts as accounts_store
 from daimon.core.stores import agent_github_binding as agent_github_binding_store
+from daimon.core.stores import credential_requests as credential_requests_store
 from daimon.core.stores import github_credentials as github_credentials_store
 from daimon.core.stores import github_oauth_states as github_oauth_states_store
 from daimon.core.stores import identity as identity_store
@@ -64,6 +65,7 @@ class PurgePreview(BaseModel):
     agent_github_binding: PurgePreviewRow
     slack_user_tokens: PurgePreviewRow
     slack_turn_contexts: PurgePreviewRow
+    credential_requests: PurgePreviewRow
 
 
 def _format_platform_principal(p: PlatformPrincipalRow) -> str:
@@ -259,6 +261,29 @@ async def collect_purge_preview(
             )
         slack_turn_contexts = PurgePreviewRow(count=slack_turn_contexts_total, example=None)
 
+        # 13. credential_requests — requester_platform_user_id-scoped. Keyed by
+        # (platform_user_id, tenant_id) mirroring purge_principal's actual
+        # per-principal tenant-scoped delete call exactly (unlike the
+        # github_oauth_states block above, which counts platform principals
+        # cross-tenant), so this preview agrees field-for-field with what
+        # purge_account actually deletes. Dedup avoids double-counting when two
+        # principals under the account share a (platform_user_id, tenant_id) key.
+        credential_request_keys: set[tuple[str, uuid.UUID]] = set()
+        for pp in pp_list:
+            credential_request_keys.add((pp.external_id, pp.tenant_id))
+        for cli in cli_list:
+            credential_request_keys.add((cli.os_user, cli.tenant_id))
+        credential_requests_total = 0
+        for platform_user_id, key_tenant_id in credential_request_keys:
+            credential_requests_total += (
+                await credential_requests_store.count_credential_requests_for_platform_user(
+                    session,
+                    platform_user_id=platform_user_id,
+                    tenant_id=key_tenant_id,
+                )
+            )
+        credential_requests = PurgePreviewRow(count=credential_requests_total, example=None)
+
     return PurgePreview(
         linked_principals=linked_principals,
         principal_links=principal_links,
@@ -272,4 +297,5 @@ async def collect_purge_preview(
         agent_github_binding=agent_github_binding,
         slack_user_tokens=slack_user_tokens,
         slack_turn_contexts=slack_turn_contexts,
+        credential_requests=credential_requests,
     )

--- a/packages/core/daimon/core/purge.py
+++ b/packages/core/daimon/core/purge.py
@@ -8,11 +8,19 @@ Registry note: the per-store delete sequence is hardcoded inside
 `_purge_principal_in_session`. Adding a new principal-scoped table means
 appending one helper call here plus one int field on `PurgeReport`. Current
 sequence: user_skills -> github_credentials -> agent_github_binding ->
-github_oauth_states (both kinds where the table permits) -> routines (platform
-only) -> principal_links -> principal row. Account-level deletes (mcp_tokens,
-user_configs, accounts) run in `purge_account` after all principal rows are
-gone; mcp_tokens is keyed by account_id and is deleted before delete_account so
-its NO-ACTION/CASCADE FK to accounts.id is satisfied.
+github_oauth_states (both kinds where the table permits) -> credential_requests
+(both kinds, platform-user-scoped like github_oauth_states) -> routines
+(platform only) -> principal_links -> principal row. Account-level deletes
+(mcp_tokens, user_configs, accounts) run in `purge_account` after all principal
+rows are gone; mcp_tokens is keyed by account_id and is deleted before
+delete_account so its NO-ACTION/CASCADE FK to accounts.id is satisfied.
+
+credential_requests carries a Discord snowflake in requester_platform_user_id
+with no cleanup sweep by design (the table is one row per credential request,
+TTL-bounded relevance) — erasure therefore rides this purge path exactly like
+the OAuth handshake table, rather than a scheduled job. Precedent sweepers
+(`mcp_credential_sweep.py`, `pending_file_sweeper.py`) exist if volume ever
+justifies one instead.
 
 Divergent helper signatures: identity-store `delete_for_principal` is keyed by
 UUID; routines `delete_for_principal` is keyed by `(platform, external_id)`
@@ -46,6 +54,7 @@ from anthropic import APIError, AsyncAnthropic
 from daimon.core.ma import SessionDeletionReport, delete_sessions_for_account
 from daimon.core.stores import accounts as accounts_store
 from daimon.core.stores import agent_github_binding as agent_github_binding_store
+from daimon.core.stores import credential_requests as credential_requests_store
 from daimon.core.stores import github_credentials as github_credentials_store
 from daimon.core.stores import github_oauth_states as github_oauth_states_store
 from daimon.core.stores import identity as identity_store
@@ -82,6 +91,7 @@ class PurgeReport(BaseModel):
     agent_github_binding: int = 0
     slack_user_tokens: int = 0
     slack_turn_contexts: int = 0
+    credential_requests: int = 0
 
     def merge(self, other: PurgeReport) -> PurgeReport:
         return PurgeReport(
@@ -98,6 +108,7 @@ class PurgeReport(BaseModel):
             agent_github_binding=self.agent_github_binding + other.agent_github_binding,
             slack_user_tokens=self.slack_user_tokens + other.slack_user_tokens,
             slack_turn_contexts=self.slack_turn_contexts + other.slack_turn_contexts,
+            credential_requests=self.credential_requests + other.credential_requests,
         )
 
 
@@ -141,6 +152,15 @@ async def _purge_principal_in_session(
             platform_user_id=principal.external_id,
             tenant_id=principal.tenant_id,
         )
+        # credential_requests carries the same non-globally-unique
+        # platform_user_id caveat as oauth_states above — always tenant-scoped.
+        credential_requests_count = (
+            await credential_requests_store.delete_credential_requests_for_platform_user(
+                session,
+                platform_user_id=principal.external_id,
+                tenant_id=principal.tenant_id,
+            )
+        )
     else:
         routines_count = 0
         kind = "cli"
@@ -159,6 +179,16 @@ async def _purge_principal_in_session(
             platform="cli",
             platform_user_id=principal.os_user,
             tenant_id=principal.tenant_id,
+        )
+        # CLI principals never own credential_requests rows in practice (the
+        # credential button flow is Discord-only), so this always reports 0 —
+        # kept for symmetry with the platform branch and future-proofing.
+        credential_requests_count = (
+            await credential_requests_store.delete_credential_requests_for_platform_user(
+                session,
+                platform_user_id=principal.os_user,
+                tenant_id=principal.tenant_id,
+            )
         )
 
     # user_skills and github_credentials are keyed by principal_id alone — both
@@ -202,6 +232,7 @@ async def _purge_principal_in_session(
         github_oauth_states=oauth_states_count,
         agent_github_binding=agent_github_binding_count,
         slack_user_tokens=slack_user_tokens_count,
+        credential_requests=credential_requests_count,
     )
 
 

--- a/packages/core/daimon/core/skill_sync/orchestrator.py
+++ b/packages/core/daimon/core/skill_sync/orchestrator.py
@@ -394,6 +394,7 @@ async def sync_agent_skills(
     http_client: httpx.AsyncClient,
     anthropic_client: AsyncAnthropic,
     credential_override: str | None = None,
+    github_fallback_pat: str | None = None,
     max_tarball_bytes: int = 50 * 1024 * 1024,
 ) -> SyncReport:
     """Sync all skill_repos for one agent. Named error boundary.
@@ -407,6 +408,14 @@ async def sync_agent_skills(
         App-installation-token tier actually win when both an installation and a
         per-agent PAT exist. When None (panel / CLI / MCP paths), the per-agent PAT is
         resolved here as before.
+
+        ``github_fallback_pat`` is the operator-wide service default, threaded
+        by callers that already have ``settings.github.fallback_pat`` in scope
+        (panel / CLI / MCP). It is only consulted on the internal ``get_pat``
+        call — when ``credential_override`` is supplied, the caller's
+        pre-selected credential remains the single authority and the fallback
+        is not consulted. Defaults to None so all pre-existing callers stay
+        source-compatible without threading it.
 
         ``max_tarball_bytes`` bounds the per-repo tarball download
     . Defaults to the safe 50 MiB constant so all pre-existing callers
@@ -444,6 +453,8 @@ async def sync_agent_skills(
             agent_id=resolved_agent_id,
             sessionmaker=sessionmaker,
             fernet=fernet,
+            allow_service_default=True,
+            fallback_pat=github_fallback_pat,
         )
 
     # CR-01: user_skills is a per-AGENT ledger, not a per-user one. Both the panel

--- a/packages/core/daimon/core/skill_sync/resync.py
+++ b/packages/core/daimon/core/skill_sync/resync.py
@@ -144,8 +144,9 @@ async def _select_credential(
 
     Priority:
     1. App installation token (preferred when an installation exists AND App is configured)
-    2. Per-agent PAT overlay ONLY (binding.agent_id keyed; never falls back to principal-default)
-    3. None (anon — public repos only)
+    2. Per-agent PAT overlay, else operator service default, else anon
+       (binding.agent_id keyed; never falls back to principal-default)
+    3. None (anon — public repos only, when no fallback is configured either)
 
     Never resolves agent_id=None (principal-default). That is the credential-bleed vector.
     """
@@ -168,12 +169,19 @@ async def _select_credential(
                 return token
 
     # Tier 2: per-agent PAT overlay — agent_id given, NEVER agent_id=None
-    # get_pat with agent_id resolves the overlay-only path; returns None if no overlay row
+    # get_pat with agent_id resolves the overlay-only path; falls through to the
+    # opted-in operator service default when no overlay resolves, else None (anon).
     pat = await get_pat(
         principal_id=binding.agent_id,  # per-agent path: principal_id not used when agent_id is set
         agent_id=binding.agent_id,
         sessionmaker=sessionmaker,
         fernet=fernet,
+        allow_service_default=True,
+        fallback_pat=(
+            github_settings.fallback_pat.get_secret_value()
+            if github_settings is not None and github_settings.fallback_pat is not None
+            else None
+        ),
     )
     return pat  # may be None (anon)
 

--- a/packages/core/daimon/core/stores/credential_requests.py
+++ b/packages/core/daimon/core/stores/credential_requests.py
@@ -1,0 +1,147 @@
+"""Async store for credential_requests — the credential-button handshake.
+
+No try/except anywhere in this module — exceptions propagate to the adapter
+boundary. `consume_credential_request`'s single atomic UPDATE is the entire
+single-use gate: its own row lock serializes concurrent clicks, so no
+advisory lock (unlike the vault get-or-create critical section in
+`mcp_vault.py`, which needs one because it spans a read-then-create) is
+needed here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, cast
+
+from daimon.core._models import CredentialRequest
+from daimon.core.credential_requests import CredentialRequestKind
+from daimon.core.stores.domain import CredentialRequestRow
+from sqlalchemy import CursorResult, delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def create_credential_request(
+    session: AsyncSession,
+    *,
+    token: str,
+    kind: CredentialRequestKind,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    account_id: uuid.UUID,
+    target: str,
+    mcp_server_url: str | None,
+    requester_platform_user_id: str,
+    channel_id: str,
+    expires_at: datetime,
+) -> CredentialRequestRow:
+    """Insert a fresh, unused credential-request row and return it."""
+    orm = CredentialRequest(
+        token=token,
+        kind=kind,
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        account_id=account_id,
+        target=target,
+        mcp_server_url=mcp_server_url,
+        requester_platform_user_id=requester_platform_user_id,
+        channel_id=channel_id,
+        expires_at=expires_at,
+    )
+    session.add(orm)
+    await session.flush()
+    return CredentialRequestRow.model_validate(orm)
+
+
+async def peek_credential_request(
+    session: AsyncSession,
+    *,
+    token: str,
+) -> CredentialRequestRow | None:
+    """Return the row for `token`, or None if it was never minted.
+
+    Deliberately applies no lifecycle filter (unused/unexpired) — mirrors
+    `github_oauth_states.get_by_state`'s rationale: the caller needs to tell
+    "expired", "already used", and "unknown token" apart, which requires the
+    full row, not a filtered read that collapses all three into None.
+    """
+    orm = await session.get(CredentialRequest, token)
+    if orm is None:
+        return None
+    return CredentialRequestRow.model_validate(orm)
+
+
+async def consume_credential_request(
+    session: AsyncSession,
+    *,
+    token: str,
+    now: datetime,
+) -> CredentialRequestRow | None:
+    """Atomically mark `token` used, iff it is unused and unexpired.
+
+    One statement is the authoritative single-use gate: the UPDATE's own row
+    lock serializes concurrent consumers, so the loser's WHERE clause simply
+    matches zero rows — no advisory lock needed. Returns None for "not
+    consumable" (unknown token, already used, or expired); the caller cannot
+    and must not distinguish those cases from this return value alone (use
+    `peek_credential_request` for that).
+    """
+    stmt = (
+        update(CredentialRequest)
+        .where(
+            CredentialRequest.token == token,
+            CredentialRequest.used_at.is_(None),
+            CredentialRequest.expires_at > now,
+        )
+        .values(used_at=now)
+        .returning(CredentialRequest)
+    )
+    result = await session.execute(stmt)
+    orm = result.scalar_one_or_none()
+    await session.flush()
+    if orm is None:
+        return None
+    return CredentialRequestRow.model_validate(orm)
+
+
+async def delete_credential_requests_for_platform_user(
+    session: AsyncSession,
+    *,
+    platform_user_id: str,
+    tenant_id: uuid.UUID | None = None,
+) -> int:
+    """Delete ALL credential-request rows for `platform_user_id`. Idempotent.
+
+    Deliberately applies no lifecycle filter — used and expired rows still
+    carry `requester_platform_user_id` PII and must be erased, mirroring
+    `github_oauth_states.delete_states_for_platform_user`.
+
+    Callers should always pass `tenant_id`: a platform user id is not
+    globally unique (e.g. Discord snowflakes are scoped to the platform, not
+    globally deduped across a hypothetical re-key), so a tenant-agnostic
+    delete risks erasing another tenant's in-flight handshake rows.
+    """
+    predicates = [CredentialRequest.requester_platform_user_id == platform_user_id]
+    if tenant_id is not None:
+        predicates.append(CredentialRequest.tenant_id == tenant_id)
+    result = await session.execute(delete(CredentialRequest).where(*predicates))
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
+async def count_credential_requests_for_platform_user(
+    session: AsyncSession,
+    *,
+    platform_user_id: str,
+    tenant_id: uuid.UUID | None = None,
+) -> int:
+    """Count credential-request rows that `delete_credential_requests_for_platform_user`
+    would delete. Read-only. Pass the SAME `tenant_id` the delete caller uses,
+    or the preview diverges from the purge (parity contract in daimon.core.privacy).
+    """
+    predicates = [CredentialRequest.requester_platform_user_id == platform_user_id]
+    if tenant_id is not None:
+        predicates.append(CredentialRequest.tenant_id == tenant_id)
+    stmt = select(func.count()).select_from(CredentialRequest).where(*predicates)
+    return int((await session.execute(stmt)).scalar_one())

--- a/packages/core/daimon/core/stores/domain.py
+++ b/packages/core/daimon/core/stores/domain.py
@@ -394,6 +394,25 @@ class GitHubAppInstallationRow(BaseModel):
     updated_at: datetime
 
 
+class CredentialRequestRow(BaseModel):
+    """Pydantic row for CredentialRequest — the credential-button handshake."""
+
+    model_config = ConfigDict(from_attributes=True, frozen=True)
+
+    token: str
+    kind: str
+    tenant_id: uuid.UUID
+    agent_id: uuid.UUID
+    account_id: uuid.UUID
+    target: str
+    mcp_server_url: str | None
+    requester_platform_user_id: str
+    channel_id: str
+    created_at: datetime
+    expires_at: datetime
+    used_at: datetime | None
+
+
 class McpTokenRow(BaseModel):
     """Pydantic row for McpToken.
 

--- a/packages/core/tests/core/broker/test_broker.py
+++ b/packages/core/tests/core/broker/test_broker.py
@@ -29,6 +29,7 @@ from daimon.core.config import (
     CredentialsSettings,
     CryptoSettings,
     DatabaseSettings,
+    GithubSettings,
     Settings,
 )
 from daimon.core.github_credentials import build_multifernet, upsert_credential_encrypted
@@ -40,6 +41,7 @@ def _base_settings(
     *,
     crypto_keys: tuple[SecretStr, ...] = (),
     google_sa_json: SecretStr | None = None,
+    github_fallback_pat: SecretStr | None = None,
 ) -> Settings:
     """Construct a fully-populated Settings for broker tests."""
     return Settings(
@@ -52,6 +54,7 @@ def _base_settings(
         ),
         crypto=CryptoSettings(keys=crypto_keys),
         credentials=CredentialsSettings(google_sa_json=google_sa_json),
+        github=GithubSettings(fallback_pat=github_fallback_pat),
     )
 
 
@@ -132,6 +135,88 @@ async def test_github_passthrough_raises_no_binding_when_unbound(
             sessionmaker=db_session_factory,
             settings=github_settings,
         )
+
+
+@pytest.mark.asyncio
+async def test_github_opt_in_returns_fallback_when_unbound_and_configured(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet_key: SecretStr,
+) -> None:
+    """allow_service_default=True + a configured fallback_pat -> the fallback
+    token resolves instead of NoBindingError for an unbound account."""
+    account_id = uuid.uuid4()
+    settings = _base_settings(
+        crypto_keys=(fernet_key,),
+        github_fallback_pat=SecretStr("ghp_operator_fallback"),
+    )
+
+    token = await dispatch_mint_token(
+        service="github",
+        account_id=account_id,
+        agent_id=None,
+        sessionmaker=db_session_factory,
+        settings=settings,
+        allow_service_default=True,
+    )
+    assert token == "ghp_operator_fallback", (
+        "opted-in dispatch with a configured fallback must return it instead of raising"
+    )
+
+
+@pytest.mark.asyncio
+async def test_github_opt_in_raises_no_binding_when_fallback_unset(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet_key: SecretStr,
+) -> None:
+    """allow_service_default=True but no configured fallback_pat -> still
+    raises NoBindingError (a deployment that hasn't provisioned the service
+    token gets the same error as before)."""
+    account_id = uuid.uuid4()
+    settings = _base_settings(crypto_keys=(fernet_key,))
+
+    with pytest.raises(NoBindingError):
+        await dispatch_mint_token(
+            service="github",
+            account_id=account_id,
+            agent_id=None,
+            sessionmaker=db_session_factory,
+            settings=settings,
+            allow_service_default=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_gcloud_opt_in_is_inert(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+    gcloud_settings: Settings,
+) -> None:
+    """allow_service_default=True is a no-op for the gcloud provider — behavior
+    is identical to the opt-out call."""
+
+    def _fake_refresh(self: Any, request: Any) -> None:
+        self.token = "fake-access-token"
+
+    monkeypatch.setattr(
+        "google.oauth2.service_account.Credentials.refresh",
+        _fake_refresh,
+    )
+    account_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    await _insert_google_binding(db_session, agent_id=agent_id)
+
+    token = await dispatch_mint_token(
+        service="gcloud",
+        account_id=account_id,
+        agent_id=agent_id,
+        sessionmaker=db_session_factory,
+        settings=gcloud_settings,
+        allow_service_default=True,
+    )
+    assert token == "fake-access-token", (
+        "allow_service_default must be inert for the gcloud provider"
+    )
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/defaults/test_defaults_dir.py
+++ b/packages/core/tests/defaults/test_defaults_dir.py
@@ -61,6 +61,29 @@ def test_defaults_skills_parse() -> None:
     )
 
 
+def test_defaults_daimon_agent_guidance_routes_credentials_to_request_tools() -> None:
+    """The daimon agent's guidance must name both credential-request tools and
+    no longer route credential entry to the /agent-setup panel — replacing the
+    setup-panel redirect was the whole point of the request_env_credential /
+    request_mcp_credential tools."""
+    specs = load_agent_specs(DEFAULTS / "agents")
+    daimon = next(s for s in specs if s.name == "daimon")
+    system = daimon.system or ""
+    assert "request_env_credential" in system, (
+        "guidance must name request_env_credential for ad hoc env secrets"
+    )
+    assert "request_mcp_credential" in system, (
+        "guidance must name request_mcp_credential for auth-required MCP servers"
+    )
+    for line in system.splitlines():
+        if "/agent-setup" not in line:
+            continue
+        lowered = line.lower()
+        assert not any(
+            word in lowered for word in ("token", "secret", "credential", "mcps modal")
+        ), f"a line mentioning /agent-setup must not also route credential entry there: {line!r}"
+
+
 def test_defaults_agent_skill_references_resolve() -> None:
     agents = load_agent_specs(DEFAULTS / "agents")
     skill_names = {load_skill_spec(d)[0].name for d in load_skill_paths(DEFAULTS / "skills")}

--- a/packages/core/tests/skill_sync/test_orchestrator.py
+++ b/packages/core/tests/skill_sync/test_orchestrator.py
@@ -169,6 +169,86 @@ async def test_pat_missing_falls_back_to_unauthenticated_fetch(
     assert report.synced == 0, "no skill should be created when fetch fails"
 
 
+async def test_github_fallback_pat_used_when_no_overlay_and_no_override(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """No per-agent overlay PAT, no credential_override, but github_fallback_pat
+    is threaded -> the fetch carries the fallback as its Authorization header
+    instead of falling back to an anonymous (unauthenticated) fetch."""
+    cli = await make_cli_principal(db_session, os_user="alice")
+    await db_session.commit()
+
+    fernet = _make_fernet()
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
+    anthropic_client = _build_anthropic(router)
+
+    captured_requests: list[httpx.Request] = []
+
+    def tarball_handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(404)
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(tarball_handler))
+
+    await sync_agent_skills(
+        principal_id=cli.id,
+        tenant_id=cli.tenant_id,
+        agent_name="agent",
+        repos=[SkillRepo(url="https://github.com/o/r", branch="main", split=False)],
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        http_client=http_client,
+        anthropic_client=anthropic_client,
+        github_fallback_pat="ghp_operator_fallback",
+    )
+
+    assert len(captured_requests) == 1, "fetcher should be invoked exactly once"
+    assert captured_requests[0].headers.get("Authorization") == "token ghp_operator_fallback", (
+        "github_fallback_pat must be used as the fetch credential when no overlay PAT resolves"
+    )
+
+
+async def test_github_fallback_pat_omitted_behaves_as_before(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Callers that don't pass github_fallback_pat keep the pre-existing
+    anonymous-fetch behavior — the new kwarg is source-compatible."""
+    cli = await make_cli_principal(db_session, os_user="alice")
+    await db_session.commit()
+
+    fernet = _make_fernet()
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
+    anthropic_client = _build_anthropic(router)
+
+    captured_requests: list[httpx.Request] = []
+
+    def tarball_handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(404)
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(tarball_handler))
+
+    await sync_agent_skills(
+        principal_id=cli.id,
+        tenant_id=cli.tenant_id,
+        agent_name="agent",
+        repos=[SkillRepo(url="https://github.com/o/r", branch="main", split=False)],
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        http_client=http_client,
+        anthropic_client=anthropic_client,
+    )
+
+    assert len(captured_requests) == 1, "fetcher should be invoked exactly once"
+    assert "Authorization" not in captured_requests[0].headers, (
+        "omitting github_fallback_pat must keep the pre-existing anonymous fetch behavior"
+    )
+
+
 async def test_first_sync_creates_new_skill(
     db_session: AsyncSession,
     db_session_factory: async_sessionmaker[AsyncSession],

--- a/packages/core/tests/stores/test_credential_requests.py
+++ b/packages/core/tests/stores/test_credential_requests.py
@@ -1,0 +1,234 @@
+"""Integration tests for the credential_requests store — real Postgres.
+
+Covers the atomic single-use consume (the authoritative security gate) and
+the platform-user-scoped erasure helpers.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from daimon.core.credential_requests import mint_request_token
+from daimon.core.stores import credential_requests as store
+from daimon.core.stores.domain import CredentialRequestRow
+from daimon.testing.factories import make_account, make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _seed_request(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID,
+    token: str | None = None,
+    requester_platform_user_id: str = "requester-1",
+    expires_at: datetime | None = None,
+) -> CredentialRequestRow:
+    return await store.create_credential_request(
+        session,
+        token=token or mint_request_token(),
+        kind="env",
+        tenant_id=tenant_id,
+        agent_id=uuid.uuid4(),
+        account_id=account_id,
+        target="OPENAI_API_KEY",
+        mcp_server_url=None,
+        requester_platform_user_id=requester_platform_user_id,
+        channel_id="chan-1",
+        expires_at=expires_at or (datetime.now(tz=UTC) + timedelta(minutes=30)),
+    )
+
+
+async def test_create_credential_request_returns_row_with_used_at_none(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+
+    row = await _seed_request(db_session, tenant_id=tenant.id, account_id=account.id)
+
+    assert row.used_at is None, "a freshly created request must be unused"
+
+
+async def test_peek_credential_request_returns_row_for_unused_unexpired_token(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    created = await _seed_request(db_session, tenant_id=tenant.id, account_id=account.id)
+
+    peeked = await store.peek_credential_request(db_session, token=created.token)
+
+    assert peeked is not None
+    assert peeked.token == created.token
+
+
+async def test_peek_credential_request_returns_row_even_when_expired(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    created = await _seed_request(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=account.id,
+        expires_at=datetime.now(tz=UTC) - timedelta(minutes=1),
+    )
+
+    peeked = await store.peek_credential_request(db_session, token=created.token)
+
+    assert peeked is not None, "peek must return an expired row so the caller can tell it apart"
+
+
+async def test_peek_credential_request_returns_row_even_when_used(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    created = await _seed_request(db_session, tenant_id=tenant.id, account_id=account.id)
+    await store.consume_credential_request(
+        db_session, token=created.token, now=datetime.now(tz=UTC)
+    )
+
+    peeked = await store.peek_credential_request(db_session, token=created.token)
+
+    assert peeked is not None, "peek must return a used row so the caller can tell it apart"
+    assert peeked.used_at is not None
+
+
+async def test_peek_credential_request_returns_none_for_unknown_token(
+    db_session: AsyncSession,
+) -> None:
+    peeked = await store.peek_credential_request(db_session, token=mint_request_token())
+
+    assert peeked is None
+
+
+async def test_consume_credential_request_sets_used_at_on_first_call(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    created = await _seed_request(db_session, tenant_id=tenant.id, account_id=account.id)
+    now = datetime.now(tz=UTC)
+
+    consumed = await store.consume_credential_request(db_session, token=created.token, now=now)
+
+    assert consumed is not None
+    assert consumed.used_at == now
+
+
+async def test_consume_credential_request_second_call_returns_none_and_preserves_used_at(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    created = await _seed_request(db_session, tenant_id=tenant.id, account_id=account.id)
+    first_now = datetime.now(tz=UTC)
+
+    first = await store.consume_credential_request(db_session, token=created.token, now=first_now)
+    second = await store.consume_credential_request(
+        db_session, token=created.token, now=datetime.now(tz=UTC) + timedelta(seconds=5)
+    )
+
+    assert first is not None
+    assert second is None, "a second consume of an already-used token must return None"
+
+    peeked = await store.peek_credential_request(db_session, token=created.token)
+    assert peeked is not None
+    assert peeked.used_at == first_now, (
+        "used_at must still hold the first call's timestamp, not be overwritten"
+    )
+
+
+async def test_consume_credential_request_returns_none_when_expired(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    created = await _seed_request(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=account.id,
+        expires_at=datetime.now(tz=UTC) - timedelta(minutes=1),
+    )
+
+    consumed = await store.consume_credential_request(
+        db_session, token=created.token, now=datetime.now(tz=UTC)
+    )
+
+    assert consumed is None, "an expired token must not be consumable"
+
+    peeked = await store.peek_credential_request(db_session, token=created.token)
+    assert peeked is not None
+    assert peeked.used_at is None, "a rejected consume must leave used_at NULL"
+
+
+async def test_consume_credential_request_returns_none_for_unknown_token(
+    db_session: AsyncSession,
+) -> None:
+    consumed = await store.consume_credential_request(
+        db_session, token=mint_request_token(), now=datetime.now(tz=UTC)
+    )
+
+    assert consumed is None
+
+
+async def test_delete_credential_requests_for_platform_user_deletes_regardless_of_state(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    unused = await _seed_request(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=account.id,
+        requester_platform_user_id="erase-me",
+    )
+    used = await _seed_request(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=account.id,
+        requester_platform_user_id="erase-me",
+    )
+    await store.consume_credential_request(db_session, token=used.token, now=datetime.now(tz=UTC))
+    expired = await _seed_request(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=account.id,
+        requester_platform_user_id="erase-me",
+        expires_at=datetime.now(tz=UTC) - timedelta(minutes=1),
+    )
+
+    deleted = await store.delete_credential_requests_for_platform_user(
+        db_session, platform_user_id="erase-me", tenant_id=tenant.id
+    )
+
+    assert deleted == 3, "delete must remove unused, used, AND expired rows"
+    assert (await store.peek_credential_request(db_session, token=unused.token)) is None
+    assert (await store.peek_credential_request(db_session, token=used.token)) is None
+    assert (await store.peek_credential_request(db_session, token=expired.token)) is None
+
+
+async def test_count_credential_requests_for_platform_user_matches_delete_rowcount(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    for _ in range(3):
+        await _seed_request(
+            db_session,
+            tenant_id=tenant.id,
+            account_id=account.id,
+            requester_platform_user_id="count-me",
+        )
+
+    count_before = await store.count_credential_requests_for_platform_user(
+        db_session, platform_user_id="count-me", tenant_id=tenant.id
+    )
+    deleted = await store.delete_credential_requests_for_platform_user(
+        db_session, platform_user_id="count-me", tenant_id=tenant.id
+    )
+
+    assert count_before == deleted == 3

--- a/packages/core/tests/stores/test_credential_requests.py
+++ b/packages/core/tests/stores/test_credential_requests.py
@@ -6,14 +6,17 @@ the platform-user-scoped erasure helpers.
 
 from __future__ import annotations
 
+import asyncio
+import os
 import uuid
 from datetime import UTC, datetime, timedelta
 
+import pytest
 from daimon.core.credential_requests import mint_request_token
 from daimon.core.stores import credential_requests as store
 from daimon.core.stores.domain import CredentialRequestRow
 from daimon.testing.factories import make_account, make_tenant
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 async def _seed_request(
@@ -232,3 +235,70 @@ async def test_count_credential_requests_for_platform_user_matches_delete_rowcou
     )
 
     assert count_before == deleted == 3
+
+
+def _concurrency_dsn() -> str:
+    """Read the real test DSN.
+
+    The single-use guarantee rests on Postgres row locks serializing two
+    *separate* connections, so this needs two independent engines rather than
+    the shared single-connection ``db_session`` fixture the rest of this file
+    uses.
+    """
+    url = os.environ.get("DAIMON_DATABASE__TEST_URL")
+    if not url:
+        pytest.skip("DAIMON_DATABASE__TEST_URL must be set for the concurrency test")
+    return url
+
+
+async def test_concurrent_consume_of_one_token_succeeds_exactly_once() -> None:
+    """Two connections racing the same token: one wins, one gets None.
+
+    The consume is a single `UPDATE ... WHERE used_at IS NULL AND
+    expires_at > now RETURNING`, so the loser's WHERE clause matches zero rows
+    once the winner's row lock is released. Asserting that empirically is the
+    difference between trusting the SQL shape and knowing it holds — and this
+    is the only gate standing between a leaked button and a second credential
+    write.
+
+    Runs against the default schema with a freshly minted token, so parallel
+    pytest workers cannot collide.
+    """
+    dsn = _concurrency_dsn()
+    engine_a = create_async_engine(dsn)
+    engine_b = create_async_engine(dsn)
+    factory_a = async_sessionmaker(engine_a, expire_on_commit=False)
+    factory_b = async_sessionmaker(engine_b, expire_on_commit=False)
+
+    token = mint_request_token()
+    try:
+        async with factory_a.begin() as seed:
+            tenant = await make_tenant(seed)
+            account = await make_account(seed, tenant=tenant)
+            await _seed_request(seed, tenant_id=tenant.id, account_id=account.id, token=token)
+
+        now = datetime.now(tz=UTC)
+
+        async def consume(factory: async_sessionmaker[AsyncSession]) -> CredentialRequestRow | None:
+            async with factory.begin() as session:
+                return await store.consume_credential_request(session, token=token, now=now)
+
+        first, second = await asyncio.gather(consume(factory_a), consume(factory_b))
+
+        winners = [row for row in (first, second) if row is not None]
+        assert len(winners) == 1, (
+            "exactly one racing connection may consume a single-use credential request; "
+            f"got {len(winners)} winners"
+        )
+        assert winners[0].token == token, "the winning consume must return the raced row"
+
+        async with factory_a() as check:
+            after = await store.peek_credential_request(check, token=token)
+        assert after is not None, "the row must survive consumption (it is marked, not deleted)"
+        assert after.used_at is not None, "the winning consume must persist used_at"
+
+        replayed = await consume(factory_a)
+        assert replayed is None, "a consumed token must never be consumable again"
+    finally:
+        await engine_a.dispose()
+        await engine_b.dispose()

--- a/packages/core/tests/stores/test_credential_requests_schema.py
+++ b/packages/core/tests/stores/test_credential_requests_schema.py
@@ -1,0 +1,48 @@
+"""Schema-drift guard for credential_requests.
+
+The single-column PK on `token` and the `tenant_id` FK cascade are load-bearing
+invariants: a lookup is always by the opaque token, and a tenant teardown must
+not strand credential-request rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import Connection, Inspector, inspect
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+
+def _pk_columns(sync_conn: Connection, table: str) -> list[str]:
+    inspector: Inspector = inspect(sync_conn)
+    pk = inspector.get_pk_constraint(table)
+    return list(pk["constrained_columns"])
+
+
+def _tenant_id_fk_ondelete(sync_conn: Connection, table: str) -> str | None:
+    inspector: Inspector = inspect(sync_conn)
+    for fk in inspector.get_foreign_keys(table):
+        if fk["referred_table"] == "tenants" and "tenant_id" in fk["constrained_columns"]:
+            options = fk.get("options") or {}
+            ondelete = options.get("ondelete")
+            return str(ondelete) if ondelete is not None else None
+    return None
+
+
+async def test_credential_requests_has_single_column_token_pk(db_session: AsyncSession) -> None:
+    pk_cols = await db_session.run_sync(
+        lambda s: _pk_columns(s.connection(), "credential_requests")
+    )
+    assert pk_cols == ["token"], f"credential_requests PK drift: expected ['token'], got {pk_cols}"
+
+
+async def test_credential_requests_tenant_id_fk_cascades_on_delete(
+    db_session: AsyncSession,
+) -> None:
+    ondelete = await db_session.run_sync(
+        lambda s: _tenant_id_fk_ondelete(s.connection(), "credential_requests")
+    )
+    assert ondelete == "CASCADE", (
+        f"credential_requests.tenant_id FK must be ON DELETE CASCADE, got {ondelete}"
+    )

--- a/packages/core/tests/test_agent_lifecycle.py
+++ b/packages/core/tests/test_agent_lifecycle.py
@@ -18,12 +18,16 @@ from daimon.core.agent_lifecycle import (
     archive_memory_store_best_effort,
     copy_credential_and_repo_binding,
 )
+from daimon.core.config import AnthropicSettings, DatabaseSettings, GithubSettings, Settings
 from daimon.core.errors import DaimonError
 from daimon.core.github_credentials import build_multifernet, get_pat, upsert_credential_encrypted
 from daimon.core.stores.agent_github_binding import set_agent_github_binding
 from daimon.core.stores.agent_memory_stores import get_memory_store_id, insert_memory_store
 from daimon.core.stores.agent_repo_binding import get_binding, set_binding
-from daimon.core.stores.github_credentials import delete_credential_for_principal
+from daimon.core.stores.github_credentials import (
+    delete_credential_for_principal,
+    get_credential_by_principal,
+)
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import (
     FakeMemoryStoreState,
@@ -31,6 +35,7 @@ from daimon.testing.ma import (
     build_fake_anthropic,
     make_fake_memory_store_handler,
 )
+from pydantic import HttpUrl, PostgresDsn, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 pytestmark = pytest.mark.asyncio
@@ -150,6 +155,69 @@ async def test_copy_raises_when_source_credential_unresolvable(
 
     fork_binding = await get_binding(db_session, tenant_id=tenant.id, agent_id=fork_agent_uuid)
     assert fork_binding is None, "no partial write on the fail-loud path"
+
+
+async def test_copy_raises_even_with_operator_fallback_configured(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    """Regression guard: copy_credential_and_repo_binding has no wiring to
+    receive an operator fallback PAT at all (no settings/
+    allow_service_default/fallback_pat parameter exists on this function) --
+    an inline-pat source with no resolvable credential must still fail loud
+    and write nothing for the fork, even in an environment where
+    settings.github.fallback_pat IS configured. This proves the fork path
+    cannot silently inherit the shared operator secret, structurally, not
+    just by convention."""
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    source_agent_uuid = uuid.uuid4()
+    fork_agent_uuid = uuid.uuid4()
+
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    # An ambient operator fallback PAT is configured in this environment --
+    # copy_credential_and_repo_binding takes no settings/fallback_pat
+    # parameter, so it structurally cannot see or use it.
+    fallback_settings = Settings(
+        database=DatabaseSettings(
+            url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon"),
+        ),
+        anthropic=AnthropicSettings(
+            api_key=SecretStr("sk-test"),
+            base_url=HttpUrl("https://api.anthropic.com"),
+        ),
+        github=GithubSettings(fallback_pat=SecretStr("ghp_operator_fallback")),
+    )
+    assert fallback_settings.github.fallback_pat is not None, "sanity: fallback is configured"
+
+    async with db_session_factory() as s, s.begin():
+        await set_binding(
+            s,
+            tenant_id=tenant.id,
+            agent_id=source_agent_uuid,
+            repo_url="github.com/acme/repo",
+            default_branch="main",
+            ma_secret_ref=f"inline-pat:{source_agent_uuid}",
+        )
+
+    with pytest.raises(DaimonError, match="github git-proxy"):
+        await copy_credential_and_repo_binding(
+            anthropic=_refusing_anthropic(),  # type: ignore[arg-type]
+            sessionmaker=db_session_factory,
+            fernet=fernet,
+            oauth_scopes=_OAUTH_SCOPES,
+            tenant_id=tenant.id,
+            source_agent_uuid=source_agent_uuid,
+            fork_agent_uuid=fork_agent_uuid,
+        )
+
+    fork_binding = await get_binding(db_session, tenant_id=tenant.id, agent_id=fork_agent_uuid)
+    assert fork_binding is None, "no partial binding write on the fail-loud path"
+    fork_credential = await get_credential_by_principal(db_session, principal_id=fork_agent_uuid)
+    assert fork_credential is None, (
+        "no github_credentials row for the fork -- the fallback was never persisted"
+    )
 
 
 async def test_copy_anon_binding_without_error_or_credential_write(

--- a/packages/core/tests/test_credential_requests.py
+++ b/packages/core/tests/test_credential_requests.py
@@ -1,0 +1,71 @@
+"""Unit tests for the credential-request wire contract (no I/O, no DB)."""
+
+from __future__ import annotations
+
+from daimon.core.credential_requests import (
+    CUSTOM_ID_PATTERN,
+    MAX_BUTTON_LABEL_CHARS,
+    build_button_label,
+    build_custom_id,
+    mint_request_token,
+)
+
+
+def test_mint_request_token_returns_fresh_string_each_call() -> None:
+    first = mint_request_token()
+    second = mint_request_token()
+    assert first != second, "two mints must never collide"
+
+
+def test_build_custom_id_prefixes_the_token() -> None:
+    token = mint_request_token()
+    assert build_custom_id(token) == f"ztc:{token}"
+
+
+def test_build_custom_id_stays_within_discord_custom_id_limit() -> None:
+    custom_id = build_custom_id(mint_request_token())
+    assert len(custom_id) <= 100, "custom_id must fit Discord's 100-char cap"
+
+
+def test_custom_id_pattern_fullmatches_a_minted_custom_id_and_round_trips_the_token() -> None:
+    token = mint_request_token()
+    custom_id = build_custom_id(token)
+
+    match = CUSTOM_ID_PATTERN.fullmatch(custom_id)
+
+    assert match is not None, "the template must fullmatch a real minted custom_id"
+    assert match["token"] == token, "the token group must round-trip the minted token"
+
+
+def test_custom_id_pattern_rejects_bare_prefix() -> None:
+    assert CUSTOM_ID_PATTERN.fullmatch("ztc:") is None, "a token-less custom_id must not match"
+
+
+def test_custom_id_pattern_rejects_token_with_disallowed_characters() -> None:
+    assert CUSTOM_ID_PATTERN.fullmatch("ztc:abc def") is None, (
+        "a space is outside the allowed token charset"
+    )
+
+
+def test_custom_id_pattern_rejects_wrong_prefix() -> None:
+    token = mint_request_token()
+    assert CUSTOM_ID_PATTERN.fullmatch(f"xyz:{token}") is None, (
+        "a custom_id minted by an unrelated feature must not match this template"
+    )
+
+
+def test_build_button_label_env() -> None:
+    assert build_button_label("env", "OPENAI_API_KEY") == "Add env credential: OPENAI_API_KEY"
+
+
+def test_build_button_label_mcp() -> None:
+    assert build_button_label("mcp", "linear") == "Add MCP credential: linear"
+
+
+def test_build_button_label_truncates_long_target_within_discord_label_limit() -> None:
+    label = build_button_label("mcp", "x" * 200)
+
+    assert len(label) <= MAX_BUTTON_LABEL_CHARS, "label must fit Discord's 80-char button limit"
+    assert label.startswith("Add MCP credential: "), (
+        "truncation must not lose the human-readable prefix"
+    )

--- a/packages/core/tests/test_github_credentials.py
+++ b/packages/core/tests/test_github_credentials.py
@@ -217,3 +217,165 @@ async def test_get_github_login_agent_no_overlay_returns_none(
         sessionmaker=db_session_factory,
     )
     assert result is None, "get_github_login(agent_id=X) with no overlay binding must return None"
+
+
+# --- Opt-in operator service-default tier (allow_service_default + fallback_pat) ---
+
+
+async def test_get_pat_agent_unbound_returns_fallback_when_opted_in(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+) -> None:
+    """agent_id given, no binding row at all, opted in with a fallback value
+    -> the fallback wins (no bleed to principal-default; still no real credential)."""
+    result = await get_pat(
+        principal_id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        allow_service_default=True,
+        fallback_pat="ghp_service",
+    )
+    assert result == "ghp_service", (
+        "get_pat must return the fallback when opted in and no binding resolves"
+    )
+
+
+async def test_get_pat_agent_bound_no_credential_returns_fallback_when_opted_in(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+) -> None:
+    """agent_id given, binding row exists but the bound principal has no
+    credential row -> opted-in fallback still resolves."""
+    agent_id = uuid.uuid4()
+    unbound_principal_id = uuid.uuid4()  # no credential row for this principal
+    async with db_session_factory.begin() as session:
+        session.add(AgentGithubBinding(agent_id=agent_id, principal_id=unbound_principal_id))
+
+    result = await get_pat(
+        principal_id=uuid.uuid4(),
+        agent_id=agent_id,
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        allow_service_default=True,
+        fallback_pat="ghp_service",
+    )
+    assert result == "ghp_service", (
+        "get_pat must return the fallback when the bound principal has no credential row"
+    )
+
+
+async def test_get_pat_agent_overlay_credential_wins_over_fallback(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+) -> None:
+    """A real overlay credential must win over a configured fallback — the
+    fallback can never shadow a resolved real credential."""
+    overlay_principal_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    await upsert_credential_encrypted(
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        principal_id=overlay_principal_id,
+        github_login="overlay-user",
+        plaintext_token="ghp_overlay",
+        scopes=("repo",),
+    )
+    async with db_session_factory.begin() as session:
+        session.add(AgentGithubBinding(agent_id=agent_id, principal_id=overlay_principal_id))
+
+    result = await get_pat(
+        principal_id=uuid.uuid4(),
+        agent_id=agent_id,
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        allow_service_default=True,
+        fallback_pat="ghp_service",
+    )
+    assert result == "ghp_overlay", (
+        "a resolved overlay credential must win over the fallback, never be shadowed by it"
+    )
+
+
+async def test_get_pat_agent_path_fallback_none_still_resolves_none(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+) -> None:
+    """allow_service_default=True alone (fallback_pat=None) resolves None —
+    the flag is the authorization, the value is the payload; neither alone does anything."""
+    result = await get_pat(
+        principal_id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        allow_service_default=True,
+        fallback_pat=None,
+    )
+    assert result is None, (
+        "allow_service_default=True with fallback_pat=None must still resolve None"
+    )
+
+
+async def test_get_pat_principal_default_path_returns_fallback_when_opted_in(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+) -> None:
+    """agent_id=None, no principal-default credential -> opted-in fallback wins."""
+    result = await get_pat(
+        principal_id=uuid.uuid4(),
+        agent_id=None,
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        allow_service_default=True,
+        fallback_pat="ghp_service",
+    )
+    assert result == "ghp_service", (
+        "get_pat(agent_id=None) must return the fallback when opted in and unbound"
+    )
+
+
+async def test_get_pat_principal_default_credential_wins_over_fallback(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+) -> None:
+    """agent_id=None with a real principal-default credential -> that credential
+    wins over the fallback."""
+    principal_id = uuid.uuid4()
+    await upsert_credential_encrypted(
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        principal_id=principal_id,
+        github_login="octocat",
+        plaintext_token="ghp_principal_default",
+        scopes=("repo",),
+    )
+
+    result = await get_pat(
+        principal_id=principal_id,
+        agent_id=None,
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        allow_service_default=True,
+        fallback_pat="ghp_service",
+    )
+    assert result == "ghp_principal_default", (
+        "the real principal-default credential must win over the fallback"
+    )
+
+
+async def test_get_pat_fallback_value_alone_without_flag_resolves_none(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+) -> None:
+    """fallback_pat set but allow_service_default left at its False default ->
+    the value alone must never leak without the flag."""
+    result = await get_pat(
+        principal_id=uuid.uuid4(),
+        agent_id=None,
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        fallback_pat="ghp_service",
+    )
+    assert result is None, (
+        "fallback_pat set without allow_service_default=True must never leak the value"
+    )

--- a/packages/core/tests/test_privacy.py
+++ b/packages/core/tests/test_privacy.py
@@ -10,7 +10,7 @@ fails CI if `PurgeReport` grows a category that `PurgePreview` does not mirror
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from daimon.core._models import (
     Account,
@@ -22,6 +22,7 @@ from daimon.core._models import (
     Routine,
     UserConfig,
 )
+from daimon.core.credential_requests import mint_request_token
 from daimon.core.privacy import (
     PurgePreview,
     PurgePreviewRow,
@@ -29,6 +30,7 @@ from daimon.core.privacy import (
 )
 from daimon.core.purge import PurgeReport, purge_account
 from daimon.core.stores import agent_github_binding as agent_github_binding_store
+from daimon.core.stores import credential_requests as credential_requests_store
 from daimon.core.stores import github_credentials as github_credentials_store
 from daimon.core.stores import mcp_tokens as mcp_tokens_store
 from daimon.core.stores import routines as routines_store
@@ -395,6 +397,47 @@ async def test_collect_purge_preview_counts_slack_user_tokens_and_turn_contexts(
     )
 
 
+async def test_collect_purge_preview_credential_requests_matches_purge_account(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Preview counts credential_requests and agrees with purge_account's
+    actual deletion count — the right-to-erasure parity contract."""
+    tenant = await make_tenant(db_session, workspace_id="pv-cred-req")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="PV_CRED_TARGET",
+        tenant=tenant,
+        account=account,
+    )
+    await credential_requests_store.create_credential_request(
+        db_session,
+        token=mint_request_token(),
+        kind="env",
+        tenant_id=tenant.id,
+        agent_id=uuid.uuid4(),
+        account_id=account.id,
+        target="OPENAI_API_KEY",
+        mcp_server_url=None,
+        requester_platform_user_id="PV_CRED_TARGET",
+        channel_id="C1",
+        expires_at=datetime.now(tz=UTC) + timedelta(minutes=30),
+    )
+    await db_session.commit()
+
+    preview = await collect_purge_preview(sm=db_session_factory, account_id=account.id)
+    report = await purge_account(sm=db_session_factory, account_id=account.id)
+
+    assert preview.credential_requests.count == 1, (
+        "must count the platform principal's credential-request row"
+    )
+    assert preview.credential_requests.count == report.db.credential_requests, (
+        "preview and purge must agree on credential_requests"
+    )
+
+
 async def test_collect_purge_preview_matches_purge_account_coverage_field_for_field() -> None:
     """If `PurgeReport` grows a new int field, `PurgePreview` MUST mirror it.
 
@@ -422,6 +465,7 @@ async def test_collect_purge_preview_matches_purge_account_coverage_field_for_fi
         "agent_github_binding": "agent_github_binding",
         "slack_user_tokens": "slack_user_tokens",
         "slack_turn_contexts": "slack_turn_contexts",
+        "credential_requests": "credential_requests",
     }
 
     uncovered = report_fields - set(mapping.keys())

--- a/packages/core/tests/test_purge.py
+++ b/packages/core/tests/test_purge.py
@@ -28,6 +28,7 @@ from daimon.core._models import (
     TenantConfig,
     UserConfig,
 )
+from daimon.core.credential_requests import mint_request_token
 from daimon.core.purge import (
     AccountPurgeResult,
     PrincipalPurgeResult,
@@ -35,6 +36,7 @@ from daimon.core.purge import (
     purge_account,
     purge_principal,
 )
+from daimon.core.stores import credential_requests as credential_requests_store
 from daimon.core.stores import github_credentials as github_credentials_store
 from daimon.core.stores import github_oauth_states as github_oauth_states_store
 from daimon.core.stores import routines as routines_store
@@ -1387,3 +1389,111 @@ async def test_purge_principal_upstream_failure_after_commit_reports_upstream_er
         "post-commit upstream APIError must be folded into sessions.upstream_error"
     )
     assert result.sessions.deleted == 0, "no sessions were deleted before the failure"
+
+
+async def test_purge_principal_platform_deletes_credential_request_and_reports_count(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Platform principal purge removes its credential-request row and reports the count."""
+    from datetime import UTC, datetime, timedelta
+
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    pp = await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="user-cred-req",
+        tenant=tenant,
+        account=account,
+    )
+    await credential_requests_store.create_credential_request(
+        db_session,
+        token=mint_request_token(),
+        kind="env",
+        tenant_id=tenant.id,
+        agent_id=uuid.uuid4(),
+        account_id=account.id,
+        target="OPENAI_API_KEY",
+        mcp_server_url=None,
+        requester_platform_user_id="user-cred-req",
+        channel_id="C1",
+        expires_at=datetime.now(tz=UTC) + timedelta(minutes=30),
+    )
+    await db_session.commit()
+
+    report = await purge_principal(sm=db_session_factory, principal_id=pp.id, kind="platform")
+
+    assert report.db.credential_requests == 1, "must delete the platform principal's request row"
+
+
+async def test_purge_principal_cli_credential_requests_reports_zero_when_none_exist(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """CLI principal purge runs the same delete for its platform user id, reporting 0."""
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    cli = await make_cli_principal(
+        db_session, os_user="cli-cred-req", tenant=tenant, account=account
+    )
+    await db_session.commit()
+
+    report = await purge_principal(sm=db_session_factory, principal_id=cli.id, kind="cli")
+
+    assert report.db.credential_requests == 0, "CLI principals own no credential-request rows"
+
+
+async def test_purge_principal_credential_requests_does_not_delete_same_user_in_other_tenant(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A same-platform-user-id credential-request row under a DIFFERENT tenant must survive."""
+    from datetime import UTC, datetime, timedelta
+
+    tenant_a = await make_tenant(db_session, workspace_id="cred-req-guild-a")
+    tenant_b = await make_tenant(db_session, workspace_id="cred-req-guild-b")
+    account_a = await make_account(db_session, tenant=tenant_a)
+    pp_a = await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="shared-user-id",
+        tenant=tenant_a,
+        account=account_a,
+    )
+    # A DIFFERENT tenant's row, same platform_user_id.
+    await credential_requests_store.create_credential_request(
+        db_session,
+        token=mint_request_token(),
+        kind="env",
+        tenant_id=tenant_b.id,
+        agent_id=uuid.uuid4(),
+        account_id=uuid.uuid4(),
+        target="OPENAI_API_KEY",
+        mcp_server_url=None,
+        requester_platform_user_id="shared-user-id",
+        channel_id="C1",
+        expires_at=datetime.now(tz=UTC) + timedelta(minutes=30),
+    )
+    await credential_requests_store.create_credential_request(
+        db_session,
+        token=mint_request_token(),
+        kind="env",
+        tenant_id=tenant_a.id,
+        agent_id=uuid.uuid4(),
+        account_id=account_a.id,
+        target="OPENAI_API_KEY",
+        mcp_server_url=None,
+        requester_platform_user_id="shared-user-id",
+        channel_id="C1",
+        expires_at=datetime.now(tz=UTC) + timedelta(minutes=30),
+    )
+    await db_session.commit()
+
+    report = await purge_principal(sm=db_session_factory, principal_id=pp_a.id, kind="platform")
+
+    assert report.db.credential_requests == 1, "only tenant A's row must be deleted"
+    surviving = await credential_requests_store.count_credential_requests_for_platform_user(
+        db_session, platform_user_id="shared-user-id", tenant_id=tenant_b.id
+    )
+    assert surviving == 1, "the other tenant's same-user-id row must survive"

--- a/packages/core/tests/test_sessions.py
+++ b/packages/core/tests/test_sessions.py
@@ -1267,6 +1267,129 @@ async def test_create_session_skips_copilot_when_no_pat(
     assert len(session_bodies) == 1
 
 
+async def test_create_session_never_mirrors_fallback_pat_into_copilot_vault(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An agent with no per-agent PAT but a configured operator fallback still
+    gets NO Copilot vault credential -- the fallback must never be mirrored
+    into a per-agent MA vault. This is a regression guard: the signature
+    change that added allow_service_default/fallback_pat to get_pat makes it
+    newly *possible* for this call site to opt in; sessions.py's single
+    get_pat call (feeding both the Copilot mirror and the clone resolver)
+    must stay at the default so this never happens."""
+    tenant = await make_tenant(db_session)
+    agent_uuid = uuid.uuid4()
+    account_id = uuid.UUID("00000000-0000-0000-0000-0000000000c2")
+    public_url = "https://mcp.example.com/mcp"
+    await _seed_anon_binding(db_session, tenant_id=tenant.id, agent_uuid=agent_uuid)
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+
+    agent = _make_agent(anthropic_id="ag_fallback_novault")
+    env = _make_env(anthropic_id="env_fallback_novault")
+    cred_bodies: list[dict[str, Any]] = []
+    session_bodies: list[dict[str, Any]] = []
+    client = build_fake_anthropic_http(
+        _warm_vault_copilot_handler(
+            account_id=account_id,
+            agent_uuid=agent_uuid,
+            public_url=public_url,
+            credential_post_bodies=cred_bodies,
+            session_create_bodies=session_bodies,
+            session_id="sess_fallback_novault",
+        )
+    )
+
+    await create_session(
+        client,
+        agent=agent,
+        environment=env,
+        account_id=account_id,
+        mcp_settings=McpSettings(jwt_secret=SecretStr("x" * 32), public_url=HttpUrl(public_url)),
+        tenant_id=tenant.id,
+        agent_uuid=agent_uuid,
+        session_factory=db_session_factory,
+        fernet=fernet,
+        github_fallback_pat="ghp_operator_fallback",
+    )
+
+    assert len(cred_bodies) == 0, (
+        "the operator fallback PAT must never be mirrored into a per-agent Copilot vault "
+        "credential, even when a repo binding resolves it for the clone resource"
+    )
+    assert len(session_bodies) == 1, "the session is still created"
+    resources = _without_memory_resource(session_bodies[0].get("resources"))
+    assert resources == [
+        {
+            "type": "github_repository",
+            "url": "https://github.com/example-org/example-repo",
+            "authorization_token": "ghp_operator_fallback",
+            "checkout": {"type": "branch", "name": "main"},
+        }
+    ], "the clone resource still resolves via the fallback -- only the Copilot mirror is guarded"
+
+
+async def test_create_session_app_installation_token_wins_over_fallback_for_anon_binding(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An anon: (verified-public) binding with a configured GitHub App
+    installation AND a configured operator fallback must clone via the
+    installation token, not the fallback -- the App keeps winning. Regression
+    guard for the resolve_clone_token ordering (per_agent_pat -> App ->
+    fallback) now that get_pat can itself resolve a fallback: sessions.py
+    must keep passing per_agent_pat=None to resolve_clone_token so the App
+    branch is reached first, exactly as before this phase's changes."""
+    tenant = await make_tenant(db_session)
+    agent_uuid = uuid.uuid4()
+    await _seed_anon_binding(db_session, tenant_id=tenant.id, agent_uuid=agent_uuid)
+
+    agent = _make_agent(anthropic_id="ag_app_over_fallback")
+    env = _make_env(anthropic_id="env_app_over_fallback")
+    bodies: list[dict[str, Any]] = []
+    client = build_fake_anthropic_http(
+        _files_and_session_handler(
+            file_id="file_unused",
+            session_id="sess_app_over_fallback",
+            session_create_bodies=bodies,
+        )
+    )
+
+    def github_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/example-org/example-repo/installation":
+            return httpx.Response(status_code=200, json={"id": 4242})
+        if request.url.path == "/app/installations/4242/access_tokens":
+            return httpx.Response(status_code=201, json={"token": "ghs_installation_wins"})
+        raise AssertionError(f"unexpected GitHub request: {request.method} {request.url}")
+
+    github_client = httpx.AsyncClient(transport=httpx.MockTransport(github_handler))
+
+    await create_session(
+        client,
+        agent=agent,
+        environment=env,
+        tenant_id=tenant.id,
+        agent_uuid=agent_uuid,
+        session_factory=db_session_factory,
+        github_fallback_pat="ghp_operator_fallback",
+        github_app_id="12345",
+        github_app_private_key=_generate_rsa_keypair(),
+        http_client=github_client,
+    )
+    await github_client.aclose()
+
+    assert len(bodies) == 1, "exactly one session-create call"
+    resources = _without_memory_resource(bodies[0].get("resources"))
+    assert resources == [
+        {
+            "type": "github_repository",
+            "url": "https://github.com/example-org/example-repo",
+            "authorization_token": "ghs_installation_wins",
+            "checkout": {"type": "branch", "name": "main"},
+        }
+    ], "the App installation token must win over a configured operator fallback"
+
+
 def _warm_vault_copilot_500_handler(
     *,
     account_id: uuid.UUID,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ source_modules = [
     "daimon.core.broker",
     "daimon.core.config",
     "daimon.core.constants",
+    "daimon.core.credential_requests",
     "daimon.core.db",
     "daimon.core.errors",
     "daimon.core.headless_runner",


### PR DESCRIPTION
## Summary

Two pieces of onboarding friction removed, so a freshly installed bot is useful
without the operator hand-configuring each agent.

**1. No agent starts credential-empty.** The deployment-wide
`github.fallback_pat` becomes a resolved default for GitHub reads, so an agent
with no linked account can clone public repos and sync public skills. This
setting already existed but was wired into exactly one branch of the clone
resolver; the token broker raised `NoBindingError` for every other public-read
path.

**2. Credentials can be attached from chat.** When an agent needs an env secret
or an auth-required MCP server, it now posts a single-use, expiring button
naming the exact key or server. Clicking it opens a native Discord modal, so
the secret never enters channel history or the agent transcript. This replaces
the previous "go open `/agent-setup`" redirect without weakening the rule that
tokens must not be pasted into chat.

Discord only — the Slack equivalent needs a send path that does not exist yet,
and is deliberately left for a follow-up.

## Changes

**Core**
- `daimon.core.credential_requests` — pure wire contract (opaque token mint,
  `custom_id` builder, button label). Lives in core so the MCP server and the
  Discord bot, which may not import each other, share one format.
- `credential_requests` table + migration `0003`, with an atomic single-use
  consume (`UPDATE … WHERE used_at IS NULL AND expires_at > now RETURNING`).
- `get_pat` gains `allow_service_default` **and** a companion `fallback_pat`
  value (it is a pure DB resolver with no access to settings, so the flag alone
  would be inert). Default is off, so no existing caller changes behaviour.
- Erasure: credential requests are covered by the account/principal purge
  cascade and the privacy preview.

**Discord**
- `CredentialRequestButton`, a `discord.ui.DynamicItem` registered once in
  `setup_hook`. This is a deliberate, documented exception to the
  otherwise-global rule that views are non-persistent — the button is posted by
  a different process than the one that handles the click, so it cannot rely on
  an in-memory handler.
- Two single-field modals reusing the existing credential write paths verbatim.
- Agent panel gains a third GitHub state for "public access via the shared
  service account", and a private-repo bind is now refused at bind time with an
  actionable message rather than GitHub's bare 404.

**MCP**
- `request_env_credential` and `request_mcp_credential`. Neither takes a token
  parameter — that is the point of the flow. `attach_mcp_server` still has no
  token parameter either.
- Seeded agent guidance rewritten: a pasted token is still refused, and the user
  is now told to rotate it, since it has already reached channel history.

## Why the default credential is public-read-only

The shared token is scope-free: it can read public repos and nothing else. Write
operations still require a user to link their own account, and fail with a
message saying so. The design deliberately prevents the shared credential from
ever becoming durable per-agent state — forking an agent does not copy it into a
credential row, the Copilot mirror does not mount it into a vault, the
self-edit path does not upload it as a stored credential, and an installed
GitHub App still takes precedence for clone tokens. Five regression tests assert
each of those paths still resolves to "no credential" for an unbound agent.

## Verification

- [x] Full suite: 3486 passed, 4 skipped
- [x] pyright (strict, project-wide), import-linter, ruff check + format,
      test anti-pattern lint, migration downgrade-marker lint, Discord modal
      lint, `.env.example` staleness — all pass
- [x] Single-use consumption is covered by a test racing two independent
      Postgres connections; the test was mutation-checked (it fails when the
      `used_at IS NULL` guard is removed)
- [x] The cross-process button contract is guaranteed by construction — poster
      and handler both derive the `custom_id` from the same core builder, with a
      test on each side
- [ ] Manual, needs a live gateway: click a posted button from a second Discord
      account and confirm the non-requester is rejected

## Notes for deploy

- Seeded agent defaults changed, so `daimon defaults apply` is required for the
  running agent to pick up the new guidance.
- The fallback credential must have a populated secret version, or the new
  default resolves to nothing. It had never been populated before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
