### PR TITLE
Guard the public repo against companion-repo leakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: lint migrations
         run: uv run python scripts/lint_migrations.py
 
+      - name: lint companion-repo leakage
+        run: bash scripts/lint_designators.sh
+
       - name: env example check
         run: uv run python scripts/generate_env_example.py --check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,13 @@ repos:
         pass_filenames: false
         files: ^packages/core/alembic/versions/.*\.py$
 
+      - id: lint-designators
+        name: lint companion-repo leakage
+        entry: bash scripts/lint_designators.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+
       - id: env-example-check
         name: env example up to date
         entry: uv run python scripts/generate_env_example.py --check

--- a/packages/core/daimon/core/specs.py
+++ b/packages/core/daimon/core/specs.py
@@ -2,7 +2,7 @@
 
 Principle: thin passthrough. Field names mirror the `anthropic` SDK's
 `*CreateParams` TypedDicts so that YAML authors write what the SDK sees.
-No daimon-private aliases, no runtime translation layer inside these models —
+No daimon-specific aliases, no runtime translation layer inside these models —
 the seed converter (separate module) is the one place that maps a `*Spec` to
 the SDK's kwargs shape.
 

--- a/packages/core/tests/test_sessions.py
+++ b/packages/core/tests/test_sessions.py
@@ -1467,7 +1467,7 @@ async def test_create_session_degrades_when_copilot_credential_mount_fails(
 ) -> None:
     """SYNC-04: a transient anthropic.APIError on the Copilot credential POST
     must not raise out of create_session — the session is still created, and
-    a stable-keyed structured warning fires (Phase 04 consumes these keys)."""
+    a stable-keyed structured warning fires (the alerting pipeline keys off these)."""
     tenant = await make_tenant(db_session)
     agent_uuid = uuid.uuid4()
     account_id = uuid.UUID("00000000-0000-0000-0000-0000000000c2")

--- a/scripts/lint_designators.sh
+++ b/scripts/lint_designators.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Guard the public repo against leaking companion-repo material.
+#
+# This repo is public. A handful of things must never appear in it: the name of
+# the companion planning repo, production hostnames and cloud project ids, paths
+# into the planning directory (symlinked in and gitignored), and internal phase
+# designators.
+#
+# Deliberately NOT checked: threat-model ids (T-nn-nn), decision ids (D-nn), and
+# requirement ids (SYNC-nn, SUITE-nn, ...). Those are an established convention
+# here -- ~195 occurrences across ~79 files -- and the threat-model references in
+# particular are load-bearing security documentation. Banning them would delete
+# traceability, not protect anything.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+# Trees to scan. This script is excluded from its own scan (it names the patterns).
+readonly SELF="scripts/lint_designators.sh"
+readonly TREES=(packages apps scripts .github)
+
+failed=0
+
+# report <rule> <explanation> <extended-regex>
+report() {
+    local rule="$1" why="$2" pattern="$3" hits
+    hits=$(grep -rnE "$pattern" "${TREES[@]}" 2>/dev/null | grep -v "^${SELF}:") || true
+    if [[ -n "$hits" ]]; then
+        echo "FAIL [$rule] $why"
+        echo "$hits" | sed 's/^/    /'
+        echo
+        failed=1
+    fi
+}
+
+report "private-repo-name" \
+    "the companion planning repo must not be named in public code; say \"the companion planning repo\"" \
+    'daimon-private'
+
+report "production-identifiers" \
+    "production hostnames and cloud project ids belong in config or the companion repo, not in source" \
+    'daimon\.decision\.ai|pymc-daimon-prod'
+
+report "planning-paths" \
+    "the planning directory is gitignored here; code must not reference paths inside it" \
+    '\.planning/'
+
+report "phase-designator" \
+    "internal phase numbers are meaningless outside the companion repo; describe the behavior instead" \
+    '\bPhase [0-9]'
+
+if [[ "$failed" -ne 0 ]]; then
+    echo "lint_designators: found material that must not appear in the public repo."
+    echo "Fix the lines above. Do not add exemptions to work around them."
+    exit 1
+fi
+
+echo "lint_designators: 4 rules clean"


### PR DESCRIPTION
## Why

This repo is public and sits alongside a companion planning repo. A few things must never appear here: that repo's name, production hostnames and cloud project ids, paths into the gitignored planning directory, and internal phase designators.

That rule has been relying on discipline. It doesn't hold — a recent change leaked designators into 38 docstrings and assertion messages across 14 files despite explicit instruction, and it was caught only by a late review pass. Every other hard rule in this repo is enforced by a linter; this one now is too.

## What

`scripts/lint_designators.sh`, wired into pre-commit and the CI `lint` job next to the existing whole-tree linters (`lint_discord_modals.py`, `lint_anti_patterns.sh`, `lint_migrations.py`). Four rules, each with an explanation and the offending lines in its output.

Two existing violations fixed:

- `packages/core/daimon/core/specs.py` — "no daimon-private aliases" meant *aliases private to daimon*, a hyphenated adjective that reads exactly like the companion repo's name. Reworded to "daimon-specific", which is what it means.
- `packages/core/tests/test_sessions.py` — a phase number in a docstring, replaced with what the sentence was actually about.

## What is deliberately not checked

Threat-model ids (`T-nn-nn`), decision ids (`D-nn`), and requirement ids (`SYNC-nn`, `SUITE-nn`, …) are **not** flagged. There are ~195 such references across ~79 files, and the threat-model ones in particular are load-bearing security documentation — `"Per threat model T-13-01: label carries tool name only for tool_use events"`, `"Mitigation T-19-W0-01: ephemeral keypair generated per call"`. Banning them would delete traceability rather than protect anything, and `scripts/lint_anti_patterns.sh` itself cites two of them. The rationale is recorded in the script's header so the next person doesn't "tighten" it by accident.

## Verification

- Clean tree: exit 0, `4 rules clean`
- Planted a `daimon-private` reference in an unrelated source file: exit 1, correct file and line reported; exit 0 again after reverting
- Ran in the real pre-commit chain on this commit: passed