### PR TITLE
feat: cut Slack over to the shared turn orchestrator path

### DIFF
--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import functools
 import time
 import uuid
 from collections.abc import Coroutine
@@ -81,24 +80,13 @@ from daimon.adapters.slack.vision import (
     download_as_image_blocks,
     is_vision_image,
 )
-from daimon.core.billing import is_over_cap
-from daimon.core.defaults.provisioning import reconcile_tenant_defaults, teardown_slack_install
+from daimon.core.defaults.provisioning import teardown_slack_install
 from daimon.core.errors import DaimonError
 from daimon.core.github_credentials import build_multifernet, decrypt_token
-from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
-from daimon.core.ma_resolver import (
-    MAResolverMissError,
-    new_resolver_cache,
-    resolve_agent,
-    resolve_environment,
-)
+from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.ma_resolver import MAResolverMissError
 from daimon.core.observability import capture_exception_with_scope
-from daimon.core.pricing import MODEL_PRICING
-from daimon.core.scope import ScopeContext
-from daimon.core.sessions import create_session
 from daimon.core.slack_oauth import build_slack_connect_url
-from daimon.core.stores.identity import get_or_create_platform_principal
-from daimon.core.stores.scoped_config_read import resolve as resolve_config
 from daimon.core.stores.slack_bot_tokens import get_slack_bot_token
 from daimon.core.stores.slack_connect_prompts import mark_connect_prompted, was_connect_prompted
 from daimon.core.stores.slack_event_dedup import insert_if_new
@@ -107,16 +95,12 @@ from daimon.core.stores.slack_turn_contexts import (
     delete_slack_turn_context,
 )
 from daimon.core.stores.slack_user_tokens import get_slack_user_token
-from daimon.core.stores.thread_sessions import (
-    create_thread_session,
-    get_live_thread_session,
-    update_watermark,
-)
-from daimon.core.tenant_balance import is_over_balance
-from daimon.core.turn.driver import run_turn
+from daimon.core.stores.thread_sessions import update_watermark
+from daimon.core.turn.admission import AdmissionDenied, MissingTurnConfigError, admit
 from daimon.core.turn.gating import should_admit_turn
