### PR TITLE
Make /agent-setup navigable: one GitHub door, clearer labels, expiring panels

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -23,6 +23,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 
 import structlog
+from daimon.adapters.discord.agent_setup.expiry import ExpiringView
 from daimon.adapters.discord.agent_setup.state import PanelState
 from daimon.adapters.discord.errors import generate_request_id, render_error
 from daimon.adapters.discord.layout import hairline, header
@@ -171,7 +172,7 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
         await self._on_added(interaction)
 
 
-class CredentialsSubView(discord.ui.LayoutView):
+class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
     """F5 Components V2 env-vars sub-view opened from EditView's Env vars button.
 
     Container: ## 🔑 Env vars — {agent} + write-only subtext, KEY chips on one
@@ -305,7 +306,7 @@ class CredentialsSubView(discord.ui.LayoutView):
                 self._state,
                 runtime=self._runtime,
                 allowed_user_id=self._allowed_user_id,
-            ),
+            ).bind_render_interaction(interaction, panel=self._state),
             allowed_mentions=discord.AllowedMentions.none(),
         )
 
@@ -316,8 +317,12 @@ class CredentialsSubView(discord.ui.LayoutView):
             )
         self._secret_names = [row.key for row in rows]
         self._build_items()
+        # This view is re-rendered IN PLACE (same instance across renders, not
+        # reconstructed like the other four views), so the binding must be
+        # refreshed here on every render — an interaction bound once at
+        # construction would go stale (Pitfall 2, 09-RESEARCH.md).
         await interaction.edit_original_response(
-            view=self,
+            view=self.bind_render_interaction(interaction, panel=self._state),
             allowed_mentions=discord.AllowedMentions.none(),
         )
 

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -60,7 +60,7 @@ def build_credentials_container(
     container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container()
     container.add_item(
         header(
-            f"🔑 Secrets — {agent_name}",
+            f"🔑 Env vars — {agent_name}",
             subtext="values are write-only; only key names are shown",
         )
     )
@@ -71,12 +71,12 @@ def build_credentials_container(
         container.add_item(discord.ui.TextDisplay(chips))
     else:
         # Design-language collapse: dim hint instead of "(none)" copy.
-        container.add_item(discord.ui.TextDisplay("-# ＋ add your first secret"))
+        container.add_item(discord.ui.TextDisplay("-# ＋ add your first env var"))
 
     return container
 
 
-class PasteSecretModal(discord.ui.Modal, title="Add secrets"):
+class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
     """Paste KEY=VALUE lines → per-key ``put_agent_file``.
 
     No URL fetch, no attachment, no HTTP: pasted bytes go modal text → store
@@ -166,16 +166,16 @@ class PasteSecretModal(discord.ui.Modal, title="Add secrets"):
         if n == 1:
             toast = f"Added `{pairs[0][0]}`. Takes effect on the next session."
         else:
-            toast = f"Added {n} secrets. Takes effect on the next session."
+            toast = f"Added {n} env vars. Takes effect on the next session."
         await interaction.followup.send(toast, ephemeral=True)
         await self._on_added(interaction)
 
 
 class CredentialsSubView(discord.ui.LayoutView):
-    """F5 Components V2 secrets sub-view opened from EditView's Secrets button.
+    """F5 Components V2 env-vars sub-view opened from EditView's Env vars button.
 
-    Container: ## 🔑 Secrets — {agent} + write-only subtext, KEY chips on one
-    line, ✕ Remove a secret… select, + Add secrets · ← Back button row.
+    Container: ## 🔑 Env vars — {agent} + write-only subtext, KEY chips on one
+    line, ✕ Remove a var… select, + Add env vars · ← Back button row.
 
     Carries key NAMES only (``secret_names``) — never values. Mutations
     re-render this view in place via ``edit_original_response``; '← Back'
@@ -216,7 +216,7 @@ class CredentialsSubView(discord.ui.LayoutView):
             is_system=self._is_system,
         )
 
-        # ✕ Remove a secret… select (cap 20, glyph in placeholder not emoji=).
+        # ✕ Remove a var… select (cap 20, glyph in placeholder not emoji=).
         remove_select = _build_remove_select(self._secret_names, is_system=self._is_system)
         remove_select.callback = self._make_remove_cb(remove_select)  # type: ignore[method-assign]
 
@@ -224,11 +224,11 @@ class CredentialsSubView(discord.ui.LayoutView):
         select_row.add_item(remove_select)
         container.add_item(select_row)
 
-        # Button row: + Add secrets · ← Back.
+        # Button row: + Add env vars · ← Back.
         btn_row: discord.ui.ActionRow[CredentialsSubView] = discord.ui.ActionRow()
 
         add_btn: discord.ui.Button[CredentialsSubView] = discord.ui.Button(
-            label="+ Add secrets",
+            label="+ Add env vars",
             style=discord.ButtonStyle.success,
             disabled=self._is_system or len(self._secret_names) >= _SECRET_CAP,
         )
@@ -325,7 +325,7 @@ class CredentialsSubView(discord.ui.LayoutView):
 def _build_remove_select(
     secret_names: list[str], *, is_system: bool
 ) -> discord.ui.Select[CredentialsSubView]:
-    """✕ Remove a secret… select listing every key (no cap).
+    """✕ Remove a var… select listing every key (no cap).
 
     Each option's ``label``/``value`` carries ONLY the secret KEY NAME — never a
     value, never a per-key custom_id. Disabled (empty placeholder) when
@@ -333,14 +333,14 @@ def _build_remove_select(
     """
     if len(secret_names) == 0:
         return discord.ui.Select(
-            placeholder="(no secrets — use + Add secrets)",
+            placeholder="(no env vars — use + Add env vars)",
             min_values=1,
             max_values=1,
-            options=[discord.SelectOption(label="(no secrets)", value="__none__")],
+            options=[discord.SelectOption(label="(no env vars)", value="__none__")],
             disabled=True,
         )
     return discord.ui.Select(
-        placeholder="✕ Remove a secret…",
+        placeholder="✕ Remove a var…",
         min_values=1,
         max_values=1,
         options=[discord.SelectOption(label=f"✕ {key}"[:100], value=key) for key in secret_names],

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -11,7 +11,7 @@ Secret hygiene is enforced structurally, not by convention:
   URL-fetch path and no attachment path),
 - values never reach a custom_id (the remove-select option carries the key name only).
 
-`tenant_id` and `agent_id` are resolved once in `EditView._on_secrets` and
+`tenant_id` and `agent_id` are resolved once in `EditView._on_env_vars` and
 threaded down here as explicit constructor args — the sub-view never re-derives
 the tenant from user input.
 """

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -320,7 +320,7 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         # This view is re-rendered IN PLACE (same instance across renders, not
         # reconstructed like the other four views), so the binding must be
         # refreshed here on every render — an interaction bound once at
-        # construction would go stale (Pitfall 2, 09-RESEARCH.md).
+        # construction would go stale.
         await interaction.edit_original_response(
             view=self.bind_render_interaction(interaction, panel=self._state),
             allowed_mentions=discord.AllowedMentions.none(),

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
@@ -12,6 +12,7 @@ import structlog
 from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
     BetaManagedAgentsURLMCPServerParams,
 )
+from daimon.adapters.discord.agent_setup.expiry import ExpiringView
 from daimon.adapters.discord.agent_setup.modals import (
     AddMcpModal,
     AddSkillModal,
@@ -145,7 +146,7 @@ class _SkillRemoveSelect(discord.ui.Select["EditView"]):
                     self.view.state,
                     runtime=self.view.runtime,
                     allowed_user_id=self.view.allowed_user_id,
-                )
+                ).bind_render_interaction(interaction, panel=self.view.state)
             )
         except Exception as err:
             rid = generate_request_id()
@@ -254,11 +255,11 @@ class _McpRemoveSelect(discord.ui.Select["EditView"]):
                 self.view.state,
                 runtime=self.view.runtime,
                 allowed_user_id=self.view.allowed_user_id,
-            )
+            ).bind_render_interaction(interaction, panel=self.view.state)
         )
 
 
-class EditView(discord.ui.LayoutView):
+class EditView(ExpiringView, discord.ui.LayoutView):
     """F5 Components V2 edit view.
 
     Container with ## ✏️ Editing {agent} header, two remove selects, and two
@@ -438,7 +439,7 @@ class EditView(discord.ui.LayoutView):
                 agent_id=agent_id,
                 secret_names=secret_names,
                 is_system=selected.is_system,
-            ),
+            ).bind_render_interaction(interaction, panel=self.state),
             allowed_mentions=discord.AllowedMentions.none(),
         )
 
@@ -480,7 +481,8 @@ async def open_edit_view(
 
     Owns the swap site for the Edit button callback.
     """
+    view = EditView(state, runtime=runtime, allowed_user_id=allowed_user_id)
     await interaction.response.edit_message(
-        view=EditView(state, runtime=runtime, allowed_user_id=allowed_user_id),
+        view=view.bind_render_interaction(interaction, panel=state),
         allowed_mentions=discord.AllowedMentions.none(),
     )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