-from daimon.core.turn.posture import Billed, UsageRecorder
-from daimon.core.usage_recording import record_turn_usage
+from daimon.core.turn.lifecycle import TurnLifecycle
+from daimon.core.turn.prepare import bind_session
+from daimon.core.turn.run import run_prepared_turn
 from slack_sdk.errors import SlackApiError
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
@@ -917,51 +901,31 @@ class SlackApp:
         No try/except — errors propagate to the listener boundary in
         ``_handle_app_mention``.
         """
-        # --- Identity ---
-        async with self.runtime.sessionmaker() as s:
-            principal = await get_or_create_platform_principal(
-                s,
+        # --- Stage one: admission (identity, config cascade, missing-config
+        # bail, MA resolve/retrieve, balance gate, cap gate) -- D-01 admit(). ---
+        try:
+            admission = await admit(
+                self.runtime.turn_deps,
                 tenant_id=tenant_id,
                 platform="slack",
-                external_id=str(event.get("user") or ""),
+                external_user_id=str(event.get("user") or ""),
+                channel_id=channel,
+                now=datetime.now(UTC),
             )
-            await s.commit()
-
-        # --- Config resolution (mirror bot.py:776-815): channel → tenant →
-        # deployment cascade, so /agent-setup propagations take effect here.
-        # Runs on EVERY turn (new session or reused) so admission gates and
-        # usage_record below always have a resolved agent/model to bind against.
-        async with self.runtime.sessionmaker() as s:
-            config = await resolve_config(
-                s,
-                context=ScopeContext(
-                    tenant_id=tenant_id,
-                    channel_id=channel,
-                    account_id=principal.account_id,
-                ),
-                default=self.runtime.deployment_default,
-            )
-        agent_tag = config.agent_name
-        environment_tag = config.environment_name
-        if agent_tag is None or environment_tag is None:
-            missing = [
-                name
-                for name, value in (("agent", agent_tag), ("environment", environment_tag))
-                if value is None
-            ]
+        except MissingTurnConfigError as err:
             log.info(
                 "slack.missing_config",
                 team_id=team_id,
                 channel_id=channel,
-                missing=missing,
+                missing=list(err.missing),
             )
             hints: list[str] = []
-            if agent_tag is None:
+            if "agent" in err.missing:
                 hints.append(
                     "An admin can set the default agent in `/agent-setup` → "
                     "*Set as default…* → [This channel] or [Whole workspace]."
                 )
-            if environment_tag is None:
+            if "environment" in err.missing:
                 hints.append(
                     "Environment is operator-only — an operator can set it via the CLI "
                     "(`daimon config set environment_name=...`)."
@@ -969,42 +933,11 @@ class SlackApp:
             await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
                 channel=channel,
                 thread_ts=thread_id,
-                text=(f"No {' or '.join(missing)} configured for this channel. " + " ".join(hints)),
+                text=(
+                    f"No {' or '.join(err.missing)} configured for this channel. " + " ".join(hints)
+                ),
             )
             return
-
-        resolver_cache = new_resolver_cache()
-        public_url = (
-            str(self.runtime.settings.mcp.public_url)
-            if self.runtime.settings.mcp.public_url is not None
-            else None
-        )
-
-        async def _apply() -> object:
-            return await reconcile_tenant_defaults(
-                self.runtime.anthropic,
-                self.runtime.settings.defaults_root,
-                tenant_id=tenant_id,
-                public_url=public_url,
-            )
-
-        try:
-            agent_id = await resolve_agent(
-                self.runtime.anthropic,
-                tenant_id=tenant_id,
-                daimon_tag=agent_tag,
-                apply_callable=_apply,
-                cache=resolver_cache,
-                cached_id=None,
-            )
-            env_id = await resolve_environment(
-                self.runtime.anthropic,
-                tenant_id=tenant_id,
-                daimon_tag=environment_tag,
-                apply_callable=_apply,
-                cache=resolver_cache,
-                cached_id=None,
-            )
         except MAResolverMissError as err:
             log.warning(
                 "slack.resolver.miss",
@@ -1023,138 +956,69 @@ class SlackApp:
                 ),
             )
             return
-        agent = await self.runtime.anthropic.beta.agents.retrieve(agent_id)
-        agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(agent.id))
+        except AdmissionDenied as err:
+            if err.reason == "balance_depleted":
+                log.info(
+                    "turn.skipped.over_balance",
+                    tenant_id=str(tenant_id),
+                    team_id=team_id,
+                    channel_id=channel,
+                    thread_id=thread_id,
+                )
+                await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
+                    channel=channel,
+                    thread_ts=thread_id,
+                    text=(
+                        "This workspace's daimon credit is depleted. "
+                        "An admin can top up with `/billing`."
+                    ),
+                )
+            else:
+                log.info(
+                    "turn.skipped.over_cap",
+                    tenant_id=str(tenant_id),
+                    user_id=str(event.get("user") or ""),
+                    team_id=team_id,
+                    channel_id=channel,
+                    thread_id=thread_id,
+                )
+                await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
+                    channel=channel,
+                    thread_ts=thread_id,
+                    text=(
+                        "Monthly usage cap reached for this workspace. "
+                        "An admin can adjust the cap with `/billing` (when available)."
+                    ),
+                )
+            return
+
+        agent = admission.agent
         _lc_agent_name: str = agent.name
         _lc_model_id: str = agent.model.id
-        env = await self.runtime.anthropic.beta.environments.retrieve(env_id)
 
-        # --- Admission gate: per-tenant balance — independent of Stripe config ---
-        if await is_over_balance(sessionmaker=self.runtime.sessionmaker, tenant_id=tenant_id):
-            log.info(
-                "turn.skipped.over_balance",
-                tenant_id=str(tenant_id),
-                team_id=team_id,
-                channel_id=channel,
-                thread_id=thread_id,
-            )
-            await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
-                channel=channel,
-                thread_ts=thread_id,
-                text=(
-                    "This workspace's daimon credit is depleted. "
-                    "An admin can top up with `/billing`."
-                ),
-            )
-            return
-
-        # --- Admission gate: monthly usage cap ---
-        over_cap = await is_over_cap(
-            billing_config=self.runtime.billing_config,
-            sessionmaker=self.runtime.sessionmaker,
+        # --- Stage two: bind_session (find-or-create, mapping write,
+        # recorder binding) -- D-01 bind_session(). Slack has no
+        # per_caller_thread_sessions equivalent: session_account_id is always
+        # the admitted caller's account, and threads always pre-exist. ---
+        prepared = await bind_session(
+            self.runtime.turn_deps,
+            admission,
             tenant_id=tenant_id,
-            user_id=str(event.get("user") or ""),
-            now=datetime.now(UTC),
+            platform="slack",
+            external_user_id=str(event.get("user") or ""),
+            thread_id=thread_id,
+            session_account_id=admission.account_id,
+            reuse_existing=True,
         )
-        if over_cap:
-            log.info(
-                "turn.skipped.over_cap",
-                tenant_id=str(tenant_id),
-                user_id=str(event.get("user") or ""),
-                team_id=team_id,
-                channel_id=channel,
-                thread_id=thread_id,
-            )
-            await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
-                channel=channel,
-                thread_ts=thread_id,
-                text=(
-                    "Monthly usage cap reached for this workspace. "
-                    "An admin can adjust the cap with `/billing` (when available)."
-                ),
-            )
-            return
-
-        # --- Session find-or-create ---
-        async with self.runtime.sessionmaker() as s:
-            existing = await get_live_thread_session(
-                s,
-                tenant_id=tenant_id,
-                platform="slack",
-                thread_id=thread_id,
-                account_id=principal.account_id,
-            )
-
-        ma_session_id: str
-        mapping_id: uuid.UUID
-        watermark: str | None
-        reused: bool
-
-        if existing is not None:
-            ma_session_id = existing.ma_session_id
-            mapping_id = existing.id
-            watermark = existing.watermark_message_id
-            reused = True
-            log.info(
-                "slack.session.reused",
-                session_id=ma_session_id,
-                thread_id=thread_id,
-                watermark=watermark,
-            )
-        else:
-            # Create a fresh MA session (mirror bot.py:852-871).
-            ma_session = await create_session(
-                self.runtime.anthropic,
-                agent=agent,
-                environment=env,
-                mcp_settings=self.runtime.settings.mcp,
-                tenant_id=tenant_id,
-                account_id=principal.account_id,
-                agent_uuid=agent_uuid,
-                session_factory=self.runtime.sessionmaker,
-                github_fallback_pat=(
-                    self.runtime.settings.github.fallback_pat.get_secret_value()
-                    if self.runtime.settings.github.fallback_pat is not None
-                    else None
-                ),
-                github_app_id=self.runtime.settings.github.app_id,
-                github_app_private_key=(
-                    self.runtime.settings.github.app_private_key.get_secret_value()
-                    if self.runtime.settings.github.app_private_key is not None
-                    else None
-                ),
-            )
-            ma_session_id = ma_session.id
-
-            async with self.runtime.sessionmaker() as s:
-                row = await create_thread_session(
-                    s,
-                    tenant_id=tenant_id,
-                    platform="slack",
-                    thread_id=thread_id,
-                    account_id=principal.account_id,
-                    ma_session_id=ma_session_id,
-                )
-                await s.commit()
-            mapping_id = row.id
-            watermark = None
-            reused = False
-            log.info(
-                "slack.session.created",
-                session_id=ma_session_id,
-                thread_id=thread_id,
-            )
-
-        # --- usage_record binding: unconditional, mirrors bot.py:1107-1116 ---
-        usage_record: UsageRecorder = functools.partial(
-            record_turn_usage,
-            sessionmaker=self.runtime.sessionmaker,
-            platform_user_id=str(event.get("user") or ""),
-            managed_session_id=ma_session_id,
-            model_id=agent.model.id,
-            tenant_id=tenant_id,
-            markup=self.runtime.settings.billing.markup,
-            pricing=MODEL_PRICING.get(agent.model.id),
+        ma_session_id = prepared.ma_session_id
+        watermark = prepared.watermark
+        reused = prepared.reused
+        log.info(
+            "slack.session.ready",
+            session_id=ma_session_id,
+            thread_id=thread_id,
+            reused=reused,
+            watermark=watermark,
         )
 
         # --- Build user message ---
@@ -1213,8 +1077,9 @@ class SlackApp:
         skipped_ids = {f["id"] for f, _ in images_skipped}
         inlined = [f for f in trigger_images if f["id"] not in skipped_ids]
 
+        synthetic_prefix = ""
         if proxy_ctx is not None:
-            prefix = "\n".join(
+            synthetic_prefix = "\n".join(
                 part
                 for part in (
                     build_attachment_url_prefix(data_files, proxy_ctx),
@@ -1223,8 +1088,8 @@ class SlackApp:
                 )
                 if part
             )
-            if prefix:
-                user_message = prefix + "\n" + user_message
+            if synthetic_prefix:
+                user_message = synthetic_prefix + "\n" + user_message
 
             # Only claim the images were "linked" when the proxy is configured —
             # that's the branch that actually minted fetchable URLs into the prefix.
@@ -1239,7 +1104,12 @@ class SlackApp:
                     ),
                 )
 
-        # --- Run turn ---
+        # --- Run the turn (D-08/D-09/D-10: run_prepared_turn owns the driver
+        # call and the one-shot dead-session recovery cycle). ---
+        # lifecycle_holder tracks whichever SlackTurnLifecycle actually
+        # completed the turn -- recovery_lifecycle rebuilds a fresh one against
+        # the recreated session, and the watermark write below must read
+        # final_ts off THAT lifecycle, not the pre-recovery one.
         log.info(
             "slack.turn.started",
             thread_id=thread_id,
@@ -1258,26 +1128,62 @@ class SlackApp:
             register=self._register_cancel,
             deregister=self._deregister_cancel,
         )
+        lifecycle_holder: list[SlackTurnLifecycle] = [lifecycle]
+
+        async def _reseed_user_message() -> str:
+            """Full history re-seed for the recreated session (dead-session recovery)."""
+            full_message = await build_context_xml(
+                web_client,
+                channel=channel,
+                thread_ts=thread_id,
+                user_query=user_text,
+                author_id=author_id,
+                proxy=proxy_ctx,
+            )
+            if synthetic_prefix:
+                full_message = synthetic_prefix + "\n" + full_message
+            return full_message
+
+        def _recovery_lifecycle(cancel: asyncio.Event) -> TurnLifecycle:
+            new_lifecycle = SlackTurnLifecycle(
+                client=web_client,
+                channel=channel,
+                thread_ts=thread_id,
+                cancel=cancel,
+                author_id=str(event.get("user") or ""),
+                agent_name=_lc_agent_name,
+                model_id=_lc_model_id,
+                register=self._register_cancel,
+                deregister=self._deregister_cancel,
+            )
+            lifecycle_holder[0] = new_lifecycle
+            return new_lifecycle
+
         async with self.runtime.sessionmaker() as s:
             turn_context = await create_slack_turn_context(
                 s,
                 tenant_id=tenant_id,
-                account_id=principal.account_id,
+                account_id=admission.account_id,
                 channel_id=channel,
                 thread_ts=thread_id,
                 started_at=datetime.now(tz=UTC),
             )
             await s.commit()
         try:
-            await run_turn(
-                anthropic=self.runtime.anthropic,
-                session_id=ma_session_id,
+            outcome = await run_prepared_turn(
+                self.runtime.turn_deps,
+                prepared,
+                tenant_id=tenant_id,
+                platform="slack",
+                thread_id=thread_id,
+                external_user_id=str(event.get("user") or ""),
                 user_message=user_message,
                 lifecycle=lifecycle,
                 cancel=cancel_event,
-                render_interval_s=2.0,
+                reseed_user_message=_reseed_user_message,
+                recovery_lifecycle=_recovery_lifecycle,
                 image_blocks=image_blocks or None,
-                billing=Billed(record=usage_record),
+                render_interval_s=2.0,
             )
         finally:
             # Leak-policy bookkeeping only — a delete failure must not mask the
@@ -1287,18 +1193,30 @@ class SlackApp:
                     await delete_slack_turn_context(s, id=turn_context.id)
                     await s.commit()
 
+        mapping_id = outcome.mapping_id
+        final_lifecycle = lifecycle_holder[0]
+
         # --- Watermark ---
-        if lifecycle.final_ts is not None:
+        if outcome.state.error is not None:
+            log.warning(
+                "slack.turn.error",
+                thread_id=thread_id,
+                session_id=outcome.ma_session_id,
+                kind=outcome.state.error.kind,
+            )
+        elif mapping_id is not None and final_lifecycle.final_ts is not None:
             async with self.runtime.sessionmaker() as s:
-                await update_watermark(s, id=mapping_id, watermark_message_id=lifecycle.final_ts)
+                await update_watermark(
+                    s, id=mapping_id, watermark_message_id=final_lifecycle.final_ts
+                )
                 await s.commit()
             log.info(
                 "slack.watermark.updated",
                 thread_id=thread_id,
-                watermark=lifecycle.final_ts,
+                watermark=final_lifecycle.final_ts,
             )
         else:
-            log.info("slack.turn.completed", thread_id=thread_id, session_id=ma_session_id)
+            log.info("slack.turn.completed", thread_id=thread_id, session_id=outcome.ma_session_id)
 
     async def drain_and_close(self, client: AsyncBaseSocketModeClient) -> None:
         """Graceful shutdown drain.

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -1196,15 +1196,11 @@ class SlackApp:
         mapping_id = outcome.mapping_id
         final_lifecycle = lifecycle_holder[0]
 