@@ -60,16 +60,34 @@ def build_edit_container(*, agent_name: str) -> discord.ui.Container[discord.ui.
 
 
 class BackButton(discord.ui.Button[discord.ui.LayoutView]):
-    """UX-25-01: closes the ephemeral sub-view so the main panel is visible again."""
+    """Swaps the root panel back onto this message; it no longer closes anything."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        state: PanelState,
+        runtime: DiscordRuntime,
+        allowed_user_id: int,
+    ) -> None:
         super().__init__(label="← Back", style=discord.ButtonStyle.secondary)
+        self.state = state
+        self.runtime = runtime
+        self.allowed_user_id = allowed_user_id
 
     async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
         log.info("agent_setup.back_btn.click")
         await interaction.response.defer()
         try:
-            await interaction.delete_original_response()
+            # Lazy import: panel.py imports EditView/BackButton from this module
+            # at module scope, so a module-scope import back would be circular.
+            from daimon.adapters.discord.agent_setup.panel import rerender_root_panel
+
+            await rerender_root_panel(
+                interaction,
+                self.state,
+                runtime=self.runtime,
+                allowed_user_id=self.allowed_user_id,
+            )
         except Exception as err:
             rid = generate_request_id()
             log.exception(
@@ -516,7 +534,16 @@ class EditView(discord.ui.LayoutView):
         log.info("agent_setup.back_btn.click")
         await interaction.response.defer()
         try:
-            await interaction.delete_original_response()
+            # Lazy import: panel.py imports EditView from this module at module
+            # scope, so a module-scope import back would be circular.
+            from daimon.adapters.discord.agent_setup.panel import rerender_root_panel
+
+            await rerender_root_panel(
+                interaction,
+                self.state,
+                runtime=self.runtime,
+                allowed_user_id=self.allowed_user_id,
+            )
         except Exception as err:
             rid = generate_request_id()
             log.exception(
@@ -537,9 +564,11 @@ async def open_edit_view(
     runtime: DiscordRuntime,
     allowed_user_id: int,
 ) -> None:
-    """Send the ephemeral EditView. Owns the send site for the Edit button callback."""
-    await interaction.response.send_message(
+    """Swap EditView onto the panel's own message.
+
+    Owns the swap site for the Edit button callback.
+    """
+    await interaction.response.edit_message(
         view=EditView(state, runtime=runtime, allowed_user_id=allowed_user_id),
-        ephemeral=True,
         allowed_mentions=discord.AllowedMentions.none(),
     )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
@@ -1,11 +1,9 @@
 """EditView (LayoutView) + selects + BackButton + open_edit_view launcher.
 
-Moved verbatim from panel.py.
-V2 migration: classic View → LayoutView, Auth… merge.
-
-The Connect-GitHub (OAuth) button was removed — the Auth… button
-now opens a single-option ephemeral follow-up (Paste a PAT…) that writes the
-per-agent github_credentials slot.
+EditView's container holds a header, two remove selects (skills, MCPs), and
+two button rows: ``Agent…`` / ``GitHub…`` / ``Env vars`` and
+``+ Add skill`` / ``+ Add MCP`` / ``← Back``. ``Agent…`` and ``GitHub…`` each
+open their modal directly — no intermediate view.
 """
 
 from __future__ import annotations
@@ -98,45 +96,6 @@ class BackButton(discord.ui.Button[discord.ui.LayoutView]):
             await interaction.followup.send(
                 render_error(err, request_id=rid),
                 ephemeral=True,
-            )
-
-
-class _ScalarFieldSelect(discord.ui.Select["EditView"]):
-    """Select: pick a scalar field (Agent / Repo) to open its modal."""
-
-    def __init__(self) -> None:
-        options = [
-            discord.SelectOption(label="✎ Agent · name / prompt / model", value="agent"),
-            discord.SelectOption(label="✎ Repo · URL + branch", value="repo"),
-        ]
-        super().__init__(
-            placeholder="Edit a field…",
-            min_values=1,
-            max_values=1,
-            options=options,
-        )
-
-    async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
-        if self.view is None:
-            return
-        chosen = self.values[0]
-        log.info("agent_setup.edit.scalar.pick", chosen=chosen)
-        if chosen == "agent":
-            await interaction.response.send_modal(
-                AgentSectionModal(
-                    self.view.state,
-                    runtime=self.view.runtime,
-                    allowed_user_id=self.view.allowed_user_id,
-                )
-            )
-        else:
-            # "repo" opens the combined RepoAuthModal.
-            await interaction.response.send_modal(
-                RepoAuthModal(
-                    self.view.state,
-                    runtime=self.view.runtime,
-                    allowed_user_id=self.view.allowed_user_id,
-                )
             )
 
 
@@ -299,72 +258,12 @@ class _McpRemoveSelect(discord.ui.Select["EditView"]):
         )
 
 
-class _AuthFollowUpView(discord.ui.LayoutView):
-    """Ephemeral follow-up for the Auth… button: Paste a PAT… (modal).
-
-    The Connect-GitHub (OAuth) option was removed; this now
-    writes the per-agent github_credentials slot via the PAT modal
-    only.
-    """
-
-    def __init__(
-        self,
-        state: PanelState,
-        *,
-        runtime: DiscordRuntime,
-        allowed_user_id: int,
-    ) -> None:
-        super().__init__(timeout=300)
-        self._state = state
-        self._runtime = runtime
-        self._allowed_user_id = allowed_user_id
-
-        container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container()
-        container.add_item(
-            header(
-                "🔗 GitHub auth",
-                subtext="both options fill the same per-agent slot",
-            )
-        )
-
-        btn_row: discord.ui.ActionRow[_AuthFollowUpView] = discord.ui.ActionRow()
-
-        pat_btn: discord.ui.Button[_AuthFollowUpView] = discord.ui.Button(
-            label="Paste a PAT…",
-            style=discord.ButtonStyle.secondary,
-        )
-        pat_btn.callback = self._on_pat  # type: ignore[method-assign]
-        btn_row.add_item(pat_btn)
-
-        container.add_item(btn_row)
-        self.add_item(container)
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:  # type: ignore[override]
-        if interaction.user.id != self._allowed_user_id:
-            await interaction.response.send_message(
-                "Only the command invoker can use these buttons.", ephemeral=True
-            )
-            return False
-        return True
-
-    def _selected_name(self) -> str | None:
-        return self._state.selected.name if self._state.selected else None
-
-    async def _on_pat(self, interaction: discord.Interaction) -> None:
-        log.info("agent_setup.edit.pat.click", agent_name=self._selected_name())
-        await interaction.response.send_modal(
-            RepoAuthModal(self._state, runtime=self._runtime, allowed_user_id=self._allowed_user_id)
-        )
-
-
 class EditView(discord.ui.LayoutView):
     """F5 Components V2 edit view.
 
-    Container with ## ✏️ Editing {agent} header, three selects, and a button
-    row: + Add skill · + Add MCP · Auth… · Secrets · ← Back.
-
-    Auth… opens an ephemeral follow-up (Paste a PAT…) that binds a per-agent
-    GitHub PAT (Connect-GitHub OAuth option removed).
+    Container with ## ✏️ Editing {agent} header, two remove selects, and two
+    button rows: Agent… · GitHub… · Env vars, then + Add skill · + Add MCP ·
+    ← Back. Agent… and GitHub… each open their modal directly.
 
     Preserves the isolation invariant: this view is ephemeral and
     never edits the main panel message. Mutations re-render this view via
@@ -391,19 +290,6 @@ class EditView(discord.ui.LayoutView):
         agent_name = state.selected.name if state.selected is not None else "agent"
         container = build_edit_container(agent_name=agent_name)
 
-        # Three select rows inside the container.
-        scalar_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
-        scalar_row.add_item(_ScalarFieldSelect())
-        container.add_item(scalar_row)
-
-        skill_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
-        skill_row.add_item(_SkillRemoveSelect(state))
-        container.add_item(skill_row)
-
-        mcp_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
-        mcp_row.add_item(_McpRemoveSelect(state, public_url=public_url))
-        container.add_item(mcp_row)
-
         skill_count = len(state.selected.spec.skills) if state.selected is not None else 0
         user_mcp_count = sum(
             1
@@ -411,7 +297,38 @@ class EditView(discord.ui.LayoutView):
             if not _is_default_mcp(e, public_url)
         )
 
-        # Button row 1: + Add skill · + Add MCP · Auth… · Secrets · ← Back.
+        # Button row 1: Agent… · GitHub… · Env vars.
+        field_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
+
+        agent_btn: discord.ui.Button[EditView] = discord.ui.Button(
+            label="Agent…",
+            style=discord.ButtonStyle.secondary,
+        )
+        agent_btn.callback = self._on_agent  # type: ignore[method-assign]
+        field_row.add_item(agent_btn)
+
+        github_btn: discord.ui.Button[EditView] = discord.ui.Button(
+            label="GitHub…",
+            style=discord.ButtonStyle.secondary,
+        )
+        github_btn.callback = self._on_github  # type: ignore[method-assign]
+        field_row.add_item(github_btn)
+
+        # Defensive read-only gate: system agents can never reach EditView (the
+        # main panel disables Edit for them), so this `disabled` is belt-and-
+        # braces (defensive).
+        is_system = bool(state.selected and state.selected.is_system)
+        env_vars_btn: discord.ui.Button[EditView] = discord.ui.Button(
+            label="Env vars",
+            style=discord.ButtonStyle.secondary,
+            disabled=is_system,
+        )
+        env_vars_btn.callback = self._on_env_vars  # type: ignore[method-assign]
+        field_row.add_item(env_vars_btn)
+
+        container.add_item(field_row)
+
+        # Button row 2: + Add skill · + Add MCP · ← Back.
         btn_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
 
         add_skill_btn: discord.ui.Button[EditView] = discord.ui.Button(
@@ -430,25 +347,6 @@ class EditView(discord.ui.LayoutView):
         add_mcp_btn.callback = self._on_add_mcp  # type: ignore[method-assign]
         btn_row.add_item(add_mcp_btn)
 
-        auth_btn: discord.ui.Button[EditView] = discord.ui.Button(
-            label="Auth…",
-            style=discord.ButtonStyle.secondary,
-        )
-        auth_btn.callback = self._on_auth  # type: ignore[method-assign]
-        btn_row.add_item(auth_btn)
-
-        # Defensive read-only gate: system agents can never reach EditView (the
-        # main panel disables Edit for them), so this `disabled` is belt-and-
-        # braces (defensive).
-        is_system = bool(state.selected and state.selected.is_system)
-        secrets_btn: discord.ui.Button[EditView] = discord.ui.Button(
-            label="Secrets",
-            style=discord.ButtonStyle.secondary,
-            disabled=is_system,
-        )
-        secrets_btn.callback = self._on_secrets  # type: ignore[method-assign]
-        btn_row.add_item(secrets_btn)
-
         back_btn: discord.ui.Button[EditView] = discord.ui.Button(
             label="← Back",
             style=discord.ButtonStyle.secondary,
@@ -457,6 +355,16 @@ class EditView(discord.ui.LayoutView):
         btn_row.add_item(back_btn)
 
         container.add_item(btn_row)
+
+        # Select row 3: skill remove; row 4: MCP remove.
+        skill_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
+        skill_row.add_item(_SkillRemoveSelect(state))
+        container.add_item(skill_row)
+
+        mcp_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
+        mcp_row.add_item(_McpRemoveSelect(state, public_url=public_url))
+        container.add_item(mcp_row)
+
         self.add_item(container)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:  # type: ignore[override]  # base uses broader Interaction[Client] type
@@ -482,17 +390,21 @@ class EditView(discord.ui.LayoutView):
             AddMcpModal(self.state, runtime=self.runtime, allowed_user_id=self.allowed_user_id)
         )
 
-    async def _on_auth(self, interaction: discord.Interaction) -> None:
-        log.info("agent_setup.edit.auth.click", agent_name=self._selected_name())
-        await interaction.response.send_message(
-            view=_AuthFollowUpView(
+    async def _on_agent(self, interaction: discord.Interaction) -> None:
+        log.info("agent_setup.edit.agent.click", agent_name=self._selected_name())
+        await interaction.response.send_modal(
+            AgentSectionModal(
                 self.state, runtime=self.runtime, allowed_user_id=self.allowed_user_id
-            ),
-            ephemeral=True,
-            allowed_mentions=discord.AllowedMentions.none(),
+            )
         )
 
-    async def _on_secrets(self, interaction: discord.Interaction) -> None:
+    async def _on_github(self, interaction: discord.Interaction) -> None:
+        log.info("agent_setup.edit.github.click", agent_name=self._selected_name())
+        await interaction.response.send_modal(
+            RepoAuthModal(self.state, runtime=self.runtime, allowed_user_id=self.allowed_user_id)
+        )
+
+    async def _on_env_vars(self, interaction: discord.Interaction) -> None:
         # Lazy import: credentials.py imports EditView from this module, so a
         # top-level import here would be circular.
         from daimon.adapters.discord.agent_setup.credentials import CredentialsSubView
@@ -500,7 +412,7 @@ class EditView(discord.ui.LayoutView):
         selected = self.state.selected
         if selected is None:
             return
-        log.info("agent_setup.edit.secrets.click", agent_name=selected.name)
+        log.info("agent_setup.edit.env_vars.click", agent_name=selected.name)
         tenant_id = await _resolve_tenant(self.runtime, interaction)
         ma_agent = await find_agent_by_daimon_tag(
             self.runtime.anthropic,

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/expiry.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/expiry.py
@@ -1,4 +1,4 @@
-"""Shared expiry handling for every /agent-setup view (D-10).
+"""Shared expiry handling for every /agent-setup view.
 
 discord.py never populates ``view.message`` for a view sent through an
 interaction response (``_ViewStore.add_view`` only registers a component
@@ -70,7 +70,7 @@ async def edit_expired_message(
 
 
 class ExpiringView:
-    """Mixin supplying the one shared ``on_timeout`` D-10 asks for.
+    """Mixin supplying the one shared ``on_timeout`` every /agent-setup view needs.
 
     Holds no discord API state and defines no ``__init__`` — co-inheriting
     this mixin leaves every view's own ``super().__init__(timeout=...)``
@@ -110,7 +110,7 @@ class ExpiringView:
         return self._render_panel is not None and self._render_panel.render_seq > self._render_seq
 
     async def on_timeout(self) -> None:
-        """Shared D-10 implementation: expire unless superseded."""
+        """Shared on_timeout implementation: expire unless superseded."""
         if self._is_superseded():
             return
         await edit_expired_message(build_expired_view(), interaction=self._render_interaction)

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/expiry.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/expiry.py
@@ -1,0 +1,116 @@
+"""Shared expiry handling for every /agent-setup view (D-10).
+
+discord.py never populates ``view.message`` for a view sent through an
+interaction response (``_ViewStore.add_view`` only registers a component
+dispatcher) — so the *interaction* that produced a view's message, not a
+``discord.Message`` reference, is the only handle left once the view's own
+buttons/selects have gone quiet. ``interaction.edit_original_response()`` is
+the one call that can still reach that message afterward, on any interaction
+object, regardless of whether it was originally a slash command, a component
+click, or a modal submit.
+
+``ExpiringView`` is a mixin the five /agent-setup views co-inherit so they
+share one ``on_timeout`` instead of each hand-rolling the disable/notify
+dance. Render sites call ``bind_render_interaction`` at render time (never at
+``__init__``) so the mixin always holds the interaction whose original
+response is the message currently on screen.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from daimon.adapters.discord.agent_setup.state import PanelState
+from daimon.adapters.discord.layout import header, static_view
+from daimon.adapters.discord.theme import COLOR_GREYPLE
+
+import discord
+
+EXPIRED_PANEL_TITLE = "⏳ Panel expired"
+EXPIRED_PANEL_SUBTEXT = "Run `/agent-setup` again to continue."
+EXPIRED_BUTTON_LABEL = "Expired — run /agent-setup"
+
+
+def build_expired_view() -> discord.ui.LayoutView:
+    """Controls-less terminal render for an expired /agent-setup view.
+
+    Carries no interactive children at all — nothing needs disabling, and
+    discord.py registers no new dispatcher or timer for it.
+    """
+    container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container(
+        header(EXPIRED_PANEL_TITLE, subtext=EXPIRED_PANEL_SUBTEXT),
+        accent_colour=COLOR_GREYPLE,
+    )
+    return static_view(container)
+
+
+async def edit_expired_message(
+    view: discord.ui.View | discord.ui.LayoutView,
+    *,
+    interaction: discord.Interaction | None,
+) -> None:
+    """Edit the interaction's original response to ``view``.
+
+    Returns immediately when ``interaction is None`` — a view that was never
+    rendered has no message to expire. ``discord.NotFound`` is the ONE
+    expected failure (the token or message is already gone, so there is
+    nothing to notify) and the only exception this may catch: ``on_timeout``
+    is dispatched as a bare asyncio task with no library-side handler, which
+    makes this the named background boundary for error-handling purposes. Do
+    not widen this catch, log-and-swallow, or retry.
+    """
+    if interaction is None:
+        return
+    try:
+        await interaction.edit_original_response(
+            view=view, allowed_mentions=discord.AllowedMentions.none()
+        )
+    except discord.NotFound:
+        return
+
+
+class ExpiringView:
+    """Mixin supplying the one shared ``on_timeout`` D-10 asks for.
+
+    Holds no discord API state and defines no ``__init__`` — co-inheriting
+    this mixin leaves every view's own ``super().__init__(timeout=...)``
+    reaching ``discord.ui.View`` / ``discord.ui.LayoutView`` untouched, so
+    timeout values are never affected by adding this mixin.
+    """
+
+    _render_interaction: discord.Interaction | None = None
+    _render_panel: PanelState | None = None
+    _render_seq: int = 0
+
+    def bind_render_interaction(
+        self, interaction: discord.Interaction, *, panel: PanelState | None
+    ) -> Self:
+        """Record the interaction and render generation for THIS render.
+
+        Call this at the RENDER site, not in ``__init__`` — the binding must
+        name the interaction whose original response is the message this
+        render actually produced, and it must be refreshed whenever the same
+        instance is re-rendered (see ``CredentialsSubView._reload_and_rerender``).
+        """
+        self._render_interaction = interaction
+        self._render_panel = panel
+        if panel is not None:
+            panel.render_seq += 1
+            self._render_seq = panel.render_seq
+        return self
+
+    def _is_superseded(self) -> bool:
+        """True when a newer view has since been rendered onto the same panel.
+
+        ``_ViewStore.add_view`` neither stops nor cancels the view it
+        replaces, so a view that is no longer on screen still owns a live
+        timer; this generation check is what stops it from overwriting the
+        message a newer view owns.
+        """
+        return self._render_panel is not None and self._render_panel.render_seq > self._render_seq
+
+    async def on_timeout(self) -> None:
+        """Shared D-10 implementation: expire unless superseded."""
+        if self._is_superseded():
+            return
+        await edit_expired_message(build_expired_view(), interaction=self._render_interaction)

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/mcp_access.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/mcp_access.py
@@ -26,6 +26,11 @@ import uuid
 
 import jwt as pyjwt
 import structlog
+from daimon.adapters.discord.agent_setup.expiry import (
+    EXPIRED_BUTTON_LABEL,
+    ExpiringView,
+    edit_expired_message,
+)
 from daimon.adapters.discord.agent_setup.state import PanelState
 from daimon.adapters.discord.agent_setup.tenant import resolve_tenant_for_panel
 from daimon.adapters.discord.runtime import DiscordRuntime
@@ -117,13 +122,18 @@ async def send_connect_via_mcp(
         # Never log the token itself.
     )
 
+    # This view owns its own ephemeral (created via response.send_message from
+    # the panel button), so it must NOT join the panel's render generation —
+    # doing so would let the next panel render silence this view's expiry, and
+    # it can never be superseded on its own message anyway.
+    mcp_view = _McpAccessView(
+        jti=jti,
+        runtime=runtime,
+        allowed_user_id=allowed_user_id,
+    )
     await interaction.response.send_message(
         content=config_block,
-        view=_McpAccessView(
-            jti=jti,
-            runtime=runtime,
-            allowed_user_id=allowed_user_id,
-        ),
+        view=mcp_view.bind_render_interaction(interaction, panel=None),
         ephemeral=True,
         allowed_mentions=discord.AllowedMentions.none(),
     )
@@ -163,7 +173,7 @@ def render_mcp_config(*, agent_name: str, public_url: str, jwt: str) -> str:
     )
 
 
-class _McpAccessView(discord.ui.View):
+class _McpAccessView(ExpiringView, discord.ui.View):
     """Ephemeral classic View carrying just the Revoke button.
 
     The config itself is sent as plain message ``content`` (see
@@ -173,6 +183,13 @@ class _McpAccessView(discord.ui.View):
     `interaction_check` gates the Revoke button to the original invoker only
     (same pattern as EditView.interaction_check — the allowed_user_id passed
     in from the handler).
+
+    Diverges from the other four /agent-setup views' shared ``on_timeout``:
+    its message body is plain ``content=`` (the copyable MCP config block and
+    the one-time token), so on expiry it disables and relabels its one button
+    IN PLACE and passes NO ``content`` override — replacing the body with the
+    standard expiry container would destroy the artifact the message exists
+    to deliver.
     """
 
     def __init__(
@@ -187,12 +204,12 @@ class _McpAccessView(discord.ui.View):
         self._runtime = runtime
         self._allowed_user_id = allowed_user_id
 
-        revoke_btn: discord.ui.Button[_McpAccessView] = discord.ui.Button(
+        self._revoke_btn: discord.ui.Button[_McpAccessView] = discord.ui.Button(
             label="Revoke",
             style=discord.ButtonStyle.danger,
         )
-        revoke_btn.callback = self._on_revoke  # type: ignore[method-assign]
-        self.add_item(revoke_btn)
+        self._revoke_btn.callback = self._on_revoke  # type: ignore[method-assign]
+        self.add_item(self._revoke_btn)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:  # type: ignore[override]
         if interaction.user.id != self._allowed_user_id:
@@ -201,6 +218,11 @@ class _McpAccessView(discord.ui.View):
             )
             return False
         return True
+
+    async def on_timeout(self) -> None:
+        self._revoke_btn.disabled = True
+        self._revoke_btn.label = EXPIRED_BUTTON_LABEL
+        await edit_expired_message(self, interaction=self._render_interaction)
 
     async def _on_revoke(self, interaction: discord.Interaction) -> None:
         log.info("agent_setup.mcp_access.revoke.click", jti=str(self._jti))
@@ -221,3 +243,7 @@ class _McpAccessView(discord.ui.View):
             content="Token revoked. Agents using this token will get 401 on next request.",
             view=None,
         )
+        # That edit deliberately drops the view; a still-running timer would
+        # later re-attach a disabled button to a message intentionally left
+        # button-free.
+        self.stop()

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -31,7 +31,11 @@ from daimon.adapters.discord.agent_setup.write import (
     store_inline_pat,
     validate_model_id,
 )
-from daimon.adapters.discord.github_visibility import is_public_repo, pat_can_access_repo
+from daimon.adapters.discord.github_visibility import (
+    is_public_repo,
+    is_valid_pat,
+    pat_can_access_repo,
+)
 from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.errors import DaimonError
@@ -177,12 +181,20 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
         )
 
 
-class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
-    """Bind repo URL + branch; optional inline PAT.
+class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
+    """Bind a repo URL, store a GitHub token, or both (D-06).
 
-    Per LD-04-01, persists via `agent_repo_binding.set_binding` — AgentSpec
-    does NOT carry repo_url. Per LD-04-02, modals cannot mix buttons with
-    TextInputs, so the Connect-GitHub button lives on a separate panel view.
+    Repo URL is optional: a token submitted with no repo is verified against
+    its own GitHub identity (`is_valid_pat`, no repo-scoped permission
+    needed), stored, and writes NO `agent_repo_binding` row — the GitHub
+    Copilot MCP mirror in `core/sessions.py` picks it up on the next session
+    with zero core changes. A repo submitted with no token still runs the
+    existing App-coverage / public-visibility probes; per D-07, it ALSO
+    re-verifies any already-stored inline PAT against the newly-typed repo
+    before trusting it, since that stored PAT — not App/public coverage — is
+    what will actually clone the repo. Per LD-04-01, the repo binding
+    persists via `agent_repo_binding.set_binding`, never on AgentSpec. Per
+    LD-04-02, modals cannot mix buttons with TextInputs.
     """
 
     def __init__(
@@ -197,8 +209,9 @@ class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
         self.runtime = runtime
         self.allowed_user_id = allowed_user_id
         self.url_in: discord.ui.TextInput[RepoAuthModal] = discord.ui.TextInput(
-            label="Repo URL",
-            placeholder="https://github.com/org/repo",
+            label="Repo URL (optional)",
+            placeholder="Leave blank to store only the token below",
+            required=False,
             max_length=1024,
         )
         self.branch_in: discord.ui.TextInput[RepoAuthModal] = discord.ui.TextInput(
@@ -207,7 +220,8 @@ class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
             max_length=255,
         )
         self.pat_in: discord.ui.TextInput[RepoAuthModal] = discord.ui.TextInput(
-            label="PAT (optional)",
+            label="Token (optional; also powers GitHub MCP)",
+            placeholder="ghp_… — clones the repo and powers the GitHub MCP server",
             required=False,
             max_length=255,
         )
@@ -220,10 +234,18 @@ class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
         branch = str(self.branch_in).strip() or "main"
         pat = str(self.pat_in).strip()
         agent_name = self.state.selected.name if self.state.selected else None
+        if not url and not pat:
+            # D-06: both fields blank must be refused, not written as an
+            # empty binding. Before defer() so the user gets an immediate
+            # validation reply.
+            await interaction.response.send_message(
+                "Enter a repo URL, a GitHub token, or both.", ephemeral=True
+            )
+            return
         _log.info(
             "agent_setup.repo_auth.submit",
             agent_name=agent_name,
-            repo_url=url,
+            repo_url=url or None,
             branch=branch,
             pat_masked=mask_tail(pat) if pat else None,
         )
@@ -255,121 +277,150 @@ class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
                 ma_agent_id=str(ma_agent.id),
             )
 
-            pat_last4: str | None = None
-            ma_secret_ref: str
             coverage_note: str | None = None
-            if pat:
-                # Verify the pasted PAT actually grants access to this repo BEFORE
-                # binding. Otherwise a guild could bind a repo it does not control
-                # with a junk PAT and, on the next webhook resync, ride the
-                # deployment's GitHub App installation token (keyed by repo, not
-                # tenant) to clone another tenant's private repo.
-                owner_repo = _owner_repo_from_url(url)
+            if not url:
+                # PAT-only path (D-06): the guard above guarantees `pat` is
+                # non-empty here. There's no repo to check access against yet,
+                # so verify only the token's own GitHub identity, store it,
+                # and write NO agent_repo_binding row — neither `inline-pat:`
+                # nor `anon:` applies when there is no repo, and no third ref
+                # may be invented. Nothing on the AgentSpec changed, so skip
+                # reconcile too.
                 async with httpx.AsyncClient() as http_client:
-                    has_access = await pat_can_access_repo(
-                        http_client, owner_repo=owner_repo, pat=pat
-                    )
-                if not has_access:
+                    token_valid = await is_valid_pat(http_client, pat=pat)
+                if not token_valid:
                     raise DaimonError(
-                        "That token can't access this repo (or the repo doesn't "
-                        "exist). Paste a PAT that has access, or connect GitHub."
+                        "GitHub rejected that token. Paste a valid personal "
+                        "access token (it must not be expired)."
                     )
-                # inline PAT is written as a per-agent credential keyed on
-                # agent_uuid (not account_id). Only this agent can resolve it.
-                ma_secret_ref = await store_inline_pat(
+                await store_inline_pat(
                     self.runtime,
                     account_id=self.state.account_id,
                     agent_id=agent_uuid,
                     plaintext_pat=pat,
                 )
-                pat_last4 = pat[-4:]
-            else:
-                owner_repo = _owner_repo_from_url(url)
-                # D-07: a blank PAT field does NOT mean "no inline PAT will
-                # clone this repo" -- an earlier repo-free submit (D-06) may
-                # already have stored one for this agent. sessions.py resolves
-                # per_agent_pat via get_pat(agent_id=...) unconditionally, and
-                # select_clone_auth gives it unconditional precedence over both
-                # the App and public paths -- so that stored PAT, not App/public
-                # coverage, is what will actually clone this repo. It must be
-                # re-verified against THIS repo before the bind is allowed to
-                # succeed; falling through to the App/public probes on failure
-                # would let a "successful" bind silently produce a broken or
-                # cross-tenant clone later.
-                existing_pat = await load_agent_inline_pat(self.runtime, agent_id=agent_uuid)
-                if existing_pat is not None:
-                    async with httpx.AsyncClient() as http_client:
-                        covers_new_repo = await pat_can_access_repo(
-                            http_client, owner_repo=owner_repo, pat=existing_pat
-                        )
-                    if not covers_new_repo:
-                        raise DaimonError(
-                            "This agent already has a stored GitHub token that "
-                            "can't access this repo. Paste a token that can, or "
-                            "clear the stored one, then bind again."
-                        )
-                    # The stored PAT covers this repo -> it (not App/public) is
-                    # what will clone it, so record that ref and skip both probes.
-                    ma_secret_ref = f"inline-pat:{agent_uuid}"
-                else:
-                    # No inline PAT -> probe GitHub App coverage first. If the
-                    # App is installed on the repo owner, App mode will clone it
-                    # (public or private) without the operator fallback PAT, so the
-                    # public-only visibility check is unnecessary. A probe failure
-                    # must never block the bind (T-97-12) -- it degrades to the
-                    # existing public-repo check, same as an App-less deployment.
-                    owner, repo_name = owner_repo.split("/", 1)
-                    app_covered = False
-                    async with httpx.AsyncClient() as http_client:
-                        try:
-                            app_covered = await is_app_installed_for_repo(
-                                http_client,
-                                app_id=self.runtime.settings.github.app_id,
-                                app_private_key=self.runtime.settings.github.app_private_key,
-                                owner=owner,
-                                repo=repo_name,
-                                now=int(time.time()),
-                            )
-                        except Exception:  # noqa: BLE001 -- T-97-12: a coverage probe is best-effort UI; ANY failure (HTTP, or a malformed App key raising from build_app_jwt) must degrade to the public-repo check, never block the bind.
-                            _log.warning(
-                                "agent_setup.repo_auth.app_coverage_probe_failed",
-                                agent_name=agent_name,
-                                repo_url=url,
-                            )
-                            coverage_note = "Couldn't verify App coverage."
-                        if app_covered:
-                            coverage_note = "✅ App-covered (clones via the configured GitHub App)"
-                        else:
-                            # No App coverage (or unverifiable) -> the only remaining
-                            # clone token will be the operator fallback PAT, which is
-                            # public-only. Verify the repo is public BEFORE writing an
-                            # anon: binding, so a private repo can never be cloned
-                            # cross-tenant with the operator token.
-                            public = await is_public_repo(http_client, owner_repo=owner_repo)
-                            if not public:
-                                raise DaimonError(
-                                    "This repo isn't visible to the shared service account "
-                                    "(it's private, or it doesn't exist) — paste a PAT or "
-                                    "connect your GitHub to bind it."
-                                )
-                    # No inline PAT -> no per-agent credential is written. The resync
-                    # path is agent-overlay-only and never consults a principal-default, so
-                    # mark the ref as anonymous rather than implying a fallback exists.
-                    ma_secret_ref = "anon:"
-
-            # LD-04-01: persist binding via the dedicated store.
-            async with self.runtime.sessionmaker.begin() as session:
-                await set_agent_repo_binding(
-                    session,
-                    tenant_id=tenant_id,
-                    agent_id=agent_uuid,
-                    repo_url=url,
-                    default_branch=branch,
-                    ma_secret_ref=ma_secret_ref,
+                self.state.pat_last4 = pat[-4:]
+                coverage_note = (
+                    "Token stored — no repo pinned. The GitHub MCP server "
+                    "picks it up on the next session."
                 )
+            else:
+                pat_last4: str | None = None
+                ma_secret_ref: str
+                if pat:
+                    # Verify the pasted PAT actually grants access to this repo BEFORE
+                    # binding. Otherwise a guild could bind a repo it does not control
+                    # with a junk PAT and, on the next webhook resync, ride the
+                    # deployment's GitHub App installation token (keyed by repo, not
+                    # tenant) to clone another tenant's private repo.
+                    owner_repo = _owner_repo_from_url(url)
+                    async with httpx.AsyncClient() as http_client:
+                        has_access = await pat_can_access_repo(
+                            http_client, owner_repo=owner_repo, pat=pat
+                        )
+                    if not has_access:
+                        raise DaimonError(
+                            "That token can't access this repo (or the repo doesn't "
+                            "exist). Paste a PAT that has access, or connect GitHub."
+                        )
+                    # inline PAT is written as a per-agent credential keyed on
+                    # agent_uuid (not account_id). Only this agent can resolve it.
+                    ma_secret_ref = await store_inline_pat(
+                        self.runtime,
+                        account_id=self.state.account_id,
+                        agent_id=agent_uuid,
+                        plaintext_pat=pat,
+                    )
+                    pat_last4 = pat[-4:]
+                else:
+                    owner_repo = _owner_repo_from_url(url)
+                    # D-07: a blank PAT field does NOT mean "no inline PAT will
+                    # clone this repo" -- an earlier repo-free submit (D-06) may
+                    # already have stored one for this agent. sessions.py resolves
+                    # per_agent_pat via get_pat(agent_id=...) unconditionally, and
+                    # select_clone_auth gives it unconditional precedence over both
+                    # the App and public paths -- so that stored PAT, not App/public
+                    # coverage, is what will actually clone this repo. It must be
+                    # re-verified against THIS repo before the bind is allowed to
+                    # succeed; falling through to the App/public probes on failure
+                    # would let a "successful" bind silently produce a broken or
+                    # cross-tenant clone later.
+                    existing_pat = await load_agent_inline_pat(self.runtime, agent_id=agent_uuid)
+                    if existing_pat is not None:
+                        async with httpx.AsyncClient() as http_client:
+                            covers_new_repo = await pat_can_access_repo(
+                                http_client, owner_repo=owner_repo, pat=existing_pat
+                            )
+                        if not covers_new_repo:
+                            raise DaimonError(
+                                "This agent already has a stored GitHub token that "
+                                "can't access this repo. Paste a token that can, or "
+                                "clear the stored one, then bind again."
+                            )
+                        # The stored PAT covers this repo -> it (not App/public) is
+                        # what will clone it, so record that ref and skip both probes.
+                        ma_secret_ref = f"inline-pat:{agent_uuid}"
+                    else:
+                        # No inline PAT -> probe GitHub App coverage first. If the
+                        # App is installed on the repo owner, App mode will clone it
+                        # (public or private) without the operator fallback PAT, so the
+                        # public-only visibility check is unnecessary. A probe failure
+                        # must never block the bind (T-97-12) -- it degrades to the
+                        # existing public-repo check, same as an App-less deployment.
+                        owner, repo_name = owner_repo.split("/", 1)
+                        app_covered = False
+                        async with httpx.AsyncClient() as http_client:
+                            try:
+                                app_covered = await is_app_installed_for_repo(
+                                    http_client,
+                                    app_id=self.runtime.settings.github.app_id,
+                                    app_private_key=self.runtime.settings.github.app_private_key,
+                                    owner=owner,
+                                    repo=repo_name,
+                                    now=int(time.time()),
+                                )
+                            except Exception:  # noqa: BLE001 -- T-97-12: a coverage probe is best-effort UI; ANY failure (HTTP, or a malformed App key raising from build_app_jwt) must degrade to the public-repo check, never block the bind.
+                                _log.warning(
+                                    "agent_setup.repo_auth.app_coverage_probe_failed",
+                                    agent_name=agent_name,
+                                    repo_url=url,
+                                )
+                                coverage_note = "Couldn't verify App coverage."
+                            if app_covered:
+                                coverage_note = (
+                                    "✅ App-covered (clones via the configured GitHub App)"
+                                )
+                            else:
+                                # No App coverage (or unverifiable) -> the only remaining
+                                # clone token will be the operator fallback PAT, which is
+                                # public-only. Verify the repo is public BEFORE writing an
+                                # anon: binding, so a private repo can never be cloned
+                                # cross-tenant with the operator token.
+                                public = await is_public_repo(http_client, owner_repo=owner_repo)
+                                if not public:
+                                    raise DaimonError(
+                                        "This repo isn't visible to the shared service account "
+                                        "(it's private, or it doesn't exist) — paste a PAT or "
+                                        "connect your GitHub to bind it."
+                                    )
+                        # No inline PAT -> no per-agent credential is written. The resync
+                        # path is agent-overlay-only and never consults a principal-default, so
+                        # mark the ref as anonymous rather than implying a fallback exists.
+                        ma_secret_ref = "anon:"
 
-            self.state.apply_repo_modal(url=url, branch=branch, pat_last4=pat_last4)
-            await call_reconcile_for_panel(self.runtime, self.state, tenant_id=tenant_id)
+                # LD-04-01: persist binding via the dedicated store.
+                async with self.runtime.sessionmaker.begin() as session:
+                    await set_agent_repo_binding(
+                        session,
+                        tenant_id=tenant_id,
+                        agent_id=agent_uuid,
+                        repo_url=url,
+                        default_branch=branch,
+                        ma_secret_ref=ma_secret_ref,
+                    )
+
+                self.state.apply_repo_modal(url=url, branch=branch, pat_last4=pat_last4)
+                await call_reconcile_for_panel(self.runtime, self.state, tenant_id=tenant_id)
 
             from daimon.adapters.discord.agent_setup.edit_view import EditView
 
@@ -400,7 +451,7 @@ class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
         _log.info(
             "agent_setup.repo_auth.bound",
             agent_name=agent_name,
-            repo_url=url,
+            repo_url=url or None,
             branch=branch,
             pat_provided=bool(pat),
         )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -157,7 +157,7 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
                     self.state,
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
-                ),
+                ).bind_render_interaction(interaction, panel=self.state),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
         except Exception as err:
@@ -429,7 +429,7 @@ class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
                     self.state,
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
-                ),
+                ).bind_render_interaction(interaction, panel=self.state),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
             if coverage_note is not None:
@@ -500,7 +500,7 @@ class AddSkillModal(discord.ui.Modal, title="Add skill repo"):
                     self.state,
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
-                ),
+                ).bind_render_interaction(interaction, panel=self.state),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
         except Exception as err:

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -145,17 +145,13 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
             tenant_id = await resolve_tenant_for_panel(self.runtime, interaction)
             self.state.apply_agent_modal(system=system_value, model=model_value)
             outcome = await call_reconcile_for_panel(self.runtime, self.state, tenant_id=tenant_id)
-            from daimon.adapters.discord.agent_setup.panel import (
-                AgentSetupView,
-                _get_thumbnail_url,  # pyright: ignore[reportPrivateUsage]  # module-internal helper
-            )
+            from daimon.adapters.discord.agent_setup.edit_view import EditView
 
             await interaction.edit_original_response(
-                view=AgentSetupView(
+                view=EditView(
                     self.state,
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
-                    thumbnail_url=_get_thumbnail_url(interaction),
                 ),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
@@ -347,17 +343,13 @@ class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
             self.state.apply_repo_modal(url=url, branch=branch, pat_last4=pat_last4)
             await call_reconcile_for_panel(self.runtime, self.state, tenant_id=tenant_id)
 
-            from daimon.adapters.discord.agent_setup.panel import (
-                AgentSetupView,
-                _get_thumbnail_url,  # pyright: ignore[reportPrivateUsage]  # module-internal helper
-            )
+            from daimon.adapters.discord.agent_setup.edit_view import EditView
 
             await interaction.edit_original_response(
-                view=AgentSetupView(
+                view=EditView(
                     self.state,
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
-                    thumbnail_url=_get_thumbnail_url(interaction),
                 ),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
@@ -422,17 +414,13 @@ class AddSkillModal(discord.ui.Modal, title="Add skill repo"):
         tenant_id = await resolve_tenant_for_panel(self.runtime, interaction)
         try:
             self.state.add_skill_repo_pending(url)
-            from daimon.adapters.discord.agent_setup.panel import (
-                AgentSetupView,
-                _get_thumbnail_url,  # pyright: ignore[reportPrivateUsage]  # module-internal helper
-            )
+            from daimon.adapters.discord.agent_setup.edit_view import EditView
 
             await interaction.edit_original_response(
-                view=AgentSetupView(
+                view=EditView(
                     self.state,
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
-                    thumbnail_url=_get_thumbnail_url(interaction),
                 ),
                 allowed_mentions=discord.AllowedMentions.none(),
             )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -26,6 +26,7 @@ from daimon.adapters.discord.agent_setup.tenant import resolve_tenant_for_panel
 from daimon.adapters.discord.agent_setup.write import (
     call_reconcile_for_panel,
     kick_off_skill_sync,
+    load_agent_inline_pat,
     mask_tail,
     store_inline_pat,
     validate_model_id,
@@ -283,51 +284,78 @@ class RepoAuthModal(discord.ui.Modal, title="Repo + Auth"):
                 )
                 pat_last4 = pat[-4:]
             else:
-                # No inline PAT -> probe GitHub App coverage first. If the
-                # App is installed on the repo owner, App mode will clone it
-                # (public or private) without the operator fallback PAT, so the
-                # public-only visibility check is unnecessary. A probe failure
-                # must never block the bind (T-97-12) -- it degrades to the
-                # existing public-repo check, same as an App-less deployment.
                 owner_repo = _owner_repo_from_url(url)
-                owner, repo_name = owner_repo.split("/", 1)
-                app_covered = False
-                async with httpx.AsyncClient() as http_client:
-                    try:
-                        app_covered = await is_app_installed_for_repo(
-                            http_client,
-                            app_id=self.runtime.settings.github.app_id,
-                            app_private_key=self.runtime.settings.github.app_private_key,
-                            owner=owner,
-                            repo=repo_name,
-                            now=int(time.time()),
+                # D-07: a blank PAT field does NOT mean "no inline PAT will
+                # clone this repo" -- an earlier repo-free submit (D-06) may
+                # already have stored one for this agent. sessions.py resolves
+                # per_agent_pat via get_pat(agent_id=...) unconditionally, and
+                # select_clone_auth gives it unconditional precedence over both
+                # the App and public paths -- so that stored PAT, not App/public
+                # coverage, is what will actually clone this repo. It must be
+                # re-verified against THIS repo before the bind is allowed to
+                # succeed; falling through to the App/public probes on failure
+                # would let a "successful" bind silently produce a broken or
+                # cross-tenant clone later.
+                existing_pat = await load_agent_inline_pat(self.runtime, agent_id=agent_uuid)
+                if existing_pat is not None:
+                    async with httpx.AsyncClient() as http_client:
+                        covers_new_repo = await pat_can_access_repo(
+                            http_client, owner_repo=owner_repo, pat=existing_pat
                         )
-                    except Exception:  # noqa: BLE001 -- T-97-12: a coverage probe is best-effort UI; ANY failure (HTTP, or a malformed App key raising from build_app_jwt) must degrade to the public-repo check, never block the bind.
-                        _log.warning(
-                            "agent_setup.repo_auth.app_coverage_probe_failed",
-                            agent_name=agent_name,
-                            repo_url=url,
+                    if not covers_new_repo:
+                        raise DaimonError(
+                            "This agent already has a stored GitHub token that "
+                            "can't access this repo. Paste a token that can, or "
+                            "clear the stored one, then bind again."
                         )
-                        coverage_note = "Couldn't verify App coverage."
-                    if app_covered:
-                        coverage_note = "✅ App-covered (clones via the configured GitHub App)"
-                    else:
-                        # No App coverage (or unverifiable) -> the only remaining
-                        # clone token will be the operator fallback PAT, which is
-                        # public-only. Verify the repo is public BEFORE writing an
-                        # anon: binding, so a private repo can never be cloned
-                        # cross-tenant with the operator token.
-                        public = await is_public_repo(http_client, owner_repo=owner_repo)
-                        if not public:
-                            raise DaimonError(
-                                "This repo isn't visible to the shared service account "
-                                "(it's private, or it doesn't exist) — paste a PAT or "
-                                "connect your GitHub to bind it."
+                    # The stored PAT covers this repo -> it (not App/public) is
+                    # what will clone it, so record that ref and skip both probes.
+                    ma_secret_ref = f"inline-pat:{agent_uuid}"
+                else:
+                    # No inline PAT -> probe GitHub App coverage first. If the
+                    # App is installed on the repo owner, App mode will clone it
+                    # (public or private) without the operator fallback PAT, so the
+                    # public-only visibility check is unnecessary. A probe failure
+                    # must never block the bind (T-97-12) -- it degrades to the
+                    # existing public-repo check, same as an App-less deployment.
+                    owner, repo_name = owner_repo.split("/", 1)
+                    app_covered = False
+                    async with httpx.AsyncClient() as http_client:
+                        try:
+                            app_covered = await is_app_installed_for_repo(
+                                http_client,
+                                app_id=self.runtime.settings.github.app_id,
+                                app_private_key=self.runtime.settings.github.app_private_key,
+                                owner=owner,
+                                repo=repo_name,
+                                now=int(time.time()),
                             )
-                # No inline PAT -> no per-agent credential is written. The resync
-                # path is agent-overlay-only and never consults a principal-default, so
-                # mark the ref as anonymous rather than implying a fallback exists.
-                ma_secret_ref = "anon:"
+                        except Exception:  # noqa: BLE001 -- T-97-12: a coverage probe is best-effort UI; ANY failure (HTTP, or a malformed App key raising from build_app_jwt) must degrade to the public-repo check, never block the bind.
+                            _log.warning(
+                                "agent_setup.repo_auth.app_coverage_probe_failed",
+                                agent_name=agent_name,
+                                repo_url=url,
+                            )
+                            coverage_note = "Couldn't verify App coverage."
+                        if app_covered:
+                            coverage_note = "✅ App-covered (clones via the configured GitHub App)"
+                        else:
+                            # No App coverage (or unverifiable) -> the only remaining
+                            # clone token will be the operator fallback PAT, which is
+                            # public-only. Verify the repo is public BEFORE writing an
+                            # anon: binding, so a private repo can never be cloned
+                            # cross-tenant with the operator token.
+                            public = await is_public_repo(http_client, owner_repo=owner_repo)
+                            if not public:
+                                raise DaimonError(
+                                    "This repo isn't visible to the shared service account "
+                                    "(it's private, or it doesn't exist) — paste a PAT or "
+                                    "connect your GitHub to bind it."
+                                )
+                    # No inline PAT -> no per-agent credential is written. The resync
+                    # path is agent-overlay-only and never consults a principal-default, so
+                    # mark the ref as anonymous rather than implying a fallback exists.
+                    ma_secret_ref = "anon:"
 
             # LD-04-01: persist binding via the dedicated store.
             async with self.runtime.sessionmaker.begin() as session:

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -182,19 +182,19 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
 
 
 class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
-    """Bind a repo URL, store a GitHub token, or both (D-06).
+    """Bind a repo URL, store a GitHub token, or both.
 
     Repo URL is optional: a token submitted with no repo is verified against
     its own GitHub identity (`is_valid_pat`, no repo-scoped permission
     needed), stored, and writes NO `agent_repo_binding` row — the GitHub
     Copilot MCP mirror in `core/sessions.py` picks it up on the next session
     with zero core changes. A repo submitted with no token still runs the
-    existing App-coverage / public-visibility probes; per D-07, it ALSO
-    re-verifies any already-stored inline PAT against the newly-typed repo
-    before trusting it, since that stored PAT — not App/public coverage — is
-    what will actually clone the repo. Per LD-04-01, the repo binding
-    persists via `agent_repo_binding.set_binding`, never on AgentSpec. Per
-    LD-04-02, modals cannot mix buttons with TextInputs.
+    existing App-coverage / public-visibility probes; it ALSO re-verifies
+    any already-stored inline PAT against the newly-typed repo before
+    trusting it, since that stored PAT — not App/public coverage — is
+    what will actually clone the repo. The repo binding persists via
+    `agent_repo_binding.set_binding`, never on AgentSpec. Modals cannot mix
+    buttons with TextInputs.
     """
 
     def __init__(
@@ -235,7 +235,7 @@ class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
         pat = str(self.pat_in).strip()
         agent_name = self.state.selected.name if self.state.selected else None
         if not url and not pat:
-            # D-06: both fields blank must be refused, not written as an
+            # Both fields blank must be refused, not written as an
             # empty binding. Before defer() so the user gets an immediate
             # validation reply.
             await interaction.response.send_message(
@@ -279,7 +279,7 @@ class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
 
             coverage_note: str | None = None
             if not url:
-                # PAT-only path (D-06): the guard above guarantees `pat` is
+                # PAT-only path: the guard above guarantees `pat` is
                 # non-empty here. There's no repo to check access against yet,
                 # so verify only the token's own GitHub identity, store it,
                 # and write NO agent_repo_binding row — neither `inline-pat:`
@@ -334,8 +334,8 @@ class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
                     pat_last4 = pat[-4:]
                 else:
                     owner_repo = _owner_repo_from_url(url)
-                    # D-07: a blank PAT field does NOT mean "no inline PAT will
-                    # clone this repo" -- an earlier repo-free submit (D-06) may
+                    # A blank PAT field does NOT mean "no inline PAT will
+                    # clone this repo" -- an earlier repo-free submit may
                     # already have stored one for this agent. sessions.py resolves
                     # per_agent_pat via get_pat(agent_id=...) unconditionally, and
                     # select_clone_auth gives it unconditional precedence over both
@@ -408,7 +408,7 @@ class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
                         # mark the ref as anonymous rather than implying a fallback exists.
                         ma_secret_ref = "anon:"
 
-                # LD-04-01: persist binding via the dedicated store.
+                # Persist binding via the dedicated store.
                 async with self.runtime.sessionmaker.begin() as session:
                     await set_agent_repo_binding(
                         session,

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
@@ -207,6 +207,6 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
                 self.state,
                 runtime=self.runtime,
                 allowed_user_id=self.allowed_user_id,
-            ),
+            ).bind_render_interaction(interaction, panel=self.state),
             allowed_mentions=discord.AllowedMentions.none(),
         )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
@@ -200,17 +200,13 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
                 "401 until re-added.",
                 ephemeral=True,
             )
-        from daimon.adapters.discord.agent_setup.panel import (
-            AgentSetupView,
-            _get_thumbnail_url,  # pyright: ignore[reportPrivateUsage]  # module-internal helper
-        )
+        from daimon.adapters.discord.agent_setup.edit_view import EditView
 
         await interaction.edit_original_response(
-            view=AgentSetupView(
+            view=EditView(
                 self.state,
                 runtime=self.runtime,
                 allowed_user_id=self.allowed_user_id,
-                thumbnail_url=_get_thumbnail_url(interaction),
             ),
             allowed_mentions=discord.AllowedMentions.none(),
         )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -107,7 +107,6 @@ from daimon.adapters.discord.agent_setup.edit_view import (  # noqa: E402
     BackButton,
     EditView,
     _McpRemoveSelect,  # pyright: ignore[reportPrivateUsage]  # re-export for test backwards compat
-    _ScalarFieldSelect,  # pyright: ignore[reportPrivateUsage]  # re-export for test backwards compat
     _SkillRemoveSelect,  # pyright: ignore[reportPrivateUsage]  # re-export for test backwards compat
 )
 from daimon.adapters.discord.agent_setup.set_default import (  # noqa: E402
@@ -124,7 +123,6 @@ __all__ = [
     "SetDefaultView",
     "BackButton",
     "_McpRemoveSelect",
-    "_ScalarFieldSelect",
     "_SkillRemoveSelect",
     "NewAgentModal",
     "ForkAgentModal",

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -194,8 +194,9 @@ def _build_body_text(state: PanelState) -> str:
         )
         groups.append(f"🔌 **MCPs**\n{mcp_lines}")
 
-    # Repo & auth group: only shown when at least one of repo/auth/secrets is set,
-    # or the shared service account is the agent's only source of GitHub access.
+    # Repo group: shown when at least one of repo/auth is set, or the shared
+    # service account is the agent's only source of GitHub access. No longer
+    # gated on secrets — the 🔑 Env group below carries those independently.
     has_repo = bool(state.bound_repo_url)
     has_auth = bool(state.github_login or state.pat_last4)
     has_secrets = state.secret_count > 0
@@ -204,7 +205,7 @@ def _build_body_text(state: PanelState) -> str:
     # clone public repos. Distinct from `wont_clone` below by construction: the
     # two never fire together (wont_clone already requires fallback NOT configured).
     uses_shared_service_account = not has_auth and state.fallback_pat_configured
-    if has_repo or has_auth or has_secrets or uses_shared_service_account:
+    if has_repo or has_auth or uses_shared_service_account:
         repo_line_parts: list[str] = []
         if state.bound_repo_url:
             # Masked-link text must NOT be a URL: Discord auto-links the inner
@@ -224,8 +225,6 @@ def _build_body_text(state: PanelState) -> str:
                 "🌐 public read-only via shared service account — "
                 "link your GitHub for private repos"
             )
-        if has_secrets:
-            repo_line_parts.append(f"🔑 {state.secret_count} secrets")
         repo_line = " · ".join(repo_line_parts)
         # An anon: binding clones only when the operator fallback PAT is set.
         # inline-pat: refs always carry a per-agent PAT, so they never warn.
@@ -238,7 +237,13 @@ def _build_body_text(state: PanelState) -> str:
             repo_line += "\n⚠️ won't clone — no token"
         if state.last_sync_error is not None:
             repo_line += f"\n⚠️ last sync failed: {state.last_sync_error}"
-        groups.append(f"📦 **Repo & auth**\n{repo_line}")
+        groups.append(f"📦 **Repo**\n{repo_line}")
+
+    # Env group: count only — never key names or values (state carries only
+    # the count, so this is structurally incapable of leaking either).
+    if has_secrets:
+        unit = "variable" if state.secret_count == 1 else "variables"
+        groups.append(f"🔑 **Env**\n{state.secret_count} {unit}")
 
     # Member read-only view: append the cascade ladder as a group.
     if not state.is_admin:
@@ -277,7 +282,7 @@ def _build_body_text(state: PanelState) -> str:
     if not user_mcps:
         missing.append("＋ MCP")
     if not has_secrets:
-        missing.append("＋ secrets")
+        missing.append("＋ env vars")
     if missing and not groups and not (has_repo or has_auth or has_secrets or skills or user_mcps):
         # All resources empty — hint replaces all groups.
         hint = " · ".join(missing) + " — via **Edit**"

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -118,6 +118,7 @@ __all__ = [
     "build_panel_container",
     "load_secret_count",
     "load_repo_binding",
+    "rerender_root_panel",
     "AgentSetupView",
     "EditView",
     "SetDefaultView",
@@ -363,6 +364,44 @@ async def load_repo_binding(
     agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=entry.ma_agent_id)
     async with runtime.sessionmaker() as session:
         return await get_binding(session, tenant_id=tenant_id, agent_id=agent_id)
+
+
+async def rerender_root_panel(
+    interaction: discord.Interaction,
+    state: PanelState,
+    *,
+    runtime: DiscordRuntime,
+    allowed_user_id: int,
+) -> None:
+    """Hydrate ``state`` from the DB and edit back to the root ``AgentSetupView``.
+
+    The single hydrate-then-edit path back to the root panel — both the
+    ``EditView``/``BackButton`` Back callbacks route through this. Does NOT
+    touch ``interaction.response``; callers own the ACK (``defer()`` before
+    calling this).
+    """
+    tenant_id = await _resolve_tenant(runtime, interaction)
+    state.secret_count = (
+        await load_secret_count(runtime, tenant_id=tenant_id, agent_name=state.selected.name)
+        if state.selected is not None
+        else 0
+    )
+    state.github_login = await load_selected_github_login(
+        runtime, tenant_id=tenant_id, entry=state.selected
+    )
+    state.hydrate_repo_binding(
+        await load_repo_binding(runtime, tenant_id=tenant_id, entry=state.selected)
+    )
+    state.fallback_pat_configured = runtime.settings.github.fallback_pat is not None
+    await interaction.edit_original_response(
+        view=AgentSetupView(
+            state,
+            runtime=runtime,
+            allowed_user_id=allowed_user_id,
+            thumbnail_url=_get_thumbnail_url(interaction),
+        ),
+        allowed_mentions=discord.AllowedMentions.none(),
+    )
 
 
 class _AgentPicker(discord.ui.Select["AgentSetupView"]):

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -18,6 +18,7 @@ import structlog
 from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
     BetaManagedAgentsURLMCPServerParams,
 )
+from daimon.adapters.discord.agent_setup.expiry import ExpiringView
 from daimon.adapters.discord.agent_setup.state import PanelState, RosterEntry
 from daimon.adapters.discord.agent_setup.tenant import resolve_tenant_for_panel as _resolve_tenant
 from daimon.adapters.discord.agent_setup.write import (
@@ -402,7 +403,7 @@ async def rerender_root_panel(
             runtime=runtime,
             allowed_user_id=allowed_user_id,
             thumbnail_url=_get_thumbnail_url(interaction),
-        ),
+        ).bind_render_interaction(interaction, panel=state),
         allowed_mentions=discord.AllowedMentions.none(),
     )
 
@@ -470,7 +471,7 @@ class _AgentPicker(discord.ui.Select["AgentSetupView"]):
                     runtime=self.view.runtime,
                     allowed_user_id=self.view.allowed_user_id,
                     thumbnail_url=thumbnail_url,
-                ),
+                ).bind_render_interaction(interaction, panel=self.view.state),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
         except Exception as err:
@@ -506,7 +507,7 @@ def _get_thumbnail_url(interaction: discord.Interaction) -> str | None:
     return interaction.client.user.display_avatar.url
 
 
-class AgentSetupView(discord.ui.LayoutView):
+class AgentSetupView(ExpiringView, discord.ui.LayoutView):
     """F5 Components V2 agent-setup card.
 
     Container holds header, body, picker row, and (admins only) lifecycle row.
@@ -625,7 +626,7 @@ class AgentSetupView(discord.ui.LayoutView):
                 runtime=self.runtime,
                 allowed_user_id=self.allowed_user_id,
                 thumbnail_url=thumbnail_url,
-            ),
+            ).bind_render_interaction(interaction, panel=self.state),
             allowed_mentions=discord.AllowedMentions.none(),
         )
 
@@ -793,7 +794,7 @@ class NewAgentModal(discord.ui.Modal, title="New agent"):
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
                     thumbnail_url=thumbnail_url,
-                ),
+                ).bind_render_interaction(interaction, panel=self.state),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
         except Exception as err:
@@ -900,7 +901,7 @@ class ForkAgentModal(discord.ui.Modal, title="Fork agent"):
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
                     thumbnail_url=thumbnail_url,
-                ),
+                ).bind_render_interaction(interaction, panel=self.state),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
         except Exception as err:

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/set_default.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/set_default.py
@@ -329,7 +329,9 @@ class SetDefaultView(discord.ui.LayoutView):
         from daimon.adapters.discord.agent_setup.edit_view import BackButton
 
         back_row: discord.ui.ActionRow[discord.ui.LayoutView] = discord.ui.ActionRow()
-        back_row.add_item(BackButton())  # pyright: ignore[reportArgumentType]  # BackButton[View] is structurally compatible at runtime; discord.py V2 ActionRow accepts it
+        back_row.add_item(  # pyright: ignore[reportArgumentType]  # BackButton[View] is structurally compatible at runtime; discord.py V2 ActionRow accepts it
+            BackButton(state=state, runtime=runtime, allowed_user_id=allowed_user_id)
+        )
         container.add_item(back_row)
 
         self.add_item(container)
@@ -436,10 +438,12 @@ async def open_set_default(
     runtime: DiscordRuntime,
     allowed_user_id: int,
 ) -> None:
-    """Send the ephemeral SetDefaultView. Owns the send site for the Default… button callback."""
+    """Swap SetDefaultView onto the panel's own message.
+
+    Owns the swap site for the Default… button callback.
+    """
     blocks = await _build_scope_blocks(state, interaction)
-    await interaction.response.send_message(
+    await interaction.response.edit_message(
         view=SetDefaultView(state, runtime=runtime, allowed_user_id=allowed_user_id, blocks=blocks),
-        ephemeral=True,
         allowed_mentions=discord.AllowedMentions.none(),
     )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/set_default.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/set_default.py
@@ -11,6 +11,7 @@ import uuid
 
 import structlog
 from daimon.adapters.discord import layout
+from daimon.adapters.discord.agent_setup.expiry import ExpiringView
 from daimon.adapters.discord.agent_setup.scope_default import (
     do_propagate,
     do_unpropagate,
@@ -281,7 +282,7 @@ class _ChannelPickSelect(discord.ui.ChannelSelect["SetDefaultView"]):
         )
 
 
-class SetDefaultView(discord.ui.LayoutView):
+class SetDefaultView(ExpiringView, discord.ui.LayoutView):
     """C9 V2 cascade panel: airy routing blocks + action select + ChannelSelect.
 
     Write-immediately (no confirm); winner derivation stays in core
@@ -381,7 +382,7 @@ class SetDefaultView(discord.ui.LayoutView):
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
                     blocks=blocks,
-                ),
+                ).bind_render_interaction(interaction, panel=self.state),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
         except Exception as err:
@@ -418,7 +419,7 @@ class SetDefaultView(discord.ui.LayoutView):
                     runtime=self.runtime,
                     allowed_user_id=self.allowed_user_id,
                     blocks=blocks,
-                ),
+                ).bind_render_interaction(interaction, panel=self.state),
                 allowed_mentions=discord.AllowedMentions.none(),
             )
         except Exception as err:
@@ -443,7 +444,8 @@ async def open_set_default(
     Owns the swap site for the Default… button callback.
     """
     blocks = await _build_scope_blocks(state, interaction)
+    view = SetDefaultView(state, runtime=runtime, allowed_user_id=allowed_user_id, blocks=blocks)
     await interaction.response.edit_message(
-        view=SetDefaultView(state, runtime=runtime, allowed_user_id=allowed_user_id, blocks=blocks),
+        view=view.bind_render_interaction(interaction, panel=state),
         allowed_mentions=discord.AllowedMentions.none(),
     )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/state.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/state.py
@@ -75,6 +75,10 @@ class PanelState:
     )
     # Deployment-level default injected from the runtime (config.yaml); not from DB.
     deployment_default: DeploymentDefault = dataclasses.field(default_factory=DeploymentDefault)
+    # Render generation of the single /agent-setup ephemeral. Bumped by
+    # ExpiringView.bind_render_interaction on every render; a view holding a
+    # stale generation is off screen and must not rewrite the message (D-10).
+    render_seq: int = 0
 
     def add_skill_repo_pending(self, url: str) -> None:
         """Mark a skill repo as in-flight; idempotent."""

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/state.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/state.py
@@ -77,7 +77,7 @@ class PanelState:
     deployment_default: DeploymentDefault = dataclasses.field(default_factory=DeploymentDefault)
     # Render generation of the single /agent-setup ephemeral. Bumped by
     # ExpiringView.bind_render_interaction on every render; a view holding a
-    # stale generation is off screen and must not rewrite the message (D-10).
+    # stale generation is off screen and must not rewrite the message.
     render_seq: int = 0
 
     def add_skill_repo_pending(self, url: str) -> None:

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
@@ -236,7 +236,7 @@ async def load_agent_inline_pat(runtime: DiscordRuntime, *, agent_id: uuid.UUID)
     short-circuit will use to clone any repo later bound to this agent,
     regardless of which repo that PAT was originally verified against — which
     is why a caller binding a *different* repo must re-verify this value
-    against it before writing a binding (D-07).
+    against it before writing a binding.
 
     Returns None (no crypto call at all) when `runtime.settings.crypto.keys`
     is empty: no inline PAT can exist on a deployment that has never
@@ -248,7 +248,7 @@ async def load_agent_inline_pat(runtime: DiscordRuntime, *, agent_id: uuid.UUID)
 
     Passes `allow_service_default=False` and no `fallback_pat` explicitly:
     the operator's shared service PAT must never be treated as this agent's
-    own clone credential (Phase 08 D-11) — letting it through here would gate
+    own clone credential — letting it through here would gate
     every re-verification on whether the shared public-read token covers the
     repo, breaking private App-covered binds.
     """

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
@@ -38,6 +38,7 @@ from daimon.core.errors import DaimonError
 from daimon.core.github_credentials import (
     build_multifernet,
     get_github_login,
+    get_pat,
     upsert_credential_encrypted,
 )
 from daimon.core.ma import update_agent_with_version_retry
@@ -225,6 +226,40 @@ async def load_selected_github_login(
         principal_id=agent_uuid,
         agent_id=agent_uuid,
         sessionmaker=runtime.sessionmaker,
+    )
+
+
+async def load_agent_inline_pat(runtime: DiscordRuntime, *, agent_id: uuid.UUID) -> str | None:
+    """Return the inline PAT `core/sessions.py` would resolve for `agent_id`, or None.
+
+    This is the exact credential `resolve_clone_token`'s `per_agent_pat`
+    short-circuit will use to clone any repo later bound to this agent,
+    regardless of which repo that PAT was originally verified against — which
+    is why a caller binding a *different* repo must re-verify this value
+    against it before writing a binding (D-07).
+
+    Returns None (no crypto call at all) when `runtime.settings.crypto.keys`
+    is empty: no inline PAT can exist on a deployment that has never
+    configured crypto (storing one requires crypto too, via
+    `store_inline_pat`), and calling `_build_runtime_fernet` unconditionally
+    here would raise `ValueError` on such a deployment, breaking a
+    previously-working bind path (same tolerance rationale as
+    `_build_fork_fernet`).
+
+    Passes `allow_service_default=False` and no `fallback_pat` explicitly:
+    the operator's shared service PAT must never be treated as this agent's
+    own clone credential (Phase 08 D-11) — letting it through here would gate
+    every re-verification on whether the shared public-read token covers the
+    repo, breaking private App-covered binds.
+    """
+    if not runtime.settings.crypto.keys:
+        return None
+    return await get_pat(
+        principal_id=agent_id,
+        agent_id=agent_id,
+        sessionmaker=runtime.sessionmaker,
+        fernet=_build_runtime_fernet(runtime),
+        allow_service_default=False,
     )
 
 

--- a/packages/adapters/discord/daimon/adapters/discord/commands/agent_setup.py
+++ b/packages/adapters/discord/daimon/adapters/discord/commands/agent_setup.py
@@ -120,15 +120,14 @@ class AgentSetupCog(commands.Cog):
                 if interaction.client.user is not None
                 else None
             )
-            await interaction.followup.send(
+            await interaction.edit_original_response(
                 view=AgentSetupView(
                     state,
                     runtime=runtime,
                     allowed_user_id=interaction.user.id,
                     thumbnail_url=thumbnail_url,
-                ),
+                ).bind_render_interaction(interaction, panel=state),
                 allowed_mentions=discord.AllowedMentions.none(),
-                ephemeral=True,
             )
         except (DaimonError, anthropic.APIError, discord.HTTPException) as exc:
             await interaction.followup.send(render_error(exc, request_id=rid), ephemeral=True)

--- a/packages/adapters/discord/daimon/adapters/discord/github_visibility.py
+++ b/packages/adapters/discord/daimon/adapters/discord/github_visibility.py
@@ -1,17 +1,21 @@
-"""GitHub repo public-visibility check for the anon-bind guardrail.
+"""GitHub repo public-visibility check for the anon-bind guardrail, plus a
+repo-free PAT identity check for the PAT-only credential path.
 
 Lives in the Discord adapter (not core): core must not import adapters, and the
 bind path is already adapter-side I/O. The operator fallback PAT only clones
 ``anon:`` bindings, so an ``anon:`` binding must be verified-public at bind time
 — otherwise a guild could bind a private repo as ``anon:`` and clone it
-cross-tenant with the operator token.
+cross-tenant with the operator token. ``is_valid_pat`` covers the sibling case
+where no repo is given at all (D-06): it proves only the token's own identity,
+never repo access — the D-07 re-verification gate in ``modals.py`` is what
+protects a *later* repo bind against an already-stored PAT.
 """
 
 from __future__ import annotations
 
 import httpx
 
-__all__ = ["is_public_repo", "pat_can_access_repo"]
+__all__ = ["is_public_repo", "is_valid_pat", "pat_can_access_repo"]
 
 
 async def is_public_repo(http_client: httpx.AsyncClient, *, owner_repo: str) -> bool:
@@ -52,6 +56,32 @@ async def pat_can_access_repo(http_client: httpx.AsyncClient, *, owner_repo: str
         headers={"Authorization": f"Bearer {pat}"},
     )
     if resp.status_code in (401, 403, 404):
+        return False
+    resp.raise_for_status()
+    return True
+
+
+async def is_valid_pat(http_client: httpx.AsyncClient, *, pat: str) -> bool:
+    """Return True iff ``pat`` is a live, unexpired GitHub token.
+
+    GETs ``https://api.github.com/user`` with the PAT:
+    - 200 → True (the token authenticates as some GitHub identity).
+    - 401 / 403 → False (invalid, revoked, or expired token).
+    - any other status → raises (let failures propagate; never a sentinel).
+
+    ``GET /user`` needs no repo-scoped permission — fine-grained PATs always
+    get metadata/``/user`` access regardless of their repository grants — so
+    this is the right check when the submit carries no repo to check access
+    against. It deliberately proves only the token's own identity, never repo
+    access: a PAT that passes this check is not yet cleared to clone any
+    particular repo, which is why the D-07 re-verification gate exists for a
+    later bind that resolves this same stored PAT against a specific repo.
+    """
+    resp = await http_client.get(
+        "https://api.github.com/user",
+        headers={"Authorization": f"Bearer {pat}"},
+    )
+    if resp.status_code in (401, 403):
         return False
     resp.raise_for_status()
     return True

--- a/packages/adapters/discord/daimon/adapters/discord/github_visibility.py
+++ b/packages/adapters/discord/daimon/adapters/discord/github_visibility.py
@@ -6,8 +6,8 @@ bind path is already adapter-side I/O. The operator fallback PAT only clones
 ``anon:`` bindings, so an ``anon:`` binding must be verified-public at bind time
 — otherwise a guild could bind a private repo as ``anon:`` and clone it
 cross-tenant with the operator token. ``is_valid_pat`` covers the sibling case
-where no repo is given at all (D-06): it proves only the token's own identity,
-never repo access — the D-07 re-verification gate in ``modals.py`` is what
+where no repo is given at all: it proves only the token's own identity,
+never repo access — the re-verification gate in ``modals.py`` is what
 protects a *later* repo bind against an already-stored PAT.
 """
 
@@ -74,8 +74,9 @@ async def is_valid_pat(http_client: httpx.AsyncClient, *, pat: str) -> bool:
     this is the right check when the submit carries no repo to check access
     against. It deliberately proves only the token's own identity, never repo
     access: a PAT that passes this check is not yet cleared to clone any
-    particular repo, which is why the D-07 re-verification gate exists for a
-    later bind that resolves this same stored PAT against a specific repo.
+    particular repo, which is why the re-verification gate in ``modals.py``
+    exists for a later bind that resolves this same stored PAT against a
+    specific repo.
     """
     resp = await http_client.get(
         "https://api.github.com/user",

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -601,7 +601,7 @@ def test_editview_has_env_vars_button_disabled_for_system_agent(account_id: uuid
 
 
 # ---------------------------------------------------------------------------
-# D-10: shared on_timeout, including the reused-instance rebind (Pitfall 2)
+# Shared on_timeout, including the reused-instance rebind
 # ---------------------------------------------------------------------------
 
 
@@ -634,14 +634,14 @@ async def test_credentials_view_timeout_replaces_the_subview(account_id: uuid.UU
     assert not any(isinstance(c, discord.ui.Select) for c in walked), (
         "the expired replacement must carry no interactive children"
     )
-    assert view.timeout == 300, "D-10 leaves timeout values unchanged"
+    assert view.timeout == 300, "the shared on_timeout mixin leaves timeout values unchanged"
 
 
 @pytest.mark.asyncio
 async def test_credentials_rerender_rebinds_the_current_interaction(
     account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Pitfall 2 regression guard: `_reload_and_rerender` must rebind on every
+    """Regression guard: `_reload_and_rerender` must rebind on every
     render, not just once at __init__ — this view is re-rendered as the SAME
     instance, so a stale-bound interaction would expire against the wrong
     (or a long-dead) message."""

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -102,7 +102,7 @@ def test_container_header_and_subtext() -> None:
     # First TextDisplay is the header from layout.header()
     assert len(texts) >= 1, "at least one TextDisplay in container"
     header_text = texts[0]
-    assert header_text.startswith("## 🔑 Secrets — "), f"header mismatch: {header_text!r}"
+    assert header_text.startswith("## 🔑 Env vars — "), f"header mismatch: {header_text!r}"
     assert "bot" in header_text, "agent name in header"
     assert "-# values are write-only; only key names are shown" in header_text, "subtext present"
 
@@ -140,7 +140,7 @@ def test_container_empty_state_shows_hint() -> None:
         child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
     ]
     # The hint line should be a dim -# line
-    hint_lines = [d for d in displays if "add your first secret" in d]
+    hint_lines = [d for d in displays if "add your first env var" in d]
     assert len(hint_lines) == 1, "empty state has a hint line"
     assert hint_lines[0].startswith("-#"), "empty hint uses dim -# prefix"
 
@@ -169,13 +169,13 @@ def test_subview_renders_remove_select_add_and_back(account_id: uuid.UUID) -> No
         is_system=False,
     )
     select = _remove_select(view)
-    assert select.placeholder == "✕ Remove a secret…", "single remove-select with house placeholder"
+    assert select.placeholder == "✕ Remove a var…", "single remove-select with house placeholder"
     assert [o.label for o in select.options] == ["✕ A", "✕ B"], "one option per secret"
     assert [o.value for o in select.options] == ["A", "B"], "option value is the key name"
     labels = [b.label for b in _find_buttons(view)]
-    assert "+ Add secrets" in labels, "add button present (plural label)"
+    assert "+ Add env vars" in labels, "add button present (plural label)"
     assert "← Back" in labels, "back button present"
-    add_btn = _button_by_label(view, "+ Add secrets")
+    add_btn = _button_by_label(view, "+ Add env vars")
     assert add_btn.disabled is False, "add enabled for a user agent under cap"
 
 
@@ -191,7 +191,7 @@ def test_subview_header_and_subtext(account_id: uuid.UUID) -> None:
         is_system=False,
     )
     text = _container_all_text(view)
-    assert "## 🔑 Secrets — " in text, "container header present"
+    assert "## 🔑 Env vars — " in text, "container header present"
     assert "my-bot" in text, "agent name in header"
     assert "-# values are write-only; only key names are shown" in text, "subtext present"
 
@@ -265,7 +265,7 @@ def test_subview_system_agent_disables_mutations_but_not_back(account_id: uuid.U
         is_system=True,
     )
     assert _remove_select(view).disabled is True, "system agents cannot remove secrets"
-    assert _button_by_label(view, "+ Add secrets").disabled is True, "system add disabled"
+    assert _button_by_label(view, "+ Add env vars").disabled is True, "system add disabled"
     assert _button_by_label(view, "← Back").disabled is False, "back stays enabled (read-only)"
 
 
@@ -282,7 +282,7 @@ def test_subview_empty_state_disables_select(account_id: uuid.UUID) -> None:
     )
     select = _remove_select(view)
     assert select.disabled is True, "no-secrets select is disabled"
-    assert "no secrets" in (select.placeholder or "").lower(), "empty-state placeholder"
+    assert "no env vars" in (select.placeholder or "").lower(), "empty-state placeholder"
 
 
 # --- PasteSecretModal: parse + validate + store (real DB) ------------------
@@ -342,7 +342,7 @@ async def test_paste_modal_stores_each_pair_and_never_logs_value(
     )
 
     toast = interaction.followup.send.call_args.args[0]
-    assert "Added 2 secrets" in toast, "multi-key success copy"
+    assert "Added 2 env vars" in toast, "multi-key success copy"
     assert _SECRET_VALUE not in toast, "toast never echoes a value"
     on_added.assert_awaited_once()  # re-render callback fired after a successful paste
 

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -15,6 +15,7 @@ import discord
 import pytest
 import structlog
 from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsModelConfig
+from daimon.adapters.discord.agent_setup import credentials as credentials_mod
 from daimon.adapters.discord.agent_setup import edit_view as edit_view_mod
 from daimon.adapters.discord.agent_setup.credentials import (
     CredentialsSubView,
@@ -597,3 +598,86 @@ def test_editview_has_env_vars_button_disabled_for_system_agent(account_id: uuid
     user_view = EditView(_state(user_entry, account_id), runtime=runtime, allowed_user_id=42)
     user_buttons = {b.label: b for b in _walk_buttons(user_view) if b.label is not None}
     assert user_buttons["Env vars"].disabled is False, "user agents can open Env vars"
+
+
+# ---------------------------------------------------------------------------
+# D-10: shared on_timeout, including the reused-instance rebind (Pitfall 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_credentials_view_timeout_replaces_the_subview(account_id: uuid.UUID) -> None:
+    entry = _entry("bot")
+    view = CredentialsSubView(
+        runtime=MagicMock(spec=DiscordRuntime),
+        state=_state(entry, account_id),
+        allowed_user_id=42,
+        tenant_id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        secret_names=["A"],
+        is_system=False,
+    )
+    interaction = MagicMock()
+    interaction.edit_original_response = AsyncMock()
+    view.bind_render_interaction(interaction, panel=_state(entry, account_id))
+
+    await view.on_timeout()
+
+    interaction.edit_original_response.assert_called_once()
+    call_kwargs = interaction.edit_original_response.call_args.kwargs
+    assert "content" not in call_kwargs, "the timeout edit must not override content"
+    expired_view = call_kwargs["view"]
+    walked = list(expired_view.walk_children())
+    assert not any(isinstance(c, discord.ui.Button) for c in walked), (
+        "the expired replacement must carry no interactive children"
+    )
+    assert not any(isinstance(c, discord.ui.Select) for c in walked), (
+        "the expired replacement must carry no interactive children"
+    )
+    assert view.timeout == 300, "D-10 leaves timeout values unchanged"
+
+
+@pytest.mark.asyncio
+async def test_credentials_rerender_rebinds_the_current_interaction(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pitfall 2 regression guard: `_reload_and_rerender` must rebind on every
+    render, not just once at __init__ — this view is re-rendered as the SAME
+    instance, so a stale-bound interaction would expire against the wrong
+    (or a long-dead) message."""
+    monkeypatch.setattr(credentials_mod, "list_agent_files", AsyncMock(return_value=[]))
+
+    entry = _entry("bot")
+    state = _state(entry, account_id)
+    runtime = MagicMock()
+    runtime.sessionmaker.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+    runtime.sessionmaker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    view = CredentialsSubView(
+        runtime=runtime,
+        state=state,
+        allowed_user_id=42,
+        tenant_id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        secret_names=["A"],
+        is_system=False,
+    )
+
+    first_interaction = MagicMock()
+    first_interaction.edit_original_response = AsyncMock()
+    view.bind_render_interaction(first_interaction, panel=state)
+
+    second_interaction = MagicMock()
+    second_interaction.edit_original_response = AsyncMock()
+    await view._reload_and_rerender(second_interaction)  # pyright: ignore[reportPrivateUsage]
+
+    await view.on_timeout()
+
+    first_interaction.edit_original_response.assert_not_called()
+    second_interaction.edit_original_response.assert_called()
+    last_call_kwargs = second_interaction.edit_original_response.call_args.kwargs
+    expired_view = last_call_kwargs["view"]
+    walked = list(expired_view.walk_children())
+    assert not any(isinstance(c, discord.ui.Button) for c in walked), (
+        "the timeout edit must land through the SECOND interaction with the controls-less expired view"
+    )

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -490,11 +490,11 @@ async def test_back_replaces_with_editview_in_place(account_id: uuid.UUID) -> No
     assert isinstance(sent_view, EditView), "back returns to the unified EditView"
 
 
-# --- EditView._on_secrets opens the sub-view -------------------------------
+# --- EditView._on_env_vars opens the sub-view ------------------------------
 
 
 @pytest.mark.asyncio
-async def test_editview_secrets_button_opens_subview(
+async def test_editview_env_vars_button_opens_subview(
     db_session: AsyncSession,
     db_session_factory: async_sessionmaker[AsyncSession],
     account_id: uuid.UUID,
@@ -553,9 +553,9 @@ async def test_editview_secrets_button_opens_subview(
     interaction.response.edit_message = AsyncMock()
     interaction.guild_id = 123
 
-    await edit_view._on_secrets(interaction)  # pyright: ignore[reportPrivateUsage]
+    await edit_view._on_env_vars(interaction)  # pyright: ignore[reportPrivateUsage]
 
-    interaction.response.edit_message.assert_awaited_once()  # secrets opens the sub-view in place
+    interaction.response.edit_message.assert_awaited_once()  # env vars opens the sub-view in place
     kwargs = interaction.response.edit_message.call_args.kwargs
     assert isinstance(kwargs["view"], CredentialsSubView), "view is the CredentialsSubView"
     # The sub-view's container must not contain the secret value
@@ -563,7 +563,7 @@ async def test_editview_secrets_button_opens_subview(
     assert _SECRET_VALUE not in all_text, "the opened view lists the key masked, never its value"
 
 
-def test_editview_has_secrets_button_disabled_for_system_agent(account_id: uuid.UUID) -> None:
+def test_editview_has_env_vars_button_disabled_for_system_agent(account_id: uuid.UUID) -> None:
     settings = MagicMock()
     settings.mcp.public_url = None
     runtime = DiscordRuntime(
@@ -584,8 +584,8 @@ def test_editview_has_secrets_button_disabled_for_system_agent(account_id: uuid.
     )
     sys_view = EditView(_state(sys_entry, account_id), runtime=runtime, allowed_user_id=42)
     sys_buttons = {b.label: b for b in _walk_buttons(sys_view) if b.label is not None}
-    assert sys_buttons["Secrets"].disabled is True, (
-        "system agents see the Secrets button disabled (defensive)"
+    assert sys_buttons["Env vars"].disabled is True, (
+        "system agents see the Env vars button disabled (defensive)"
     )
 
     user_entry = RosterEntry(
@@ -596,4 +596,4 @@ def test_editview_has_secrets_button_disabled_for_system_agent(account_id: uuid.
     )
     user_view = EditView(_state(user_entry, account_id), runtime=runtime, allowed_user_id=42)
     user_buttons = {b.label: b for b in _walk_buttons(user_view) if b.label is not None}
-    assert user_buttons["Secrets"].disabled is False, "user agents can open Secrets"
+    assert user_buttons["Env vars"].disabled is False, "user agents can open Env vars"

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -10,9 +10,7 @@ import discord
 import pytest
 from daimon.adapters.discord.agent_setup.edit_view import (
     EditView,
-    _AuthFollowUpView,  # pyright: ignore[reportPrivateUsage]
     _McpRemoveSelect,  # pyright: ignore[reportPrivateUsage]
-    _ScalarFieldSelect,  # pyright: ignore[reportPrivateUsage]
     _SkillRemoveSelect,  # pyright: ignore[reportPrivateUsage]
     build_edit_container,
 )
@@ -149,7 +147,7 @@ def test_edit_view_header_and_subtext(account_id: uuid.UUID) -> None:
     assert "-# changes apply immediately" in text, "subtext must be present"
 
 
-def test_edit_view_has_three_selects_via_walk_children(account_id: uuid.UUID) -> None:
+def test_edit_view_has_only_the_two_remove_selects(account_id: uuid.UUID) -> None:
     from daimon.core.specs import SkillRef
 
     selected = _entry_with_mcps(
@@ -163,13 +161,17 @@ def test_edit_view_has_three_selects_via_walk_children(account_id: uuid.UUID) ->
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
     selects = _walk_selects(view)
+    assert len(selects) == 2, f"exactly two remove selects; got {len(selects)}"
     placeholders = [s.placeholder for s in selects]
-    assert "Edit a field…" in placeholders, "scalar select present"
     assert "✕ Remove a skill…" in placeholders, "skill remove select present"
     assert "✕ Remove an MCP…" in placeholders, "MCP remove select present"
+    for select in selects:
+        values = [o.value for o in select.options]
+        assert "agent" not in values, "no select offers an agent option value"
+        assert "repo" not in values, "no select offers a repo option value"
 
 
-def test_edit_view_has_five_buttons_via_walk_children(account_id: uuid.UUID) -> None:
+def test_edit_view_button_labels_in_row_order(account_id: uuid.UUID) -> None:
     selected = _entry("agent")
     state = PanelState(roster=[selected], selected=selected, account_id=account_id)
     runtime = MagicMock()
@@ -177,15 +179,18 @@ def test_edit_view_has_five_buttons_via_walk_children(account_id: uuid.UUID) -> 
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
     btn_labels = [b.label for b in _walk_buttons(view)]
-    assert "+ Add skill" in btn_labels, "+ Add skill button present"
-    assert "+ Add MCP" in btn_labels, "+ Add MCP button present"
-    assert "Auth…" in btn_labels, "Auth… button present"
-    assert "Secrets" in btn_labels, "Secrets button present"
-    assert "← Back" in btn_labels, "← Back button present"
+    assert btn_labels == [
+        "Agent…",
+        "GitHub…",
+        "Env vars",
+        "+ Add skill",
+        "+ Add MCP",
+        "← Back",
+    ], f"button labels must be exactly the flat row order; got {btn_labels}"
 
 
 def test_edit_view_pat_absent_from_main_view(account_id: uuid.UUID) -> None:
-    """PAT must not appear on the EditView itself — it lives in the Auth… follow-up."""
+    """PAT must not appear as its own control on EditView."""
     selected = _entry("agent")
     state = PanelState(roster=[selected], selected=selected, account_id=account_id)
     runtime = MagicMock()
@@ -206,83 +211,11 @@ def test_edit_view_timeout(account_id: uuid.UUID) -> None:
     assert view.timeout == 300, "EditView must use timeout=300"
 
 
-# --- Auth… follow-up view --------------------------------------------------
-
-
-def test_auth_followup_view_has_exactly_one_button(account_id: uuid.UUID) -> None:
-    """Connect GitHub was removed; only Paste a PAT… remains."""
-    selected = _entry("agent")
-    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
-    runtime = MagicMock()
-    runtime.settings.mcp.public_url = None
-
-    follow_up = _AuthFollowUpView(state, runtime=runtime, allowed_user_id=42)
-    buttons = _walk_buttons(follow_up)
-    labels = [b.label for b in buttons]
-    assert "Paste a PAT…" in labels, "Paste a PAT… option in follow-up"
-    assert len(buttons) == 1, f"exactly 1 button in auth follow-up; got {labels}"
+# --- Agent…/GitHub… buttons --------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_edit_view_auth_button_sends_followup(
-    account_id: uuid.UUID, mock_interaction: MagicMock
-) -> None:
-    selected = _entry("agent")
-    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
-    runtime = MagicMock()
-    runtime.settings.mcp.public_url = None
-
-    view = EditView(state, runtime=runtime, allowed_user_id=42)
-    auth_btn = _find_button(view, "Auth…")
-    assert auth_btn.callback is not None
-    await auth_btn.callback(mock_interaction)
-
-    mock_interaction.response.send_message.assert_called_once()
-    kwargs = mock_interaction.response.send_message.call_args.kwargs
-    assert isinstance(kwargs["view"], _AuthFollowUpView), "Auth… sends _AuthFollowUpView"
-    assert kwargs.get("ephemeral") is True, "follow-up must be ephemeral"
-
-
-@pytest.mark.asyncio
-async def test_auth_followup_pat_opens_repo_auth_modal(
-    account_id: uuid.UUID, mock_interaction: MagicMock
-) -> None:
-    from daimon.adapters.discord.agent_setup.modals import RepoAuthModal
-
-    selected = _entry("agent")
-    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
-    runtime = MagicMock()
-    runtime.settings.mcp.public_url = None
-
-    follow_up = _AuthFollowUpView(state, runtime=runtime, allowed_user_id=42)
-    pat_btn = next(b for b in _walk_buttons(follow_up) if b.label == "Paste a PAT…")
-    assert pat_btn.callback is not None
-    await pat_btn.callback(mock_interaction)
-
-    mock_interaction.response.send_modal.assert_called_once()
-    modal = mock_interaction.response.send_modal.call_args.args[0]
-    assert isinstance(modal, RepoAuthModal), "Paste a PAT… opens RepoAuthModal"
-
-
-# --- Select behavior -------------------------------------------------------
-
-
-def test_edit_view_scalar_select_options(account_id: uuid.UUID) -> None:
-    selected = _entry("agent")
-    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
-    runtime = MagicMock()
-    runtime.settings.mcp.public_url = None
-
-    view = EditView(state, runtime=runtime, allowed_user_id=42)
-    scalar = next(s for s in _walk_selects(view) if isinstance(s, _ScalarFieldSelect))  # pyright: ignore[reportPrivateUsage]
-    values = [o.value for o in scalar.options]
-    assert values == ["agent", "repo"], (
-        f"scalar select must offer only agent/repo in order; got {values}"
-    )
-
-
-@pytest.mark.asyncio
-async def test_edit_view_scalar_select_dispatches_agent_to_agent_section_modal(
+async def test_edit_view_agent_button_opens_agent_section_modal(
     account_id: uuid.UUID, mock_interaction: MagicMock
 ) -> None:
     from daimon.adapters.discord.agent_setup.modals import AgentSectionModal
@@ -293,18 +226,17 @@ async def test_edit_view_scalar_select_dispatches_agent_to_agent_section_modal(
     runtime.settings.mcp.public_url = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    scalar = next(s for s in _walk_selects(view) if isinstance(s, _ScalarFieldSelect))  # pyright: ignore[reportPrivateUsage]
-    scalar._values = ["agent"]  # pyright: ignore[reportPrivateUsage]
-    await scalar.callback(mock_interaction)
+    agent_btn = _find_button(view, "Agent…")
+    assert agent_btn.callback is not None
+    await agent_btn.callback(mock_interaction)
 
     mock_interaction.response.send_modal.assert_called_once()
     modal = mock_interaction.response.send_modal.call_args.args[0]
-    assert isinstance(modal, AgentSectionModal), "agent pick must open AgentSectionModal"
-    mock_interaction.response.defer.assert_not_called()
+    assert isinstance(modal, AgentSectionModal), "Agent… must open AgentSectionModal"
 
 
 @pytest.mark.asyncio
-async def test_edit_view_scalar_select_dispatches_repo_to_repo_auth_modal(
+async def test_edit_view_github_button_opens_repo_auth_modal(
     account_id: uuid.UUID, mock_interaction: MagicMock
 ) -> None:
     from daimon.adapters.discord.agent_setup.modals import RepoAuthModal
@@ -315,13 +247,14 @@ async def test_edit_view_scalar_select_dispatches_repo_to_repo_auth_modal(
     runtime.settings.mcp.public_url = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    scalar = next(s for s in _walk_selects(view) if isinstance(s, _ScalarFieldSelect))  # pyright: ignore[reportPrivateUsage]
-    scalar._values = ["repo"]  # pyright: ignore[reportPrivateUsage]
-    await scalar.callback(mock_interaction)
+    github_btn = _find_button(view, "GitHub…")
+    assert github_btn.callback is not None
+    await github_btn.callback(mock_interaction)
 
     mock_interaction.response.send_modal.assert_called_once()
     modal = mock_interaction.response.send_modal.call_args.args[0]
-    assert isinstance(modal, RepoAuthModal), "repo pick must open RepoAuthModal"
+    assert isinstance(modal, RepoAuthModal), "GitHub… must open RepoAuthModal directly"
+    mock_interaction.response.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -561,9 +494,9 @@ async def test_edit_view_remove_paths_never_mutate_main_panel(
     mock_interaction.edit_original_response.assert_called_once()
 
 
-def test_secrets_button_label_has_no_plus(account_id: uuid.UUID) -> None:
-    """The Secrets button opens a sub-view (not an add action), so its label is
-    'Secrets', not '+ Secrets'."""
+def test_env_vars_button_label_has_no_plus(account_id: uuid.UUID) -> None:
+    """The Env vars button opens a sub-view (not an add action), so its label is
+    'Env vars', not '+ Env vars'."""
     selected = _entry("agent")
     state = PanelState(roster=[selected], selected=selected, account_id=account_id)
     runtime = MagicMock()
@@ -571,11 +504,11 @@ def test_secrets_button_label_has_no_plus(account_id: uuid.UUID) -> None:
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
     labels = [b.label for b in _walk_buttons(view) if b.label is not None]
-    assert "Secrets" in labels, "Secrets button must be labeled 'Secrets'"
-    assert "+ Secrets" not in labels, "the '+' prefix must be dropped from the Secrets button"
+    assert "Env vars" in labels, "Env vars button must be labeled 'Env vars'"
+    assert "+ Env vars" not in labels, "the '+' prefix must be dropped from the Env vars button"
 
 
-def test_edit_view_secrets_button_disabled_for_system_agent(account_id: uuid.UUID) -> None:
+def test_edit_view_env_vars_button_disabled_for_system_agent(account_id: uuid.UUID) -> None:
     selected = _entry("sys")
     selected = RosterEntry(
         name="sys",
@@ -588,14 +521,14 @@ def test_edit_view_secrets_button_disabled_for_system_agent(account_id: uuid.UUI
     runtime.settings.mcp.public_url = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(view, "Secrets").disabled is True, (
-        "system agents see the Secrets button disabled (defensive)"
+    assert _find_button(view, "Env vars").disabled is True, (
+        "system agents see the Env vars button disabled (defensive)"
     )
 
     user_selected = _entry("bot")
     user_state = PanelState(roster=[user_selected], selected=user_selected, account_id=account_id)
     user_view = EditView(user_state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(user_view, "Secrets").disabled is False, "user agents can open Secrets"
+    assert _find_button(user_view, "Env vars").disabled is False, "user agents can open Env vars"
 
 
 # --- Back / open_edit_view edit-in-place (D-02, D-03) ----------------------

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -580,3 +580,56 @@ async def test_open_edit_view_swaps_onto_the_panel_message(
     mock_interaction.response.send_message.assert_not_called()
     view_kwarg = mock_interaction.response.edit_message.call_args.kwargs["view"]
     assert isinstance(view_kwarg, EditView), "open_edit_view must swap in an EditView"
+
+
+# ---------------------------------------------------------------------------
+# D-10: shared on_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_view_timeout_replaces_the_edit_view(
+    account_id: uuid.UUID, mock_interaction: MagicMock
+) -> None:
+    selected = _entry("agent")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    view.bind_render_interaction(mock_interaction, panel=state)
+
+    await view.on_timeout()
+
+    mock_interaction.edit_original_response.assert_called_once()
+    call_kwargs = mock_interaction.edit_original_response.call_args.kwargs
+    assert "content" not in call_kwargs, "the timeout edit must not override content"
+    expired_view = call_kwargs["view"]
+    walked = list(expired_view.walk_children())
+    assert not any(isinstance(c, discord.ui.Button) for c in walked), (
+        "the expired replacement must carry no interactive children"
+    )
+    assert not any(isinstance(c, discord.ui.Select) for c in walked), (
+        "the expired replacement must carry no interactive children"
+    )
+    assert view.timeout == 300, "D-10 leaves timeout values unchanged"
+
+
+@pytest.mark.asyncio
+async def test_open_edit_view_binds_the_render_interaction(
+    account_id: uuid.UUID, mock_interaction: MagicMock
+) -> None:
+    """open_edit_view's swapped-in EditView must bind the interaction that rendered it."""
+    from daimon.adapters.discord.agent_setup.edit_view import open_edit_view
+
+    selected = _entry("agent")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    await open_edit_view(mock_interaction, state, runtime=runtime, allowed_user_id=42)
+
+    view_kwarg = mock_interaction.response.edit_message.call_args.kwargs["view"]
+    await view_kwarg.on_timeout()
+
+    mock_interaction.edit_original_response.assert_called_once()

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -531,7 +531,7 @@ def test_edit_view_env_vars_button_disabled_for_system_agent(account_id: uuid.UU
     assert _find_button(user_view, "Env vars").disabled is False, "user agents can open Env vars"
 
 
-# --- Back / open_edit_view edit-in-place (D-02, D-03) ----------------------
+# --- Back / open_edit_view edit-in-place -----------------------------------
 
 
 @pytest.mark.asyncio
@@ -583,7 +583,7 @@ async def test_open_edit_view_swaps_onto_the_panel_message(
 
 
 # ---------------------------------------------------------------------------
-# D-10: shared on_timeout
+# Shared on_timeout
 # ---------------------------------------------------------------------------
 
 
@@ -612,7 +612,7 @@ async def test_edit_view_timeout_replaces_the_edit_view(
     assert not any(isinstance(c, discord.ui.Select) for c in walked), (
         "the expired replacement must carry no interactive children"
     )
-    assert view.timeout == 300, "D-10 leaves timeout values unchanged"
+    assert view.timeout == 300, "the shared on_timeout mixin leaves timeout values unchanged"
 
 
 @pytest.mark.asyncio

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -596,3 +596,54 @@ def test_edit_view_secrets_button_disabled_for_system_agent(account_id: uuid.UUI
     user_state = PanelState(roster=[user_selected], selected=user_selected, account_id=account_id)
     user_view = EditView(user_state, runtime=runtime, allowed_user_id=42)
     assert _find_button(user_view, "Secrets").disabled is False, "user agents can open Secrets"
+
+
+# --- Back / open_edit_view edit-in-place (D-02, D-03) ----------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_view_back_edits_to_agent_setup_view(
+    account_id: uuid.UUID, mock_interaction: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """EditView's ← Back edits back to AgentSetupView in place; it never deletes."""
+    import daimon.adapters.discord.agent_setup.panel as panel_mod
+    from daimon.adapters.discord.agent_setup.panel import AgentSetupView
+
+    monkeypatch.setattr(panel_mod, "load_secret_count", AsyncMock(return_value=0))
+    monkeypatch.setattr(panel_mod, "load_selected_github_login", AsyncMock(return_value=None))
+    monkeypatch.setattr(panel_mod, "load_repo_binding", AsyncMock(return_value=None))
+
+    selected = _entry("agent")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+    runtime.settings.github.fallback_pat = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    back_btn = _find_button(view, "← Back")
+    await back_btn.callback(mock_interaction)
+
+    mock_interaction.edit_original_response.assert_called_once()
+    view_kwarg = mock_interaction.edit_original_response.call_args.kwargs["view"]
+    assert isinstance(view_kwarg, AgentSetupView), "Back must edit back to AgentSetupView"
+    mock_interaction.delete_original_response.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_open_edit_view_swaps_onto_the_panel_message(
+    account_id: uuid.UUID, mock_interaction: MagicMock
+) -> None:
+    """open_edit_view swaps EditView onto the existing message; it never sends a new one."""
+    from daimon.adapters.discord.agent_setup.edit_view import open_edit_view
+
+    selected = _entry("agent")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    await open_edit_view(mock_interaction, state, runtime=runtime, allowed_user_id=42)
+
+    mock_interaction.response.edit_message.assert_called_once()
+    mock_interaction.response.send_message.assert_not_called()
+    view_kwarg = mock_interaction.response.edit_message.call_args.kwargs["view"]
+    assert isinstance(view_kwarg, EditView), "open_edit_view must swap in an EditView"

--- a/packages/adapters/discord/tests/agent_setup/test_expiry.py
+++ b/packages/adapters/discord/tests/agent_setup/test_expiry.py
@@ -1,0 +1,130 @@
+"""Tests for the shared /agent-setup expiry helpers (D-10).
+
+Covers ``build_expired_view``/``edit_expired_message`` in isolation, plus the
+structural AST guard proving every view render site in ``agent_setup/`` and
+``commands/agent_setup.py`` binds the interaction that rendered it.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from unittest.mock import MagicMock
+
+import discord
+import pytest
+from daimon.adapters.discord.agent_setup.expiry import (
+    build_expired_view,
+    edit_expired_message,
+)
+
+
+def test_expired_view_names_the_command_and_carries_no_controls() -> None:
+    view = build_expired_view()
+    children = list(view.walk_children())
+
+    assert not any(isinstance(c, discord.ui.Button) for c in children), (
+        "the expired view must carry no interactive children"
+    )
+    assert not any(isinstance(c, discord.ui.Select) for c in children), (
+        "the expired view must carry no interactive children"
+    )
+
+    text = "\n".join(c.content for c in children if isinstance(c, discord.ui.TextDisplay))
+    assert "expired" in text.lower(), "the copy must say the panel expired"
+    assert "/agent-setup" in text, "the copy must tell the user to re-run /agent-setup"
+
+
+@pytest.mark.asyncio
+async def test_edit_expired_message_does_nothing_without_a_bound_interaction() -> None:
+    # A None interaction means the view was never rendered; nothing to touch.
+    await edit_expired_message(build_expired_view(), interaction=None)
+
+
+@pytest.mark.asyncio
+async def test_edit_expired_message_swallows_not_found(mock_interaction: MagicMock) -> None:
+    resp = MagicMock(status=404, reason="Not Found")
+    mock_interaction.edit_original_response.side_effect = discord.NotFound(resp, "Unknown Webhook")
+
+    await edit_expired_message(build_expired_view(), interaction=mock_interaction)
+
+    mock_interaction.edit_original_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_edit_expired_message_propagates_other_http_errors(
+    mock_interaction: MagicMock,
+) -> None:
+    resp = MagicMock(status=500, reason="Internal Server Error")
+    mock_interaction.edit_original_response.side_effect = discord.HTTPException(resp, "boom")
+
+    with pytest.raises(discord.HTTPException):
+        await edit_expired_message(build_expired_view(), interaction=mock_interaction)
+
+
+# ---------------------------------------------------------------------------
+# Structural guard: every `view=` render site binds the render interaction.
+# ---------------------------------------------------------------------------
+
+_RENDER_SITE_MODULE_NAMES = [
+    "daimon.adapters.discord.agent_setup.panel",
+    "daimon.adapters.discord.agent_setup.edit_view",
+    "daimon.adapters.discord.agent_setup.credentials",
+    "daimon.adapters.discord.agent_setup.set_default",
+    "daimon.adapters.discord.agent_setup.mcp_access",
+    "daimon.adapters.discord.agent_setup.modals",
+    "daimon.adapters.discord.agent_setup.modals_mcp",
+    "daimon.adapters.discord.commands.agent_setup",
+]
+
+
+def _is_exempt_none(value: ast.expr) -> bool:
+    return isinstance(value, ast.Constant) and value.value is None
+
+
+def _is_exempt_static_view(value: ast.expr) -> bool:
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "static_view"
+    )
+
+
+def _is_bound(value: ast.expr) -> bool:
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "bind_render_interaction"
+    )
+
+
+def test_every_view_render_site_binds_the_render_interaction() -> None:
+    """AST guard: every `view=` keyword is bound, `None`, or a static_view() call.
+
+    This is the invariant this design depends on to make the AST guard's own
+    scope enforceable: a render site that forgets to bind is invisible to
+    pyright, so this test is the only thing standing in for that discipline.
+    Do NOT narrow this guard's module list or add exemptions beyond the two
+    named above to make a task pass — bind the missing site instead.
+    """
+    import importlib
+
+    offenders: list[str] = []
+    for module_name in _RENDER_SITE_MODULE_NAMES:
+        module = importlib.import_module(module_name)
+        source = pathlib.Path(str(module.__file__)).read_text()
+        tree = ast.parse(source, filename=str(module.__file__))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for kw in node.keywords:
+                if kw.arg != "view":
+                    continue
+                value = kw.value
+                if _is_exempt_none(value) or _is_exempt_static_view(value) or _is_bound(value):
+                    continue
+                offenders.append(f"{module.__file__}:{node.lineno}")
+
+    assert not offenders, (
+        f"every view= render site must chain .bind_render_interaction(...) — offenders: {offenders}"
+    )

--- a/packages/adapters/discord/tests/agent_setup/test_expiry.py
+++ b/packages/adapters/discord/tests/agent_setup/test_expiry.py
@@ -1,4 +1,4 @@
-"""Tests for the shared /agent-setup expiry helpers (D-10).
+"""Tests for the shared /agent-setup expiry helpers.
 
 Covers ``build_expired_view``/``edit_expired_message`` in isolation, plus the
 structural AST guard proving every view render site in ``agent_setup/`` and

--- a/packages/adapters/discord/tests/agent_setup/test_mcp_access.py
+++ b/packages/adapters/discord/tests/agent_setup/test_mcp_access.py
@@ -432,7 +432,7 @@ async def test_revoke_confirmation_edits_message_content_and_clears_view(
 
 
 # ---------------------------------------------------------------------------
-# D-10: shared timeout mechanics, but diverging shape (classic View, keeps content)
+# Shared timeout mechanics, but diverging shape (classic View, keeps content)
 # ---------------------------------------------------------------------------
 
 
@@ -495,7 +495,7 @@ async def test_mcp_access_timeout_disables_revoke_and_keeps_the_config_block(
 
     revoke_btn = _find_button(sent_view, EXPIRED_BUTTON_LABEL)
     assert revoke_btn.disabled is True, "the Revoke button must be disabled on timeout"
-    assert sent_view.timeout == 300, "D-10 leaves timeout values unchanged"
+    assert sent_view.timeout == 300, "the shared on_timeout mixin leaves timeout values unchanged"
 
 
 @pytest.mark.asyncio

--- a/packages/adapters/discord/tests/agent_setup/test_mcp_access.py
+++ b/packages/adapters/discord/tests/agent_setup/test_mcp_access.py
@@ -429,3 +429,125 @@ async def test_revoke_confirmation_edits_message_content_and_clears_view(
     assert edit_kwargs.get("view") is None, (
         "Revoke confirmation must drop the button by passing view=None"
     )
+
+
+# ---------------------------------------------------------------------------
+# D-10: shared timeout mechanics, but diverging shape (classic View, keeps content)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_access_timeout_disables_revoke_and_keeps_the_config_block(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+    account_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+) -> None:
+    from daimon.adapters.discord.agent_setup.mcp_access import EXPIRED_BUTTON_LABEL
+
+    await _setup_tenant_and_account(
+        db_session,
+        tenant_id=tenant_id,
+        account_id=account_id,
+        external_id="test-guild-77-timeout",
+    )
+
+    ma_agent_id = "agent_017abc_77_timeout"
+    real_agent = _make_ma_agent(ma_agent_id, "expert-bot-timeout", tenant_id)
+
+    async def fake_find(*_a: Any, **_k: Any) -> BetaManagedAgentsAgent:
+        return real_agent
+
+    monkeypatch.setattr(mcp_access_mod, "find_agent_by_daimon_tag", fake_find)
+    monkeypatch.setattr(
+        mcp_access_mod, "resolve_tenant_for_panel", AsyncMock(return_value=tenant_id)
+    )
+
+    settings = _make_settings()
+    runtime = DiscordRuntime(
+        settings=settings,
+        anthropic=build_stub_anthropic(),
+        sessionmaker=db_session_factory,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+    )
+    entry = _entry("expert-bot-timeout")
+    state = PanelState(roster=[entry], selected=entry, account_id=account_id)
+
+    interaction_mint = _make_interaction()
+    await send_connect_via_mcp(interaction_mint, runtime=runtime, state=state, allowed_user_id=42)
+
+    mint_kwargs = interaction_mint.response.send_message.call_args.kwargs
+    sent_view = mint_kwargs["view"]
+
+    await sent_view.on_timeout()
+
+    interaction_mint.edit_original_response.assert_called_once()
+    call_kwargs = interaction_mint.edit_original_response.call_args.kwargs
+    assert "content" not in call_kwargs, (
+        "the config block and its token must survive — no content override"
+    )
+    assert call_kwargs["view"] is sent_view, "the SAME instance is edited back, not a replacement"
+
+    revoke_btn = _find_button(sent_view, EXPIRED_BUTTON_LABEL)
+    assert revoke_btn.disabled is True, "the Revoke button must be disabled on timeout"
+    assert sent_view.timeout == 300, "D-10 leaves timeout values unchanged"
+
+
+@pytest.mark.asyncio
+async def test_revoke_stops_the_view_so_the_timer_cannot_fire(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+    account_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+) -> None:
+    await _setup_tenant_and_account(
+        db_session,
+        tenant_id=tenant_id,
+        account_id=account_id,
+        external_id="test-guild-77-stop",
+    )
+
+    ma_agent_id = "agent_017abc_77_stop"
+    real_agent = _make_ma_agent(ma_agent_id, "expert-bot-stop", tenant_id)
+
+    async def fake_find(*_a: Any, **_k: Any) -> BetaManagedAgentsAgent:
+        return real_agent
+
+    monkeypatch.setattr(mcp_access_mod, "find_agent_by_daimon_tag", fake_find)
+    monkeypatch.setattr(
+        mcp_access_mod, "resolve_tenant_for_panel", AsyncMock(return_value=tenant_id)
+    )
+
+    settings = _make_settings()
+    runtime = DiscordRuntime(
+        settings=settings,
+        anthropic=build_stub_anthropic(),
+        sessionmaker=db_session_factory,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+    )
+    entry = _entry("expert-bot-stop")
+    state = PanelState(roster=[entry], selected=entry, account_id=account_id)
+
+    interaction_mint = _make_interaction()
+    await send_connect_via_mcp(interaction_mint, runtime=runtime, state=state, allowed_user_id=42)
+
+    mint_kwargs = interaction_mint.response.send_message.call_args.kwargs
+    sent_view = mint_kwargs["view"]
+    revoke_btn = _find_button(sent_view, "Revoke")
+
+    interaction_revoke = _make_interaction()
+    await revoke_btn.callback(interaction_revoke)
+
+    assert sent_view.is_finished() is True, (
+        "revoke must stop the view so its timer cannot re-attach a button later"
+    )

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -1451,6 +1451,226 @@ async def test_app_coverage_probe_error_does_not_block_bind(
 
 
 # ---------------------------------------------------------------------------
+# D-07: a blank PAT field must not mean "no inline PAT exists" (T-09-11)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blank_pat_bind_refused_when_stored_inline_pat_cannot_access_repo(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """A repo bound with a blank PAT field must re-verify any already-stored
+    inline PAT against the newly typed repo, and refuse the bind when that PAT
+    can't access it -- never falling through to the App/public probes. This is
+    the D-07 regression guard: removing the mitigation block must make this
+    test fail (verified by temporary local revert per the plan's acceptance
+    criteria)."""
+    app_installed_called = False
+    public_called = False
+    received: dict[str, Any] = {}
+
+    async def fake_load_inline_pat(runtime: Any, *, agent_id: uuid.UUID) -> str | None:
+        return "ghp_stale_stored_pat"
+
+    async def fake_pat_access(http_client: Any, *, owner_repo: str, pat: str) -> bool:
+        received["owner_repo"] = owner_repo
+        received["pat"] = pat
+        return False
+
+    async def fake_app_installed(http_client: Any, **kwargs: Any) -> bool:
+        nonlocal app_installed_called
+        app_installed_called = True
+        return True
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        nonlocal public_called
+        public_called = True
+        return True
+
+    set_binding_called = False
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_binding_called
+        set_binding_called = True
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "load_agent_inline_pat", fake_load_inline_pat)
+    monkeypatch.setattr(modals_mod, "pat_can_access_repo", fake_pat_access)
+    monkeypatch.setattr(modals_mod, "is_app_installed_for_repo", fake_app_installed)
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/other-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    assert not set_binding_called, (
+        "bind must be refused when the stored inline PAT can't access the new repo"
+    )
+    assert not public_called, "must not fall through to the public-visibility probe on refusal"
+    assert not app_installed_called, "must not fall through to the App-coverage probe on refusal"
+    assert received.get("owner_repo") == "me/other-repo", (
+        "re-verification must receive the normalized owner/repo, not the raw URL"
+    )
+    assert received.get("pat") == "ghp_stale_stored_pat", (
+        "re-verification must check the stored PAT, not the (blank) submitted one"
+    )
+    interaction.followup.send.assert_called_once()
+    call_text = str(interaction.followup.send.call_args).lower()
+    assert "stored" in call_text and "token" in call_text, (
+        "the refusal message must mention the stored token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_blank_pat_bind_writes_inline_pat_ref_when_stored_pat_covers_repo(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """When the stored inline PAT DOES cover the newly typed repo, the bind
+    succeeds and records inline-pat:{agent} -- skipping both the App-coverage
+    and public-visibility probes entirely, since select_clone_auth gives a
+    per-agent PAT unconditional precedence regardless of what those probes
+    would otherwise report."""
+    public_called = False
+    app_installed_called = False
+
+    async def fake_load_inline_pat(runtime: Any, *, agent_id: uuid.UUID) -> str | None:
+        return "ghp_covers_new_repo"
+
+    async def fake_pat_access(http_client: Any, *, owner_repo: str, pat: str) -> bool:
+        return True
+
+    async def fake_app_installed(http_client: Any, **kwargs: Any) -> bool:
+        nonlocal app_installed_called
+        app_installed_called = True
+        return True
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        nonlocal public_called
+        public_called = True
+        return True
+
+    captured: dict[str, Any] = {}
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        captured["ma_secret_ref"] = kwargs["ma_secret_ref"]
+        return MagicMock()
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "load_agent_inline_pat", fake_load_inline_pat)
+    monkeypatch.setattr(modals_mod, "pat_can_access_repo", fake_pat_access)
+    monkeypatch.setattr(modals_mod, "is_app_installed_for_repo", fake_app_installed)
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    sm = MagicMock()
+    sm.begin.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+    sm.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(), tenant_id=tenant_id, sessionmaker=sm
+    )
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/covered-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    await modal.on_submit(_interaction())
+
+    expected_agent_uuid = derive_agent_uuid(
+        tenant_id=tenant_id, ma_agent_id="agent_bindtest_abcdefgh1234"
+    )
+    assert captured.get("ma_secret_ref") == f"inline-pat:{expected_agent_uuid}", (
+        "a covered blank-PAT bind must record the stored inline PAT's ref"
+    )
+    assert not public_called, (
+        "must skip the public-visibility probe once the stored PAT covers the repo"
+    )
+    assert not app_installed_called, (
+        "must skip the App-coverage probe once the stored PAT covers the repo"
+    )
+
+
+@pytest.mark.asyncio
+async def test_blank_pat_bind_falls_through_to_public_check_without_stored_pat(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """No stored inline PAT for this agent -> the pre-existing anon:
+    App-coverage / public-visibility logic must run completely unchanged."""
+    public_called = False
+
+    async def fake_load_inline_pat(runtime: Any, *, agent_id: uuid.UUID) -> str | None:
+        return None
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        nonlocal public_called
+        public_called = True
+        return True
+
+    captured: dict[str, Any] = {}
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        captured["ma_secret_ref"] = kwargs["ma_secret_ref"]
+        return MagicMock()
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "load_agent_inline_pat", fake_load_inline_pat)
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    sm = MagicMock()
+    sm.begin.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+    sm.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(), tenant_id=tenant_id, sessionmaker=sm
+    )
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/public-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    await modal.on_submit(_interaction())
+
+    assert public_called, (
+        "no stored inline PAT -> the existing public-visibility check must still run"
+    )
+    assert captured.get("ma_secret_ref") == "anon:", (
+        "unchanged anon: behavior when no inline PAT is stored for this agent"
+    )
+
+
+# ---------------------------------------------------------------------------
 # D-01: modal submit returns to the launching view (EditView), not AgentSetupView
 # ---------------------------------------------------------------------------
 

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -1448,3 +1448,120 @@ async def test_app_coverage_probe_error_does_not_block_bind(
     assert "couldn't verify" in call_text or "could not verify" in call_text, (
         "user should see a neutral note that App coverage could not be verified"
     )
+
+
+# ---------------------------------------------------------------------------
+# D-01: modal submit returns to the launching view (EditView), not AgentSetupView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_section_submit_returns_to_edit_view(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """AgentSectionModal.on_submit must return the user to EditView, not AgentSetupView."""
+    from daimon.adapters.discord.agent_setup.edit_view import EditView
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        return MagicMock()
+
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+
+    selected = _entry("immutable-name")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = AgentSectionModal(state, runtime=runtime, allowed_user_id=99)
+    modal.model_in._value = "claude-sonnet-4-6"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    interaction.edit_original_response.assert_called_once()
+    view_kwarg = interaction.edit_original_response.call_args.kwargs["view"]
+    assert isinstance(view_kwarg, EditView), (
+        "AgentSectionModal submit must return to EditView, not AgentSetupView"
+    )
+    assert view_kwarg.allowed_user_id == 99, "the invoker gate must survive the round trip"
+
+
+@pytest.mark.asyncio
+async def test_repo_auth_submit_returns_to_edit_view(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """RepoAuthModal.on_submit must return the user to EditView, not AgentSetupView."""
+    from daimon.adapters.discord.agent_setup.edit_view import EditView
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        return True
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        return MagicMock()
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    sm = MagicMock()
+    sm.begin.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+    sm.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(), tenant_id=tenant_id, sessionmaker=sm
+    )
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=99)
+    modal.url_in._value = "https://github.com/me/public-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    interaction.edit_original_response.assert_called_once()
+    view_kwarg = interaction.edit_original_response.call_args.kwargs["view"]
+    assert isinstance(view_kwarg, EditView), (
+        "RepoAuthModal submit must return to EditView, not AgentSetupView"
+    )
+    assert view_kwarg.allowed_user_id == 99, "the invoker gate must survive the round trip"
+
+
+@pytest.mark.asyncio
+async def test_add_skill_submit_returns_to_edit_view(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """AddSkillModal.on_submit must return the user to EditView, not AgentSetupView."""
+    from daimon.adapters.discord.agent_setup.edit_view import EditView
+
+    async def fake_kickoff(
+        runtime: Any, *, tenant_id: uuid.UUID, account_id: uuid.UUID, agent_name: str, repo_url: str
+    ) -> SyncReport:
+        return SyncReport(synced=1)
+
+    monkeypatch.setattr(modals_mod, "kick_off_skill_sync", fake_kickoff)
+
+    selected = _entry("research-bot")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = AddSkillModal(state, runtime=runtime, allowed_user_id=99)
+    modal.url_in._value = "https://github.com/me/skills-repo"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+    await asyncio.sleep(0)  # let the fire-and-forget sync task finish
+
+    interaction.edit_original_response.assert_called_once()
+    view_kwarg = interaction.edit_original_response.call_args.kwargs["view"]
+    assert isinstance(view_kwarg, EditView), (
+        "AddSkillModal submit must return to EditView, not AgentSetupView"
+    )
+    assert view_kwarg.allowed_user_id == 99, "the invoker gate must survive the round trip"

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -1451,7 +1451,7 @@ async def test_app_coverage_probe_error_does_not_block_bind(
 
 
 # ---------------------------------------------------------------------------
-# D-07: a blank PAT field must not mean "no inline PAT exists" (T-09-11)
+# A blank PAT field must not mean "no inline PAT exists"
 # ---------------------------------------------------------------------------
 
 
@@ -1462,7 +1462,7 @@ async def test_blank_pat_bind_refused_when_stored_inline_pat_cannot_access_repo(
     """A repo bound with a blank PAT field must re-verify any already-stored
     inline PAT against the newly typed repo, and refuse the bind when that PAT
     can't access it -- never falling through to the App/public probes. This is
-    the D-07 regression guard: removing the mitigation block must make this
+    regression guard: removing the mitigation block must make this
     test fail (verified by temporary local revert per the plan's acceptance
     criteria)."""
     app_installed_called = False
@@ -1671,7 +1671,7 @@ async def test_blank_pat_bind_falls_through_to_public_check_without_stored_pat(
 
 
 # ---------------------------------------------------------------------------
-# D-01: modal submit returns to the launching view (EditView), not AgentSetupView
+# Modal submit returns to the launching view (EditView), not AgentSetupView
 # ---------------------------------------------------------------------------
 
 
@@ -1788,7 +1788,7 @@ async def test_add_skill_submit_returns_to_edit_view(
 
 
 # ---------------------------------------------------------------------------
-# D-06: Repo URL becomes optional — the PAT-only path
+# Repo URL becomes optional — the PAT-only path
 # ---------------------------------------------------------------------------
 
 
@@ -1830,7 +1830,7 @@ async def test_pat_only_submit_stores_pat_and_writes_no_binding(
     monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
 ) -> None:
     """A PAT submitted with no repo URL is verified via GET /user, stored, and
-    leaves agent_repo_binding untouched (D-06)."""
+    leaves agent_repo_binding untouched."""
     stored: dict[str, Any] = {}
     set_binding_called = False
     reconcile_called = False

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -1785,3 +1785,226 @@ async def test_add_skill_submit_returns_to_edit_view(
         "AddSkillModal submit must return to EditView, not AgentSetupView"
     )
     assert view_kwarg.allowed_user_id == 99, "the invoker gate must survive the round trip"
+
+
+# ---------------------------------------------------------------------------
+# D-06: Repo URL becomes optional — the PAT-only path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repo_auth_refuses_submit_with_no_url_and_no_pat(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """Both fields blank must be refused before defer(), not written as an
+    empty binding."""
+    set_binding_called = False
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_binding_called
+        set_binding_called = True
+        return MagicMock()
+
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = ""  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    interaction.response.send_message.assert_called_once()
+    call_text = str(interaction.response.send_message.call_args)
+    assert "Enter a repo URL" in call_text, "user must see the validation copy"
+    interaction.response.defer.assert_not_called()
+    assert not set_binding_called, "a fully blank submit must never write a binding"
+
+
+@pytest.mark.asyncio
+async def test_pat_only_submit_stores_pat_and_writes_no_binding(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """A PAT submitted with no repo URL is verified via GET /user, stored, and
+    leaves agent_repo_binding untouched (D-06)."""
+    stored: dict[str, Any] = {}
+    set_binding_called = False
+    reconcile_called = False
+
+    async def fake_is_valid_pat(http_client: Any, *, pat: str) -> bool:
+        return True
+
+    async def fake_store_inline_pat(
+        runtime: Any, *, account_id: uuid.UUID, agent_id: uuid.UUID, plaintext_pat: str
+    ) -> str:
+        stored["agent_id"] = agent_id
+        stored["plaintext_pat"] = plaintext_pat
+        return f"inline-pat:{agent_id}"
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_binding_called
+        set_binding_called = True
+        return MagicMock()
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        nonlocal reconcile_called
+        reconcile_called = True
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "is_valid_pat", fake_is_valid_pat)
+    monkeypatch.setattr(modals_mod, "store_inline_pat", fake_store_inline_pat)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = ""  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = "ghp_pat_only_token_1234"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    assert stored.get("plaintext_pat") == "ghp_pat_only_token_1234", (
+        "the submitted token must reach store_inline_pat"
+    )
+    assert not set_binding_called, "a PAT-only submit must write no agent_repo_binding row"
+    assert not reconcile_called, "nothing on the AgentSpec changed; reconcile must not run"
+    assert state.pat_last4 == "1234", "state must show the stored token's last-4"
+    assert state.bound_repo_url is None, "a PAT-only submit must not pin a repo"
+    interaction.followup.send.assert_called_once()
+    call_text = str(interaction.followup.send.call_args)
+    assert "GitHub MCP" in call_text, "the user must see the GitHub MCP explanation"
+
+
+@pytest.mark.asyncio
+async def test_pat_only_submit_refused_when_github_rejects_token(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """GitHub rejecting the token (401 from GET /user) must refuse the store."""
+    store_called = False
+
+    async def fake_is_valid_pat(http_client: Any, *, pat: str) -> bool:
+        return False
+
+    async def fake_store_inline_pat(*args: Any, **kwargs: Any) -> str:
+        nonlocal store_called
+        store_called = True
+        return "inline-pat:unused"
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "is_valid_pat", fake_is_valid_pat)
+    monkeypatch.setattr(modals_mod, "store_inline_pat", fake_store_inline_pat)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = ""  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = "ghp_bad_token"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    assert not store_called, "a rejected token must never reach store_inline_pat"
+    interaction.followup.send.assert_called_once()
+    call_text = str(interaction.followup.send.call_args)
+    assert "rejected" in call_text.lower(), (
+        "the failure must surface through the existing followup.send error path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pat_only_submit_does_not_call_repo_visibility_helpers(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """No repo given -> none of the repo-scoped visibility/App-coverage helpers
+    may be called."""
+    pat_access_called = False
+    is_public_called = False
+    app_installed_called = False
+
+    async def fake_is_valid_pat(http_client: Any, *, pat: str) -> bool:
+        return True
+
+    async def fake_pat_access(http_client: Any, *, owner_repo: str, pat: str) -> bool:
+        nonlocal pat_access_called
+        pat_access_called = True
+        return True
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        nonlocal is_public_called
+        is_public_called = True
+        return True
+
+    async def fake_app_installed(http_client: Any, **kwargs: Any) -> bool:
+        nonlocal app_installed_called
+        app_installed_called = True
+        return True
+
+    async def fake_store_inline_pat(*args: Any, **kwargs: Any) -> str:
+        return "inline-pat:test"
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "is_valid_pat", fake_is_valid_pat)
+    monkeypatch.setattr(modals_mod, "pat_can_access_repo", fake_pat_access)
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "is_app_installed_for_repo", fake_app_installed)
+    monkeypatch.setattr(modals_mod, "store_inline_pat", fake_store_inline_pat)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = ""  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = "ghp_no_repo_token"  # pyright: ignore[reportPrivateUsage]
+
+    await modal.on_submit(_interaction())
+
+    assert not pat_access_called, (
+        "pat_can_access_repo is repo-scoped; must not run when no repo is given"
+    )
+    assert not is_public_called, "is_public_repo is repo-scoped; must not run when no repo is given"
+    assert not app_installed_called, (
+        "is_app_installed_for_repo is repo-scoped; must not run when no repo is given"
+    )
+
+
+def test_repo_auth_modal_field_labels_fit_discord_limits(
+    tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """Every RepoAuthModal TextInput label/placeholder must respect Discord's
+    45/100-char caps, and the token field's label must mention GitHub MCP."""
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    for field in (modal.url_in, modal.branch_in, modal.pat_in):
+        assert len(field.label) <= 45, f"{field.label!r} exceeds Discord's 45-char label cap"
+        if field.placeholder is not None:
+            assert len(field.placeholder) <= 100, (
+                f"{field.placeholder!r} exceeds Discord's 100-char placeholder cap"
+            )
+    assert "GitHub MCP" in modal.pat_in.label, (
+        "the token field's label must mention the GitHub MCP server"
+    )

--- a/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
@@ -511,7 +511,7 @@ async def test_add_mcp_modal_unrelated_server_proceeds_past_guard(
 
 
 # ---------------------------------------------------------------------------
-# D-01: modal submit returns to the launching view (EditView), not AgentSetupView
+# Modal submit returns to the launching view (EditView), not AgentSetupView
 # ---------------------------------------------------------------------------
 
 

--- a/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
@@ -508,3 +508,61 @@ async def test_add_mcp_modal_unrelated_server_proceeds_past_guard(
     interaction.response.defer.assert_called_once()
     # reconcile was reached
     assert reconcile_calls == ["called"], "unrelated server must proceed to reconcile"
+
+
+# ---------------------------------------------------------------------------
+# D-01: modal submit returns to the launching view (EditView), not AgentSetupView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_mcp_submit_returns_to_edit_view(
+    monkeypatch: pytest.MonkeyPatch,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """AddMcpModal.on_submit must return the user to EditView, not a nested AgentSetupView.
+
+    The vault write is made to fail (500) so this test doesn't need to model a
+    full vault bootstrap — modals_mcp.py's on_submit falls through to the final
+    edit_original_response regardless of vault-write outcome.
+    """
+    from daimon.adapters.discord.agent_setup.edit_view import EditView
+
+    monkeypatch.setattr(modals_mcp_mod, "call_reconcile_for_panel", _noop_reconcile())
+
+    async def fake_find(client: Any, *, tenant_id: uuid.UUID, name: str) -> Any:
+        return _fake_ma_agent(tenant_id)
+
+    monkeypatch.setattr(modals_mcp_mod, "find_agent_by_daimon_tag", fake_find)
+
+    def vault_handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": {"message": "boom", "type": "api_error"}})
+
+    rt = _runtime_configured(
+        anthropic=build_stub_anthropic(vault_handler), sessionmaker=db_session_factory
+    )
+    selected = _entry("my-agent")
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        guild_id=12345,
+        is_admin=False,
+    )
+
+    modal = AddMcpModal(state, runtime=rt, allowed_user_id=99)
+    modal.name_in._value = "ext-mcp"  # pyright: ignore[reportPrivateUsage]
+    modal.url_in._value = "https://ext.example.com/mcp"  # pyright: ignore[reportPrivateUsage]
+    modal.token_in._value = "tok_zzzz_9999"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    interaction.edit_original_response.assert_called_once()
+    view_kwarg = interaction.edit_original_response.call_args.kwargs["view"]
+    assert isinstance(view_kwarg, EditView), (
+        "AddMcpModal submit must return to EditView, not AgentSetupView"
+    )
+    assert view_kwarg.allowed_user_id == 99, "the invoker gate must survive the round trip"

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -887,14 +887,24 @@ async def test_admin_view_invoker_match_still_guards(account_id: uuid.UUID) -> N
 
 
 @pytest.mark.asyncio
-async def test_back_button_routes_failure_through_render_error() -> None:
-    """A failed back-button delete surfaces a render_error message (with rid), not the raw type."""
+async def test_back_button_routes_failure_through_render_error(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed back-button rerender surfaces a render_error message (with rid), not the raw type."""
+    import daimon.adapters.discord.agent_setup.panel as panel_mod
     from daimon.adapters.discord.agent_setup.edit_view import BackButton
 
-    button = BackButton()
+    async def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(panel_mod, "rerender_root_panel", _boom)
+
+    selected = _entry("alice")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    button = BackButton(state=state, runtime=_make_runtime(), allowed_user_id=42)
     interaction = MagicMock()
     interaction.response.defer = AsyncMock()
-    interaction.delete_original_response = AsyncMock(side_effect=RuntimeError("boom"))
+    interaction.delete_original_response = AsyncMock()
     interaction.followup.send = AsyncMock()
 
     await button.callback(interaction)
@@ -903,6 +913,80 @@ async def test_back_button_routes_failure_through_render_error() -> None:
     message = interaction.followup.send.call_args.args[0]
     assert "rid:" in message, "the failure message must carry a request id via render_error"
     assert "RuntimeError" not in message, "the raw exception type must not leak to the user"
+    interaction.delete_original_response.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_back_button_edits_root_panel_in_place(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: Back calls rerender_root_panel once and never deletes the message."""
+    import daimon.adapters.discord.agent_setup.panel as panel_mod
+    from daimon.adapters.discord.agent_setup.edit_view import BackButton
+
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def _fake_rerender(*args: Any, **kwargs: Any) -> None:
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(panel_mod, "rerender_root_panel", _fake_rerender)
+
+    selected = _entry("alice")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    button = BackButton(state=state, runtime=_make_runtime(), allowed_user_id=42)
+    interaction = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.delete_original_response = AsyncMock()
+    interaction.followup.send = AsyncMock()
+
+    await button.callback(interaction)
+
+    assert len(calls) == 1, "rerender_root_panel must be called exactly once"
+    interaction.delete_original_response.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rerender_root_panel_hydrates_before_edit(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rerender_root_panel re-fetches secret_count/github_login before editing."""
+    import daimon.adapters.discord.agent_setup.panel as panel_mod
+    from daimon.core.stores.domain import AgentRepoBindingRow
+
+    selected = _entry("alice")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    state.secret_count = 0
+    state.github_login = None
+
+    async def _fake_secret_count(*_args: Any, **_kwargs: Any) -> int:
+        return 7
+
+    async def _fake_github_login(*_args: Any, **_kwargs: Any) -> str | None:
+        return "octocat"
+
+    async def _fake_repo_binding(*_args: Any, **_kwargs: Any) -> AgentRepoBindingRow | None:
+        return None
+
+    monkeypatch.setattr(panel_mod, "load_secret_count", _fake_secret_count)
+    monkeypatch.setattr(panel_mod, "load_selected_github_login", _fake_github_login)
+    monkeypatch.setattr(panel_mod, "load_repo_binding", _fake_repo_binding)
+
+    interaction = MagicMock()
+    interaction.edit_original_response = AsyncMock()
+
+    await panel_mod.rerender_root_panel(
+        interaction, state, runtime=_make_runtime_with_settings(), allowed_user_id=42
+    )
+
+    assert state.secret_count == 7, (
+        "secret_count must reflect the stubbed loader, not its pre-call value"
+    )
+    assert state.github_login == "octocat", "github_login must reflect the stubbed loader"
+    interaction.edit_original_response.assert_called_once()
+    view_kwarg = interaction.edit_original_response.call_args.kwargs["view"]
+    assert isinstance(view_kwarg, panel_mod.AgentSetupView), (
+        "rerender_root_panel must edit back to the root AgentSetupView"
+    )
 
 
 @pytest.mark.asyncio

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -1364,7 +1364,7 @@ def test_daimon_error_fork_site_is_not_captured() -> None:
 
 
 # ---------------------------------------------------------------------------
-# D-10: shared on_timeout (root panel)
+# Shared on_timeout (root panel)
 # ---------------------------------------------------------------------------
 
 
@@ -1390,7 +1390,7 @@ async def test_agent_setup_view_timeout_replaces_the_panel(
     assert not any(isinstance(c, discord.ui.Select) for c in walked), (
         "the expired replacement must carry no interactive children"
     )
-    assert view.timeout == 600, "D-10 leaves timeout values unchanged"
+    assert view.timeout == 600, "the shared on_timeout mixin leaves timeout values unchanged"
 
 
 @pytest.mark.asyncio

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -1361,3 +1361,51 @@ def test_daimon_error_fork_site_is_not_captured() -> None:
     assert "_capture_panel_exception" not in daimon_clause, (
         "the DaimonError site must stay user-facing — never captured to Sentry (A4)"
     )
+
+
+# ---------------------------------------------------------------------------
+# D-10: shared on_timeout (root panel)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_setup_view_timeout_replaces_the_panel(
+    account_id: uuid.UUID, mock_interaction: MagicMock
+) -> None:
+    selected = _entry("alice")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    view = AgentSetupView(state, runtime=_make_runtime(), allowed_user_id=42)
+    view.bind_render_interaction(mock_interaction, panel=state)
+
+    await view.on_timeout()
+
+    mock_interaction.edit_original_response.assert_called_once()
+    call_kwargs = mock_interaction.edit_original_response.call_args.kwargs
+    assert "content" not in call_kwargs, "the timeout edit must not override content"
+    expired_view = call_kwargs["view"]
+    walked = list(expired_view.walk_children())
+    assert not any(isinstance(c, discord.ui.Button) for c in walked), (
+        "the expired replacement must carry no interactive children"
+    )
+    assert not any(isinstance(c, discord.ui.Select) for c in walked), (
+        "the expired replacement must carry no interactive children"
+    )
+    assert view.timeout == 600, "D-10 leaves timeout values unchanged"
+
+
+@pytest.mark.asyncio
+async def test_superseded_panel_view_does_not_rewrite_the_message(
+    account_id: uuid.UUID, mock_interaction: MagicMock
+) -> None:
+    selected = _entry("alice")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    view_a = AgentSetupView(state, runtime=_make_runtime(), allowed_user_id=42)
+    view_a.bind_render_interaction(mock_interaction, panel=state)
+    view_b = AgentSetupView(state, runtime=_make_runtime(), allowed_user_id=42)
+    view_b.bind_render_interaction(mock_interaction, panel=state)
+
+    await view_a.on_timeout()
+    mock_interaction.edit_original_response.assert_not_called()
+
+    await view_b.on_timeout()
+    mock_interaction.edit_original_response.assert_called_once()

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -243,7 +243,7 @@ def test_body_text_filters_default_mcp_from_mcp_group(account_id: uuid.UUID) -> 
 
 
 def test_body_text_shows_repo_auth_group_when_repo_set(account_id: uuid.UUID) -> None:
-    """When a repo is bound, body shows the 📦 Repo & auth group with URL."""
+    """When a repo is bound, body shows the 📦 Repo group with URL."""
     selected = _entry_with("bot")
     state = PanelState(
         roster=[selected],
@@ -254,8 +254,9 @@ def test_body_text_shows_repo_auth_group_when_repo_set(account_id: uuid.UUID) ->
     )
     container = build_panel_container(state, thumbnail_url=None)
     text = _container_text(container)
-    assert "📦" in text, "body must contain 📦 Repo & auth group when repo is set"
+    assert "📦 **Repo**" in text, "body must contain 📦 Repo group when repo is set"
     assert "github.com/me/repo" in text, "repo URL must appear in body text"
+    assert "🔑 **Env**" not in text, "no secrets configured — 🔑 Env group must be absent"
 
 
 def test_body_text_shows_pat_last4_masked(account_id: uuid.UUID) -> None:
@@ -310,18 +311,23 @@ def test_body_text_labels_inline_pat_as_pat_not_handle(account_id: uuid.UUID) ->
 
 
 def test_body_text_shows_secret_count_when_secrets_present(account_id: uuid.UUID) -> None:
-    """When secret_count > 0, body shows the 🔑 secrets count in the Repo & auth group."""
+    """When secret_count > 0, body shows a separate 🔑 Env group with the count —
+    it must never fold back into the 📦 Repo line, even when both groups render."""
     selected = _entry_with("bot")
     state = PanelState(
         roster=[selected],
         selected=selected,
         account_id=account_id,
+        bound_repo_url="https://github.com/me/repo",
+        bound_branch="main",
         secret_count=3,
     )
     container = build_panel_container(state, thumbnail_url=None)
     text = _container_text(container)
-    assert "🔑" in text, "body must show 🔑 when secrets are present"
-    assert "3 secrets" in text, "body must show the secret count"
+    assert "🔑 **Env**" in text, "body must show a separate 🔑 Env group when secrets are present"
+    assert "3 variables" in text, "body must show the secret count as N variables"
+    repo_line = text.split("📦 **Repo**")[1].split("🔑 **Env**")[0]
+    assert "3" not in repo_line, "the secret count must never appear inside the 📦 Repo line"
 
 
 def test_body_text_hint_line_when_all_empty(account_id: uuid.UUID) -> None:
@@ -338,8 +344,41 @@ def test_body_text_hint_line_when_all_empty(account_id: uuid.UUID) -> None:
     # Empty panel → hint replaces all groups (no group headers)
     assert "🧩" not in text, "empty agent must NOT show 🧩 Skills header"
     assert "🔌" not in text, "empty agent must NOT show 🔌 MCPs header"
-    assert "📦" not in text, "empty agent must NOT show 📦 Repo & auth header"
+    assert "📦" not in text, "empty agent must NOT show 📦 Repo header"
     assert "Edit" in text, "hint line must mention **Edit**"
+
+
+def test_body_text_shows_env_group_without_repo_group(account_id: uuid.UUID) -> None:
+    """Secrets present but nothing repo/auth-related bound: 🔑 Env renders on its
+    own, with no 📦 Repo group and no fallback-hint replacing it."""
+    selected = _entry_with("bot")
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        secret_count=2,
+    )
+    container = build_panel_container(state, thumbnail_url=None)
+    text = _container_text(container)
+    assert "🔑 **Env**" in text, "🔑 Env group must render when secrets are present"
+    assert "2 variables" in text, "body must show the secret count as N variables"
+    assert "📦" not in text, "no repo/auth bound — 📦 Repo group must be absent"
+
+
+def test_body_text_missing_hint_names_env_vars(account_id: uuid.UUID) -> None:
+    """The missing-resource hint names 'env vars', not 'secrets'."""
+    selected = _entry_with("bot")
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        bound_repo_url="https://github.com/me/repo",
+        bound_branch="main",
+    )
+    container = build_panel_container(state, thumbnail_url=None)
+    text = _container_text(container)
+    assert "＋ env vars" in text, "missing-resource hint must say ＋ env vars"
+    assert "＋ secrets" not in text, "the hint must not still say ＋ secrets"
 
 
 def test_body_text_no_none_literal_in_empty_fields(account_id: uuid.UUID) -> None:
@@ -352,7 +391,7 @@ def test_body_text_no_none_literal_in_empty_fields(account_id: uuid.UUID) -> Non
 
 
 def test_body_text_last_sync_error_appears_in_repo_group(account_id: uuid.UUID) -> None:
-    """When last_sync_error is set, a warning line appears in the Repo & auth group."""
+    """When last_sync_error is set, a warning line appears in the 📦 Repo group."""
     selected = _entry("my-agent")
     state = PanelState(
         roster=[selected],
@@ -437,7 +476,7 @@ def test_body_text_anon_binding_no_warning_with_fallback(account_id: uuid.UUID) 
 def test_body_text_shows_shared_service_account_line_with_no_repo_bound(
     account_id: uuid.UUID,
 ) -> None:
-    """With the fallback PAT configured but nothing bound yet, the Repo & auth group
+    """With the fallback PAT configured but nothing bound yet, the 📦 Repo group
     renders with just the shared-service-account line — not the 'unconfigured' hint."""
     selected = _entry("my-agent")
     state = PanelState(
@@ -448,11 +487,12 @@ def test_body_text_shows_shared_service_account_line_with_no_repo_bound(
     )
     container = build_panel_container(state, thumbnail_url=None)
     text = _container_text(container)
-    assert "📦" in text, "fallback PAT configured must show the Repo & auth group even unbound"
+    assert "📦 **Repo**" in text, "fallback PAT configured must show the 📦 Repo group even unbound"
     assert "shared service account" in text, (
         "fallback PAT configured with nothing bound must show the shared-service-account line"
     )
     assert "won't clone" not in text, "no repo is bound, so the clone warning must not appear"
+    assert "🔑 **Env**" not in text, "no secrets configured — 🔑 Env group must be absent"
 
 
 def test_body_text_inline_pat_binding_never_warns(account_id: uuid.UUID) -> None:
@@ -473,7 +513,7 @@ def test_body_text_inline_pat_binding_never_warns(account_id: uuid.UUID) -> None
 
 
 def test_body_text_unbound_agent_has_no_repo_group(account_id: uuid.UUID) -> None:
-    """An unbound agent shows no Repo & auth group and no clone warning."""
+    """An unbound agent shows no 📦 Repo group and no clone warning."""
     selected = _entry("my-agent")
     state = PanelState(
         roster=[selected],
@@ -484,7 +524,7 @@ def test_body_text_unbound_agent_has_no_repo_group(account_id: uuid.UUID) -> Non
     )
     container = build_panel_container(state, thumbnail_url=None)
     text = _container_text(container)
-    assert "📦" not in text, "unbound agent must not show the Repo & auth group"
+    assert "📦" not in text, "unbound agent must not show the 📦 Repo group"
     assert "won't clone" not in text, "unbound agent must not show a clone warning"
 
 

--- a/packages/adapters/discord/tests/agent_setup/test_set_default.py
+++ b/packages/adapters/discord/tests/agent_setup/test_set_default.py
@@ -610,6 +610,25 @@ def test_set_default_view_has_back_button() -> None:
     assert len(back_buttons) == 1, "exactly one ← Back button must be present"
 
 
+@pytest.mark.asyncio
+async def test_open_set_default_swaps_onto_the_panel_message() -> None:
+    """open_set_default swaps SetDefaultView onto the existing message; never sends a new one."""
+    from daimon.adapters.discord.agent_setup.set_default import open_set_default
+
+    state = _make_state()
+    interaction = MagicMock()
+    interaction.guild = None
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+
+    await open_set_default(interaction, state, runtime=_set_default_runtime(), allowed_user_id=42)
+
+    interaction.response.edit_message.assert_called_once()
+    interaction.response.send_message.assert_not_called()
+    view_kwarg = interaction.response.edit_message.call_args.kwargs["view"]
+    assert isinstance(view_kwarg, SetDefaultView), "open_set_default must swap in a SetDefaultView"
+
+
 # ---------------------------------------------------------------------------
 # Deployment-default fallback in the scope blocks (R7)
 # ---------------------------------------------------------------------------

--- a/packages/adapters/discord/tests/agent_setup/test_set_default.py
+++ b/packages/adapters/discord/tests/agent_setup/test_set_default.py
@@ -630,6 +630,36 @@ async def test_open_set_default_swaps_onto_the_panel_message() -> None:
 
 
 # ---------------------------------------------------------------------------
+# D-10: shared on_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_default_view_timeout_replaces_the_cascade_panel() -> None:
+    state = _make_state()
+    interaction = MagicMock()
+    interaction.edit_original_response = AsyncMock()
+
+    view = SetDefaultView(state, runtime=_set_default_runtime(), allowed_user_id=42)
+    view.bind_render_interaction(interaction, panel=state)
+
+    await view.on_timeout()
+
+    interaction.edit_original_response.assert_called_once()
+    call_kwargs = interaction.edit_original_response.call_args.kwargs
+    assert "content" not in call_kwargs, "the timeout edit must not override content"
+    expired_view = call_kwargs["view"]
+    walked = list(expired_view.walk_children())
+    assert not any(isinstance(c, discord.ui.Button) for c in walked), (
+        "the expired replacement must carry no interactive children"
+    )
+    assert not any(isinstance(c, discord.ui.Select) for c in walked), (
+        "the expired replacement must carry no interactive children"
+    )
+    assert view.timeout == 300, "D-10 leaves timeout values unchanged"
+
+
+# ---------------------------------------------------------------------------
 # Deployment-default fallback in the scope blocks (R7)
 # ---------------------------------------------------------------------------
 

--- a/packages/adapters/discord/tests/agent_setup/test_set_default.py
+++ b/packages/adapters/discord/tests/agent_setup/test_set_default.py
@@ -630,7 +630,7 @@ async def test_open_set_default_swaps_onto_the_panel_message() -> None:
 
 
 # ---------------------------------------------------------------------------
-# D-10: shared on_timeout
+# Shared on_timeout
 # ---------------------------------------------------------------------------
 
 
@@ -656,7 +656,7 @@ async def test_set_default_view_timeout_replaces_the_cascade_panel() -> None:
     assert not any(isinstance(c, discord.ui.Select) for c in walked), (
         "the expired replacement must carry no interactive children"
     )
-    assert view.timeout == 300, "D-10 leaves timeout values unchanged"
+    assert view.timeout == 300, "the shared on_timeout mixin leaves timeout values unchanged"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/discord/tests/agent_setup/test_write.py
+++ b/packages/adapters/discord/tests/agent_setup/test_write.py
@@ -88,6 +88,69 @@ def test_mask_tail_long_input_returns_last_four() -> None:
     assert mask_tail("abcd") == "****abcd", "exactly-4-char input may show all four"
 
 
+@pytest.mark.asyncio
+async def test_load_agent_inline_pat_returns_none_when_crypto_unconfigured() -> None:
+    """No crypto keys -> no inline PAT could exist; the sessionmaker must never
+    be touched (calling _build_runtime_fernet unconditionally would raise)."""
+    agent_id = uuid.uuid4()
+    settings = MagicMock()
+    settings.crypto.keys = ()
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("sessionmaker must not be called when crypto is unconfigured")
+
+    runtime = DiscordRuntime(
+        settings=settings,
+        anthropic=build_stub_anthropic(),
+        sessionmaker=_boom,  # type: ignore[arg-type]  # deliberately wrong shape; must never be invoked
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+    )
+
+    result = await write_mod.load_agent_inline_pat(runtime, agent_id=agent_id)
+    assert result is None, "no crypto keys configured -> no inline PAT can exist"
+
+
+@pytest.mark.asyncio
+async def test_load_agent_inline_pat_returns_stored_pat(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Round-trips through store_inline_pat -> load_agent_inline_pat, decrypted."""
+    await make_tenant(db_session, platform="discord", workspace_id="test-guild-inline-pat-load")
+
+    fernet_key = Fernet.generate_key().decode()
+    plaintext = "ghp_inline_pat_load_xxxx9999"
+
+    settings = MagicMock()
+    settings.crypto.keys = (MagicMock(get_secret_value=lambda: fernet_key),)
+    settings.github.oauth_scopes = ("repo", "read:user")
+    runtime = DiscordRuntime(
+        settings=settings,
+        anthropic=build_stub_anthropic(),
+        sessionmaker=db_session_factory,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+    )
+
+    agent_id = uuid.uuid4()
+    await write_mod.store_inline_pat(
+        runtime,
+        account_id=uuid.uuid4(),
+        agent_id=agent_id,
+        plaintext_pat=plaintext,
+    )
+
+    result = await write_mod.load_agent_inline_pat(runtime, agent_id=agent_id)
+    assert result == plaintext, "load_agent_inline_pat must decrypt and return the exact stored PAT"
+
+
 async def test_load_tenant_roster_includes_all_tenant_agents(
     tenant_id: uuid.UUID,
     account_id: uuid.UUID,

--- a/packages/adapters/discord/tests/test_github_visibility.py
+++ b/packages/adapters/discord/tests/test_github_visibility.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from daimon.adapters.discord.github_visibility import is_public_repo, pat_can_access_repo
+from daimon.adapters.discord.github_visibility import (
+    is_public_repo,
+    is_valid_pat,
+    pat_can_access_repo,
+)
 
 
 @pytest.mark.asyncio
@@ -93,3 +97,39 @@ async def test_pat_can_access_repo_raises_on_server_error() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         with pytest.raises(httpx.HTTPStatusError):
             await pat_can_access_repo(client, owner_repo="owner/repo", pat="ghp_x")
+
+
+@pytest.mark.asyncio
+async def test_is_valid_pat_true_on_200() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/user", "must GET the repo-free /user identity endpoint"
+        assert request.headers.get("Authorization") == "Bearer ghp_good", (
+            "the PAT must be sent as a Bearer token"
+        )
+        return httpx.Response(200, json={"login": "octocat"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await is_valid_pat(client, pat="ghp_good")
+
+    assert result is True, "200 from /user means the token is a live GitHub identity"
+
+
+@pytest.mark.asyncio
+async def test_is_valid_pat_false_on_401() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"message": "Bad credentials"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await is_valid_pat(client, pat="ghp_expired")
+
+    assert result is False, "401 must be reported as an invalid/expired token"
+
+
+@pytest.mark.asyncio
+async def test_is_valid_pat_raises_on_500() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"message": "boom"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await is_valid_pat(client, pat="ghp_x")


### PR DESCRIPTION
## Summary

`/agent-setup` was a set of one-way doors. This makes it navigable, collapses the two GitHub-token entry points into one that actually works without a repo, and renames the two credential destinations so it's obvious which is which.

Three operator-reported defects, all in the panel's Discord UI layer:

1. **Every sub-view was a dead end.** Submitting any modal from the Edit view replaced it with a nested copy of the main panel — which had no Back, Done, or Close. The GitHub-auth follow-up view was worse: one button, no exit at all. The only way out of either was dismissing the ephemeral message.
2. **Two doors to one modal, and the wrong precondition.** A repo-URL select option and an `Auth…` button opened the *same* modal, while `Repo URL` was required — so a token could not be stored without pinning a repo, making "just give the agent a GitHub token for the MCP server" unreachable even though that server's credential is derived from exactly that token.
3. **`Auth…` and `Secrets` sat adjacent with no cue which took a token**, and the panel read-out merged GitHub identity and environment variables into one line that also counted secrets.

## Changes

### One ephemeral message, with a working way back

A modal submit now returns to the view it was launched from instead of rendering a nested panel copy. Every `← Back` swaps views in place within the single ephemeral message — previously some paths deleted the message and others edited it. A new `rerender_root_panel` gives one hydrate-then-edit path back to the root, so returning shows current data rather than values captured when the panel first opened.

`packages/adapters/discord/.../agent_setup/{panel,edit_view,set_default,modals,modals_mcp}.py`

### One GitHub door, and it no longer needs a repo

The intermediate auth follow-up view and the scalar-field select are both deleted. The Edit row is now three peer buttons — `Agent…`, `GitHub…`, `Env vars` — where `GitHub…` opens the repo-and-token modal directly.

`Repo URL` becomes optional. A token submitted with no repo is verified against its own identity via `GET /user`, stored, and writes no repo binding; the GitHub MCP credential picks it up on the next session with no changes to `packages/core/`. Submitting with both fields blank is refused rather than writing an empty binding.

`packages/adapters/discord/.../agent_setup/{edit_view,modals,write}.py`, `github_visibility.py`

### Named for their destinations

`Auth…` / `Secrets` become `GitHub…` / `Env vars`, and the panel body splits the merged group into separate repo and environment lines. The word "Auth" no longer appears on any control in the flow.

`packages/adapters/discord/.../agent_setup/{edit_view,panel,credentials}.py`

### Expired panels say so

All five views in the flow now share one `on_timeout` that disables their controls and replaces the body with a notice to re-run the command. Previously none of them overrode `on_timeout`, so an expired panel kept rendering live-looking controls that failed with "This interaction failed". Timeout values are unchanged.

Two supporting fixes were needed for this to work at all:
- A replaced view keeps its timer — the view store neither stops nor cancels the view it replaces. Without a generation counter, an abandoned view fires its timeout and wipes a message a live view owns. A per-render sequence number on the panel state retires superseded views.
- The root panel was sent as a follow-up message, which is distinct from the interaction's original response, so the expiry edit would have landed on the loading placeholder while the real panel kept its controls. That call now edits the original response.

`packages/adapters/discord/.../agent_setup/expiry.py` (new), `{panel,edit_view,credentials,set_default,mcp_access,state}.py`, `commands/agent_setup.py`

## Security

Making `Repo URL` optional opens an ordering hazard worth calling out explicitly, because it is the reason this PR is not a pure UI change.

Once a token can be stored with no repo binding, a repo can be bound later with the token field left blank. The clone-token resolver's inline-token short-circuit wins over both the GitHub App and public-repo paths — so that bind would clone using a token that was never verified against the repo being bound. The pre-existing repo-scoped verification exists precisely to stop a guild binding a repo it does not control and riding the deployment's App installation token, which is keyed by repo rather than by tenant.

The blank-token bind path therefore resolves whichever token would actually perform the clone — including a previously stored inline one — re-verifies it against the newly typed repo, and refuses the bind on failure rather than falling through. This is covered by a regression test that fails if the gate is removed; that was confirmed by temporarily disabling the gate and observing the bind silently succeed with a stale token before restoring it.

## Verification

- [x] Full suite: 3549 passed, 4 skipped (pre-existing, unrelated), 24 snapshots
- [x] `pyright` (strict, project-wide): 0 errors
- [x] `ruff check` / `ruff format --check`: clean
- [x] `lint-imports`: 6/6 contracts kept
- [x] `scripts/lint_anti_patterns.sh`: 9/9 rules clean
- [x] `scripts/lint_discord_modals.py`: 0 failures
- [x] `packages/core/` diff across the branch: empty
- [x] Goal-backward verification against the three original defects, read from shipped code rather than from change summaries

A structural test guards the render-site invariant: it parses all eight modules that construct one of these views and fails on any view construction that does not bind its render interaction, so a future render site cannot silently skip it.

## Scope

Discord only — the Slack adapter has no equivalent panel and is untouched.

Deliberately excluded: confirmation prompts on the existing destructive controls (a pre-existing gap, worth its own change), the chat-posted credential modal and agent guidance copy, and a Back button for the MCP-access view (reached from the root panel, where dismissing is a reasonable exit).