-        # --- Watermark ---
-        if outcome.state.error is not None:
-            log.warning(
-                "slack.turn.error",
-                thread_id=thread_id,
-                session_id=outcome.ma_session_id,
-                kind=outcome.state.error.kind,
-            )
-        elif mapping_id is not None and final_lifecycle.final_ts is not None:
+        # --- Watermark --- Preserves Slack's original gate exactly (unconditional
+        # on final_ts, no state.error branch) -- Discord's inline sequence had an
+        # error-vs-success split here, but that is NOT one of SPEC Req 7's four
+        # named behaviour changes, so it is not introduced for Slack either.
+        if mapping_id is not None and final_lifecycle.final_ts is not None:
             async with self.runtime.sessionmaker() as s:
                 await update_watermark(
                     s, id=mapping_id, watermark_message_id=final_lifecycle.final_ts

--- a/packages/adapters/slack/daimon/adapters/slack/runtime.py
+++ b/packages/adapters/slack/daimon/adapters/slack/runtime.py
@@ -12,7 +12,10 @@ from daimon.core.billing import BillingConfig, load_billing_config
 from daimon.core.config import Settings
 from daimon.core.db import build_engine, build_session_factory
 from daimon.core.defaults.loader import parse_deployment_default
+from daimon.core.github_credentials import build_multifernet
+from daimon.core.ma_resolver import ResolverCache, new_resolver_cache
 from daimon.core.scope import DeploymentDefault
+from daimon.core.turn.deps import TurnDeps
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -23,10 +26,58 @@ class SlackRuntime:
     sessionmaker: async_sessionmaker[AsyncSession]
     billing_config: BillingConfig | None
     http_client: httpx.AsyncClient
+    resolver_cache: ResolverCache
+    turn_deps: TurnDeps
     # Bottom tier of the channel→tenant→deployment config cascade. Defaults to
     # empty (no deployment fallback) so existing construction sites stay valid;
     # build_runtime always parses the real defaults/config.yaml.
     deployment_default: DeploymentDefault = field(default_factory=DeploymentDefault)
+
+
+def build_turn_deps(
+    settings: Settings,
+    anthropic: AsyncAnthropic,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    deployment_default: DeploymentDefault,
+    resolver_cache: ResolverCache,
+    billing_config: BillingConfig | None,
+) -> TurnDeps:
+    """Derive the frozen `TurnDeps` bundle from `settings` (D-04/D-12).
+
+    Built ONCE per runtime construction — mirrors Discord's
+    `daimon.adapters.discord.runtime.build_turn_deps`. Duplicated here (not
+    imported from Discord) because adapters must not import each other; this
+    is the fernet-mount fix for SPEC Req 7(a) — `fernet` is now unconditional
+    for every session Slack creates, instead of the historical gap where
+    `create_session` was called without one.
+    """
+    crypto_keys = tuple(secret.get_secret_value() for secret in settings.crypto.keys)
+    fernet = build_multifernet(crypto_keys) if crypto_keys else None
+    public_url = str(settings.mcp.public_url) if settings.mcp.public_url is not None else None
+    return TurnDeps(
+        anthropic=anthropic,
+        sessionmaker=sessionmaker,
+        deployment_default=deployment_default,
+        resolver_cache=resolver_cache,
+        defaults_root=settings.defaults_root,
+        mcp=settings.mcp,
+        billing_config=billing_config,
+        markup=settings.billing.markup,
+        fernet=fernet,
+        github_fallback_pat=(
+            settings.github.fallback_pat.get_secret_value()
+            if settings.github.fallback_pat is not None
+            else None
+        ),
+        github_app_id=settings.github.app_id,
+        github_app_private_key=(
+            settings.github.app_private_key.get_secret_value()
+            if settings.github.app_private_key is not None
+            else None
+        ),
+        public_url=public_url,
+    )
 
 
 @asynccontextmanager
@@ -34,6 +85,10 @@ async def build_runtime(settings: Settings) -> AsyncIterator[SlackRuntime]:
     engine = build_engine(str(settings.database.url))
     sm = build_session_factory(engine)
     deployment_default = parse_deployment_default(settings.defaults_root)
+    # Shared, process-lifetime resolver cache (D-12) — Slack adopts Discord's
+    # <=300s TTL semantics instead of building a fresh cache per turn.
+    resolver_cache = new_resolver_cache()
+    billing_config = load_billing_config()
     async with (
         AsyncAnthropic(
             api_key=settings.anthropic.api_key.get_secret_value(),
@@ -41,13 +96,23 @@ async def build_runtime(settings: Settings) -> AsyncIterator[SlackRuntime]:
         ) as anthropic,
         httpx.AsyncClient(timeout=30.0) as http_client,
     ):
+        turn_deps = build_turn_deps(
+            settings,
+            anthropic,
+            sm,
+            deployment_default=deployment_default,
+            resolver_cache=resolver_cache,
+            billing_config=billing_config,
+        )
         try:
             yield SlackRuntime(
                 settings=settings,
                 anthropic=anthropic,
                 sessionmaker=sm,
-                billing_config=load_billing_config(),
+                billing_config=billing_config,
                 http_client=http_client,
+                resolver_cache=resolver_cache,
+                turn_deps=turn_deps,
                 deployment_default=deployment_default,
             )
         finally:

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
@@ -219,6 +219,8 @@ def _build_runtime(
         sessionmaker=db_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
 
@@ -484,6 +486,8 @@ async def test_handle_agent_setup_action_connect_mcp_sends_ephemeral_not_modal_u
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     # Override aioresponses to return is_admin=True (connect_mcp re-checks admin).

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
@@ -101,6 +101,8 @@ def _build_runtime_no_db(fernet_key: str = "dummy") -> SlackRuntime:
         sessionmaker=async_sessionmaker(),  # pyright: ignore[reportArgumentType]
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
 
@@ -631,6 +633,8 @@ async def test_run_paste_secrets_submission_when_admin_and_two_pairs_posts_count
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     secret_val_1 = "s3cr3t_one"
@@ -783,6 +787,8 @@ async def test_run_edit_repo_submission_when_pat_replace_false_preserves_inline_
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     await run_edit_repo_submission(
@@ -856,6 +862,8 @@ async def test_run_edit_repo_submission_when_pat_replace_true_stores_new_inline_
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     await run_edit_repo_submission(
@@ -935,6 +943,8 @@ async def test_run_edit_repo_submission_no_pat_binds_anon(
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     await run_edit_repo_submission(

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_write.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_write.py
@@ -286,6 +286,8 @@ def _runtime_with_db(
         sessionmaker=sessionmaker,
         billing_config=None,
         http_client=MagicMock(),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
         deployment_default=DeploymentDefault(),
     )
 

--- a/packages/adapters/slack/tests/routines_panel/test_routines_create_dispatch.py
+++ b/packages/adapters/slack/tests/routines_panel/test_routines_create_dispatch.py
@@ -48,6 +48,8 @@ def _make_app() -> SlackApp:
         sessionmaker=MagicMock(),
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
     return SlackApp(runtime=runtime)
 

--- a/packages/adapters/slack/tests/routines_panel/test_routines_create_submit.py
+++ b/packages/adapters/slack/tests/routines_panel/test_routines_create_submit.py
@@ -168,6 +168,8 @@ def _build_runtime(handler: Any, db_session_factory: Any) -> SlackRuntime:
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
 

--- a/packages/adapters/slack/tests/routines_panel/test_routines_delete_submission.py
+++ b/packages/adapters/slack/tests/routines_panel/test_routines_delete_submission.py
@@ -38,6 +38,8 @@ def _build_runtime(db_session_factory: Any) -> SlackRuntime:
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
 

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -35,10 +35,11 @@ from anthropic.types.beta.beta_managed_agents_session_stats import BetaManagedAg
 from anthropic.types.beta.beta_managed_agents_session_usage import BetaManagedAgentsSessionUsage
 from cryptography.fernet import Fernet
 from daimon.adapters.slack.app import SlackApp
-from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.adapters.slack.runtime import SlackRuntime, build_turn_deps
 from daimon.core.defaults.provisioning import provision_tenant
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.scope import ChannelScopeRef, DeploymentDefault
 from daimon.core.stores import tenant_ledger, usage_events
 from daimon.core.stores.scoped_config_write import set_fields
@@ -162,6 +163,8 @@ def _make_app(
         sessionmaker=sessionmaker,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
     return SlackApp(runtime=runtime)
 
@@ -533,6 +536,20 @@ def _make_orchestrate_app(
     settings.billing.markup = Decimal("1.0")
 
     anthropic_client = build_fake_anthropic(_make_agent_env_handler())
+    resolved_deployment_default = (
+        deployment_default
+        if deployment_default is not None
+        else DeploymentDefault(agent_name="daimon", environment_name="default")
+    )
+    resolver_cache = new_resolver_cache()
+    turn_deps = build_turn_deps(
+        settings,
+        anthropic_client,
+        sessionmaker,
+        deployment_default=resolved_deployment_default,
+        resolver_cache=resolver_cache,
+        billing_config=None,
+    )
 
     runtime = SlackRuntime(
         settings=settings,
@@ -540,11 +557,9 @@ def _make_orchestrate_app(
         sessionmaker=sessionmaker,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
-        deployment_default=(
-            deployment_default
-            if deployment_default is not None
-            else DeploymentDefault(agent_name="daimon", environment_name="default")
-        ),
+        resolver_cache=resolver_cache,
+        turn_deps=turn_deps,
+        deployment_default=resolved_deployment_default,
     )
     return SlackApp(runtime=runtime), anthropic_client
 
@@ -626,15 +641,15 @@ async def test_orchestrate_first_turn_when_new_thread_creates_session_row_and_wr
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_test_id"
         mock_resolve_env.return_value = "env_test_id"
@@ -752,15 +767,15 @@ async def test_orchestrate_continuation_when_live_session_exists_calls_build_del
     }
 
     with (
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
         patch(
             "daimon.adapters.slack.app.build_delta_xml", new_callable=AsyncMock
         ) as mock_build_delta,
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
     ):
         mock_run_turn.side_effect = _fake_run_turn
@@ -867,26 +882,26 @@ async def test_orchestrate_queue_coalesce_when_thread_in_flight_adds_hourglass_a
 
     with (
         patch(
-            "daimon.adapters.slack.app.get_or_create_platform_principal", new_callable=AsyncMock
+            "daimon.core.turn.admission.get_or_create_platform_principal", new_callable=AsyncMock
         ) as mock_principal,
         patch(
-            "daimon.adapters.slack.app.get_live_thread_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.get_live_thread_session", new_callable=AsyncMock
         ) as mock_get_session,
         patch(
-            "daimon.adapters.slack.app.create_thread_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_thread_session", new_callable=AsyncMock
         ) as mock_create_ts,
         patch("daimon.adapters.slack.app.update_watermark", new_callable=AsyncMock),
-        patch("daimon.adapters.slack.app.reconcile_tenant_defaults", new_callable=AsyncMock),
+        patch("daimon.core.turn.admission.reconcile_tenant_defaults", new_callable=AsyncMock),
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_principal.return_value = fake_principal
         mock_get_session.return_value = None  # simulate new thread each time
@@ -1029,15 +1044,15 @@ async def test_orchestrate_first_mention_adds_eyes_reaction_before_turn(
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_eyes_id"
         mock_resolve_env.return_value = "env_eyes_id"
@@ -1174,15 +1189,15 @@ async def test_orchestrate_eyes_reaction_transport_error_does_not_leak_thread_sl
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_eyes_xport_id"
         mock_resolve_env.return_value = "env_eyes_xport_id"
@@ -1241,7 +1256,7 @@ async def test_orchestrate_tenant_cap_when_exhausted_sends_ephemeral_and_skips_t
         "text": "<@U_BOT> hello",
     }
 
-    with patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn:
+    with patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn:
         await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
             event,
             team_id=team_id,
@@ -1337,15 +1352,15 @@ async def test_orchestrate_first_turn_when_channel_agent_propagated_resolves_cha
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_scoped_id"
         mock_resolve_env.return_value = "env_scoped_id"
@@ -1400,9 +1415,9 @@ async def test_orchestrate_first_turn_when_no_agent_configured_posts_guidance_an
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
             event,
@@ -1464,16 +1479,16 @@ async def test_run_thread_turn_when_over_balance_blocks_before_session_create(
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.is_over_balance", new_callable=AsyncMock
+            "daimon.core.turn.admission.is_over_balance", new_callable=AsyncMock
         ) as mock_over_balance,
-        patch("daimon.adapters.slack.app.create_session", new_callable=AsyncMock) as mock_create,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock) as mock_create,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_test_id"
         mock_resolve_env.return_value = "env_test_id"
@@ -1544,17 +1559,17 @@ async def test_run_thread_turn_when_over_cap_blocks_before_session_create(
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.is_over_balance", new_callable=AsyncMock
+            "daimon.core.turn.admission.is_over_balance", new_callable=AsyncMock
         ) as mock_over_balance,
-        patch("daimon.adapters.slack.app.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
-        patch("daimon.adapters.slack.app.create_session", new_callable=AsyncMock) as mock_create,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.admission.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
+        patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock) as mock_create,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_test_id"
         mock_resolve_env.return_value = "env_test_id"
@@ -1689,19 +1704,19 @@ async def test_run_thread_turn_when_unblocked_writes_usage_event_and_ledger_debi
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.is_over_balance", new_callable=AsyncMock
+            "daimon.core.turn.admission.is_over_balance", new_callable=AsyncMock
         ) as mock_over_balance,
-        patch("daimon.adapters.slack.app.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
+        patch("daimon.core.turn.admission.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_test_id"
         mock_resolve_env.return_value = "env_test_id"
@@ -1789,16 +1804,16 @@ async def test_run_thread_turn_reused_session_over_balance_blocks_and_skips_run_
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.is_over_balance", new_callable=AsyncMock
+            "daimon.core.turn.admission.is_over_balance", new_callable=AsyncMock
         ) as mock_over_balance,
-        patch("daimon.adapters.slack.app.create_session", new_callable=AsyncMock) as mock_create,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock) as mock_create,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_test_id"
         mock_resolve_env.return_value = "env_test_id"
@@ -1885,17 +1900,17 @@ async def test_run_thread_turn_reused_session_over_cap_blocks_and_skips_run_turn
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.is_over_balance", new_callable=AsyncMock
+            "daimon.core.turn.admission.is_over_balance", new_callable=AsyncMock
         ) as mock_over_balance,
-        patch("daimon.adapters.slack.app.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
-        patch("daimon.adapters.slack.app.create_session", new_callable=AsyncMock) as mock_create,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.admission.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
+        patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock) as mock_create,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_test_id"
         mock_resolve_env.return_value = "env_test_id"
@@ -2019,17 +2034,17 @@ async def test_run_thread_turn_reused_session_unblocked_writes_usage_event_and_l
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.is_over_balance", new_callable=AsyncMock
+            "daimon.core.turn.admission.is_over_balance", new_callable=AsyncMock
         ) as mock_over_balance,
-        patch("daimon.adapters.slack.app.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
-        patch("daimon.adapters.slack.app.create_session", new_callable=AsyncMock) as mock_create,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.admission.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
+        patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock) as mock_create,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_test_id"
         mock_resolve_env.return_value = "env_test_id"

--- a/packages/adapters/slack/tests/test_app_agent_setup_dispatch.py
+++ b/packages/adapters/slack/tests/test_app_agent_setup_dispatch.py
@@ -57,6 +57,8 @@ def _make_app() -> SlackApp:
         sessionmaker=MagicMock(),
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
     return SlackApp(runtime=runtime)
 

--- a/packages/adapters/slack/tests/test_billing_checkout.py
+++ b/packages/adapters/slack/tests/test_billing_checkout.py
@@ -90,6 +90,8 @@ async def runtime(
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
 

--- a/packages/adapters/slack/tests/test_connect_nudge.py
+++ b/packages/adapters/slack/tests/test_connect_nudge.py
@@ -22,9 +22,10 @@ from anthropic.types.beta import BetaManagedAgentsSessionAgent as _SessionAgent
 from anthropic.types.beta.beta_managed_agents_session_stats import BetaManagedAgentsSessionStats
 from anthropic.types.beta.beta_managed_agents_session_usage import BetaManagedAgentsSessionUsage
 from daimon.adapters.slack.app import SlackApp
-from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.adapters.slack.runtime import SlackRuntime, build_turn_deps
 from daimon.core.defaults.provisioning import provision_tenant
 from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.slack_connect_prompts import was_connect_prompted
 from daimon.core.stores.slack_user_tokens import upsert_slack_user_token
@@ -61,6 +62,8 @@ def _make_nudge_app(sessionmaker: async_sessionmaker[AsyncSession]) -> SlackApp:
         sessionmaker=sessionmaker,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
         deployment_default=DeploymentDefault(agent_name="daimon", environment_name="default"),
     )
     return SlackApp(runtime=runtime)
@@ -224,13 +227,26 @@ def _make_orchestrate_app_with_nudge_enabled(
     settings.mcp.app_root_url = "https://daimon.example.com"
     settings.defaults_root = MagicMock()
 
+    anthropic = build_fake_anthropic(_make_agent_env_handler())
+    deployment_default = DeploymentDefault(agent_name="daimon", environment_name="default")
+    resolver_cache = new_resolver_cache()
+    turn_deps = build_turn_deps(
+        settings,
+        anthropic,
+        sessionmaker,
+        deployment_default=deployment_default,
+        resolver_cache=resolver_cache,
+        billing_config=None,
+    )
     runtime = SlackRuntime(
         settings=settings,
-        anthropic=build_fake_anthropic(_make_agent_env_handler()),
+        anthropic=anthropic,
         sessionmaker=sessionmaker,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
-        deployment_default=DeploymentDefault(agent_name="daimon", environment_name="default"),
+        resolver_cache=resolver_cache,
+        turn_deps=turn_deps,
+        deployment_default=deployment_default,
     )
     return SlackApp(runtime=runtime)
 
@@ -304,15 +320,15 @@ async def test_orchestrate_continues_when_nudge_store_call_raises_sqlalchemy_err
             side_effect=SQLAlchemyError("db unavailable"),
         ),
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_nudge_fail_id"
         mock_resolve_env.return_value = "env_nudge_fail_id"

--- a/packages/adapters/slack/tests/test_interactions.py
+++ b/packages/adapters/slack/tests/test_interactions.py
@@ -41,6 +41,8 @@ async def test_resolve_web_client_returns_none_for_unknown_team_id(
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     result = await resolve_web_client(runtime, team_id="T_UNKNOWN")
@@ -73,6 +75,8 @@ async def test_resolve_web_client_returns_async_web_client_with_decrypted_token(
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     result = await resolve_web_client(runtime, team_id="T_INTERACTIONS")

--- a/packages/adapters/slack/tests/test_privacy_actions.py
+++ b/packages/adapters/slack/tests/test_privacy_actions.py
@@ -53,6 +53,8 @@ def _build_runtime(
         sessionmaker=db_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
 

--- a/packages/adapters/slack/tests/test_privacy_submit.py
+++ b/packages/adapters/slack/tests/test_privacy_submit.py
@@ -204,6 +204,8 @@ async def test_run_purge_and_update_deletes_account_rows_and_calls_views_update(
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     await run_purge_and_update(
@@ -258,6 +260,8 @@ async def test_run_purge_and_update_aborts_when_account_does_not_match_submitter
         sessionmaker=db_session_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
     # Submitter U_SUB_03 resolves to `account`, but metadata claims a foreign id.

--- a/packages/adapters/slack/tests/test_routines_actions.py
+++ b/packages/adapters/slack/tests/test_routines_actions.py
@@ -64,6 +64,8 @@ def _build_runtime(fernet_key: str, db_factory: async_sessionmaker[AsyncSession]
         sessionmaker=db_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
     )
 
 

--- a/packages/adapters/slack/tests/test_runtime.py
+++ b/packages/adapters/slack/tests/test_runtime.py
@@ -30,10 +30,12 @@ class TestSlackRuntime:
             "sessionmaker",
             "billing_config",
             "http_client",
+            "resolver_cache",
+            "turn_deps",
             "deployment_default",
         }, (
             "expected exactly settings/anthropic/sessionmaker/billing_config/http_client/"
-            f"deployment_default fields, got {fields}"
+            f"resolver_cache/turn_deps/deployment_default fields, got {fields}"
         )
 
     def test_frozen(self) -> None:
@@ -44,6 +46,8 @@ class TestSlackRuntime:
             sessionmaker=MagicMock(),  # pyright: ignore[reportArgumentType]
             billing_config=None,
             http_client=MagicMock(),  # pyright: ignore[reportArgumentType]
+            resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]
+            turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]
         )
         with pytest.raises(dataclasses.FrozenInstanceError):
             rt.settings = MagicMock()  # type: ignore[misc]  # intentionally testing frozen

--- a/packages/adapters/slack/tests/test_turn_context.py
+++ b/packages/adapters/slack/tests/test_turn_context.py
@@ -22,10 +22,11 @@ from anthropic.types.beta import BetaManagedAgentsSessionAgent as _SessionAgent
 from anthropic.types.beta.beta_managed_agents_session_stats import BetaManagedAgentsSessionStats
 from anthropic.types.beta.beta_managed_agents_session_usage import BetaManagedAgentsSessionUsage
 from daimon.adapters.slack.app import SlackApp
-from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.adapters.slack.runtime import SlackRuntime, build_turn_deps
 from daimon.core.defaults.provisioning import provision_tenant
 from daimon.core.errors import TurnError
 from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.identity import get_or_create_platform_principal
 from daimon.core.stores.slack_turn_contexts import get_slack_turn_channels
@@ -80,13 +81,26 @@ def _make_orchestrate_app(
     settings.mcp.app_root_url = None
     settings.defaults_root = MagicMock()
 
+    anthropic = build_fake_anthropic(_make_agent_env_handler())
+    deployment_default = DeploymentDefault(agent_name="daimon", environment_name="default")
+    resolver_cache = new_resolver_cache()
+    turn_deps = build_turn_deps(
+        settings,
+        anthropic,
+        sessionmaker,
+        deployment_default=deployment_default,
+        resolver_cache=resolver_cache,
+        billing_config=None,
+    )
     runtime = SlackRuntime(
         settings=settings,
-        anthropic=build_fake_anthropic(_make_agent_env_handler()),
+        anthropic=anthropic,
         sessionmaker=sessionmaker,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
-        deployment_default=DeploymentDefault(agent_name="daimon", environment_name="default"),
+        resolver_cache=resolver_cache,
+        turn_deps=turn_deps,
+        deployment_default=deployment_default,
     )
     return SlackApp(runtime=runtime)
 
@@ -169,15 +183,15 @@ async def test_turn_context_row_lives_exactly_during_run_turn(
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_turn_ctx_id"
         mock_resolve_env.return_value = "env_turn_ctx_id"
@@ -244,15 +258,15 @@ async def test_turn_context_row_deleted_when_run_turn_raises(
 
     with (
         patch(
-            "daimon.adapters.slack.app.resolve_agent", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
         ) as mock_resolve_agent,
         patch(
-            "daimon.adapters.slack.app.resolve_environment", new_callable=AsyncMock
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
         ) as mock_resolve_env,
         patch(
-            "daimon.adapters.slack.app.create_session", new_callable=AsyncMock
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
         ) as mock_create_session,
-        patch("daimon.adapters.slack.app.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
     ):
         mock_resolve_agent.return_value = "agent_turn_ctx_raise_id"
         mock_resolve_env.return_value = "env_turn_ctx_raise_id"

--- a/tests/parity/drivers/slack_driver.py
+++ b/tests/parity/drivers/slack_driver.py
@@ -191,7 +191,18 @@ class SlackDriver:
         user_id: str,
         text: str,
         billing_config: object | None = None,
+        thread_ts: str | None = None,
     ) -> list[str]:
+        """`thread_ts`, when given, targets an existing thread (e.g. a
+        pre-seeded live `thread_sessions` row) instead of starting a fresh
+        one -- the event's own `ts`/`event_ts` stay unique per dispatch
+        (mirrors a real follow-up mention), only `thread_ts` is pinned so
+        `_orchestrate`'s `thread_id = event.get("thread_ts") or event.get("ts")`
+        resolves to the caller-chosen id. Not part of the `PlatformDriver`
+        Protocol (Discord's `channel_id` already doubles as the thread id) --
+        this is Slack-only, keyword-only, and defaults to None so every
+        existing call site is unaffected.
+        """
         fernet_key = Fernet.generate_key().decode()
         fernet = build_multifernet((fernet_key,))
         async with sessionmaker() as s:
@@ -214,6 +225,8 @@ class SlackDriver:
             "user": user_id,
             "text": f"<@U_BOT> {text}",
         }
+        if thread_ts is not None:
+            event["thread_ts"] = thread_ts
 
         with (
             AioResponsesMock() as mock,

--- a/tests/parity/drivers/slack_driver.py
+++ b/tests/parity/drivers/slack_driver.py
@@ -32,9 +32,10 @@ from anthropic.types.beta.beta_managed_agents_session_usage import BetaManagedAg
 from cryptography.fernet import Fernet
 from daimon.adapters.slack.agent_setup import write as slack_write
 from daimon.adapters.slack.app import SlackApp
-from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.adapters.slack.runtime import SlackRuntime, build_turn_deps
 from daimon.core.defaults.provisioning import teardown_slack_install
 from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.purge import AccountPurgeResult
 from daimon.core.purge import purge_account as core_purge_account
 from daimon.core.scope import DeploymentDefault
@@ -157,15 +158,26 @@ class SlackDriver:
         settings.mcp.jwt_secret = None
         settings.defaults_root = MagicMock()
         settings.billing.markup = Decimal("1.0")
+        anthropic = build_fake_anthropic(router.dispatch)
+        deployment_default = DeploymentDefault(agent_name="test-agent", environment_name="test-env")
+        resolver_cache = new_resolver_cache()
+        turn_deps = build_turn_deps(
+            settings,
+            anthropic,
+            sessionmaker,
+            deployment_default=deployment_default,
+            resolver_cache=resolver_cache,
+            billing_config=billing_config,  # pyright: ignore[reportArgumentType]  # test-injected BillingConfig | None
+        )
         return SlackRuntime(
             settings=settings,
-            anthropic=build_fake_anthropic(router.dispatch),
+            anthropic=anthropic,
             sessionmaker=sessionmaker,
             billing_config=billing_config,  # pyright: ignore[reportArgumentType]  # test-injected BillingConfig | None
             http_client=MagicMock(spec=httpx.AsyncClient),
-            deployment_default=DeploymentDefault(
-                agent_name="test-agent", environment_name="test-env"
-            ),
+            resolver_cache=resolver_cache,
+            turn_deps=turn_deps,
+            deployment_default=deployment_default,
         )
 
     async def dispatch_turn(
@@ -205,7 +217,7 @@ class SlackDriver:
 
         with (
             AioResponsesMock() as mock,
-            patch("daimon.adapters.slack.app.create_session") as mock_create_session,
+            patch("daimon.core.turn.prepare.create_session") as mock_create_session,
         ):
             _register_slack_defaults(mock)
             mock_create_session.return_value = _make_fake_session(

--- a/tests/parity/test_dead_session.py
+++ b/tests/parity/test_dead_session.py
@@ -5,12 +5,14 @@ GC'd (confirmed signal: 404 `not_found_error` from `events.send`) must mark
 the stale row dead, create a fresh MA session + a new live row, re-run once
 with full history, and bill the NEW session id -- never the dead one. This is
 `run_prepared_turn`'s one-shot recovery cycle (D-08/D-09/D-10), proven here at
-the real platform entry point (`DaimonBot.on_message`) rather than only at
-the core unit-test level (`packages/core/tests/turn/test_run_prepared_turn.py`).
+the real platform entry point (`DaimonBot.on_message` / `SlackApp._handle_app_mention`)
+rather than only at the core unit-test level
+(`packages/core/tests/turn/test_run_prepared_turn.py`).
 
-Discord only for this plan -- the Slack half lands in a follow-up plan once
-its adapter is cut over to the orchestrator; the fixtures below are written
-so a Slack scenario can be added without reshaping this file.
+Both platforms: Discord landed with the 06-06 cutover; the Slack scenario
+below was added once Slack's own cutover (06-07) closed its dead-session gap.
+The router fixture is platform-agnostic (it only fakes the `/v1/...` MA
+endpoints), so both scenarios share `_build_dead_session_router`.
 """
 
 from __future__ import annotations
@@ -58,6 +60,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .conftest import AGENT_ID, AGENT_TEXT, ENV_ID, MODEL_ID
 from .drivers.discord_driver import DiscordDriver
+from .drivers.slack_driver import SlackDriver
 
 # The Discord driver's `create_session` stub always returns this fixed session
 # id for the recreate call (see DiscordDriver._make_fake_session usage in
@@ -233,6 +236,97 @@ async def test_dead_session_recreates_marks_old_row_dead_and_bills_new_session(
 
     # usage_events must bill the NEW session id, never the dead one (the exact
     # attribution bug D-08/D-09/D-10 fixes -- RESEARCH § "Known attribution bug").
+    usage_rows = await usage_events.list_for_tenant(db_session, tenant_id=tenant.id)
+    assert len(usage_rows) == 1, "the recovered turn must write exactly one usage_events row"
+    assert usage_rows[0].managed_session_id == _RECOVERED_SESSION_ID, (
+        "usage_events must attribute the recovered turn to the NEW session id"
+    )
+    assert usage_rows[0].managed_session_id != _DEAD_SESSION_ID, (
+        "usage_events must never attribute the recovered turn to the dead session id"
+    )
+
+    ledger_rows = await tenant_ledger.list_for_tenant(db_session, tenant_id=tenant.id)
+    debit_rows = [row for row in ledger_rows if row.delta_usd < 0]
+    assert len(debit_rows) == 1, "the recovered turn must write exactly one tenant_ledger debit"
+
+
+async def test_dead_session_recreates_marks_old_row_dead_and_bills_new_session_slack(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The Slack half of the same scenario -- proves the D-08/D-09/D-10 recovery
+    cycle at `SlackApp._handle_app_mention`, the real entry point 06-07 cut
+    over onto `run_prepared_turn`. Before 06-07 this loop never terminated:
+    the discarded `run_turn` return value meant a dead Slack session recreated
+    on every turn but the stale mapping was never superseded by a new live row.
+    """
+    workspace_id = "T_DEAD_SESSION_PARITY"
+    user_id = "U_DEAD_SESSION_PARITY"
+    thread_id = "9000005000.000001"
+
+    tenant = await make_tenant(db_session, platform="slack", workspace_id=workspace_id)
+    await tenant_ledger.insert_entry(
+        db_session,
+        tenant_id=tenant.id,
+        delta_usd=Decimal("100.00"),
+        reason="trial",
+        idempotency_key=f"trial:{tenant.id}",
+    )
+    # Identity resolution inside admit() is idempotent get-or-create -- pre-creating
+    # here just lets the test learn the account_id up front to seed the live row.
+    principal = await get_or_create_platform_principal(
+        db_session, tenant_id=tenant.id, platform="slack", external_id=user_id
+    )
+    old_row = await create_thread_session(
+        db_session,
+        tenant_id=tenant.id,
+        platform="slack",
+        thread_id=thread_id,
+        account_id=principal.account_id,
+        ma_session_id=_DEAD_SESSION_ID,
+        watermark_message_id="9000005000.000000",
+    )
+    await db_session.commit()
+
+    router = _build_dead_session_router(str(tenant.id))
+    driver = SlackDriver()
+    posted = await driver.dispatch_turn(
+        sessionmaker=db_session_factory,
+        router=router,
+        tenant_id=tenant.id,
+        workspace_id=workspace_id,
+        channel_id="C_DEAD_SESSION_PARITY",
+        user_id=user_id,
+        text="hello after recovery",
+        thread_ts=thread_id,
+    )
+    assert posted, f"expected the recovered turn's reply to be posted, got: {posted}"
+
+    # The stale mapping is marked dead.
+    dead_row = await get_thread_session_by_id(db_session, id=old_row.id)
+    assert dead_row is not None, "the pre-existing mapping row must still exist"
+    assert dead_row.status == "dead", "the pre-existing mapping must be marked dead"
+
+    # A new live row exists with a different ma_session_id.
+    live_row = await get_live_thread_session(
+        db_session,
+        tenant_id=tenant.id,
+        platform="slack",
+        thread_id=thread_id,
+        account_id=principal.account_id,
+    )
+    assert live_row is not None, "a new live row must exist after recovery"
+    assert live_row.id != old_row.id, "the new live row must be a distinct row"
+    assert live_row.ma_session_id == _RECOVERED_SESSION_ID, (
+        "the new live row must store the recreated session id"
+    )
+    assert live_row.ma_session_id != _DEAD_SESSION_ID, (
+        "the new live row must NOT reuse the dead session id"
+    )
+
+    # usage_events must bill the NEW session id, never the dead one -- this is
+    # the exact assertion that would have caught Slack's permanent dead-session
+    # loop (the discarded run_turn return value pre-06-07).
     usage_rows = await usage_events.list_for_tenant(db_session, tenant_id=tenant.id)
     assert len(usage_rows) == 1, "the recovered turn must write exactly one usage_events row"
     assert usage_rows[0].managed_session_id == _RECOVERED_SESSION_ID, (


### PR DESCRIPTION
## Summary

Slack now runs every turn through the same core pre-turn chokepoint Discord already uses: `admit()` resolves config and enforces the admission and billing gates, `bind_session()` owns session lifecycle, and `run_prepared_turn()` drives the turn with one-shot dead-session recovery. This finishes the orchestrator cutover; both adapters share one enforcement path.

What changed:

- `SlackRuntime` builds its `TurnDeps` bundle and a single process-lifetime resolver cache at construction instead of a fresh cache per turn. `create_session` now always mounts fernet, which closes a long-standing gap where Slack sessions were created without it.
- `_run_thread_turn`'s inline pre-turn sequence is deleted in favor of the core path. Every Slack denial string stays byte-identical to its pre-cutover text, and the adapter keeps its queue, drain, reactions, and concurrency-cap logic unchanged.
- Dead-session recovery (mark dead, recreate, rebind, reseed, retry once) is proven at the platform entry point. A new parity scenario in `tests/parity/test_dead_session.py` seeds a live session row that 404s on stream open, recovers through `SlackApp._handle_app_mention`, and asserts usage attribution lands on the new session. That is the exact failure that used to loop forever on Slack.
- The audit also caught and reverted an unintended behavior change: Slack's thread watermark write stays unconditional on `final_ts` instead of picking up Discord's skip-on-error gate.

## Test plan

- Slack adapter suite retargeted to the new module homes and runtime fields; the shared parity suite now holds both platforms' dead-session scenarios side by side.
- CI runs the full sharded pytest matrix, pyright strict, ruff, and import-linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)