### PR TITLE
First-run agent provisioning: onboarding default agent, member-level configuration, admin-only reachability

### DIFF
--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -1,11 +1,10 @@
 name: daimon
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 system: |
-  You are daimon, a local development assistant embedded in the `daimon`
-  CLI and chat bots (Discord and Slack). You help the operator ideate, design, and execute
-  software tasks in the repo at the working directory. Prefer concise
-  answers; propose small, reversible actions; cite file paths and line
-  numbers when referencing code.
+  You are daimon, the agent this workspace starts with — available in the
+  channel you were mentioned in, able to write and run code, fit models, and
+  produce notebooks and charts. Prefer concise answers; propose small,
+  reversible actions; cite file paths and line numbers when referencing code.
 
   Align before you build. Before producing anything substantial — a notebook,
   analysis, dashboard, report, or multi-step change — make sure you're building
@@ -49,85 +48,21 @@ system: |
   user to paste a channel link for the channel you are already in, and never
   assume a platform: read it from the `<channel>` element.
 
-  If a user asks you to help them set up (e.g. "help me set up", "configure
-  me", "get me started", "set up my agent"), guide them through first-time
-  configuration of THIS agent using your available MCP tools:
+  Credentials never travel through chat as plaintext, during setup or at any
+  other time. If a user pastes one anyway, acknowledge it, call no tool with
+  it, and tell them to rotate it — never store or act on the value itself.
 
-  1. Ask which GitHub repository they want this agent bound to. Use
-     `set_repo_binding` to attach it once they share a URL and (if needed)
-     a PAT or device-code auth.
-  2. Ask whether they want to attach any Skills (knowledge bundles). Call
-     `list_skills` first to see what is already installed and prefer an
-     existing skill over re-syncing a near-duplicate. If they want a new
-     one, collect a GitHub URL containing `SKILL.md` files, then call
-     `sync_skills(url, branch="main", path="")` to fetch and upload them
-     to MA. After sync, pin the new skill(s) to the agent via
-     `update_agent(name, skills=[...])` — sync alone does not attach.
-  3. Ask whether they want to attach any additional MCP servers.
-     - For servers that do NOT require an auth token: collect a server
-       name and URL, then call
-       `attach_mcp_server(agent_name, server_name, url)`. Confirm with
-       the user before invoking.
-     - For servers that require an auth token: do NOT accept the token
-       in chat. Refuse, then call
-       `request_mcp_credential(agent_name, server_name, url, channel_id)`
-       and tell the user to click the button it posts in this thread —
-       clicking it opens a private modal where they enter the token, so
-       it never enters channel history or your context.
-  4. Confirm the final shape with the user before applying.
+  If this workspace looks unconfigured — no repository bound, no MCP servers
+  or skills attached beyond what you shipped with — lead your first reply
+  with a short orientation (what you are, plus two or three concrete next
+  steps) before answering whatever was actually asked. This is a judgement
+  you make fresh each time from what you can see; nothing here fires
+  automatically and nothing is remembered. When the workspace already looks
+  configured, or the request is concrete, just answer — don't manufacture an
+  orientation nobody asked for.
 
-  Credentials never travel through chat as plaintext — during this setup
-  flow or at any other time. If a task needs an environment secret you do
-  not already have, call
-  `request_env_credential(agent_name, key, purpose, channel_id)` rather
-  than asking the user to paste it: it posts the same kind of button. If a
-  user pastes a token or secret in chat anyway, acknowledge that you saw
-  it, call NO tool with it, and tell them to rotate it immediately since it is already in this channel's history and in MA's tenant-wide session log, which the bot cannot delete or scrub — then call
-  `request_mcp_credential` or `request_env_credential` (whichever
-  matches) so the replacement is entered privately via the button. Once
-  added via either tool, the credential becomes usable by everyone who
-  talks to this agent — say so when you post the button.
-
-  You can also perform agent roster operations on your tenant via MCP:
-
-  - `fork_agent(source_name, new_name)` clones an existing agent.
-  - `create_agent(spec)` creates a new agent from scratch (skills must be
-    attached after via `update_agent`).
-  - `update_agent(name, *, model, description, system, tools, mcp_servers, skills)`
-    patch-updates an existing agent — omitted fields are preserved, `[]`
-    clears a list field.
-  - `attach_mcp_server(agent_name, server_name, url)` attaches a no-auth
-    MCP server to an agent. NO auth token parameter; for auth-required
-    servers call `request_mcp_credential` instead.
-  - `list_agents` / `get_agent` for discovery.
-
-  When a user asks for a roster operation in chat ("fork yourself into
-  X", "create an agent named Y with system prompt Z", "edit my fork to
-  use model M"), invoke the corresponding tool directly. Always confirm
-  the resulting agent's name and id back to the user. The
-  `/agent-setup` panel (Discord or Slack) remains available as an
-  alternative UI for the same operations.
-
-  You CANNOT create scheduled/recurring routines yourself — routine creation
-  needs the invoking user's platform identity, which does not reach your
-  tools. When a user asks for recurring or scheduled updates ("every day at
-  9am summarize this channel", "remind me weekly"), do NOT try to do it with
-  your tools. Tell them to open the `/routines` panel and use "+ New Routine"
-  (there they pick the agent, a cron schedule, a timezone, and the trigger
-  message). You CAN read a channel and produce the summary on demand in the
-  moment — only the recurring schedule must be set up through `/routines`.
-
-  When the user asks to change an existing agent, environment, or skill's
-  configuration (model, system prompt, attached skills/MCPs, etc.),
-  use the live MCP tools — `update_agent`, `attach_mcp_server`,
-  `sync_skills`, etc. Those change the deployed resource the user is talking
-  to. Only edit `defaults/*.yaml` when the user explicitly asks to change the
-  repo's seed defaults or open a PR against them — editing the YAML does NOT
-  change the running agent.
-
-  `archive_agent` is intentionally NOT available via chat — destructive
-  deletes go through the `/agent-setup` panel or the `daimon agents
-  archive` CLI command.
+  For workspace setup, roster operations (creating, forking, and configuring
+  agents), credentials, and scheduled routines, see the workspace-setup skill.
 skills:
   - type: custom
     skill_id: cli-auth
@@ -135,6 +70,8 @@ skills:
     skill_id: marimo_notebooks
   - type: custom
     skill_id: marimo_blog
+  - type: custom
+    skill_id: workspace-setup
 tools:
   - type: agent_toolset_20260401
     configs:

--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: workspace-setup
+description: First-time workspace setup and agent-roster operations for a daimon workspace — repo binding, skills, MCP servers, credentials, routines, and what's admin-managed versus open to build.
+---
+
+# workspace-setup
+
+## Setting up a workspace for the first time
+
+When someone asks to configure this agent or get a workspace started ("help
+me set up", "configure me", "get me started"), walk through the following, in
+order, and confirm the shape with the user before you consider it done:
+
+1. **Repository.** Ask which GitHub repository they want the agent working
+   against. Repo binding cannot be done from a chat turn — a chat session
+   doesn't carry the identity the binding tool needs. Send them to
+   `/agent-setup` → the agent's **GitHub…** door instead, and say why in one
+   line (binding needs a fuller session than a chat turn carries).
+2. **Skills.** Call `list_skills` to see what's already available in this
+   workspace, and prefer an existing one over asking for a near-duplicate.
+   Attaching an existing skill to an agent works via
+   `update_agent(name, skills=[...])`. Bringing a brand-new skill bundle into
+   the workspace from a GitHub repository is an admin action, done from
+   `/agent-setup`'s Skills door — not from chat.
+3. **Additional MCP servers.** For a server that needs no auth token, collect
+   a name and URL, confirm with the user, then call
+   `attach_mcp_server(agent_name, server_name, url)`. For one that needs a
+   token, never accept it in chat — call
+   `request_mcp_credential(agent_name, server_name, url, channel_id)` instead
+   (see "Credentials never travel through chat" below).
+4. **Confirm the final shape** — repository, skills, MCP servers — with the
+   user before calling it done.
+
+If the agent doing the configuring is the one this deployment ships with,
+steps 2 and 3 can't target it directly — it isn't editable at all (see "When
+an operation is refused"). Offer to `fork_agent` it into an editable copy
+first, then run these steps against the fork.
+
+## Roster operations
+
+| Tool | What it does |
+|---|---|
+| `list_agents` | List every agent in this workspace. |
+| `get_agent` | Get one agent's full configuration by name. |
+| `create_agent` | Create a new agent from scratch. |
+| `fork_agent` | Clone an existing agent under a new name — the way to get an editable copy of an agent you can't edit directly. |
+| `update_agent` | Patch-update an agent's model, prompt, tools, skills, or MCP servers. Omitted fields are left alone; passing `[]` for a list field clears it. |
+| `attach_mcp_server` | Attach a new MCP server to an agent. |
+| `detach_mcp_server` | Remove an attached MCP server from an agent, and its matching tool entry, together. |
+| `remove_skill` | Detach one skill from one agent. |
+| `list_env_credential_keys` | List the environment-variable KEY NAMES set on an agent — never values. |
+| `remove_env_credential` | Remove one environment variable from an agent. |
+| `create_routine` | Schedule a recurring turn (see "Scheduled routines" below). |
+
+`remove_skill` only detaches this one agent's reference to a skill — the
+skill itself, and every other agent using it, are untouched. That is a
+DIFFERENT operation from **delete_skill**, which deletes the skill for the
+entire workspace; don't reach for it when a user just means "stop this agent
+using X."
+
+## When an operation is refused
+
+Anyone can build and configure their own agent. But an agent that is
+currently set as the default for a channel or for the whole workspace is
+admin-managed — changing its prompt, model, skills, or MCP servers needs a
+workspace admin, because people are already relying on that configuration.
+And the agent this deployment ships with can't be edited at all, by anyone,
+admin included — fork it (`fork_agent`) to get an editable copy, and
+configure that instead. Deleting an agent (**archive_agent**) is never
+available from chat either way — that always goes through `/agent-setup` or
+the `daimon agents archive` CLI command.
+
+## Credentials never travel through chat
+
+`request_env_credential` and `request_mcp_credential` post a single-use,
+expiring button in the thread; clicking it opens a private modal where the
+user enters the value, so it never enters channel history or the session
+log. Both are Discord-only today — on Slack, credential entry goes through
+`/agent-setup` instead.
+
+If a user pastes a token or secret in chat anyway: acknowledge that you saw
+it, call no tool with it, and tell them to rotate it immediately — it is
+already in this channel's history and in the tenant-wide session log,
+neither of which the bot can scrub. Then post the right button so the
+replacement is entered privately. Once a credential is added via either
+tool, it becomes usable by everyone who talks to that agent — say so when
+you post the button.
+
+## Scheduled routines
+
+The agent creates routines itself, with
+`create_routine(agent_name, cron_expr, timezone, trigger_message)`. Confirm
+the agent, the cron expression, the timezone, and the trigger message back to
+the user before calling it, and confirm the created routine back afterward.
+
+## Changing a running resource vs. changing the repo defaults
+
+The live tools above (`update_agent`, `attach_mcp_server`, and the rest)
+change the deployed resource the user is talking to, right now. Editing
+`defaults/*.yaml` in the repository only changes what a fresh install seeds
+going forward — it does not change any agent that is already running. Only
+touch the YAML when a user explicitly asks to change the repo's seed
+defaults or open a PR against them.

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
@@ -1,0 +1,82 @@
+"""Click-time authorization gate for the panel's spec-mutating writes.
+
+`EditView`'s spec controls are disabled when the render-time snapshot says a
+control shouldn't be usable — that snapshot is a rendering hint, not a
+boundary. This module is the boundary: every callback that would write an
+agent's prompt, model, skills, or MCP servers calls
+`refuse_if_reachable_and_not_admin` first, which re-derives both admin status
+and reachability from live state rather than trusting anything the view was
+constructed with, so a stale open panel or a demoted admin cannot write a
+change the rendered panel had already forbidden.
+"""
+
+from __future__ import annotations
+
+import structlog
+from daimon.adapters.discord.agent_setup.state import RosterEntry
+from daimon.adapters.discord.agent_setup.tenant import resolve_tenant_for_panel
+from daimon.adapters.discord.checks import is_guild_admin
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
+
+import discord
+
+log = structlog.get_logger()
+
+_SYSTEM_AGENT_MESSAGE = (
+    "This agent ships with the deployment and is managed from the repo defaults. "
+    "Fork it to make an editable copy."
+)
+_REACHABLE_AGENT_MESSAGE = (
+    "This agent is currently the default for this channel or the server, so "
+    "changing its setup needs Manage Server. Fork it to make an editable copy."
+)
+
+
+async def _send_ephemeral(interaction: discord.Interaction, content: str) -> None:  # type: ignore[type-arg]  # discord.Interaction default generic arg; only response/followup are used
+    if interaction.response.is_done():
+        await interaction.followup.send(content, ephemeral=True)
+    else:
+        await interaction.response.send_message(content, ephemeral=True)
+
+
+async def refuse_if_reachable_and_not_admin(
+    interaction: discord.Interaction,  # type: ignore[type-arg]  # discord.Interaction default generic arg; only response/followup/guild_id are used
+    *,
+    runtime: DiscordRuntime,
+    entry: RosterEntry | None,
+) -> bool:
+    """Click-time re-check shared by every panel callback that writes an agent spec.
+
+    Returns True when the caller must return immediately (the write is
+    refused); False when the write may proceed. Order, each short-circuiting:
+
+    1. No target selected -> refuse silently (belt and braces; every call
+       site already narrows `entry` past its own `selected is None` check).
+    2. The target is a system agent -> refuse, unconditionally, even for an
+       admin (a panel edit never stamps the seed's spec hash, so an admin
+       bypass here would reintroduce silent drift against the defaults).
+    3. A live guild admin -> allow, without reading the database.
+    4. Otherwise, read reachability fresh from the database and refuse when
+       the target currently resolves for some channel or the workspace.
+    """
+    if entry is None:
+        log.debug("agent_setup.authz.no_target")
+        return True
+    if entry.is_system:
+        await _send_ephemeral(interaction, _SYSTEM_AGENT_MESSAGE)
+        return True
+    if is_guild_admin(interaction):  # pyright: ignore[reportArgumentType]  # discord.Interaction vs Interaction[commands.Bot]; is_guild_admin only reads user/guild
+        return False
+    tenant_id = await resolve_tenant_for_panel(runtime, interaction)
+    async with runtime.sessionmaker() as session:
+        reachable = await is_agent_reachable_in_tenant(
+            session,
+            tenant_id=tenant_id,
+            agent_name=entry.name,
+            default=runtime.deployment_default,
+        )
+    if reachable:
+        await _send_ephemeral(interaction, _REACHABLE_AGENT_MESSAGE)
+        return True
+    return False

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -51,12 +51,16 @@ def build_credentials_container(
     *,
     agent_name: str,
     secret_names: list[str],
-    is_system: bool,
 ) -> discord.ui.Container[discord.ui.LayoutView]:
     """Pure: render the Credentials container from key NAMES only.
 
     Never receives or renders a secret value — every value is omitted entirely
     Key names render as `KEY` chips on a single line separated by · .
+
+    Env variables are per-agent daimon state (agent_files, keyed by
+    tenant/agent/key) and are never part of the agent spec, so provenance
+    (system-agent or not) does not gate them — every member, on every agent,
+    including the seeded default, can view and manage this sub-view.
     """
     container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container()
     container.add_item(
@@ -193,7 +197,6 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         tenant_id: uuid.UUID,
         agent_id: uuid.UUID,
         secret_names: list[str],
-        is_system: bool,
     ) -> None:
         super().__init__(timeout=300)
         self._runtime = runtime
@@ -202,7 +205,6 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         self._tenant_id = tenant_id
         self._agent_id = agent_id
         self._secret_names = secret_names
-        self._is_system = is_system
         self._build_items()
 
     def _agent_name(self) -> str:
@@ -214,11 +216,10 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         container = build_credentials_container(
             agent_name=self._agent_name(),
             secret_names=self._secret_names,
-            is_system=self._is_system,
         )
 
         # ✕ Remove a var… select (cap 20, glyph in placeholder not emoji=).
-        remove_select = _build_remove_select(self._secret_names, is_system=self._is_system)
+        remove_select = _build_remove_select(self._secret_names)
         remove_select.callback = self._make_remove_cb(remove_select)  # type: ignore[method-assign]
 
         select_row: discord.ui.ActionRow[CredentialsSubView] = discord.ui.ActionRow()
@@ -231,7 +232,7 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         add_btn: discord.ui.Button[CredentialsSubView] = discord.ui.Button(
             label="+ Add env vars",
             style=discord.ButtonStyle.success,
-            disabled=self._is_system or len(self._secret_names) >= _SECRET_CAP,
+            disabled=len(self._secret_names) >= _SECRET_CAP,
         )
         add_btn.callback = self._on_add  # type: ignore[method-assign]
         btn_row.add_item(add_btn)
@@ -327,14 +328,13 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         )
 
 
-def _build_remove_select(
-    secret_names: list[str], *, is_system: bool
-) -> discord.ui.Select[CredentialsSubView]:
+def _build_remove_select(secret_names: list[str]) -> discord.ui.Select[CredentialsSubView]:
     """✕ Remove a var… select listing every key (no cap).
 
     Each option's ``label``/``value`` carries ONLY the secret KEY NAME — never a
-    value, never a per-key custom_id. Disabled (empty placeholder) when
-    there are no secrets; disabled (mutation-blocked) for system agents.
+    value, never a per-key custom_id. Disabled (empty placeholder) only when
+    there are no secrets — env vars are per-agent daimon state, never part of
+    the agent spec, so provenance does not gate removal here.
     """
     if len(secret_names) == 0:
         return discord.ui.Select(
@@ -349,5 +349,5 @@ def _build_remove_select(
         min_values=1,
         max_values=1,
         options=[discord.SelectOption(label=f"✕ {key}"[:100], value=key) for key in secret_names],
-        disabled=is_system,
+        disabled=False,
     )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
@@ -12,6 +12,7 @@ import structlog
 from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
     BetaManagedAgentsURLMCPServerParams,
 )
+from daimon.adapters.discord.agent_setup import authz
 from daimon.adapters.discord.agent_setup.expiry import ExpiringView
 from daimon.adapters.discord.agent_setup.modals import (
     AddMcpModal,
@@ -129,6 +130,10 @@ class _SkillRemoveSelect(discord.ui.Select["EditView"]):
     async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
         if self.view is None or self.values[0] == "__none__":
             return
+        if await authz.refuse_if_reachable_and_not_admin(
+            interaction, runtime=self.view.runtime, entry=self.view.state.selected
+        ):
+            return
         await interaction.response.defer()
         index = int(self.values[0])
         agent_name = self.view.state.selected.name if self.view.state.selected else None
@@ -211,6 +216,10 @@ class _McpRemoveSelect(discord.ui.Select["EditView"]):
 
     async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
         if self.view is None or self.values[0] == "__none__":
+            return
+        if await authz.refuse_if_reachable_and_not_admin(
+            interaction, runtime=self.view.runtime, entry=self.view.state.selected
+        ):
             return
         await interaction.response.defer()
         # Snapshot the selected RosterEntry BEFORE the in-memory mutation —

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
@@ -103,7 +103,7 @@ class BackButton(discord.ui.Button[discord.ui.LayoutView]):
 class _SkillRemoveSelect(discord.ui.Select["EditView"]):
     """Select: pick a skill to remove (pick-to-remove, no confirm)."""
 
-    def __init__(self, state: PanelState) -> None:
+    def __init__(self, state: PanelState, *, disabled: bool = False) -> None:
         skills = state.selected.spec.skills if state.selected is not None else []
         if len(skills) == 0:
             super().__init__(
@@ -123,7 +123,7 @@ class _SkillRemoveSelect(discord.ui.Select["EditView"]):
             min_values=1,
             max_values=1,
             options=options,
-            disabled=False,
+            disabled=disabled,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
@@ -179,7 +179,9 @@ class _McpRemoveSelect(discord.ui.Select["EditView"]):
     into the full unfiltered list.
     """
 
-    def __init__(self, state: PanelState, *, public_url: str | None) -> None:
+    def __init__(
+        self, state: PanelState, *, public_url: str | None, disabled: bool = False
+    ) -> None:
         mcps = (state.selected.spec.mcp_servers if state.selected is not None else None) or []
         options: list[discord.SelectOption] = []
         for idx, entry in enumerate(mcps):
@@ -204,7 +206,7 @@ class _McpRemoveSelect(discord.ui.Select["EditView"]):
             min_values=1,
             max_values=1,
             options=options,
-            disabled=False,
+            disabled=disabled,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:  # type: ignore[override]
@@ -298,12 +300,26 @@ class EditView(ExpiringView, discord.ui.LayoutView):
             if not _is_default_mcp(e, public_url)
         )
 
+        # is_system gates the spec controls unconditionally — the seeded
+        # agent's prompt/model/skills/mcp_servers stay panel-un-editable for
+        # everyone, admin included (a panel edit never stamps
+        # daimon_spec_hash, so reconcile would skip the drift forever).
+        # spec_editable gates the same controls on reachability instead: an
+        # agent nobody has scoped is every member's scratchpad; once some
+        # channel or the workspace points at it, only an admin may change its
+        # spec. Env vars and GitHub… are per-agent attachments, never part of
+        # the spec, so neither guard applies to them.
+        is_system = bool(state.selected and state.selected.is_system)
+        spec_editable = state.is_admin or not state.is_selected_reachable()
+        spec_controls_disabled = is_system or not spec_editable
+
         # Button row 1: Agent… · GitHub… · Env vars.
         field_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
 
         agent_btn: discord.ui.Button[EditView] = discord.ui.Button(
             label="Agent…",
             style=discord.ButtonStyle.secondary,
+            disabled=spec_controls_disabled,
         )
         agent_btn.callback = self._on_agent  # type: ignore[method-assign]
         field_row.add_item(agent_btn)
@@ -315,14 +331,9 @@ class EditView(ExpiringView, discord.ui.LayoutView):
         github_btn.callback = self._on_github  # type: ignore[method-assign]
         field_row.add_item(github_btn)
 
-        # Defensive read-only gate: system agents can never reach EditView (the
-        # main panel disables Edit for them), so this `disabled` is belt-and-
-        # braces (defensive).
-        is_system = bool(state.selected and state.selected.is_system)
         env_vars_btn: discord.ui.Button[EditView] = discord.ui.Button(
             label="Env vars",
             style=discord.ButtonStyle.secondary,
-            disabled=is_system,
         )
         env_vars_btn.callback = self._on_env_vars  # type: ignore[method-assign]
         field_row.add_item(env_vars_btn)
@@ -335,7 +346,7 @@ class EditView(ExpiringView, discord.ui.LayoutView):
         add_skill_btn: discord.ui.Button[EditView] = discord.ui.Button(
             label="+ Add skill",
             style=discord.ButtonStyle.success,
-            disabled=skill_count >= _SKILL_CAP,
+            disabled=(skill_count >= _SKILL_CAP) or spec_controls_disabled,
         )
         add_skill_btn.callback = self._on_add_skill  # type: ignore[method-assign]
         btn_row.add_item(add_skill_btn)
@@ -343,7 +354,7 @@ class EditView(ExpiringView, discord.ui.LayoutView):
         add_mcp_btn: discord.ui.Button[EditView] = discord.ui.Button(
             label="+ Add MCP",
             style=discord.ButtonStyle.success,
-            disabled=user_mcp_count >= _MCP_CAP,
+            disabled=(user_mcp_count >= _MCP_CAP) or spec_controls_disabled,
         )
         add_mcp_btn.callback = self._on_add_mcp  # type: ignore[method-assign]
         btn_row.add_item(add_mcp_btn)
@@ -359,11 +370,13 @@ class EditView(ExpiringView, discord.ui.LayoutView):
 
         # Select row 3: skill remove; row 4: MCP remove.
         skill_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
-        skill_row.add_item(_SkillRemoveSelect(state))
+        skill_row.add_item(_SkillRemoveSelect(state, disabled=spec_controls_disabled))
         container.add_item(skill_row)
 
         mcp_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
-        mcp_row.add_item(_McpRemoveSelect(state, public_url=public_url))
+        mcp_row.add_item(
+            _McpRemoveSelect(state, public_url=public_url, disabled=spec_controls_disabled)
+        )
         container.add_item(mcp_row)
 
         self.add_item(container)
@@ -438,7 +451,6 @@ class EditView(ExpiringView, discord.ui.LayoutView):
                 tenant_id=tenant_id,
                 agent_id=agent_id,
                 secret_names=secret_names,
-                is_system=selected.is_system,
             ).bind_render_interaction(interaction, panel=self.state),
             allowed_mentions=discord.AllowedMentions.none(),
         )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -20,6 +20,7 @@ import time
 
 import httpx
 import structlog
+from daimon.adapters.discord.agent_setup import authz
 from daimon.adapters.discord.agent_setup.modals_mcp import AddMcpModal as AddMcpModal
 from daimon.adapters.discord.agent_setup.state import PanelState
 from daimon.adapters.discord.agent_setup.tenant import resolve_tenant_for_panel
@@ -144,6 +145,10 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
         error = validate_model_id(model_value)
         if error is not None:
             await interaction.response.send_message(error, ephemeral=True)
+            return
+        if await authz.refuse_if_reachable_and_not_admin(
+            interaction, runtime=self.runtime, entry=self.state.selected
+        ):
             return
         await interaction.response.defer()
         try:
@@ -487,9 +492,14 @@ class AddSkillModal(discord.ui.Modal, title="Add skill repo"):
             agent_name=agent_name,
             repo_url=url,
         )
-        await interaction.response.defer()
         if selected is None or not url:
+            await interaction.response.defer()
             return
+        if await authz.refuse_if_reachable_and_not_admin(
+            interaction, runtime=self.runtime, entry=selected
+        ):
+            return
+        await interaction.response.defer()
         tenant_id = await resolve_tenant_for_panel(self.runtime, interaction)
         try:
             self.state.add_skill_repo_pending(url)

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
@@ -8,6 +8,7 @@ import structlog
 from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
     BetaManagedAgentsURLMCPServerParams,
 )
+from daimon.adapters.discord.agent_setup import authz
 from daimon.adapters.discord.agent_setup.state import PanelState
 from daimon.adapters.discord.agent_setup.tenant import resolve_tenant_for_panel
 from daimon.adapters.discord.agent_setup.write import call_reconcile_for_panel, mask_tail
@@ -76,6 +77,10 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
         _rejection = get_reserved_mcp_rejection(server_name=name, url=url, public_url=_public_url)
         if _rejection is not None:
             await interaction.response.send_message(_rejection, ephemeral=True)
+            return
+        if await authz.refuse_if_reachable_and_not_admin(
+            interaction, runtime=self.runtime, entry=self.state.selected
+        ):
             return
         await interaction.response.defer()
         server_entry = BetaManagedAgentsURLMCPServerParams(name=name, type="url", url=url)

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -310,10 +310,9 @@ def build_panel_container(
     turn lifecycle uses theme.COLOR_BLURPLE).
     """
     if state.selected is None:
-        if state.is_admin:
-            copy = "_This server has no agents yet._ Use **New** to create the first one."
-        else:
-            copy = "_This server has no agents yet._\n\nView only — ask an admin to change defaults"
+        # Every member can create an agent — the copy is identical for admins
+        # and members alike (no "View only" variant on an empty roster).
+        copy = "_This server has no agents yet._ Use **New** to create the first one."
         return discord.ui.Container(discord.ui.TextDisplay(copy))
 
     selected = state.selected
@@ -510,11 +509,12 @@ def _get_thumbnail_url(interaction: discord.Interaction) -> str | None:
 class AgentSetupView(ExpiringView, discord.ui.LayoutView):
     """F5 Components V2 agent-setup card.
 
-    Container holds header, body, picker row, and (admins only) lifecycle row.
-    Member gating is structural: non-admins get a container WITHOUT the lifecycle
-    row — built that way, not cleared after the fact.
-
-    Mutation buttons only appear when state.is_admin.
+    Container holds header, body, picker row, a member row (New / Fork / Edit —
+    unconditional, every member can build and configure an agent), and, admins
+    only, an admin row (Set as default… / Delete / Connect via MCP — reachability
+    and destructive controls stay admin-gated). The split is structural: a
+    member's container never contains the admin row's components at all, not a
+    disabled flag on an otherwise-present button.
     """
 
     def __init__(
@@ -539,30 +539,44 @@ class AgentSetupView(ExpiringView, discord.ui.LayoutView):
         picker_row.add_item(picker)
         container.add_item(picker_row)
 
+        # Member row: New / Fork / Edit — unconditional. Building and
+        # configuring an unreachable agent is open to every member; only
+        # making one reachable, or destroying one, is admin-gated below.
+        selected = state.selected
+        has_selection = selected is not None
+        is_system = bool(selected and selected.is_system)
+
+        member_row: discord.ui.ActionRow[AgentSetupView] = discord.ui.ActionRow()
+
+        new_btn: discord.ui.Button[AgentSetupView] = discord.ui.Button(
+            label="New", style=discord.ButtonStyle.success
+        )
+        new_btn.callback = self._on_new  # type: ignore[method-assign]
+
+        fork_btn: discord.ui.Button[AgentSetupView] = discord.ui.Button(
+            label="Fork", style=discord.ButtonStyle.success
+        )
+        fork_btn.callback = self._on_fork  # type: ignore[method-assign]
+
+        self.edit_btn: discord.ui.Button[AgentSetupView] = discord.ui.Button(
+            label="Edit",
+            style=discord.ButtonStyle.primary,
+            disabled=not has_selection,
+        )
+        self.edit_btn.callback = self._on_edit  # type: ignore[method-assign]
+
+        member_row.add_item(new_btn)
+        member_row.add_item(fork_btn)
+        member_row.add_item(self.edit_btn)
+        container.add_item(hairline())
+        container.add_item(member_row)
+
         if state.is_admin:
-            # Lifecycle row: New / Fork / Edit / Set as default… / Delete.
-            selected = state.selected
-            has_selection = selected is not None
-            is_system = bool(selected and selected.is_system)
-
-            lifecycle_row: discord.ui.ActionRow[AgentSetupView] = discord.ui.ActionRow()
-
-            new_btn: discord.ui.Button[AgentSetupView] = discord.ui.Button(
-                label="New", style=discord.ButtonStyle.success
-            )
-            new_btn.callback = self._on_new  # type: ignore[method-assign]
-
-            fork_btn: discord.ui.Button[AgentSetupView] = discord.ui.Button(
-                label="Fork", style=discord.ButtonStyle.success
-            )
-            fork_btn.callback = self._on_fork  # type: ignore[method-assign]
-
-            self.edit_btn: discord.ui.Button[AgentSetupView] = discord.ui.Button(
-                label="Edit",
-                style=discord.ButtonStyle.primary,
-                disabled=(not has_selection) or is_system,
-            )
-            self.edit_btn.callback = self._on_edit  # type: ignore[method-assign]
+            # Admin row: Set as default… / Delete / Connect via MCP. All three
+            # touch tenant-wide reachability, destroy an agent, or mint a
+            # long-lived credential — blast radius beyond one member's own
+            # agent, so these stay admin-only.
+            admin_row: discord.ui.ActionRow[AgentSetupView] = discord.ui.ActionRow()
 
             self.set_default_btn: discord.ui.Button[AgentSetupView] = discord.ui.Button(
                 label="Set as default…",
@@ -578,25 +592,17 @@ class AgentSetupView(ExpiringView, discord.ui.LayoutView):
             )
             self.delete_btn.callback = self._on_delete  # type: ignore[method-assign]
 
-            lifecycle_row.add_item(new_btn)
-            lifecycle_row.add_item(fork_btn)
-            lifecycle_row.add_item(self.edit_btn)
-            lifecycle_row.add_item(self.set_default_btn)
-            lifecycle_row.add_item(self.delete_btn)
-            container.add_item(hairline())
-            container.add_item(lifecycle_row)
-
-            # Connect row: hooks a coding agent (Claude Code, etc.) up to the
-            # selected agent over MCP. Own row — the lifecycle row is full at 5.
-            connect_row: discord.ui.ActionRow[AgentSetupView] = discord.ui.ActionRow()
             self.connect_mcp_btn: discord.ui.Button[AgentSetupView] = discord.ui.Button(
                 label="🔌 Connect via MCP",
                 style=discord.ButtonStyle.primary,
                 disabled=(not has_selection) or is_system,
             )
             self.connect_mcp_btn.callback = self._on_connect_via_mcp  # type: ignore[method-assign]
-            connect_row.add_item(self.connect_mcp_btn)
-            container.add_item(connect_row)
+
+            admin_row.add_item(self.set_default_btn)
+            admin_row.add_item(self.delete_btn)
+            admin_row.add_item(self.connect_mcp_btn)
+            container.add_item(admin_row)
 
         self.add_item(container)
 

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/state.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/state.py
@@ -9,7 +9,12 @@ from typing import Any
 from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
     BetaManagedAgentsURLMCPServerParams,
 )
-from daimon.core.scope import ChannelConfigRow, DeploymentDefault, TenantConfigRow
+from daimon.core.scope import (
+    ChannelConfigRow,
+    DeploymentDefault,
+    TenantConfigRow,
+    is_agent_reachable,
+)
 from daimon.core.specs import AgentSpec
 from daimon.core.stores.domain import AgentRepoBindingRow
 
@@ -231,6 +236,26 @@ class PanelState:
         else:
             self.selected = self.roster[min(idx, len(self.roster) - 1)]
         return self.selected
+
+    def is_selected_reachable(self) -> bool:
+        """Whether some channel or the workspace currently resolves to the
+        selected agent, including through the deployment default fall-through.
+
+        This is a distinct question from `RosterEntry.is_system`: reachability
+        is a live cascade property (does anything currently point at this
+        agent), while `is_system` is a provenance marker (was this agent
+        created by the defaults seed). They coincide for the seeded agent on
+        a fresh install, but one never implies the other.
+        """
+        if self.selected is None:
+            return False
+        tenant_row, channel_rows = self.cascade_view
+        return is_agent_reachable(
+            self.selected.name,
+            tenant=tenant_row,
+            channels=channel_rows,
+            default=self.deployment_default,
+        )
 
     @classmethod
     def initial(

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -34,6 +34,7 @@ from daimon.adapters.discord.vision import (
     is_vision_image_attachment,
 )
 from daimon.core.config import Settings
+from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.defaults.provisioning import provision_tenant, reconcile_tenant_defaults
 from daimon.core.errors import DaimonError
 from daimon.core.ma_identity import derive_tenant_uuid
@@ -304,15 +305,28 @@ class DaimonBot(commands.Bot):
                 tenant_id=tenant_id,
                 public_url=public_url,
             )
-            if report.is_failure():
-                await set_provision_status(
-                    self.runtime.sessionmaker, tenant_id=tenant_id, status="failed"
-                )
-            else:
-                await set_provision_status(
-                    self.runtime.sessionmaker, tenant_id=tenant_id, status="ready"
-                )
-            embed = _build_snag_embed() if report.is_failure() else _build_ready_embed()
+            seed_ok = not report.is_failure()
+            if seed_ok:
+                agent_name = self.runtime.deployment_default.agent_name
+                if agent_name is None:
+                    log.info("guild_seed_roster_check_skipped", tenant_id=str(tenant_id))
+                else:
+                    default_agent = await find_agent_by_daimon_tag(
+                        self.runtime.anthropic, tenant_id=tenant_id, name=agent_name
+                    )
+                    if default_agent is None:
+                        seed_ok = False
+                        log.warning(
+                            "guild_seed_default_agent_missing",
+                            tenant_id=str(tenant_id),
+                            agent_name=agent_name,
+                        )
+            await set_provision_status(
+                self.runtime.sessionmaker,
+                tenant_id=tenant_id,
+                status="ready" if seed_ok else "failed",
+            )
+            embed = _build_ready_embed() if seed_ok else _build_snag_embed()
             await self._post_to_guild(guild, embed)
         except (DaimonError, _anthropic.APIError, discord.HTTPException) as exc:
             log.warning("guild_seed_failed", tenant_id=str(tenant_id), error=str(exc))

--- a/packages/adapters/discord/daimon/adapters/discord/commands/agent_setup.py
+++ b/packages/adapters/discord/daimon/adapters/discord/commands/agent_setup.py
@@ -27,6 +27,7 @@ from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
 from daimon.core.errors import DaimonError
 from daimon.core.stores.identity import get_or_create_platform_principal
+from daimon.core.stores.tenants import get_tenant
 
 import discord
 from discord import Interaction, app_commands
@@ -34,6 +35,17 @@ from discord.ext import commands
 
 log = structlog.get_logger()
 BotInteraction = Interaction[commands.Bot]
+
+
+def _not_ready_message(provision_status: str) -> str:
+    """Pure: copy for a tenant that isn't ready for the roster panel yet.
+
+    An unrecognized status fails closed to the same message as "pending"
+    rather than falling through to the panel.
+    """
+    if provision_status == "failed":
+        return "Setup hit a snag — check the message I posted in this server, then try again."
+    return "This install is still being set up — try again in a moment."
 
 
 def _get_runtime(interaction: BotInteraction) -> DiscordRuntime:
@@ -68,6 +80,15 @@ class AgentSetupCog(commands.Cog):
             is_admin = is_guild_admin(interaction)
             tenant_id = await resolve_tenant_for_interaction(interaction.client, interaction)
             assert tenant_id is not None, "require_registered_guild guarantees a tenant"
+            async with runtime.sessionmaker() as session:
+                tenant_row = await get_tenant(session, tenant_id)
+            assert tenant_row is not None, "require_registered_guild guarantees a tenant row"
+            if tenant_row.provision_status != "ready":
+                await interaction.edit_original_response(
+                    content=_not_ready_message(tenant_row.provision_status),
+                    allowed_mentions=discord.AllowedMentions.none(),
+                )
+                return
             async with runtime.sessionmaker() as session:
                 principal = await get_or_create_platform_principal(
                     session,

--- a/packages/adapters/discord/tests/agent_setup/conftest.py
+++ b/packages/adapters/discord/tests/agent_setup/conftest.py
@@ -5,15 +5,27 @@ from __future__ import annotations
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 from daimon.testing.ma import make_stub_anthropic, stub_anthropic  # noqa: F401
 
 
 @pytest.fixture
 def mock_interaction() -> MagicMock:
-    """A discord.Interaction stand-in — Discord boundary mock (allowed)."""
+    """A discord.Interaction stand-in — Discord boundary mock (allowed).
+
+    ``user`` is spec'd as a live guild admin (``discord.Member`` with
+    ``administrator=True``) so `authz.refuse_if_reachable_and_not_admin`'s
+    real admin short-circuit passes without a DB read — these unit tests
+    otherwise carry no real Postgres session for it to read from. Tests that
+    need a non-admin caller build their own interaction (see
+    ``test_authz.py``, and the reachable/system negative cases in
+    test_modals.py / test_modals_mcp.py / test_edit_view.py).
+    """
     interaction = MagicMock()
+    interaction.user = MagicMock(spec=discord.Member)
     interaction.user.id = 42
+    interaction.user.guild_permissions.administrator = True
     interaction.response.defer = AsyncMock()
     interaction.response.send_message = AsyncMock()
     interaction.response.send_modal = AsyncMock()

--- a/packages/adapters/discord/tests/agent_setup/test_authz.py
+++ b/packages/adapters/discord/tests/agent_setup/test_authz.py
@@ -1,0 +1,189 @@
+"""Tests for refuse_if_reachable_and_not_admin — the click-time write-path gate."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from daimon.adapters.discord.agent_setup.authz import refuse_if_reachable_and_not_admin
+from daimon.adapters.discord.agent_setup.state import RosterEntry
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault
+from daimon.core.specs import AgentSpec
+from daimon.testing.factories import make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+def _entry(name: str = "bot", *, is_system: bool = False) -> RosterEntry:
+    return RosterEntry(
+        name=name,
+        model="claude-sonnet-4-6",
+        spec=AgentSpec(name=name, model="claude-sonnet-4-6"),
+        is_system=is_system,
+    )
+
+
+def _runtime(
+    *,
+    sessionmaker: object,
+    deployment_default: DeploymentDefault | None = None,
+) -> DiscordRuntime:
+    return DiscordRuntime(
+        settings=MagicMock(),
+        anthropic=MagicMock(),
+        sessionmaker=sessionmaker,  # type: ignore[arg-type]  # a real async_sessionmaker or a spy MagicMock, never invoked as a client
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=deployment_default or DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+    )
+
+
+def _admin_interaction(*, guild_id: int = 111, acked: bool = False) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 1
+    interaction.user.guild_permissions.administrator = True
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.is_done.return_value = acked
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _member_interaction(*, guild_id: int = 111, acked: bool = False) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 2
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.is_done.return_value = acked
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+async def test_no_target_refuses_silently_without_db_read() -> None:
+    session_factory = MagicMock()
+    runtime = _runtime(sessionmaker=session_factory)
+    interaction = _member_interaction()
+
+    refused = await refuse_if_reachable_and_not_admin(interaction, runtime=runtime, entry=None)
+
+    assert refused is True, "no selected agent must refuse"
+    session_factory.assert_not_called()
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_system_agent_refuses_even_for_a_live_admin() -> None:
+    session_factory = MagicMock()
+    runtime = _runtime(sessionmaker=session_factory)
+    interaction = _admin_interaction()
+    entry = _entry("daimon", is_system=True)
+
+    refused = await refuse_if_reachable_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is True, "a system agent must refuse even a live admin"
+    session_factory.assert_not_called()
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+    interaction.followup.send.assert_not_called()
+
+
+async def test_admin_passes_without_touching_the_database() -> None:
+    session_factory = MagicMock()
+    runtime = _runtime(sessionmaker=session_factory)
+    interaction = _admin_interaction()
+    entry = _entry("bot")
+
+    refused = await refuse_if_reachable_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is False, "a live admin editing a non-system agent must pass"
+    session_factory.assert_not_called()
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_non_admin_unreachable_agent_passes(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 222001
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    runtime = _runtime(sessionmaker=db_session_factory)
+    interaction = _member_interaction(guild_id=guild_id)
+    entry = _entry("bot")
+
+    refused = await refuse_if_reachable_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is False, "an agent nobody has scoped must not be refused for a non-admin"
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_non_admin_reachable_agent_refuses(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 222002
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    entry = _entry("bot")
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        deployment_default=DeploymentDefault(agent_name=entry.name),
+    )
+    interaction = _member_interaction(guild_id=guild_id)
+
+    refused = await refuse_if_reachable_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is True, "the workspace's current default agent must refuse a non-admin"
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+    interaction.followup.send.assert_not_called()
+
+
+async def test_reachable_refusal_uses_followup_when_already_acked(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 222003
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    entry = _entry("bot")
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        deployment_default=DeploymentDefault(agent_name=entry.name),
+    )
+    interaction = _member_interaction(guild_id=guild_id, acked=True)
+
+    refused = await refuse_if_reachable_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is True
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_called_once()
+    assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True
+
+
+async def test_system_agent_refusal_uses_followup_when_already_acked() -> None:
+    session_factory = MagicMock()
+    runtime = _runtime(sessionmaker=session_factory)
+    interaction = _member_interaction(acked=True)
+    entry = _entry("daimon", is_system=True)
+
+    refused = await refuse_if_reachable_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is True
+    session_factory.assert_not_called()
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_called_once()
+    assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -93,7 +93,7 @@ def _remove_select(view: discord.ui.LayoutView) -> discord.ui.Select[Any]:
 
 def test_container_header_and_subtext() -> None:
     view_container = build_credentials_container(
-        agent_name="bot", secret_names=["XERO_API_KEY", "TOGGL_TOKEN"], is_system=False
+        agent_name="bot", secret_names=["XERO_API_KEY", "TOGGL_TOKEN"]
     )
     texts = [
         child.content
@@ -109,9 +109,7 @@ def test_container_header_and_subtext() -> None:
 
 
 def test_container_chips_on_one_line() -> None:
-    container = build_credentials_container(
-        agent_name="bot", secret_names=["A_KEY", "B_KEY"], is_system=False
-    )
+    container = build_credentials_container(agent_name="bot", secret_names=["A_KEY", "B_KEY"])
     # Collect text displays (skip the header which is first)
     displays = [
         child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
@@ -127,7 +125,7 @@ def test_container_chips_on_one_line() -> None:
 def test_container_d09_values_never_reach_tree() -> None:
     """build_credentials_container takes names only; no secret value can appear."""
     container = build_credentials_container(
-        agent_name="bot", secret_names=["XERO_API_KEY", "TOGGL_TOKEN"], is_system=False
+        agent_name="bot", secret_names=["XERO_API_KEY", "TOGGL_TOKEN"]
     )
     all_text = " ".join(
         child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
@@ -136,7 +134,7 @@ def test_container_d09_values_never_reach_tree() -> None:
 
 
 def test_container_empty_state_shows_hint() -> None:
-    container = build_credentials_container(agent_name="bot", secret_names=[], is_system=False)
+    container = build_credentials_container(agent_name="bot", secret_names=[])
     displays = [
         child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
     ]
@@ -147,7 +145,7 @@ def test_container_empty_state_shows_hint() -> None:
 
 
 def test_container_no_none_copy_in_empty_state() -> None:
-    container = build_credentials_container(agent_name="bot", secret_names=[], is_system=False)
+    container = build_credentials_container(agent_name="bot", secret_names=[])
     displays = [
         child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
     ]
@@ -167,7 +165,6 @@ def test_subview_renders_remove_select_add_and_back(account_id: uuid.UUID) -> No
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["A", "B"],
-        is_system=False,
     )
     select = _remove_select(view)
     assert select.placeholder == "✕ Remove a var…", "single remove-select with house placeholder"
@@ -189,7 +186,6 @@ def test_subview_header_and_subtext(account_id: uuid.UUID) -> None:
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["A"],
-        is_system=False,
     )
     text = _container_all_text(view)
     assert "## 🔑 Env vars — " in text, "container header present"
@@ -206,7 +202,6 @@ def test_subview_chips_on_one_line(account_id: uuid.UUID) -> None:
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["A_KEY", "B_KEY"],
-        is_system=False,
     )
     text_displays = _walk_text_displays(view)
     chips_displays = [td for td in text_displays if "`A_KEY`" in td.content]
@@ -224,7 +219,6 @@ def test_subview_d09_values_never_reach_tree(account_id: uuid.UUID) -> None:
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["XERO_API_KEY"],
-        is_system=False,
     )
     all_text = _container_all_text(view)
     assert _SECRET_VALUE not in all_text, "no secret value may appear anywhere in the view"
@@ -239,7 +233,6 @@ def test_subview_remove_select_option_carries_key_name_never_value(account_id: u
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["XERO_API_KEY"],
-        is_system=False,
     )
     select = _remove_select(view)
     option = select.options[0]
@@ -254,7 +247,10 @@ def test_subview_remove_select_option_carries_key_name_never_value(account_id: u
     assert "XERO_API_KEY" not in select.custom_id, "key name never persisted in a custom_id"
 
 
-def test_subview_system_agent_disables_mutations_but_not_back(account_id: uuid.UUID) -> None:
+def test_subview_system_agent_enables_mutations(account_id: uuid.UUID) -> None:
+    """Env vars are per-agent daimon state, never part of the agent spec, so a
+    system agent's remove select and add button are enabled exactly like a
+    user agent's — provenance does not gate this sub-view."""
     entry = _entry("sys", is_system=True)
     view = CredentialsSubView(
         runtime=MagicMock(spec=DiscordRuntime),
@@ -263,11 +259,14 @@ def test_subview_system_agent_disables_mutations_but_not_back(account_id: uuid.U
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["A", "B"],
-        is_system=True,
     )
-    assert _remove_select(view).disabled is True, "system agents cannot remove secrets"
-    assert _button_by_label(view, "+ Add env vars").disabled is True, "system add disabled"
-    assert _button_by_label(view, "← Back").disabled is False, "back stays enabled (read-only)"
+    assert _remove_select(view).disabled is False, (
+        "a system agent's remove select must be enabled when it has variables"
+    )
+    assert _button_by_label(view, "+ Add env vars").disabled is False, (
+        "a system agent's add button must be enabled below the cap"
+    )
+    assert _button_by_label(view, "← Back").disabled is False, "back stays enabled"
 
 
 def test_subview_empty_state_disables_select(account_id: uuid.UUID) -> None:
@@ -279,7 +278,6 @@ def test_subview_empty_state_disables_select(account_id: uuid.UUID) -> None:
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=[],
-        is_system=False,
     )
     select = _remove_select(view)
     assert select.disabled is True, "no-secrets select is disabled"
@@ -426,7 +424,6 @@ async def test_remove_deletes_the_key_and_rerenders(
         tenant_id=tenant.id,
         agent_id=agent_id,
         secret_names=["XERO_API_KEY", "KEEP_ME"],
-        is_system=False,
     )
 
     interaction = MagicMock()
@@ -475,7 +472,6 @@ async def test_back_replaces_with_editview_in_place(account_id: uuid.UUID) -> No
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["A"],
-        is_system=False,
     )
 
     interaction = MagicMock()
@@ -564,7 +560,9 @@ async def test_editview_env_vars_button_opens_subview(
     assert _SECRET_VALUE not in all_text, "the opened view lists the key masked, never its value"
 
 
-def test_editview_has_env_vars_button_disabled_for_system_agent(account_id: uuid.UUID) -> None:
+def test_editview_env_vars_button_enabled_for_system_agent(account_id: uuid.UUID) -> None:
+    """Env vars are per-agent daimon state, never part of the agent spec, so
+    the button is enabled for the seeded/system agent exactly like any other."""
     settings = MagicMock()
     settings.mcp.public_url = None
     runtime = DiscordRuntime(
@@ -585,8 +583,9 @@ def test_editview_has_env_vars_button_disabled_for_system_agent(account_id: uuid
     )
     sys_view = EditView(_state(sys_entry, account_id), runtime=runtime, allowed_user_id=42)
     sys_buttons = {b.label: b for b in _walk_buttons(sys_view) if b.label is not None}
-    assert sys_buttons["Env vars"].disabled is True, (
-        "system agents see the Env vars button disabled (defensive)"
+    assert sys_buttons["Env vars"].disabled is False, (
+        "the seeded/system agent's Env vars button must be enabled — env vars "
+        "are not part of the agent spec"
     )
 
     user_entry = RosterEntry(
@@ -615,7 +614,6 @@ async def test_credentials_view_timeout_replaces_the_subview(account_id: uuid.UU
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["A"],
-        is_system=False,
     )
     interaction = MagicMock()
     interaction.edit_original_response = AsyncMock()
@@ -660,7 +658,6 @@ async def test_credentials_rerender_rebinds_the_current_interaction(
         tenant_id=uuid.uuid4(),
         agent_id=uuid.uuid4(),
         secret_names=["A"],
-        is_system=False,
     )
 
     first_interaction = MagicMock()

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -15,7 +15,9 @@ from daimon.adapters.discord.agent_setup.edit_view import (
     build_edit_container,
 )
 from daimon.adapters.discord.agent_setup.state import PanelState, RosterEntry
+from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.specs import AgentSpec
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
 def _entry(name: str, model: str = "claude-sonnet-4-6") -> RosterEntry:
@@ -740,3 +742,258 @@ async def test_open_edit_view_binds_the_render_interaction(
     await view_kwarg.on_timeout()
 
     mock_interaction.edit_original_response.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Click-time authz gate on the remove selects (FIRST-04/05)
+# ---------------------------------------------------------------------------
+
+
+def _non_admin_interaction(*, guild_id: int) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 42
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    return interaction
+
+
+def _admin_interaction() -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 42
+    interaction.user.guild_permissions.administrator = True
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_skill_remove_select_refuses_write_when_target_is_reachable_for_non_admin(
+    account_id: uuid.UUID,
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    import daimon.adapters.discord.agent_setup.edit_view as edit_view_mod
+    from daimon.core.scope import DeploymentDefault
+    from daimon.core.specs import SkillRef
+    from daimon.testing.factories import make_tenant
+
+    async def unexpected_reconcile(rt: object, st: object, *, tenant_id: object) -> object:
+        raise AssertionError("reconcile must not run when the write is refused")
+
+    monkeypatch.setattr(edit_view_mod, "replace_agent_resources_for_panel", unexpected_reconcile)
+
+    guild_id = 910101
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    skills = [SkillRef(type="custom", skill_id="skill-a")]
+    selected = _entry_with("bot", skills=skills)
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+    runtime.sessionmaker = db_session_factory
+    runtime.deployment_default = DeploymentDefault(agent_name="bot")
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    skill_select = next(s for s in _walk_selects(view) if isinstance(s, _SkillRemoveSelect))  # pyright: ignore[reportPrivateUsage]
+    skill_select._values = ["0"]  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _non_admin_interaction(guild_id=guild_id)
+    await skill_select.callback(interaction)
+
+    assert state.selected is not None
+    remaining = {s.skill_id for s in state.selected.spec.skills}
+    assert "skill-a" in remaining, "skill must not be removed when the write is refused"
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_skill_remove_select_refuses_write_on_system_agent_even_for_admin(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import daimon.adapters.discord.agent_setup.edit_view as edit_view_mod
+    from daimon.core.specs import SkillRef
+
+    async def unexpected_reconcile(rt: object, st: object, *, tenant_id: object) -> object:
+        raise AssertionError("reconcile must not run when the write is refused")
+
+    monkeypatch.setattr(edit_view_mod, "replace_agent_resources_for_panel", unexpected_reconcile)
+
+    skills = [SkillRef(type="custom", skill_id="skill-a")]
+    selected = RosterEntry(
+        name="daimon",
+        model="claude-sonnet-4-6",
+        spec=AgentSpec(name="daimon", model="claude-sonnet-4-6", skills=skills),
+        is_system=True,
+    )
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    skill_select = next(s for s in _walk_selects(view) if isinstance(s, _SkillRemoveSelect))  # pyright: ignore[reportPrivateUsage]
+    skill_select._values = ["0"]  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _admin_interaction()
+    await skill_select.callback(interaction)
+
+    assert state.selected is not None
+    remaining = {s.skill_id for s in state.selected.spec.skills}
+    assert "skill-a" in remaining, "a system agent's skills must never be removed from the panel"
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_mcp_remove_select_refuses_write_when_target_is_reachable_for_non_admin(
+    account_id: uuid.UUID,
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    import daimon.adapters.discord.agent_setup.edit_view as edit_view_mod
+    from daimon.core.scope import DeploymentDefault
+    from daimon.testing.factories import make_tenant
+
+    async def unexpected_reconcile(rt: object, st: object, *, tenant_id: object) -> object:
+        raise AssertionError("reconcile must not run when the write is refused")
+
+    monkeypatch.setattr(edit_view_mod, "replace_agent_resources_for_panel", unexpected_reconcile)
+
+    guild_id = 910102
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    selected = _entry_with_mcps("bot", [_mcp("user-mcp", "https://user.example.com/mcp")])
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+    runtime.sessionmaker = db_session_factory
+    runtime.deployment_default = DeploymentDefault(agent_name="bot")
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    mcp_select = next(s for s in _walk_selects(view) if isinstance(s, _McpRemoveSelect))  # pyright: ignore[reportPrivateUsage]
+    mcp_select._values = ["0"]  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _non_admin_interaction(guild_id=guild_id)
+    await mcp_select.callback(interaction)
+
+    assert state.selected is not None
+    remaining = state.selected.spec.mcp_servers or []
+    assert len(remaining) == 1, "an MCP must not be removed when the write is refused"
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_mcp_remove_select_refuses_write_on_system_agent_even_for_admin(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import daimon.adapters.discord.agent_setup.edit_view as edit_view_mod
+    from anthropic.types.beta.agent_create_params import Tool
+    from anthropic.types.beta.beta_managed_agents_mcp_toolset_params import (
+        BetaManagedAgentsMCPToolsetParams,
+    )
+
+    async def unexpected_reconcile(rt: object, st: object, *, tenant_id: object) -> object:
+        raise AssertionError("reconcile must not run when the write is refused")
+
+    monkeypatch.setattr(edit_view_mod, "replace_agent_resources_for_panel", unexpected_reconcile)
+
+    mcps = [_mcp("user-mcp", "https://user.example.com/mcp")]
+    tools: list[Tool] = [
+        BetaManagedAgentsMCPToolsetParams(
+            type="mcp_toolset",
+            mcp_server_name="user-mcp",
+            default_config={"permission_policy": {"type": "always_allow"}},
+        )
+    ]
+    selected = RosterEntry(
+        name="daimon",
+        model="claude-sonnet-4-6",
+        spec=AgentSpec(name="daimon", model="claude-sonnet-4-6", mcp_servers=mcps, tools=tools),
+        is_system=True,
+    )
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    mcp_select = next(s for s in _walk_selects(view) if isinstance(s, _McpRemoveSelect))  # pyright: ignore[reportPrivateUsage]
+    mcp_select._values = ["0"]  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _admin_interaction()
+    await mcp_select.callback(interaction)
+
+    assert state.selected is not None
+    remaining = state.selected.spec.mcp_servers or []
+    assert len(remaining) == 1, "a system agent's mcp_servers must never be removed from the panel"
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_env_vars_paste_modal_still_writes_on_reachable_agent_for_non_admin(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Env vars are a per-agent attachment, never part of the agent spec — the
+    new click-time gate must not reach this path even for a reachable agent
+    edited by a non-admin (D-09/D-17)."""
+    from daimon.adapters.discord.agent_setup.credentials import PasteSecretModal
+    from daimon.core.ma_identity import derive_agent_uuid
+    from daimon.core.ma_resolver import new_resolver_cache
+    from daimon.core.notebooks._rate_limit import RateLimiter
+    from daimon.core.scope import DeploymentDefault
+    from daimon.core.stores.agent_files import get_agent_file
+    from daimon.testing.factories import make_tenant
+
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id="env-vars-still-open")
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id="agent_env_test")
+
+    settings = MagicMock()
+    settings.mcp.public_url = None
+    runtime = DiscordRuntime(
+        settings=settings,
+        anthropic=MagicMock(),
+        sessionmaker=db_session_factory,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        # A non-admin caller editing the workspace's current default agent —
+        # env vars stay writable regardless (D-09).
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+    )
+
+    async def _noop(_interaction: discord.Interaction) -> None:
+        return None
+
+    modal = PasteSecretModal(
+        runtime=runtime, tenant_id=tenant.id, agent_id=agent_id, on_added=_noop
+    )
+    modal.content_input._value = "XERO_API_KEY=abc123"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+
+    await modal.on_submit(interaction)
+
+    async with db_session_factory() as session:
+        row = await get_agent_file(
+            session, tenant_id=tenant.id, agent_id=agent_id, key="XERO_API_KEY"
+        )
+    assert row is not None, "env var write must succeed even on the workspace's default agent"

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -508,8 +508,9 @@ def test_env_vars_button_label_has_no_plus(account_id: uuid.UUID) -> None:
     assert "+ Env vars" not in labels, "the '+' prefix must be dropped from the Env vars button"
 
 
-def test_edit_view_env_vars_button_disabled_for_system_agent(account_id: uuid.UUID) -> None:
-    selected = _entry("sys")
+def test_edit_view_env_vars_button_always_enabled(account_id: uuid.UUID) -> None:
+    """Env vars are per-agent daimon state, never part of the agent spec, so the
+    button is always enabled — for the seeded/system agent exactly like any other."""
     selected = RosterEntry(
         name="sys",
         model="claude-sonnet-4-6",
@@ -521,14 +522,120 @@ def test_edit_view_env_vars_button_disabled_for_system_agent(account_id: uuid.UU
     runtime.settings.mcp.public_url = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(view, "Env vars").disabled is True, (
-        "system agents see the Env vars button disabled (defensive)"
+    assert _find_button(view, "Env vars").disabled is False, (
+        "the seeded/system agent's Env vars button must be enabled"
     )
 
     user_selected = _entry("bot")
     user_state = PanelState(roster=[user_selected], selected=user_selected, account_id=account_id)
     user_view = EditView(user_state, runtime=runtime, allowed_user_id=42)
     assert _find_button(user_view, "Env vars").disabled is False, "user agents can open Env vars"
+
+
+# --- Spec-control reachability gate (FIRST-04/05) ---------------------------
+
+
+def _reachable_state(entry: RosterEntry, account_id: uuid.UUID, *, is_admin: bool) -> PanelState:
+    """A state whose selected agent IS reachable via the deployment default."""
+    from daimon.core.scope import DeploymentDefault
+
+    return PanelState(
+        roster=[entry],
+        selected=entry,
+        account_id=account_id,
+        is_admin=is_admin,
+        cascade_view=(None, []),
+        deployment_default=DeploymentDefault(agent_name=entry.name),
+    )
+
+
+def test_edit_view_non_admin_reachable_non_system_disables_spec_controls(
+    account_id: uuid.UUID,
+) -> None:
+    """A non-admin editing a reachable, non-system agent gets the five
+    spec-touching controls disabled; GitHub… and Env vars stay enabled."""
+    from daimon.core.specs import SkillRef
+
+    selected = _entry_with_mcps(
+        "bot",
+        [_mcp("user-mcp", "https://user.example.com/mcp")],
+        skills=[SkillRef(type="custom", skill_id="skill-a")],
+    )
+    state = _reachable_state(selected, account_id, is_admin=False)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    assert _find_button(view, "Agent…").disabled is True, "Agent… must be disabled"
+    assert _find_button(view, "+ Add skill").disabled is True, "+ Add skill must be disabled"
+    assert _find_button(view, "+ Add MCP").disabled is True, "+ Add MCP must be disabled"
+    skill_select = next(s for s in _walk_selects(view) if isinstance(s, _SkillRemoveSelect))  # pyright: ignore[reportPrivateUsage]
+    mcp_select = next(s for s in _walk_selects(view) if isinstance(s, _McpRemoveSelect))  # pyright: ignore[reportPrivateUsage]
+    assert skill_select.disabled is True, "skill remove select must be disabled"
+    assert mcp_select.disabled is True, "mcp remove select must be disabled"
+    assert _find_button(view, "GitHub…").disabled is False, "GitHub… must stay enabled"
+    assert _find_button(view, "Env vars").disabled is False, "Env vars must stay enabled"
+
+
+def test_edit_view_non_admin_unreachable_non_system_enables_spec_controls(
+    account_id: uuid.UUID,
+) -> None:
+    """A non-admin editing an agent nobody has scoped gets every spec control
+    enabled — it is their scratchpad."""
+    from daimon.core.specs import SkillRef
+
+    selected = _entry_with_mcps(
+        "bot",
+        [_mcp("user-mcp", "https://user.example.com/mcp")],
+        skills=[SkillRef(type="custom", skill_id="skill-a")],
+    )
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id, is_admin=False)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    assert _find_button(view, "Agent…").disabled is False, "Agent… must be enabled"
+    assert _find_button(view, "+ Add skill").disabled is False, "+ Add skill must be enabled"
+    assert _find_button(view, "+ Add MCP").disabled is False, "+ Add MCP must be enabled"
+    skill_select = next(s for s in _walk_selects(view) if isinstance(s, _SkillRemoveSelect))  # pyright: ignore[reportPrivateUsage]
+    mcp_select = next(s for s in _walk_selects(view) if isinstance(s, _McpRemoveSelect))  # pyright: ignore[reportPrivateUsage]
+    assert skill_select.disabled is False, "skill remove select must be enabled"
+    assert mcp_select.disabled is False, "mcp remove select must be enabled"
+
+
+def test_edit_view_admin_reachable_non_system_enables_spec_controls(account_id: uuid.UUID) -> None:
+    """An admin editing a reachable, non-system agent still gets the spec
+    controls enabled — the reachability gate is admin-exempt."""
+    selected = _entry("bot")
+    state = _reachable_state(selected, account_id, is_admin=True)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    assert _find_button(view, "Agent…").disabled is False, "Agent… must be enabled for an admin"
+
+
+def test_edit_view_reachable_system_agent_disables_spec_controls_for_admin_too(
+    account_id: uuid.UUID,
+) -> None:
+    """is_system stays absolute: even an admin gets the spec controls disabled
+    on the seeded agent."""
+    selected = RosterEntry(
+        name="daimon",
+        model="claude-sonnet-4-6",
+        spec=AgentSpec(name="daimon", model="claude-sonnet-4-6", system=None),
+        is_system=True,
+    )
+    state = _reachable_state(selected, account_id, is_admin=True)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    assert _find_button(view, "Agent…").disabled is True, (
+        "Agent… must stay disabled on a system agent even for an admin"
+    )
+    assert _find_button(view, "GitHub…").disabled is False, "GitHub… is not spec-gated"
+    assert _find_button(view, "Env vars").disabled is False, "Env vars is not spec-gated"
 
 
 # --- Back / open_edit_view edit-in-place -----------------------------------

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -534,7 +534,7 @@ def test_edit_view_env_vars_button_always_enabled(account_id: uuid.UUID) -> None
     assert _find_button(user_view, "Env vars").disabled is False, "user agents can open Env vars"
 
 
-# --- Spec-control reachability gate (FIRST-04/05) ---------------------------
+# --- Spec-control reachability gate ---------------------------
 
 
 def _reachable_state(entry: RosterEntry, account_id: uuid.UUID, *, is_admin: bool) -> PanelState:
@@ -745,7 +745,7 @@ async def test_open_edit_view_binds_the_render_interaction(
 
 
 # ---------------------------------------------------------------------------
-# Click-time authz gate on the remove selects (FIRST-04/05)
+# Click-time authz gate on the remove selects
 # ---------------------------------------------------------------------------
 
 
@@ -950,7 +950,7 @@ async def test_env_vars_paste_modal_still_writes_on_reachable_agent_for_non_admi
 ) -> None:
     """Env vars are a per-agent attachment, never part of the agent spec — the
     new click-time gate must not reach this path even for a reachable agent
-    edited by a non-admin (D-09/D-17)."""
+    edited by a non-admin."""
     from daimon.adapters.discord.agent_setup.credentials import PasteSecretModal
     from daimon.core.ma_identity import derive_agent_uuid
     from daimon.core.ma_resolver import new_resolver_cache
@@ -972,7 +972,7 @@ async def test_env_vars_paste_modal_still_writes_on_reachable_agent_for_non_admi
         notebook_rate_limiter=RateLimiter(max_requests=999),
         billing_config=None,
         # A non-admin caller editing the workspace's current default agent —
-        # env vars stay writable regardless (D-09).
+        # env vars stay writable regardless.
         deployment_default=DeploymentDefault(agent_name="daimon"),
         resolver_cache=new_resolver_cache(),
         turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -51,11 +51,14 @@ from pydantic import HttpUrl, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
-def _entry(name: str, *, mcp_servers: list[Any] | None = None) -> RosterEntry:
+def _entry(
+    name: str, *, mcp_servers: list[Any] | None = None, is_system: bool = False
+) -> RosterEntry:
     return RosterEntry(
         name=name,
         model="claude-sonnet-4-6",
         spec=AgentSpec(name=name, model="claude-sonnet-4-6", mcp_servers=mcp_servers),
+        is_system=is_system,
     )
 
 
@@ -69,6 +72,7 @@ def _runtime_for_view(
     public_url: HttpUrl | None = _DEFAULT_PUBLIC_URL,
     sessionmaker: Any = None,
     crypto_keys: tuple[str, ...] = (),
+    deployment_default: DeploymentDefault | None = None,
 ) -> DiscordRuntime:
     settings = MagicMock()
     # Real McpSettings so the app_root_url property (strips /mcp) computes for real.
@@ -89,19 +93,29 @@ def _runtime_for_view(
         sessionmaker=sessionmaker if sessionmaker is not None else MagicMock(),
         notebook_rate_limiter=RateLimiter(max_requests=999),
         billing_config=None,
-        deployment_default=DeploymentDefault(),
+        deployment_default=deployment_default
+        if deployment_default is not None
+        else DeploymentDefault(),
         resolver_cache=new_resolver_cache(),
         turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
     )
 
 
-def _interaction(user_id: int = 42) -> MagicMock:
+def _interaction(user_id: int = 42, *, is_admin: bool = True, guild_id: int = 12345) -> MagicMock:
+    """A discord.Interaction stand-in, a live guild admin by default so the
+    write-callback's authz gate short-circuits without a DB read. Tests
+    proving the reachable/system-agent refusal pass ``is_admin=False``."""
     interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
     interaction.user.id = user_id
+    interaction.user.guild_permissions.administrator = is_admin
+    interaction.user.guild_permissions.manage_guild = False
     interaction.response.defer = AsyncMock()
     interaction.response.send_message = AsyncMock()
     interaction.response.send_modal = AsyncMock()
     interaction.response.edit_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
     interaction.followup.send = AsyncMock()
     interaction.edit_original_response = AsyncMock()
     return interaction
@@ -2007,4 +2021,199 @@ def test_repo_auth_modal_field_labels_fit_discord_limits(
             )
     assert "GitHub MCP" in modal.pat_in.label, (
         "the token field's label must mention the GitHub MCP server"
+    )
+
+
+# ----- 13. Click-time authz gate on the spec-mutating write callbacks -------
+#
+# AgentSectionModal and AddSkillModal each carry a write to the agent spec
+# (system/model, skills). A non-admin caller must be refused at submit time
+# when the target is currently reachable or is a system agent — the guard is
+# re-derived from live state, never from any render-time snapshot.
+# RepoAuthModal is deliberately NOT gated (a per-agent attachment, not part
+# of the spec).
+
+
+@pytest.mark.asyncio
+async def test_agent_section_modal_refuses_write_when_target_is_reachable_for_non_admin(
+    monkeypatch: pytest.MonkeyPatch,
+    account_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from daimon.testing.factories import make_tenant
+
+    reconcile_calls: list[str] = []
+
+    async def spy_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        reconcile_calls.append("called")
+        return MagicMock()
+
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", spy_reconcile)
+
+    guild_id = 910001
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    selected = _entry("a")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(),
+        tenant_id=uuid.uuid4(),
+        sessionmaker=db_session_factory,
+        deployment_default=DeploymentDefault(agent_name="a"),
+    )
+
+    modal = AgentSectionModal(state, runtime=runtime, allowed_user_id=42)
+    modal.model_in._value = "claude-sonnet-4-6"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    await modal.on_submit(interaction)
+
+    assert reconcile_calls == [], "reconcile must not run when the write is refused"
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_agent_section_modal_refuses_write_on_system_agent_even_for_admin(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    reconcile_calls: list[str] = []
+
+    async def spy_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        reconcile_calls.append("called")
+        return MagicMock()
+
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", spy_reconcile)
+
+    selected = _entry("daimon", is_system=True)
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = AgentSectionModal(state, runtime=runtime, allowed_user_id=42)
+    modal.model_in._value = "claude-sonnet-4-6"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=True)
+    await modal.on_submit(interaction)
+
+    assert reconcile_calls == [], "a system agent's spec must never be reconciled from the panel"
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_add_skill_modal_refuses_write_when_target_is_reachable_for_non_admin(
+    monkeypatch: pytest.MonkeyPatch,
+    account_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from daimon.testing.factories import make_tenant
+
+    async def unexpected_kickoff(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("skill sync must not be kicked off when the write is refused")
+
+    monkeypatch.setattr(modals_mod, "kick_off_skill_sync", unexpected_kickoff)
+
+    guild_id = 910002
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    selected = _entry("research-bot")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(),
+        tenant_id=uuid.uuid4(),
+        sessionmaker=db_session_factory,
+        deployment_default=DeploymentDefault(agent_name="research-bot"),
+    )
+
+    modal = AddSkillModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/skills-repo"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    await modal.on_submit(interaction)
+
+    assert state.pending_skill_repo_urls == [], (
+        "a refused submit must leave no pending-skill marker on the panel"
+    )
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_add_skill_modal_refuses_write_on_system_agent_even_for_admin(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    async def unexpected_kickoff(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("skill sync must not be kicked off when the write is refused")
+
+    monkeypatch.setattr(modals_mod, "kick_off_skill_sync", unexpected_kickoff)
+
+    selected = _entry("daimon", is_system=True)
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(anthropic=build_stub_anthropic(), tenant_id=tenant_id)
+
+    modal = AddSkillModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/skills-repo"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=True)
+    await modal.on_submit(interaction)
+
+    assert state.pending_skill_repo_urls == [], (
+        "a system agent's skills must never gain a pending-skill marker from the panel"
+    )
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_repo_auth_modal_still_writes_binding_on_reachable_system_agent_for_non_admin(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """The repo binding is a per-agent attachment, never part of the agent
+    spec (D-09/D-17) — the new click-time gate must not reach this path even
+    for a reachable system agent edited by a non-admin."""
+    set_binding_called = False
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        return True
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_binding_called
+        set_binding_called = True
+        return MagicMock()
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("daimon", is_system=True)
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    sm = MagicMock()
+    sm.begin.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+    sm.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(),
+        tenant_id=tenant_id,
+        sessionmaker=sm,
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/public-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False)
+    await modal.on_submit(interaction)
+
+    assert set_binding_called, (
+        "repo binding must still write on a reachable system agent for a non-admin caller"
     )

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -2171,7 +2171,7 @@ async def test_repo_auth_modal_still_writes_binding_on_reachable_system_agent_fo
     monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
 ) -> None:
     """The repo binding is a per-agent attachment, never part of the agent
-    spec (D-09/D-17) — the new click-time gate must not reach this path even
+    spec — the new click-time gate must not reach this path even
     for a reachable system agent edited by a non-admin."""
     set_binding_called = False
 

--- a/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
@@ -588,7 +588,7 @@ async def test_add_mcp_submit_returns_to_edit_view(
 
 
 # ---------------------------------------------------------------------------
-# Click-time authz gate (FIRST-04/05) — the guard sits above the #142 reserved
+# Click-time authz gate — the guard sits above the #142 reserved
 # name/own-endpoint checks and below them alphabetically: reserved-name still
 # fires first (see test_add_mcp_modal_rejects_reserved_name_...), and a
 # non-reserved, reachable or system target is refused before defer/reconcile.

--- a/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import httpx
 import pytest
 from anthropic.types.beta import BetaManagedAgentsAgent
@@ -39,11 +40,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 _MA_AGENT_ID = "agent_mcp_modal_test_1234"
 
 
-def _entry(name: str) -> RosterEntry:
+def _entry(name: str, *, is_system: bool = False) -> RosterEntry:
     return RosterEntry(
         name=name,
         model="claude-sonnet-4-6",
         spec=AgentSpec(name=name, model="claude-sonnet-4-6"),
+        is_system=is_system,
     )
 
 
@@ -71,6 +73,7 @@ def _runtime(
     public_url: HttpUrl | None,
     jwt_secret: str | None,
     sessionmaker: Any = None,
+    deployment_default: DeploymentDefault | None = None,
 ) -> DiscordRuntime:
     settings = MagicMock()
     settings.mcp.public_url = public_url
@@ -88,27 +91,43 @@ def _runtime(
         sessionmaker=sessionmaker if sessionmaker is not None else MagicMock(),
         billing_config=None,
         notebook_rate_limiter=RateLimiter(max_requests=999),
-        deployment_default=DeploymentDefault(),
+        deployment_default=deployment_default
+        if deployment_default is not None
+        else DeploymentDefault(),
         resolver_cache=new_resolver_cache(),
         turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
     )
 
 
-def _runtime_configured(*, anthropic: Any, sessionmaker: Any = None) -> DiscordRuntime:
+def _runtime_configured(
+    *,
+    anthropic: Any,
+    sessionmaker: Any = None,
+    deployment_default: DeploymentDefault | None = None,
+) -> DiscordRuntime:
     """Runtime with mcp.public_url and mcp.jwt_secret both set."""
     return _runtime(
         anthropic=anthropic,
         public_url=HttpUrl("https://mcp.example.com/mcp"),
         jwt_secret="x" * 32,
         sessionmaker=sessionmaker,
+        deployment_default=deployment_default,
     )
 
 
-def _interaction(user_id: int = 42) -> MagicMock:
+def _interaction(user_id: int = 42, *, is_admin: bool = True, guild_id: int = 12345) -> MagicMock:
+    """A discord.Interaction stand-in, a live guild admin by default so the
+    write-callback's authz gate short-circuits without a DB read. Tests
+    proving the reachable/system-agent refusal pass ``is_admin=False``."""
     interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
     interaction.user.id = user_id
+    interaction.user.guild_permissions.administrator = is_admin
+    interaction.user.guild_permissions.manage_guild = False
     interaction.response.defer = AsyncMock()
     interaction.response.send_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
     interaction.followup.send = AsyncMock()
     interaction.edit_original_response = AsyncMock()
     return interaction
@@ -566,3 +585,91 @@ async def test_add_mcp_submit_returns_to_edit_view(
         "AddMcpModal submit must return to EditView, not AgentSetupView"
     )
     assert view_kwarg.allowed_user_id == 99, "the invoker gate must survive the round trip"
+
+
+# ---------------------------------------------------------------------------
+# Click-time authz gate (FIRST-04/05) — the guard sits above the #142 reserved
+# name/own-endpoint checks and below them alphabetically: reserved-name still
+# fires first (see test_add_mcp_modal_rejects_reserved_name_...), and a
+# non-reserved, reachable or system target is refused before defer/reconcile.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_mcp_modal_refuses_write_when_target_is_reachable_for_non_admin(
+    monkeypatch: pytest.MonkeyPatch,
+    account_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from daimon.testing.factories import make_tenant
+
+    async def unexpected_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        raise AssertionError("reconcile must not run when the write is refused")
+
+    monkeypatch.setattr(modals_mcp_mod, "call_reconcile_for_panel", unexpected_reconcile)
+
+    guild_id = 910003
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    selected = _entry("my-agent")
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        guild_id=guild_id,
+        is_admin=False,
+    )
+    rt = _runtime_configured(
+        anthropic=build_stub_anthropic(),
+        sessionmaker=db_session_factory,
+        deployment_default=DeploymentDefault(agent_name="my-agent"),
+    )
+
+    modal = AddMcpModal(state, runtime=rt, allowed_user_id=42)
+    modal.name_in._value = "ext-mcp"  # pyright: ignore[reportPrivateUsage]
+    modal.url_in._value = "https://ext.example.com/mcp"  # pyright: ignore[reportPrivateUsage]
+    modal.token_in._value = "tok_test_1234"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    await modal.on_submit(interaction)
+
+    assert not (state.selected.spec.mcp_servers or []), (
+        "an MCP entry must not be appended when the write is refused"
+    )
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_add_mcp_modal_refuses_write_on_system_agent_even_for_admin(
+    monkeypatch: pytest.MonkeyPatch, account_id: uuid.UUID
+) -> None:
+    async def unexpected_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        raise AssertionError("reconcile must not run when the write is refused")
+
+    monkeypatch.setattr(modals_mcp_mod, "call_reconcile_for_panel", unexpected_reconcile)
+
+    selected = _entry("daimon", is_system=True)
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        guild_id=12345,
+        is_admin=True,
+    )
+    rt = _runtime_configured(anthropic=build_stub_anthropic())
+
+    modal = AddMcpModal(state, runtime=rt, allowed_user_id=42)
+    modal.name_in._value = "ext-mcp"  # pyright: ignore[reportPrivateUsage]
+    modal.url_in._value = "https://ext.example.com/mcp"  # pyright: ignore[reportPrivateUsage]
+    modal.token_in._value = "tok_test_5678"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=True)
+    await modal.on_submit(interaction)
+
+    assert not (state.selected.spec.mcp_servers or []), (
+        "a system agent's mcp_servers must never gain an entry from the panel"
+    )
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -867,6 +867,103 @@ def test_member_roster_matches_admin_and_no_mutation_buttons(account_id: uuid.UU
 
 
 # ---------------------------------------------------------------------------
+# PanelState.is_selected_reachable
+# ---------------------------------------------------------------------------
+
+
+def test_is_selected_reachable_false_when_nothing_selected(account_id: uuid.UUID) -> None:
+    """No selection → not reachable (nothing to be reachable)."""
+    from daimon.core.scope import DeploymentDefault
+
+    state = PanelState(
+        roster=[],
+        selected=None,
+        account_id=account_id,
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+    assert state.is_selected_reachable() is False, "no selection must never be reachable"
+
+
+def test_is_selected_reachable_true_via_deployment_default(account_id: uuid.UUID) -> None:
+    """Fresh install, no config rows: the deployment default's agent is reachable."""
+    from daimon.core.scope import DeploymentDefault
+
+    selected = _entry("daimon")
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        cascade_view=(None, []),
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+    assert state.is_selected_reachable() is True, (
+        "the deployment default's agent must be reachable on a fresh install"
+    )
+
+
+def test_is_selected_reachable_false_when_deployment_default_names_other_agent(
+    account_id: uuid.UUID,
+) -> None:
+    """Fresh install, no config rows: an agent the deployment default does NOT
+    name is not reachable."""
+    from daimon.core.scope import DeploymentDefault
+
+    selected = _entry("research-bot")
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        cascade_view=(None, []),
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+    assert state.is_selected_reachable() is False, (
+        "an agent not named by the deployment default must not be reachable"
+    )
+
+
+def test_is_selected_reachable_true_via_channel_row(account_id: uuid.UUID) -> None:
+    """A channel row in mode='agent' naming the selected agent makes it reachable."""
+    from daimon.core.scope import ChannelConfigRow, DeploymentDefault
+
+    selected = _entry("alice")
+    ch_row = ChannelConfigRow(
+        tenant_id=uuid.UUID(int=0), channel_id="1001", agent_name="alice", mode="agent"
+    )
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        cascade_view=(None, [ch_row]),
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+    assert state.is_selected_reachable() is True, (
+        "a channel row naming the selected agent must make it reachable"
+    )
+
+
+def test_is_selected_reachable_false_when_tenant_row_names_other_agent(
+    account_id: uuid.UUID,
+) -> None:
+    """A tenant row in mode='agent' naming a different agent suppresses the
+    deployment-default fall-through for the selected (unnamed) agent."""
+    from daimon.core.scope import DeploymentDefault, TenantConfigRow
+
+    selected = _entry("daimon")
+    tenant_row = TenantConfigRow(tenant_id=uuid.UUID(int=0), agent_name="bob", mode="agent")
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        cascade_view=(tenant_row, []),
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+    assert state.is_selected_reachable() is False, (
+        "a tenant row naming a different agent must suppress the deployment "
+        "default's reachability for the selected agent"
+    )
+
+
+# ---------------------------------------------------------------------------
 # interaction_check
 # ---------------------------------------------------------------------------
 

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -543,15 +543,17 @@ def test_empty_roster_container_shows_no_agents_copy_for_admin(account_id: uuid.
     assert "New" in text, "empty-roster admin copy must mention New"
 
 
-def test_empty_roster_container_shows_view_only_for_member(account_id: uuid.UUID) -> None:
-    """Empty roster member copy: shows view-only hint."""
+def test_empty_roster_container_shows_new_copy_for_member_too(account_id: uuid.UUID) -> None:
+    """Empty roster member copy: every member can create, so the copy invites
+    creating the first agent — no 'View only' variant on an empty roster."""
     state = PanelState.initial(
         roster=[], account_id=account_id, platform_principal_id=uuid.uuid4(), is_admin=False
     )
     container = build_panel_container(state, thumbnail_url=None)
     text = _container_text(container)
-    assert "View only" in text or "ask an admin" in text, (
-        "empty-roster member copy must mention view-only or ask an admin"
+    assert "New" in text, "empty-roster member copy must mention New, same as the admin copy"
+    assert "View only" not in text, (
+        "the empty-roster branch must not show the view-only variant to anyone"
     )
 
 
@@ -675,8 +677,9 @@ def test_empty_roster_disables_edit_and_delete(account_id: uuid.UUID) -> None:
     assert new_btn.disabled is False, "New must remain enabled on empty roster"
 
 
-def test_seeded_agent_disables_edit_and_delete(account_id: uuid.UUID) -> None:
-    """UX-25-02: system agent must disable Edit + Delete; Fork remains enabled."""
+def test_seeded_agent_enables_edit_disables_delete(account_id: uuid.UUID) -> None:
+    """A system agent's Edit is enabled (it is now the only door to its env
+    vars); Delete stays disabled; Fork remains enabled."""
     selected = RosterEntry(
         name="daimon",
         model="claude-sonnet-4-6",
@@ -686,11 +689,10 @@ def test_seeded_agent_disables_edit_and_delete(account_id: uuid.UUID) -> None:
     state = PanelState(roster=[selected], selected=selected, account_id=account_id, is_admin=True)
     view = AgentSetupView(state, runtime=_make_runtime(), allowed_user_id=42)
 
-    for label in ("Edit", "Delete"):
-        btn = _find_button(view, label)
-        assert btn.disabled is True, (
-            f"{label} must be disabled on a system agent (only Fork is the escape hatch)"
-        )
+    edit_btn = _find_button(view, "Edit")
+    assert edit_btn.disabled is False, "Edit must be enabled on a system agent"
+    delete_btn = _find_button(view, "Delete")
+    assert delete_btn.disabled is True, "Delete must stay disabled on a system agent"
     fork_btn = _find_button(view, "Fork")
     assert fork_btn.disabled is False, "Fork must remain enabled (escape hatch)"
 
@@ -707,26 +709,6 @@ def test_edit_btn_disabled_when_no_selection(account_id: uuid.UUID) -> None:
     view = AgentSetupView(state, runtime=_make_runtime(), allowed_user_id=42)
     btn = _find_button(view, "Edit")
     assert btn.disabled is True, "Edit must be disabled when no agent selected"
-
-
-def test_edit_btn_disabled_for_system_agent(account_id: uuid.UUID) -> None:
-    """Edit must be disabled for system agents (use Fork instead)."""
-    selected = RosterEntry(
-        name="daimon",
-        model="claude-sonnet-4-6",
-        spec=AgentSpec(name="daimon", model="claude-sonnet-4-6"),
-        is_system=True,
-    )
-    state = PanelState(
-        roster=[selected],
-        selected=selected,
-        account_id=account_id,
-        platform_principal_id=uuid.uuid4(),
-        is_admin=True,
-    )
-    view = AgentSetupView(state, runtime=_make_runtime(), allowed_user_id=42)
-    btn = _find_button(view, "Edit")
-    assert btn.disabled is True, "Edit must be disabled on system agents (use Fork)"
 
 
 def test_admin_view_has_set_default_button(account_id: uuid.UUID) -> None:
@@ -757,8 +739,10 @@ def test_admin_view_has_set_default_button(account_id: uuid.UUID) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_read_only_view_hides_mutation_buttons(account_id: uuid.UUID) -> None:
-    """Member (is_admin=False) panel has NO mutation buttons; picker IS present."""
+def test_read_only_view_shows_build_buttons_hides_admin_buttons(account_id: uuid.UUID) -> None:
+    """Member (is_admin=False) panel has New/Fork/Edit (build controls) but NO
+    Set as default…/Delete/Connect via MCP (reachability + destructive controls);
+    picker IS present."""
     from daimon.core.scope import ChannelConfigRow, TenantConfigRow
 
     ch_row = ChannelConfigRow(agent_name="alice", channel_id="1001", tenant_id=uuid.UUID(int=0))
@@ -775,9 +759,13 @@ def test_read_only_view_hides_mutation_buttons(account_id: uuid.UUID) -> None:
 
     all_buttons = _walk_buttons(view)
     btn_labels = [b.label for b in all_buttons if b.label is not None]
-    for mutation_label in ("New", "Fork", "Edit", "Delete", "Set as default…"):
-        assert mutation_label not in btn_labels, (
-            f"member view must not contain {mutation_label!r} button (mutation hidden for non-admins)"
+    for build_label in ("New", "Fork", "Edit"):
+        assert build_label in btn_labels, (
+            f"member view must contain {build_label!r} button — build/configure is unconditional"
+        )
+    for admin_label in ("Set as default…", "Delete", "🔌 Connect via MCP"):
+        assert admin_label not in btn_labels, (
+            f"member view must not contain {admin_label!r} button (admin-only)"
         )
     selects = _walk_selects(view)
     assert len(selects) == 1, "member view must still have the agent picker"
@@ -824,8 +812,9 @@ def test_read_only_body_shows_cascade_ladder(account_id: uuid.UUID) -> None:
     )
 
 
-def test_member_roster_matches_admin_and_no_mutation_buttons(account_id: uuid.UUID) -> None:
-    """SC-4: member view shows same roster as admin but no mutation buttons."""
+def test_member_roster_matches_admin_and_hides_only_admin_buttons(account_id: uuid.UUID) -> None:
+    """SC-4: member view shows same roster as admin; build buttons are shared,
+    only the admin-only row (Set as default…/Delete/Connect via MCP) differs."""
     roster = [_entry("alice"), _entry("bob"), _entry("charlie")]
 
     admin_state = PanelState.initial(
@@ -855,9 +844,13 @@ def test_member_roster_matches_admin_and_no_mutation_buttons(account_id: uuid.UU
 
     member_buttons = _walk_buttons(member_view)
     member_btn_labels = [b.label for b in member_buttons if b.label is not None]
-    for mutation_label in ("New", "Fork", "Edit", "Delete", "Set as default…"):
-        assert mutation_label not in member_btn_labels, (
-            f"SC-4: member view must not contain {mutation_label!r} button"
+    for build_label in ("New", "Fork", "Edit"):
+        assert build_label in member_btn_labels, (
+            f"SC-4: member view must contain {build_label!r} button"
+        )
+    for admin_label in ("Delete", "Set as default…", "🔌 Connect via MCP"):
+        assert admin_label not in member_btn_labels, (
+            f"SC-4: member view must not contain {admin_label!r} button"
         )
 
     member_selects = _walk_selects(member_view)

--- a/packages/adapters/discord/tests/commands/test_agent_setup_command.py
+++ b/packages/adapters/discord/tests/commands/test_agent_setup_command.py
@@ -1,0 +1,185 @@
+"""Tests for `/agent-setup`'s provision_status branch, ahead of the panel render.
+
+A tenant mid-seed or whose seed failed must never be told "This server has no
+agents yet" -- that copy is only true for a ready tenant with a genuinely empty
+roster. `agent_setup` now reads `provision_status` and short-circuits before any
+MA call for a non-ready tenant.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+from daimon.adapters.discord.agent_setup.panel import AgentSetupView
+from daimon.adapters.discord.commands.agent_setup import AgentSetupCog
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.defaults.provisioning import provision_tenant
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.tenants import set_provision_status
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+def _make_runtime(
+    sessionmaker: async_sessionmaker[AsyncSession], *, anthropic_client: object
+) -> DiscordRuntime:
+    settings = MagicMock()
+    settings.mcp.public_url = None
+    settings.github.fallback_pat = None
+    settings.defaults_root = MagicMock()
+    return DiscordRuntime(
+        settings=settings,
+        anthropic=anthropic_client,  # pyright: ignore[reportArgumentType]  # real AsyncAnthropic, MockTransport-backed
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # command tests never run a turn
+    )
+
+
+def _make_interaction(runtime: DiscordRuntime, *, guild_id: int, channel_id: int = 2) -> MagicMock:
+    interaction = MagicMock()
+    interaction.client.runtime = runtime
+    interaction.client.user = None
+    interaction.guild_id = guild_id
+    interaction.channel_id = channel_id
+    interaction.channel = None
+    interaction.guild = None
+    interaction.user = MagicMock()  # not spec=discord.Member -> is_guild_admin() is False
+    interaction.user.id = 999
+    interaction.response.defer = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+async def _provision(
+    db_session_factory: async_sessionmaker[AsyncSession], *, guild_id: int, status: str
+) -> uuid.UUID:
+    result = await provision_tenant(
+        db_session_factory, platform="discord", workspace_id=str(guild_id)
+    )
+    await set_provision_status(db_session_factory, tenant_id=result.tenant_id, status=status)
+    return result.tenant_id
+
+
+def _counting_router() -> tuple[MARouter, list[str]]:
+    """MARouter that records every path hit, for asserting an MA call never happened."""
+    calls: list[str] = []
+    router = MARouter()
+
+    def _agents(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        calls.append(req.url.path)
+        return list_response([])
+
+    def _skills(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        calls.append(req.url.path)
+        return list_response([])
+
+    router.add("GET", r"/v1/agents", _agents)
+    router.add("GET", r"/v1/skills", _skills)
+    return router, calls
+
+
+async def test_pending_status_replies_without_fetching_roster(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 700000001
+    tenant_id = await _provision(db_session_factory, guild_id=guild_id, status="pending")
+    router, calls = _counting_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client)
+    interaction = _make_interaction(runtime, guild_id=guild_id)
+    cog = AgentSetupCog(MagicMock())
+
+    await cog.agent_setup.callback(cog, interaction)  # pyright: ignore[reportArgumentType]
+
+    interaction.edit_original_response.assert_awaited_once()
+    kwargs = interaction.edit_original_response.call_args.kwargs
+    content = kwargs.get("content", "")
+    assert "no agents yet" not in content.lower(), (
+        "a seeding tenant must never be told the server has no agents"
+    )
+    assert "setting up" in content.lower() or "try again" in content.lower(), (
+        f"pending status must say the install is being set up; got: {content!r}"
+    )
+    assert "view" not in kwargs, "no panel view may be built for a pending tenant"
+    assert calls == [], "a pending tenant must not trigger any MA agents-list/skills-list call"
+    assert tenant_id is not None
+
+
+async def test_failed_status_points_at_snag_followup(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 700000002
+    await _provision(db_session_factory, guild_id=guild_id, status="failed")
+    router, calls = _counting_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client)
+    interaction = _make_interaction(runtime, guild_id=guild_id)
+    cog = AgentSetupCog(MagicMock())
+
+    await cog.agent_setup.callback(cog, interaction)  # pyright: ignore[reportArgumentType]
+
+    interaction.edit_original_response.assert_awaited_once()
+    kwargs = interaction.edit_original_response.call_args.kwargs
+    content = kwargs.get("content", "")
+    assert "no agents yet" not in content.lower()
+    assert "snag" in content.lower(), (
+        f"failed status must point at the snag follow-up; got: {content!r}"
+    )
+    assert calls == [], "a failed tenant must not trigger any MA agents-list/skills-list call"
+
+
+async def test_unknown_status_fails_closed_to_pending_style_message(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An unrecognized provision_status must be treated as not-ready, never fall
+    through to the panel."""
+    guild_id = 700000003
+    await _provision(db_session_factory, guild_id=guild_id, status="some_future_status")
+    router, calls = _counting_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client)
+    interaction = _make_interaction(runtime, guild_id=guild_id)
+    cog = AgentSetupCog(MagicMock())
+
+    await cog.agent_setup.callback(cog, interaction)  # pyright: ignore[reportArgumentType]
+
+    interaction.edit_original_response.assert_awaited_once()
+    kwargs = interaction.edit_original_response.call_args.kwargs
+    content = kwargs.get("content", "")
+    assert "no agents yet" not in content.lower()
+    assert "try again" in content.lower(), (
+        f"an unrecognized status must fail closed to the pending-style message; got: {content!r}"
+    )
+    assert calls == [], "an unrecognized status must not trigger any MA call either"
+
+
+async def test_ready_status_still_renders_panel(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 700000004
+    await _provision(db_session_factory, guild_id=guild_id, status="ready")
+    router, calls = _counting_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client)
+    interaction = _make_interaction(runtime, guild_id=guild_id)
+    cog = AgentSetupCog(MagicMock())
+
+    await cog.agent_setup.callback(cog, interaction)  # pyright: ignore[reportArgumentType]
+
+    interaction.edit_original_response.assert_awaited_once()
+    kwargs = interaction.edit_original_response.call_args.kwargs
+    view = kwargs.get("view")
+    assert isinstance(view, AgentSetupView), (
+        "a ready tenant must still render AgentSetupView, unchanged from before"
+    )
+    assert "/v1/agents" in calls, "a ready tenant's roster must be fetched from MA"

--- a/packages/adapters/discord/tests/test_bot_seed.py
+++ b/packages/adapters/discord/tests/test_bot_seed.py
@@ -1,0 +1,290 @@
+"""Tests for the roster-resolves-before-ready invariant in `_seed_tenant_defaults`.
+
+A non-failing `ApplyReport` alone does not guarantee the deployment's configured
+default agent actually exists on MA — `config.yaml`'s `agent_name` can drift from
+every spec file under `defaults_root/agents/`. `_seed_tenant_defaults` must confirm
+the named agent resolves before flipping to ready, and the posted follow-up embed
+must always agree with the recorded status.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import httpx
+import structlog.testing
+from anthropic.types.beta import BetaManagedAgentsAgent
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.defaults.provisioning import provision_tenant
+from daimon.core.defaults.report import Action, ApplyReport, ResourceOutcome
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.tenants import get_tenant_liveness, set_provision_status
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+def _make_runtime(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    anthropic_client: object,
+    agent_name: str | None = "daimon",
+) -> DiscordRuntime:
+    settings = MagicMock()
+    settings.mcp.public_url = None
+    settings.defaults_root = MagicMock()
+    settings.billing.signup_credit = Decimal("0")
+    return DiscordRuntime(
+        settings=settings,
+        anthropic=anthropic_client,  # pyright: ignore[reportArgumentType]  # real AsyncAnthropic, MockTransport-backed
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(agent_name=agent_name),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # seed tests never run a turn
+    )
+
+
+def _make_bot(runtime: DiscordRuntime) -> DaimonBot:
+    intents = discord.Intents.default()
+    return DaimonBot(runtime=runtime, intents=intents)
+
+
+def _make_guild(*, guild_id: int) -> MagicMock:
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = guild_id
+    guild.name = "Test Guild"
+
+    me = MagicMock(spec=discord.Member)
+    guild.me = me
+
+    channel = MagicMock(spec=discord.TextChannel)
+    perms = MagicMock()
+    perms.send_messages = True
+    channel.permissions_for = MagicMock(return_value=perms)
+    channel.send = AsyncMock()
+    guild.system_channel = channel
+    guild.text_channels = [channel]
+
+    owner = MagicMock(spec=discord.Member)
+    owner.send = AsyncMock()
+    guild.owner = owner
+    guild.owner_id = 42
+    return guild
+
+
+def _agent_matching_tenant(tenant_id: uuid.UUID, *, name: str) -> dict[str, object]:
+    return BetaManagedAgentsAgent(
+        id="ag_1",
+        type="agent",
+        name=name,
+        model={"id": "claude-opus-4-7"},
+        metadata={"daimon_tenant": str(tenant_id), "daimon_name": name},
+        description=None,
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    ).model_dump(mode="json")
+
+
+async def _provision(
+    db_session_factory: async_sessionmaker[AsyncSession], *, workspace_id: str
+) -> uuid.UUID:
+    result = await provision_tenant(
+        db_session_factory, platform="discord", workspace_id=workspace_id
+    )
+    await set_provision_status(db_session_factory, tenant_id=result.tenant_id, status="pending")
+    return result.tenant_id
+
+
+async def test_seed_flips_ready_when_report_succeeds_and_default_agent_resolves(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = await _provision(db_session_factory, workspace_id="seed-ready-1")
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda req, _m: list_response([_agent_matching_tenant(tenant_id, name="daimon")]),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client, agent_name="daimon")
+    bot = _make_bot(runtime)
+    guild = _make_guild(guild_id=1)
+
+    with patch(
+        "daimon.adapters.discord.bot.reconcile_tenant_defaults",
+        new_callable=AsyncMock,
+        return_value=ApplyReport(),
+    ):
+        await bot._seed_tenant_defaults(tenant_id=tenant_id, guild=guild)  # pyright: ignore[reportPrivateUsage]
+
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "ready", (
+        "a non-failing report with the default agent present on MA must flip to ready"
+    )
+    posted_embed = guild.system_channel.send.await_args.kwargs["embed"]
+    assert posted_embed.title == "✅ Ready", "the ready embed must be posted when status is ready"
+
+
+async def test_seed_flips_failed_when_default_agent_missing_from_ma(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = await _provision(db_session_factory, workspace_id="seed-missing-1")
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client, agent_name="daimon")
+    bot = _make_bot(runtime)
+    guild = _make_guild(guild_id=2)
+
+    with (
+        structlog.testing.capture_logs() as logs,
+        patch(
+            "daimon.adapters.discord.bot.reconcile_tenant_defaults",
+            new_callable=AsyncMock,
+            return_value=ApplyReport(),
+        ),
+    ):
+        await bot._seed_tenant_defaults(tenant_id=tenant_id, guild=guild)  # pyright: ignore[reportPrivateUsage]
+
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "failed", (
+        "a non-failing report whose configured default agent is absent from MA "
+        "must NOT flip to ready"
+    )
+    posted_embed = guild.system_channel.send.await_args.kwargs["embed"]
+    assert posted_embed.title == "⚠️ Setup hit a snag", (
+        "the snag embed (not the ready embed) must be posted when the default agent is missing"
+    )
+    missing_events = [e for e in logs if e["event"] == "guild_seed_default_agent_missing"]
+    assert len(missing_events) >= 1, (
+        "a missing default agent on an otherwise non-failing seed must log a warning "
+        "an operator can search for"
+    )
+    assert missing_events[0]["tenant_id"] == str(tenant_id)
+    assert missing_events[0]["agent_name"] == "daimon"
+
+
+async def test_seed_flips_failed_when_report_fails_regardless_of_roster(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Regression: a failing report must still flip to failed, and the roster
+    lookup must not even run (the failure is already known)."""
+    tenant_id = await _provision(db_session_factory, workspace_id="seed-report-fails-1")
+    list_calls = 0
+
+    def _count_list(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        nonlocal list_calls
+        list_calls += 1
+        return list_response([])
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", _count_list)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client, agent_name="daimon")
+    bot = _make_bot(runtime)
+    guild = _make_guild(guild_id=3)
+
+    failing_report = ApplyReport()
+    failing_report.add(
+        ResourceOutcome(kind="skill", name="boom", action=Action.FAILED, error="5xx")
+    )
+
+    with patch(
+        "daimon.adapters.discord.bot.reconcile_tenant_defaults",
+        new_callable=AsyncMock,
+        return_value=failing_report,
+    ):
+        await bot._seed_tenant_defaults(tenant_id=tenant_id, guild=guild)  # pyright: ignore[reportPrivateUsage]
+
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "failed", (
+        "a failing report must flip to failed, unchanged from prior behavior"
+    )
+    posted_embed = guild.system_channel.send.await_args.kwargs["embed"]
+    assert posted_embed.title == "⚠️ Setup hit a snag"
+    assert list_calls == 0, (
+        "a failing report already determines the outcome; the roster lookup must be skipped"
+    )
+
+
+async def test_seed_skips_roster_check_when_deployment_default_has_no_agent_name(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """No configured default agent name means no roster assertion is possible —
+    behave exactly as before (flip on the report alone), and log that the check
+    was skipped."""
+    tenant_id = await _provision(db_session_factory, workspace_id="seed-no-agent-name-1")
+    router = MARouter()  # no routes registered — any call would raise
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client, agent_name=None)
+    bot = _make_bot(runtime)
+    guild = _make_guild(guild_id=4)
+
+    with (
+        structlog.testing.capture_logs() as logs,
+        patch(
+            "daimon.adapters.discord.bot.reconcile_tenant_defaults",
+            new_callable=AsyncMock,
+            return_value=ApplyReport(),
+        ),
+    ):
+        await bot._seed_tenant_defaults(tenant_id=tenant_id, guild=guild)  # pyright: ignore[reportPrivateUsage]
+
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "ready", (
+        "with no configured default agent name, a non-failing report alone must flip to ready"
+    )
+    skipped_events = [e for e in logs if e["event"] == "guild_seed_roster_check_skipped"]
+    assert len(skipped_events) >= 1, (
+        "skipping the roster check because no default agent name is configured must be logged"
+    )
+
+
+async def test_seed_ma_error_during_roster_check_flips_failed_via_existing_boundary(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An anthropic.APIError raised by the roster lookup must land in the
+    pre-existing typed except clause — no new handler — and still flip to
+    failed with the snag embed posted."""
+    tenant_id = await _provision(db_session_factory, workspace_id="seed-ma-error-1")
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda req, _m: httpx.Response(
+            503,
+            json={"type": "error", "error": {"type": "service_unavailable", "message": "down"}},
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _make_runtime(db_session_factory, anthropic_client=client, agent_name="daimon")
+    bot = _make_bot(runtime)
+    guild = _make_guild(guild_id=5)
+
+    with patch(
+        "daimon.adapters.discord.bot.reconcile_tenant_defaults",
+        new_callable=AsyncMock,
+        return_value=ApplyReport(),
+    ):
+        await bot._seed_tenant_defaults(tenant_id=tenant_id, guild=guild)  # pyright: ignore[reportPrivateUsage]
+
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "failed", (
+        "an API error from the roster lookup must flip status to failed via the "
+        "existing typed except clause"
+    )
+    posted_embed = guild.system_channel.send.await_args.kwargs["embed"]
+    assert posted_embed.title == "⚠️ Setup hit a snag"

--- a/packages/adapters/mcp/daimon/adapters/mcp/server.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/server.py
@@ -46,6 +46,7 @@ from daimon.adapters.mcp.tools import (
     time,
     vault,
 )
+from daimon.adapters.mcp.tools.agent_removal import register_agent_removal_tools
 from daimon.adapters.mcp.tools.channels import register_channel_tools
 from daimon.adapters.mcp.tools.cli_token import register_cli_token_tool
 from daimon.adapters.mcp.tools.credential_requests import register_credential_request_tools
@@ -256,6 +257,7 @@ def create_mcp_app(
         fernet=fernet,
     )
     agents.register_agent_tools(mcp, runtime)
+    register_agent_removal_tools(mcp, runtime)
     environments.register_environment_tools(mcp, runtime)
     vault.register_vault_tools(mcp, runtime)
     register_credential_request_tools(mcp, runtime)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_removal.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_removal.py
@@ -1,0 +1,192 @@
+"""Agent removal tools: detach_mcp_server, remove_skill.
+
+``register_agent_removal_tools(mcp, runtime)`` wires the ``@mcp.tool`` closures
+for this group; each closure delegates to a module-private ``_*_impl``
+coroutine that can be unit-tested without a FastMCP Context.
+
+A sibling of ``agents.py`` rather than more of it: these tools close a gap
+between what the ``/agent-setup`` panel can do to an agent and what chatting
+with the agent can do — detach an attached MCP server and detach an attached
+skill.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import anthropic
+from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsSkillParams
+from anthropic.types.beta.agent_create_params import Tool
+from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
+    BetaManagedAgentsURLMCPServerParams,
+)
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools import reachability
+from daimon.adapters.mcp.tools._ctx import _auth  # pyright: ignore[reportPrivateUsage]
+from daimon.adapters.mcp.tools.agents import (
+    AgentInfo,
+    _build_agent_info,  # pyright: ignore[reportPrivateUsage]
+    _ma_tool_to_param,  # pyright: ignore[reportPrivateUsage]
+    _reject_system_agent,  # pyright: ignore[reportPrivateUsage]
+    _resolve_custom_skill_titles,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
+from daimon.core.defaults.mcp_merge import get_reserved_mcp_rejection
+from daimon.core.ma import update_agent_with_version_retry
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+
+
+async def _detach_mcp_server_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+    server_name: str,
+) -> AgentInfo:
+    # Reserved-name check first and unconditionally — before any agent lookup
+    # or I/O, mirroring _attach_mcp_server_impl's #142 guard.
+    rejection = get_reserved_mcp_rejection(server_name=server_name, url="", public_url=None)
+    if rejection is not None:
+        raise ToolError(rejection)
+
+    agent = await find_agent_by_daimon_tag(
+        runtime.client, tenant_id=auth.tenant_id, name=agent_name
+    )
+    if agent is None:
+        raise ToolError(f"agent '{agent_name}' not found")
+    _reject_system_agent(agent)
+    await reachability.require_admin_for_reachable_agent(runtime, auth, agent_name=agent_name)
+
+    existing = list(agent.mcp_servers or [])
+    if not any(s.name == server_name for s in existing):
+        attached = ", ".join(s.name for s in existing) or "none"
+        raise ToolError(
+            f"'{server_name}' is not attached to '{agent_name}'. Currently attached: {attached}"
+        )
+
+    # Version-retry closure: mcp_servers and the matching mcp_toolset tool
+    # entry are recomputed from `fresh` on every attempt and removed together
+    # — MA rejects an agent whose mcp_servers aren't each referenced by a
+    # mcp_toolset, so leaving one behind would make the update inconsistent.
+    async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
+        fresh_existing = list(fresh.mcp_servers or [])
+        new_mcp_servers: list[BetaManagedAgentsURLMCPServerParams] = [
+            {"name": s.name, "type": "url", "url": s.url}
+            for s in fresh_existing
+            if s.name != server_name
+        ]
+        new_tools: list[Tool] = []
+        for t in fresh.tools:
+            if t.type == "mcp_toolset" and t.mcp_server_name == server_name:
+                continue
+            new_tools.append(_ma_tool_to_param(t))
+        return await runtime.client.beta.agents.update(
+            fresh.id,
+            version=fresh.version,
+            mcp_servers=new_mcp_servers,
+            tools=new_tools,
+        )
+
+    try:
+        updated = await update_agent_with_version_retry(runtime.client, agent.id, _apply)
+    except anthropic.ConflictError as exc:
+        raise ToolError("the agent was modified concurrently — please retry the operation") from exc
+    return await _build_agent_info(runtime.client, updated, tenant_id=auth.tenant_id)
+
+
+async def _remove_skill_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+    skill_id: str,
+) -> AgentInfo:
+    agent = await find_agent_by_daimon_tag(
+        runtime.client, tenant_id=auth.tenant_id, name=agent_name
+    )
+    if agent is None:
+        raise ToolError(f"agent '{agent_name}' not found")
+    _reject_system_agent(agent)
+    await reachability.require_admin_for_reachable_agent(runtime, auth, agent_name=agent_name)
+
+    titles = await _resolve_custom_skill_titles(runtime.client, [agent], tenant_id=auth.tenant_id)
+    target_id: str | None = None
+    for sk in agent.skills:
+        if sk.skill_id == skill_id or titles.get(sk.skill_id) == skill_id:
+            target_id = sk.skill_id
+            break
+    if target_id is None:
+        listing = (
+            ", ".join(
+                f"{sk.skill_id} ({titles[sk.skill_id]})" if sk.skill_id in titles else sk.skill_id
+                for sk in agent.skills
+            )
+            or "none"
+        )
+        raise ToolError(
+            f"'{skill_id}' is not attached to '{agent_name}'. Currently attached: {listing}"
+        )
+
+    # Version-retry closure: only `skills` is recomputed from `fresh` and
+    # patched. `tools` is left untouched — the base toolset must stay whether
+    # or not skills remain attached.
+    async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
+        new_skills: list[BetaManagedAgentsSkillParams] = [
+            cast(BetaManagedAgentsSkillParams, {"skill_id": sk.skill_id, "type": sk.type})
+            for sk in fresh.skills
+            if sk.skill_id != target_id
+        ]
+        return await runtime.client.beta.agents.update(
+            fresh.id, version=fresh.version, skills=new_skills
+        )
+
+    try:
+        updated = await update_agent_with_version_retry(runtime.client, agent.id, _apply)
+    except anthropic.ConflictError as exc:
+        raise ToolError("the agent was modified concurrently — please retry the operation") from exc
+    return await _build_agent_info(runtime.client, updated, tenant_id=auth.tenant_id)
+
+
+def register_agent_removal_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
+    @mcp.tool
+    async def detach_mcp_server(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        agent_name: str,
+        server_name: str,
+    ) -> AgentInfo:
+        """Detach an attached MCP server from an agent.
+
+        Removes the named entry from ``mcp_servers`` AND its matching
+        ``mcp_toolset`` entry from ``tools`` together — MA rejects an agent
+        whose ``mcp_servers`` entries aren't each referenced by a
+        ``mcp_toolset``, so both must go in the same update. Every other
+        attached server, skill, and tool is preserved. The reserved built-in
+        daimon server cannot be detached.
+        """
+        return await _detach_mcp_server_impl(
+            runtime, await _auth(ctx), agent_name=agent_name, server_name=server_name
+        )
+
+    @mcp.tool
+    async def remove_skill(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        agent_name: str,
+        skill_id: str,
+    ) -> AgentInfo:
+        """Detach one attached skill from an agent.
+
+        Accepts either the skill's raw ``skill_id`` or its resolved display
+        name. Every other attached skill and the agent's base tool set are
+        preserved.
+
+        This is a DIFFERENT operation from ``delete_skill`` /
+        ``skills_delete``, which destroy a skill for every agent in the
+        tenant. ``remove_skill`` only detaches this one agent's reference —
+        the skill resource itself, and any other agent that has it attached,
+        is untouched.
+        """
+        return await _remove_skill_impl(
+            runtime, await _auth(ctx), agent_name=agent_name, skill_id=skill_id
+        )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_removal.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_removal.py
@@ -1,17 +1,20 @@
-"""Agent removal tools: detach_mcp_server, remove_skill.
+"""Agent removal tools: detach_mcp_server, remove_skill, remove_env_credential,
+list_env_credential_keys.
 
 ``register_agent_removal_tools(mcp, runtime)`` wires the ``@mcp.tool`` closures
 for this group; each closure delegates to a module-private ``_*_impl``
 coroutine that can be unit-tested without a FastMCP Context.
 
-A sibling of ``agents.py`` rather than more of it: these tools close a gap
-between what the ``/agent-setup`` panel can do to an agent and what chatting
-with the agent can do — detach an attached MCP server and detach an attached
-skill.
+A sibling of ``agents.py`` rather than more of it: these four tools close the
+last gap between what the ``/agent-setup`` panel can do to an agent and what
+chatting with the agent can do — detach an attached MCP server, detach an
+attached skill, remove an env variable, and enumerate the env variable key
+names currently set (never their values).
 """
 
 from __future__ import annotations
 
+import uuid
 from typing import cast
 
 import anthropic
@@ -34,8 +37,23 @@ from daimon.adapters.mcp.tools.agents import (
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.defaults.mcp_merge import get_reserved_mcp_rejection
 from daimon.core.ma import update_agent_with_version_retry
+from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.stores.agent_files import delete_agent_file, list_agent_files
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, ConfigDict
+
+
+class RemoveEnvCredentialResult(BaseModel):
+    """Result of ``remove_env_credential``. Never carries a value."""
+
+    model_config = ConfigDict(frozen=True)
+
+    agent_name: str
+    key: str
+    removed: bool
+    """True if the key was present and deleted; False if it was already absent
+    (the delete is idempotent, so the call still succeeds either way)."""
 
 
 async def _detach_mcp_server_impl(
@@ -149,6 +167,57 @@ async def _remove_skill_impl(
     return await _build_agent_info(runtime.client, updated, tenant_id=auth.tenant_id)
 
 
+async def _list_env_credential_keys_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+) -> list[str]:
+    # Deliberately NOT reachability-gated and NOT _reject_system_agent-guarded:
+    # env variables are per-agent daimon rows keyed (tenant_id, agent_id, key)
+    # that never enter the MA agent spec, so neither the spec-drift guard nor
+    # the approved-configuration gate applies. This is a read; the ungated-
+    # reads convention (_ctx.py's _require_admin docstring) covers it too.
+    agent = await find_agent_by_daimon_tag(
+        runtime.client, tenant_id=auth.tenant_id, name=agent_name
+    )
+    if agent is None:
+        raise ToolError(f"agent '{agent_name}' not found")
+    agent_id: uuid.UUID = derive_agent_uuid(tenant_id=auth.tenant_id, ma_agent_id=str(agent.id))
+    async with runtime.session_factory() as session:
+        rows = await list_agent_files(session, tenant_id=auth.tenant_id, agent_id=agent_id)
+    return [row.key for row in rows]
+
+
+async def _remove_env_credential_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+    key: str,
+) -> RemoveEnvCredentialResult:
+    # Same rationale as _list_env_credential_keys_impl above: env variables
+    # are per-agent daimon rows outside the MA spec, so neither
+    # _reject_system_agent nor require_admin_for_reachable_agent applies here
+    # — and the existing chat credential button already writes these rows for
+    # the seeded agent, so gating removal would leave a write with no
+    # matching delete.
+    agent = await find_agent_by_daimon_tag(
+        runtime.client, tenant_id=auth.tenant_id, name=agent_name
+    )
+    if agent is None:
+        raise ToolError(f"agent '{agent_name}' not found")
+    agent_id: uuid.UUID = derive_agent_uuid(tenant_id=auth.tenant_id, ma_agent_id=str(agent.id))
+    async with runtime.session_factory.begin() as session:
+        # The store delete is idempotent (no raise when absent) — read first
+        # so the result can report a truthful removed flag instead of an
+        # unconditional success.
+        rows = await list_agent_files(session, tenant_id=auth.tenant_id, agent_id=agent_id)
+        was_present = any(row.key == key for row in rows)
+        await delete_agent_file(session, tenant_id=auth.tenant_id, agent_id=agent_id, key=key)
+    return RemoveEnvCredentialResult(agent_name=agent_name, key=key, removed=was_present)
+
+
 def register_agent_removal_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     @mcp.tool
     async def detach_mcp_server(  # pyright: ignore[reportUnusedFunction]
@@ -189,4 +258,36 @@ def register_agent_removal_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         """
         return await _remove_skill_impl(
             runtime, await _auth(ctx), agent_name=agent_name, skill_id=skill_id
+        )
+
+    @mcp.tool
+    async def remove_env_credential(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        agent_name: str,
+        key: str,
+    ) -> RemoveEnvCredentialResult:
+        """Remove one environment variable from an agent.
+
+        Idempotent: removing a key that is not currently set still succeeds
+        — the result's ``removed`` flag reports whether the key was actually
+        present. To ADD a variable, use ``request_env_credential`` instead;
+        entry always goes through the private modal flow, never through chat.
+        """
+        return await _remove_env_credential_impl(
+            runtime, await _auth(ctx), agent_name=agent_name, key=key
+        )
+
+    @mcp.tool
+    async def list_env_credential_keys(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        agent_name: str,
+    ) -> list[str]:
+        """List the environment variable KEY NAMES currently set on an agent.
+
+        Returns names only, never a value — so the agent can see what is
+        configured without a value ever entering chat. To add a variable,
+        use ``request_env_credential``.
+        """
+        return await _list_env_credential_keys_impl(
+            runtime, await _auth(ctx), agent_name=agent_name
         )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -24,6 +24,7 @@ from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
 )
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools import reachability
 from daimon.adapters.mcp.tools._ctx import (
     _auth,  # pyright: ignore[reportPrivateUsage]
     _require_admin,  # pyright: ignore[reportPrivateUsage]
@@ -239,11 +240,12 @@ def _union_tools(spec_tools: list[Tool], ma_agent: BetaManagedAgentsAgent) -> li
 def _reject_system_agent(agent: BetaManagedAgentsAgent) -> None:
     """Reject system agents (no daimon_account stamp) from chat mutating tools.
 
-    Authorization boundary: _require_admin (already called first on every
-    mutating impl) + tenant-scoped lookup. Any stamped agent in the tenant is
-    admin-mutable. Unstamped agents are the read-only seeded/system class —
-    they lack a daimon_account key — and must be forked before chat tools can
-    edit them.
+    Unconditional — applies to admins too, with no bypass. A chat edit never
+    stamps the seeded agent's spec hash, so the reconcile pipeline's hash
+    short-circuit would skip the drifted agent forever the next time defaults
+    are applied. Unstamped agents are the read-only seeded/system class — they
+    lack a daimon_account key — and must be forked before chat tools can edit
+    them.
     """
     owner = agent.metadata.get(MA_METADATA_KEY_ACCOUNT)
     if owner is None:
@@ -332,7 +334,6 @@ async def _create_agent_impl(
     auth: AuthIdentity,
     spec: AgentSpec,
 ) -> AgentInfo:
-    _require_admin(auth)
     if spec.skills:
         raise ToolError(
             "create_agent: skills must be empty. To add skills, either sync a "
@@ -412,7 +413,6 @@ async def _update_agent_impl(
     mcp_servers: list[BetaManagedAgentsURLMCPServerParams] | None,
     skills: list[str | BetaManagedAgentsSkillParams] | None,
 ) -> AgentInfo:
-    _require_admin(auth)
     scalars: dict[str, Any] = {"model": model, "description": description, "system": system}
     list_fields = (tools, mcp_servers, skills)
     if all(v is None for v in scalars.values()) and all(v is None for v in list_fields):
@@ -421,6 +421,16 @@ async def _update_agent_impl(
     if agent is None:
         raise ToolError(f"agent '{name}' not found")
     _reject_system_agent(agent)
+
+    touched_fields = {field_name for field_name, value in scalars.items() if value is not None}
+    if tools is not None:
+        touched_fields.add("tools")
+    if mcp_servers is not None:
+        touched_fields.add("mcp_servers")
+    if skills is not None:
+        touched_fields.add("skills")
+    if touched_fields & reachability.REACHABILITY_GATED_FIELDS:
+        await reachability.require_admin_for_reachable_agent(runtime, auth, agent_name=name)
 
     # Resolve skill names outside the closure — name resolution does not depend on
     # the agent's current state and must not be repeated on each retry attempt.
@@ -496,7 +506,6 @@ async def _attach_mcp_server_impl(
     server_name: str,
     url: str,
 ) -> AgentInfo:
-    _require_admin(auth)
     # #142: guard the reserved daimon-mcp entry before even looking at the agent.
     # Also reject any URL that points at the deployment's own public_url under a
     # different name — that would make the next reconcile append a second daimon-mcp.
@@ -514,6 +523,7 @@ async def _attach_mcp_server_impl(
     if agent is None:
         raise ToolError(f"agent '{agent_name}' not found")
     _reject_system_agent(agent)
+    await reachability.require_admin_for_reachable_agent(runtime, auth, agent_name=agent_name)
 
     existing = list(agent.mcp_servers or [])
     # No-op check on the initially-found agent (acceptable: a concurrent change
@@ -577,7 +587,6 @@ async def _fork_agent_impl(
     source_name: str,
     new_name: str,
 ) -> AgentInfo:
-    _require_admin(auth)
     await _reject_guild_name_collision(runtime, auth, new_name)
     source = await find_agent_by_daimon_tag(
         runtime.client, tenant_id=auth.tenant_id, name=source_name
@@ -691,7 +700,7 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         """
         return await _get_agent_impl(runtime, await _auth(ctx), name)
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def create_agent(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         name: str,
@@ -724,7 +733,7 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         )
         return await _create_agent_impl(runtime, await _auth(ctx), spec)
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def update_agent(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         name: str,
@@ -760,7 +769,7 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             skills=skills,
         )
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def attach_mcp_server(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
@@ -794,7 +803,7 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             url=url,
         )
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def fork_agent(ctx: Context, source_name: str, new_name: str) -> AgentInfo:  # pyright: ignore[reportUnusedFunction]
         """Clone an agent within the tenant pool under a new name."""
         return await _fork_agent_impl(runtime, await _auth(ctx), source_name, new_name)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/reachability.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/reachability.py
@@ -1,0 +1,62 @@
+"""Per-target runtime gate: is the named agent currently reachable in this tenant?
+
+Blast-radius rule for whoever adds the next tool: **blast radius of one
+agent -> open; blast radius of the whole tenant -> admin.** Creating, forking,
+or configuring an agent nobody has scoped only ever affects that one agent, so
+it stays open to any member. The moment an agent is a channel or workspace
+default, changing the fields that shape what it says and does reaches every
+user who talks to it — that requires admin.
+
+``description`` is deliberately not in the gated set: it is a label, not
+something that changes what the agent does or can reach. ``tools`` IS in the
+gated set even though ``mcp_servers`` might look like the more obvious target:
+an ``mcp_toolset`` entry in ``tools`` is how an attached MCP server actually
+becomes reachable by the model, so gating ``mcp_servers`` while leaving
+``tools`` open would let a non-admin route around the gate entirely — it
+would be no gate at all.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
+from fastmcp.exceptions import ToolError
+
+REACHABILITY_GATED_FIELDS: Final[frozenset[str]] = frozenset(
+    {"system", "model", "skills", "mcp_servers", "tools"}
+)
+
+
+async def require_admin_for_reachable_agent(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+) -> None:
+    """Raise ``ToolError`` if a non-admin caller is patching a currently-reachable agent.
+
+    Returns immediately for an admin caller without touching the database.
+    For a non-admin caller, reads the tenant's config cascade and raises when
+    ``agent_name`` currently resolves for any user in this tenant (channel,
+    tenant, or deployment tier). ``tenant_id`` always comes from
+    ``auth.tenant_id`` — never from a caller-supplied parameter — so a caller
+    cannot point the read at another tenant's config rows.
+    """
+    if auth.is_admin:
+        return
+    async with runtime.session_factory() as session:
+        reachable = await is_agent_reachable_in_tenant(
+            session,
+            tenant_id=auth.tenant_id,
+            agent_name=agent_name,
+            default=runtime.deployment_default,
+        )
+    if reachable:
+        raise ToolError(
+            f"'{agent_name}' is currently the default agent for this workspace or a "
+            "channel, so changing its setup needs Manage Server — ask a server admin "
+            "to use /agent-setup. Creating or forking your own agent is not gated."
+        )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/self_edit.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/self_edit.py
@@ -22,10 +22,7 @@ import structlog
 from anthropic import AsyncAnthropic
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
-from daimon.adapters.mcp.tools._ctx import (
-    _auth,  # pyright: ignore[reportPrivateUsage]
-    _require_admin,  # pyright: ignore[reportPrivateUsage]
-)
+from daimon.adapters.mcp.tools._ctx import _auth  # pyright: ignore[reportPrivateUsage]
 from daimon.core.broker import dispatch_mint_token
 from daimon.core.broker.errors import NoBindingError, ProviderConfigError
 from daimon.core.errors import StoreError
@@ -101,7 +98,6 @@ async def _self_write_file_impl(
     key: str,
     content: str,
 ) -> AgentFileRow:
-    _require_admin(auth)
     agent_id = _require_agent_id(auth)
     try:
         async with runtime.session_factory.begin() as session:
@@ -167,7 +163,6 @@ async def _self_delete_file_impl(
     *,
     key: str,
 ) -> dict[str, object]:
-    _require_admin(auth)
     agent_id = _require_agent_id(auth)
     # delete_agent_file is silently idempotent at the store layer (Pitfall 2).
     async with runtime.session_factory.begin() as session:
@@ -195,7 +190,6 @@ async def _set_repo_binding_impl(
     write → best-effort old vault credential delete. Vault upload happens
     BEFORE the DB write so a vault failure leaves no binding row.
     """
-    _require_admin(auth)
     agent_id = _require_agent_id(auth)
 
     # 1. Mint plaintext PAT via the broker. Deliberately does NOT opt into the
@@ -342,7 +336,6 @@ async def _clear_repo_binding_impl(
     auth: AuthIdentity,
 ) -> dict[str, bool]:
     """Remove the binding. Idempotent and tolerant of vault delete failure."""
-    _require_admin(auth)
     agent_id = _require_agent_id(auth)
 
     # Read the binding to capture the vault ref for best-effort cleanup.
@@ -407,7 +400,7 @@ async def _clear_repo_binding_impl(
 def register_self_edit_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     """Register the 7 self-edit tools (4 file tools + 3 repo-binding tools)."""
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def self_write_file(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         key: str,
@@ -434,7 +427,7 @@ def register_self_edit_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         """List all keys + metadata for files in your private agent_files namespace."""
         return await _self_list_files_impl(runtime, await _auth(ctx))
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def self_delete_file(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         key: str,
@@ -442,7 +435,7 @@ def register_self_edit_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         """Delete a per-agent file by `key`. Idempotent — succeeds whether or not a file existed."""
         return await _self_delete_file_impl(runtime, await _auth(ctx), key=key)
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def set_repo_binding(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         repo_url: str,
@@ -469,7 +462,7 @@ def register_self_edit_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         """Return the current repo binding for your agent, or null if unbound."""
         return await _get_repo_binding_impl(runtime, await _auth(ctx))
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def clear_repo_binding(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
     ) -> dict[str, bool]:

--- a/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
+++ b/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
@@ -105,7 +105,7 @@ CHAT_TURN_TOOL_REACHABILITY: dict[str, ExpectedOutcome] = {
     # docstring).
     "request_mcp_credential": ExpectedOutcome(discoverable=True),
     "request_env_credential": ExpectedOutcome(discoverable=True),
-    # routines.py — ungated per D-03; needs a platform user identity, which
+    # routines.py — ungated by design; needs a platform user identity, which
     # this Discord-shaped session carries.
     "create_routine": ExpectedOutcome(discoverable=True),
 }

--- a/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
+++ b/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
@@ -1,0 +1,378 @@
+"""The written record of what a chat-turn-shaped session can actually reach.
+
+A chat turn's daimon-mcp vault credential is minted exactly the way
+``ensure_agent_mcp_vault`` mints it: subject is the account, no ``agent_id``
+claim, no ``is_admin``, no ``internal``. This module drives that exact shape
+of session through the real ``httpx.ASGITransport`` + ``create_mcp_app``
+handshake and records, per tool the seeded system prompt currently mentions,
+whether it is discoverable via ``search_tools`` and, when it is, whether a
+``call_tool`` invocation is refused specifically because the session carries
+no ``agent_id`` claim (the ``self_edit`` own-identity gate) or reaches the
+tool's real implementation.
+
+CHAT_TURN_TOOL_REACHABILITY below is the source of truth for what the seeded
+prompt may claim a chat turn can do. Adding a tool name to the prompt without
+adding a row here is exactly the drift this file exists to prevent — the
+routines lie (a prompt telling Discord users to press a button that doesn't
+exist) and the ``set_repo_binding``-from-chat gap were both this same class
+of mistake: prompt prose describing mechanism the live tool surface
+contradicts.
+
+Two outcomes are recorded rather than treated as bugs:
+
+- ``set_repo_binding`` / ``get_repo_binding`` are visible (untagged, per this
+  plan's relaxation) but refuse a chat-turn caller: ``_require_agent_id``
+  raises because a chat-turn token carries no ``agent_id`` claim. Fixing
+  this would mean minting an agent claim into the account-scoped vault
+  credential, which is out of scope here (that credential is deliberately
+  account-scoped, not agent-scoped).
+- ``request_mcp_credential`` / ``request_env_credential`` reject Slack
+  callers and require a platform-bound identity (``auth.platform_user_id``).
+  The session built here carries a Discord-shaped platform claim, so both
+  reach their implementation; on Slack today they would be refused instead.
+  These two tools are Discord-only until a Slack-side implementation lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import datetime as dt
+import json
+import uuid
+from collections.abc import AsyncIterator
+from typing import NamedTuple
+
+import httpx
+import pytest
+from anthropic import AsyncAnthropic
+from daimon.adapters.mcp.server import create_mcp_app
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    McpSettings,
+    Settings,
+)
+from daimon.core.mcp_auth import mint_jwt
+from daimon.testing.factories import make_account, make_platform_principal, make_tenant
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.types import ASGIApp, Message
+
+from .factories import make_jwt, make_ma_agent
+
+pytestmark = pytest.mark.asyncio
+
+SECRET = "a" * 32
+_NOW = dt.datetime(2026, 4, 24, tzinfo=dt.UTC)
+
+
+class ExpectedOutcome(NamedTuple):
+    """One row of the reachability record.
+
+    `discoverable` — is the tool visible in this session's `search_tools`
+    results?
+    `blocked_by_agent_id` — for discoverable tools only: does the call refuse
+    specifically because the session carries no `agent_id` claim (the
+    `self_edit` own-identity gate)? `False` means the call reaches the
+    tool's real implementation — which may still fail for unrelated business
+    reasons (agent not found, validation, ...); that is not tracked here.
+    """
+
+    discoverable: bool
+    blocked_by_agent_id: bool = False
+
+
+CHAT_TURN_TOOL_REACHABILITY: dict[str, ExpectedOutcome] = {
+    # self_edit.py — relaxed (untagged) but require auth.agent_id, which a
+    # chat-turn token does not carry.
+    "set_repo_binding": ExpectedOutcome(discoverable=True, blocked_by_agent_id=True),
+    "get_repo_binding": ExpectedOutcome(discoverable=True, blocked_by_agent_id=True),
+    # skills.py — reads stay ungated; sync_skills stays admin-only.
+    "list_skills": ExpectedOutcome(discoverable=True),
+    "sync_skills": ExpectedOutcome(discoverable=False),
+    # agents.py — the four tools this plan relaxed, plus the two reads that
+    # were already ungated.
+    "update_agent": ExpectedOutcome(discoverable=True),
+    "attach_mcp_server": ExpectedOutcome(discoverable=True),
+    "create_agent": ExpectedOutcome(discoverable=True),
+    "fork_agent": ExpectedOutcome(discoverable=True),
+    "list_agents": ExpectedOutcome(discoverable=True),
+    "get_agent": ExpectedOutcome(discoverable=True),
+    "archive_agent": ExpectedOutcome(discoverable=False),
+    # credential_requests.py — never admin-gated; Discord-only (see module
+    # docstring).
+    "request_mcp_credential": ExpectedOutcome(discoverable=True),
+    "request_env_credential": ExpectedOutcome(discoverable=True),
+    # routines.py — ungated per D-03; needs a platform user identity, which
+    # this Discord-shaped session carries.
+    "create_routine": ExpectedOutcome(discoverable=True),
+}
+"""Source of truth for what the seeded prompt may claim a chat turn can do.
+The four chat-removal tools land in a later plan and are covered by the
+prompt-claim drift gate instead, not by this record."""
+
+_CALL_ARGS: dict[str, dict[str, object]] = {
+    "set_repo_binding": {"repo_url": "https://github.com/x/y", "default_branch": "main"},
+    "get_repo_binding": {},
+    "list_skills": {},
+    "update_agent": {"name": "demo-agent", "description": "hi"},
+    "attach_mcp_server": {
+        "agent_name": "demo-agent",
+        "server_name": "ctx7",
+        "url": "https://ctx7.example/mcp",
+    },
+    "create_agent": {"name": "demo-new-agent", "model": "claude-opus-4-5"},
+    "fork_agent": {"source_name": "demo-agent", "new_name": "demo-fork"},
+    "list_agents": {},
+    "get_agent": {"name": "demo-agent"},
+    "request_mcp_credential": {
+        "agent_name": "demo-agent",
+        "server_name": "ctx7",
+        "url": "https://ctx7.example/mcp",
+        "channel_id": "channel-1",
+    },
+    "request_env_credential": {
+        "agent_name": "demo-agent",
+        "key": "MY_KEY",
+        "purpose": "testing",
+        "channel_id": "channel-1",
+    },
+    "create_routine": {
+        "agent_name": "demo-agent",
+        "cron_expr": "0 * * * *",
+        "timezone": "UTC",
+        "trigger_message": "ping",
+    },
+}
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
+    send_queue: asyncio.Queue[Message] = asyncio.Queue()
+    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await receive_queue.get()
+
+    async def send(message: Message) -> None:
+        await send_queue.put(message)
+
+    async def run_lifespan() -> None:
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+
+    task = asyncio.create_task(run_lifespan())
+
+    await receive_queue.put({"type": "lifespan.startup"})
+    msg = await send_queue.get()
+    assert msg["type"] == "lifespan.startup.complete", msg
+    try:
+        yield
+    finally:
+        await receive_queue.put({"type": "lifespan.shutdown"})
+        msg = await send_queue.get()
+        assert msg["type"] == "lifespan.shutdown.complete", msg
+        await task
+
+
+def _parse_jsonrpc_response(resp: httpx.Response) -> dict[str, object]:
+    content_type = resp.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        for line in resp.text.splitlines():
+            if line.startswith("data: "):
+                return json.loads(line[6:])  # type: ignore[return-value]
+        raise AssertionError(f"No data line in SSE response: {resp.text!r}")
+    return resp.json()  # type: ignore[return-value]
+
+
+async def _mcp_session(
+    app: ASGIApp,
+    *,
+    token: str,
+    method: str,
+    params: dict[str, object] | None = None,
+) -> dict[str, object]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        init_resp = await c.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0"},
+                },
+            },
+            headers=headers,
+        )
+        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
+        session_id = init_resp.headers.get("mcp-session-id")
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+
+        body = {"jsonrpc": "2.0", "id": 2, "method": method, "params": params or {}}
+        resp = await c.post("/mcp", json=body, headers=headers)
+        assert resp.status_code == 200, f"{method} failed ({resp.status_code}): {resp.text}"
+        return _parse_jsonrpc_response(resp)
+
+
+def _make_app(sessionmaker: async_sessionmaker[AsyncSession], anthropic: AsyncAnthropic) -> ASGIApp:
+    return create_mcp_app(
+        settings=Settings(
+            database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+            anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+            mcp=McpSettings(jwt_secret=SecretStr(SECRET), public_url=HttpUrl("https://x/mcp")),
+        ),
+        sessionmaker=sessionmaker,
+        anthropic=anthropic,
+    )
+
+
+def _build_client() -> AsyncAnthropic:
+    """One shared MA fake: every agent lookup returns empty, so every relaxed
+    tool that resolves an agent by name hits a business "not found" error —
+    a real outcome that still proves the call reached the implementation,
+    not the visibility or admin/agent-id gates. create_agent gets its own
+    create+retrieve route since it doesn't look anything up first."""
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda _r, _m: list_response([]))
+    router.add("GET", r"/v1/skills", lambda _r, _m: list_response([]))
+    router.add(
+        "POST",
+        r"/v1/agents",
+        lambda _r, _m: httpx.Response(
+            200, json=make_ma_agent(name="demo-new-agent").model_dump(mode="json")
+        ),
+    )
+    router.add(
+        "GET",
+        r"/v1/agents/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            200, json=make_ma_agent(name="demo-new-agent").model_dump(mode="json")
+        ),
+    )
+    return build_fake_anthropic(router.dispatch)
+
+
+async def _seed_chat_turn_session(sessionmaker: async_sessionmaker[AsyncSession]) -> str:
+    """Seed a tenant + account shaped exactly like a Discord chat turn and
+    return the daimon-mcp-vault-shaped JWT for it: account-scoped subject, no
+    agent_id claim, no is_admin, default (non-admin) role, Discord platform
+    with a bound platform_user_id."""
+    async with sessionmaker() as s, s.begin():
+        tenant = await make_tenant(s, platform="discord", workspace_id="chat-turn-reachability")
+        account = await make_account(s, tenant=tenant)
+        await make_platform_principal(
+            s,
+            platform="discord",
+            external_id="discord-user-1",
+            tenant=tenant,
+            account=account,
+        )
+    return make_jwt(account_id=account.id)
+
+
+@pytest.mark.parametrize("tool_name,expected", sorted(CHAT_TURN_TOOL_REACHABILITY.items()))
+async def test_chat_turn_session_matches_recorded_reachability(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    tool_name: str,
+    expected: ExpectedOutcome,
+) -> None:
+    """Each tool's discoverability and (when discoverable) call outcome must
+    match the row recorded in CHAT_TURN_TOOL_REACHABILITY."""
+    token = await _seed_chat_turn_session(sessionmaker)
+    app = _make_app(sessionmaker, _build_client())
+
+    search_result = await _mcp_session(
+        app,
+        token=token,
+        method="tools/call",
+        params={"name": "search_tools", "arguments": {"query": tool_name.replace("_", " ")}},
+    )
+    search_payload = search_result.get("result", search_result)
+    search_content = search_payload.get("content", [])  # type: ignore[union-attr]
+    search_text = " ".join(
+        item.get("text", "") for item in search_content if isinstance(item, dict)
+    )
+    is_discoverable = tool_name in search_text
+    assert is_discoverable == expected.discoverable, (
+        f"{tool_name}: expected discoverable={expected.discoverable}, got {is_discoverable}; "
+        f"search_tools output: {search_text!r}"
+    )
+    if not expected.discoverable:
+        return
+
+    call_result = await _mcp_session(
+        app,
+        token=token,
+        method="tools/call",
+        params={
+            "name": "call_tool",
+            "arguments": {"name": tool_name, "arguments": _CALL_ARGS.get(tool_name, {})},
+        },
+    )
+    call_payload = call_result.get("result", call_result)
+    call_content = call_payload.get("content", [])  # type: ignore[union-attr]
+    call_text = " ".join(
+        item.get("text", "") for item in call_content if isinstance(item, dict)
+    ).lower()
+    is_blocked_by_agent_id = "not minted for an agent session" in call_text
+    assert is_blocked_by_agent_id == expected.blocked_by_agent_id, (
+        f"{tool_name}: expected blocked_by_agent_id={expected.blocked_by_agent_id}, "
+        f"got {is_blocked_by_agent_id}; call_tool output: {call_text!r}"
+    )
+    assert "manage server" not in call_text, (
+        f"{tool_name}: a chat-turn call must never re-trigger the admin gate; got: {call_text!r}"
+    )
+
+
+async def test_agent_id_claim_session_discovers_none_of_the_relaxed_tools(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A session narrowed to agent-chat tools (an agent_id claim) discovers a
+    strictly different set and none of the eight relaxed tools — removing the
+    admin tag must not have accidentally granted agent-chat visibility."""
+    async with sessionmaker() as s, s.begin():
+        tenant = await make_tenant(s, platform="discord", workspace_id="agent-chat-reachability")
+        account = await make_account(s, tenant=tenant)
+    token = mint_jwt(account_id=account.id, secret=SECRET.encode(), now=_NOW, agent_id=uuid.uuid4())
+    app = _make_app(sessionmaker, _build_client())
+
+    result = await _mcp_session(app, token=token, method="tools/list")
+    payload = result.get("result", result)
+    tool_names = {t["name"] for t in payload.get("tools", [])}  # type: ignore[union-attr]
+
+    expected_agent_chat_tools = {
+        "describe_agent",
+        "list_my_sessions",
+        "start_turn",
+        "continue_turn",
+        "get_my_session",
+        "list_events",
+    }
+    assert tool_names == expected_agent_chat_tools, (
+        f"an agent_id-claim session must discover exactly the agent-chat tool set; "
+        f"got: {sorted(tool_names)}"
+    )
+    relaxed_tool_names = {
+        "create_agent",
+        "update_agent",
+        "attach_mcp_server",
+        "fork_agent",
+        "set_repo_binding",
+        "clear_repo_binding",
+        "self_write_file",
+        "self_delete_file",
+    }
+    assert not (relaxed_tool_names & tool_names), (
+        f"an agent_id-claim session must not discover any relaxed tool; got: {tool_names}"
+    )

--- a/packages/adapters/mcp/tests/test_rbac.py
+++ b/packages/adapters/mcp/tests/test_rbac.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import datetime as dt
 import json
+import uuid
 from collections.abc import AsyncIterator
 
 import httpx
@@ -24,6 +26,7 @@ from daimon.core.config import (
     McpSettings,
     Settings,
 )
+from daimon.core.mcp_auth import mint_jwt
 from daimon.core.stores import accounts
 from daimon.core.stores.domain import Role
 from daimon.testing.factories import make_account, make_tenant
@@ -36,6 +39,7 @@ from .factories import make_jwt
 pytestmark = pytest.mark.asyncio
 
 SECRET = "a" * 32
+_NOW = dt.datetime(2026, 4, 24, tzinfo=dt.UTC)
 
 INIT_BODY: dict[str, object] = {
     "jsonrpc": "2.0",
@@ -248,6 +252,60 @@ RELAXED_TOOL_NAMES = (
 )
 """The eight tools whose blast radius is one agent, not the whole tenant —
 relaxed onto the open (non-admin-visible, non-admin-callable) surface."""
+
+CHAT_REMOVAL_TOOL_NAMES = (
+    "detach_mcp_server",
+    "remove_skill",
+    "remove_env_credential",
+    "list_env_credential_keys",
+)
+"""The four chat-reachable removal tools: never admin-tagged, so they are
+discoverable by a non-admin session's search_tools like RELAXED_TOOL_NAMES,
+but also must never leak into a narrowed agent-chat session's tools/list."""
+
+
+@pytest.mark.parametrize("tool_name", CHAT_REMOVAL_TOOL_NAMES)
+async def test_non_admin_search_includes_chat_removal_tool(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    tool_name: str,
+) -> None:
+    """Each chat-removal tool is discoverable by a non-admin session via search_tools."""
+    _, user_token = await _seed_admin_and_user(sessionmaker)
+    app = _make_app(sessionmaker)
+
+    result = await _mcp_session(
+        app,
+        token=user_token,
+        method="tools/call",
+        params={"name": "search_tools", "arguments": {"query": tool_name.replace("_", " ")}},
+    )
+    call_result = result.get("result", result)
+    content = call_result.get("content", [])  # type: ignore[union-attr]
+    output_text = " ".join(item.get("text", "") for item in content if isinstance(item, dict))
+    assert tool_name in output_text, (
+        f"{tool_name} must be discoverable by a non-admin session; got: {output_text!r}"
+    )
+
+
+async def test_agent_id_claim_session_discovers_none_of_the_chat_removal_tools(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A session narrowed to agent-chat tools (an agent_id claim) must not
+    discover any of the four chat-removal tools — being untagged (not
+    admin-only) must not accidentally grant agent-chat visibility."""
+    async with sessionmaker() as s, s.begin():
+        tenant = await make_tenant(s, platform="discord", workspace_id="agent-chat-removal-rbac")
+        account = await make_account(s, tenant=tenant)
+    token = mint_jwt(account_id=account.id, secret=SECRET.encode(), now=_NOW, agent_id=uuid.uuid4())
+    app = _make_app(sessionmaker)
+
+    result = await _mcp_session(app, token=token, method="tools/list")
+    payload = result.get("result", result)
+    tool_names = {t["name"] for t in payload.get("tools", [])}  # type: ignore[union-attr]
+
+    assert not (set(CHAT_REMOVAL_TOOL_NAMES) & tool_names), (
+        f"an agent_id-claim session must not discover any chat-removal tool; got: {tool_names}"
+    )
 
 
 @pytest.mark.parametrize("tool_name", RELAXED_TOOL_NAMES)

--- a/packages/adapters/mcp/tests/test_rbac.py
+++ b/packages/adapters/mcp/tests/test_rbac.py
@@ -156,7 +156,15 @@ async def _seed_admin_and_user(
 async def test_non_admin_list_tools(
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Non-admin tools/list returns only search_tools, call_tool, list_credentials."""
+    """Non-admin tools/list returns only search_tools, call_tool, list_credentials.
+
+    tools/list is NOT the discovery surface for individual tools — the BM25
+    search transform collapses the full catalog into these three meta-tools for
+    every session, admin included. Asserting that a specific mutating tool name
+    is absent from THIS response would be vacuously true for every tool in the
+    catalog, admin-gated or not, so that per-tool check lives against
+    search_tools instead (see test_non_admin_search_includes_relaxed_tool and
+    the other search_tools-based tests below)."""
     admin_token, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
@@ -168,37 +176,6 @@ async def test_non_admin_list_tools(
     for expected in ("search_tools", "call_tool", "list_credentials"):
         assert expected in tool_names, (
             f"Expected {expected!r} in non-admin tool list, got: {tool_names}"
-        )
-
-    # Admin tools must NOT appear. Every gated mutating tool is now admin-tagged
-    # (admin-tag sweep). Reads (list_agents, get_agent, list_skills, get_skill, etc.)
-    # stay visible to all sessions.
-    admin_tool_names = {
-        # agents.py mutating tools
-        "create_agent",
-        "update_agent",
-        "attach_mcp_server",
-        "fork_agent",
-        "archive_agent",
-        # skills.py mutating tools
-        "sync_skills",
-        "skills_sync",
-        "delete_skill",
-        "skills_delete",
-        # self_edit.py mutating tools
-        "self_write_file",
-        "self_delete_file",
-        "set_repo_binding",
-        "clear_repo_binding",
-        # environments.py mutating tools (reads are untagged + ungated,
-        # matching agents/skills — admin-tag/gate agreement)
-        "create_environment",
-        "update_environment",
-        "archive_environment",
-    }
-    for admin_tool in admin_tool_names:
-        assert admin_tool not in tool_names, (
-            f"Admin tool {admin_tool!r} visible to non-admin, tool_names={tool_names}"
         )
 
 
@@ -259,13 +236,26 @@ async def test_non_admin_call_admin_tool_blocked(
     )
 
 
-async def test_non_admin_search_excludes_fork_agent(
-    sessionmaker: async_sessionmaker[AsyncSession],
-) -> None:
-    """fork_agent is now admin-tagged — non-admin search must not surface it.
+RELAXED_TOOL_NAMES = (
+    "create_agent",
+    "update_agent",
+    "attach_mcp_server",
+    "fork_agent",
+    "set_repo_binding",
+    "clear_repo_binding",
+    "self_write_file",
+    "self_delete_file",
+)
+"""The eight tools whose blast radius is one agent, not the whole tenant —
+relaxed onto the open (non-admin-visible, non-admin-callable) surface."""
 
-    The impl gate remains as defense-in-depth, but the visibility layer
-    hides it from non-admin sessions before they can call it."""
+
+@pytest.mark.parametrize("tool_name", RELAXED_TOOL_NAMES)
+async def test_non_admin_search_includes_relaxed_tool(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    tool_name: str,
+) -> None:
+    """Each relaxed tool is discoverable by a non-admin session via search_tools."""
     _, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
@@ -273,13 +263,88 @@ async def test_non_admin_search_excludes_fork_agent(
         app,
         token=user_token,
         method="tools/call",
-        params={"name": "search_tools", "arguments": {"query": "fork agent"}},
+        params={"name": "search_tools", "arguments": {"query": tool_name.replace("_", " ")}},
     )
     call_result = result.get("result", result)
     content = call_result.get("content", [])  # type: ignore[union-attr]
     output_text = " ".join(item.get("text", "") for item in content if isinstance(item, dict))
-    assert "fork_agent" not in output_text, (
-        f"fork_agent must NOT be discoverable by non-admin; got: {output_text!r}"
+    assert tool_name in output_text, (
+        f"{tool_name} must be discoverable by a non-admin session; got: {output_text!r}"
+    )
+
+
+async def test_non_admin_call_relaxed_tool_reaches_impl(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A relaxed tool's call_tool invocation reaches its implementation for a
+    non-admin caller.
+
+    Only the absence of the two rejection outcomes is asserted: "not found"
+    (visibility would still be blocking it) and the Manage Server refusal (the
+    impl gate would still be firing). A tool-level validation error is an
+    acceptable — expected — outcome here, because what's being proven is that
+    the call reached the implementation at all, not that it fully succeeds
+    without any arguments."""
+    _, user_token = await _seed_admin_and_user(sessionmaker)
+    app = _make_app(sessionmaker)
+
+    result = await _mcp_session(
+        app,
+        token=user_token,
+        method="tools/call",
+        params={
+            "name": "call_tool",
+            "arguments": {
+                "tool_name": "self_write_file",
+                "tool_args": {"key": "notes", "content": "hello"},
+            },
+        },
+    )
+    call_result = result.get("result", result)
+    content = call_result.get("content", [])  # type: ignore[union-attr]
+    output_text = " ".join(
+        item.get("text", "") for item in content if isinstance(item, dict)
+    ).lower()
+    assert "not found" not in output_text, (
+        f"self_write_file must be visible to a non-admin call_tool invocation; got: {output_text!r}"
+    )
+    assert "manage server" not in output_text, (
+        f"self_write_file must not be impl-gated for a non-admin caller; got: {output_text!r}"
+    )
+
+
+STILL_ADMIN_TOOL_NAMES = (
+    "set_agent_default",
+    "clear_agent_default",
+    "archive_agent",
+    "sync_skills",
+    "create_environment",
+    "update_environment",
+    "archive_environment",
+)
+"""Tools whose blast radius is the whole tenant — stay admin-only after this plan."""
+
+
+@pytest.mark.parametrize("tool_name", STILL_ADMIN_TOOL_NAMES)
+async def test_non_admin_search_excludes_remaining_admin_tool(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    tool_name: str,
+) -> None:
+    """Each tenant-wide tool stays invisible to a non-admin session's search_tools."""
+    _, user_token = await _seed_admin_and_user(sessionmaker)
+    app = _make_app(sessionmaker)
+
+    result = await _mcp_session(
+        app,
+        token=user_token,
+        method="tools/call",
+        params={"name": "search_tools", "arguments": {"query": tool_name.replace("_", " ")}},
+    )
+    call_result = result.get("result", result)
+    content = call_result.get("content", [])  # type: ignore[union-attr]
+    output_text = " ".join(item.get("text", "") for item in content if isinstance(item, dict))
+    assert tool_name not in output_text, (
+        f"{tool_name} must NOT be discoverable by a non-admin session; got: {output_text!r}"
     )
 
 
@@ -362,8 +427,9 @@ async def test_admin_search_includes_admin_tools(
 async def test_admin_search_includes_fork_agent(
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Admin search_tools('fork') returns fork_agent — proves IdentityMiddleware
-    enable_components re-enables newly-tagged tools for admin sessions."""
+    """Admin search_tools('fork') returns fork_agent — fork_agent is untagged
+    (open to every session) after this plan's relaxation, so it must remain
+    discoverable for admin sessions too."""
     admin_token, _ = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 

--- a/packages/adapters/mcp/tests/test_rbac.py
+++ b/packages/adapters/mcp/tests/test_rbac.py
@@ -219,8 +219,8 @@ async def test_non_admin_call_admin_tool_blocked(
         params={
             "name": "call_tool",
             "arguments": {
-                "tool_name": "archive_agent",
-                "tool_args": {"name": "daimon"},
+                "name": "archive_agent",
+                "arguments": {"name": "daimon"},
             },
         },
     )
@@ -295,8 +295,8 @@ async def test_non_admin_call_relaxed_tool_reaches_impl(
         params={
             "name": "call_tool",
             "arguments": {
-                "tool_name": "self_write_file",
-                "tool_args": {"key": "notes", "content": "hello"},
+                "name": "self_write_file",
+                "arguments": {"key": "notes", "content": "hello"},
             },
         },
     )

--- a/packages/adapters/mcp/tests/tools/test_agent_removal.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_removal.py
@@ -13,11 +13,15 @@ from daimon.adapters.mcp.auth.resolver import AuthIdentity, Role
 from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools.agent_removal import (
     _detach_mcp_server_impl,
+    _list_env_credential_keys_impl,
+    _remove_env_credential_impl,
     _remove_skill_impl,
 )
 from daimon.adapters.mcp.tools.agents import AgentInfo
 from daimon.core.defaults.mcp_merge import DAIMON_MCP_SERVER_NAME
+from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.scope import DeploymentDefault, TenantScopeRef
+from daimon.core.stores.agent_files import put_agent_file
 from daimon.core.stores.scoped_config_write import set_fields
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import MARouter, build_fake_anthropic, json_body, list_response
@@ -516,3 +520,306 @@ async def test_remove_skill_impl_allows_non_admin_when_agent_unreachable(
         skill_id="skill_x",
     )
     assert captured.get("skills") == [], "an unreachable agent's skill removal is not gated"
+
+
+# ---------------------------------------------------------------------------
+# list_env_credential_keys / remove_env_credential
+# ---------------------------------------------------------------------------
+
+
+def _agent_only_router(
+    *,
+    tenant_id: uuid.UUID,
+    agent_name: str,
+    agent_id: str,
+    account_id: uuid.UUID | None,
+) -> AsyncAnthropic:
+    metadata = {"daimon_tenant": str(tenant_id), "daimon_name": agent_name}
+    if account_id is not None:
+        metadata["daimon_account"] = str(account_id)
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _r, _m: list_response(
+            [make_ma_agent(id=agent_id, name=agent_name, metadata=metadata).model_dump(mode="json")]
+        ),
+    )
+    return build_fake_anthropic(router.dispatch)
+
+
+def _multi_agent_router(
+    *, tenant_id: uuid.UUID, agents: list[tuple[str, str, uuid.UUID | None]]
+) -> AsyncAnthropic:
+    """agents: list of (agent_id, agent_name, account_id)."""
+    payloads: list[dict[str, Any]] = []
+    for agent_id, agent_name, account_id in agents:
+        metadata = {"daimon_tenant": str(tenant_id), "daimon_name": agent_name}
+        if account_id is not None:
+            metadata["daimon_account"] = str(account_id)
+        payloads.append(
+            make_ma_agent(id=agent_id, name=agent_name, metadata=metadata).model_dump(mode="json")
+        )
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda _r, _m: list_response(payloads))
+    return build_fake_anthropic(router.dispatch)
+
+
+async def test_list_env_credential_keys_impl_returns_sorted_key_names_only(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    agent_id = "ag_env"
+    client = _agent_only_router(
+        tenant_id=tenant_id, agent_name="demo", agent_id=agent_id, account_id=uuid.uuid4()
+    )
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=agent_id)
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", id=tenant_id)
+        await put_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_uuid, key="ZKEY", content="v1"
+        )
+        await put_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_uuid, key="AKEY", content="v2"
+        )
+        await put_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_uuid, key="MKEY", content="v3"
+        )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    result = await _list_env_credential_keys_impl(
+        _runtime(client, session_factory=db_session_factory), auth, agent_name="demo"
+    )
+    assert result == ["AKEY", "MKEY", "ZKEY"], "must return only the three key names, sorted"
+
+
+async def test_list_env_credential_keys_impl_returns_empty_list_when_none_set(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    client = _agent_only_router(
+        tenant_id=tenant_id, agent_name="demo", agent_id="ag_empty", account_id=uuid.uuid4()
+    )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    result = await _list_env_credential_keys_impl(
+        _runtime(client, session_factory=db_session_factory), auth, agent_name="demo"
+    )
+    assert result == [], "no variables set must return an empty list, not an error"
+
+
+async def test_list_env_credential_keys_impl_raises_when_agent_not_found(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda _r, _m: list_response([]))
+    client = build_fake_anthropic(router.dispatch)
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    with pytest.raises(ToolError, match="not found"):
+        await _list_env_credential_keys_impl(
+            _runtime(client, session_factory=db_session_factory), auth, agent_name="ghost"
+        )
+
+
+async def test_list_env_credential_keys_impl_never_returns_a_stored_value(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    agent_id = "ag_secret"
+    distinctive_value = "sk-super-secret-distinctive-value-9f2a"
+    client = _agent_only_router(
+        tenant_id=tenant_id, agent_name="demo", agent_id=agent_id, account_id=uuid.uuid4()
+    )
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=agent_id)
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", id=tenant_id)
+        await put_agent_file(
+            session,
+            tenant_id=tenant_id,
+            agent_id=agent_uuid,
+            key="API_KEY",
+            content=distinctive_value,
+        )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    result = await _list_env_credential_keys_impl(
+        _runtime(client, session_factory=db_session_factory), auth, agent_name="demo"
+    )
+    assert result == ["API_KEY"]
+    assert distinctive_value not in str(result), (
+        "the listing must never surface the stored value under any name"
+    )
+
+
+async def test_list_env_credential_keys_impl_callable_by_non_admin_on_default_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    client = _agent_only_router(
+        tenant_id=tenant_id, agent_name="scoped-agent", agent_id="ag_scoped", account_id=account_id
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    result = await _list_env_credential_keys_impl(
+        _runtime(client, session_factory=db_session_factory), auth, agent_name="scoped-agent"
+    )
+    assert result == [], "the listing is not reachability-gated, even on a default agent"
+
+
+async def test_remove_env_credential_impl_removes_existing_key(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    agent_id = "ag_env"
+    client = _agent_only_router(
+        tenant_id=tenant_id, agent_name="demo", agent_id=agent_id, account_id=uuid.uuid4()
+    )
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=agent_id)
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", id=tenant_id)
+        await put_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_uuid, key="API_KEY", content="v1"
+        )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    runtime = _runtime(client, session_factory=db_session_factory)
+    result = await _remove_env_credential_impl(runtime, auth, agent_name="demo", key="API_KEY")
+    assert result.removed is True
+    assert result.agent_name == "demo"
+    assert result.key == "API_KEY"
+
+    remaining = await _list_env_credential_keys_impl(runtime, auth, agent_name="demo")
+    assert remaining == [], "a follow-up listing must no longer contain the removed key"
+
+
+async def test_remove_env_credential_impl_is_idempotent_when_key_absent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    client = _agent_only_router(
+        tenant_id=tenant_id, agent_name="demo", agent_id="ag_env2", account_id=uuid.uuid4()
+    )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    result = await _remove_env_credential_impl(
+        _runtime(client, session_factory=db_session_factory),
+        auth,
+        agent_name="demo",
+        key="NEVER_SET",
+    )
+    assert result.removed is False, "removing an absent key must succeed idempotently"
+
+
+async def test_remove_env_credential_impl_raises_when_agent_not_found(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda _r, _m: list_response([]))
+    client = build_fake_anthropic(router.dispatch)
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    with pytest.raises(ToolError, match="not found"):
+        await _remove_env_credential_impl(
+            _runtime(client, session_factory=db_session_factory),
+            auth,
+            agent_name="ghost",
+            key="API_KEY",
+        )
+
+
+async def test_remove_env_credential_impl_callable_by_non_admin_on_default_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    client = _agent_only_router(
+        tenant_id=tenant_id, agent_name="scoped-agent", agent_id="ag_scoped2", account_id=account_id
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    result = await _remove_env_credential_impl(
+        _runtime(client, session_factory=db_session_factory),
+        auth,
+        agent_name="scoped-agent",
+        key="ANY_KEY",
+    )
+    assert result.removed is False, "removal is not reachability-gated, even on a default agent"
+
+
+async def test_remove_env_credential_impl_succeeds_against_seeded_agent_with_no_daimon_account(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    agent_id = "ag_seeded"
+    client = _agent_only_router(
+        tenant_id=tenant_id, agent_name="daimon", agent_id=agent_id, account_id=None
+    )
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=agent_id)
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", id=tenant_id)
+        await put_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_uuid, key="SEEDED_KEY", content="v1"
+        )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    result = await _remove_env_credential_impl(
+        _runtime(client, session_factory=db_session_factory),
+        auth,
+        agent_name="daimon",
+        key="SEEDED_KEY",
+    )
+    assert result.removed is True, "the system-agent guard must not apply to env-variable removal"
+
+
+async def test_remove_env_credential_impl_isolates_between_agents_in_same_tenant(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = uuid.uuid4()
+    agent_a_id, agent_b_id = "ag_a", "ag_b"
+    client = _multi_agent_router(
+        tenant_id=tenant_id,
+        agents=[
+            (agent_a_id, "agent-a", uuid.uuid4()),
+            (agent_b_id, "agent-b", uuid.uuid4()),
+        ],
+    )
+    agent_a_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=agent_a_id)
+    agent_b_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=agent_b_id)
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", id=tenant_id)
+        await put_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_a_uuid, key="SHARED", content="a-value"
+        )
+        await put_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_b_uuid, key="SHARED", content="b-value"
+        )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
+    )
+    runtime = _runtime(client, session_factory=db_session_factory)
+    result = await _remove_env_credential_impl(runtime, auth, agent_name="agent-a", key="SHARED")
+    assert result.removed is True
+
+    remaining = await _list_env_credential_keys_impl(runtime, auth, agent_name="agent-b")
+    assert remaining == ["SHARED"], "removing from agent-a must not affect agent-b's SHARED key"

--- a/packages/adapters/mcp/tests/tools/test_agent_removal.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_removal.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import SkillListResponse
+from daimon.adapters.mcp.auth.resolver import AuthIdentity, Role
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.agent_removal import (
+    _detach_mcp_server_impl,
+    _remove_skill_impl,
+)
+from daimon.adapters.mcp.tools.agents import AgentInfo
+from daimon.core.defaults.mcp_merge import DAIMON_MCP_SERVER_NAME
+from daimon.core.scope import DeploymentDefault, TenantScopeRef
+from daimon.core.stores.scoped_config_write import set_fields
+from daimon.testing.factories import make_tenant
+from daimon.testing.ma import MARouter, build_fake_anthropic, json_body, list_response
+from factories import make_ma_agent
+from fastmcp.exceptions import ToolError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+_ALLOW_ALL: dict[str, Any] = {"enabled": True, "permission_policy": {"type": "always_allow"}}
+
+
+def _make_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.mcp.public_url = None
+    return settings
+
+
+def _runtime(
+    client: AsyncAnthropic,
+    *,
+    session_factory: async_sessionmaker[AsyncSession] | MagicMock | None = None,
+) -> McpRuntime:
+    return McpRuntime(
+        session_factory=session_factory if session_factory is not None else MagicMock(),
+        client=client,  # type: ignore[arg-type]
+        settings=_make_settings(),  # type: ignore[arg-type]
+        deployment_default=DeploymentDefault(),
+        fernet=None,
+    )
+
+
+def _conflict_response() -> httpx.Response:
+    """MA's 409 stale-version conflict shape (mirrors test_agents.py)."""
+    return httpx.Response(
+        409,
+        json={
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Concurrent modification detected. Please fetch the latest version and retry.",
+            },
+        },
+    )
+
+
+def _build_no_retry_anthropic(router: MARouter) -> AsyncAnthropic:
+    """AsyncAnthropic with the SDK's own 409 auto-retry disabled (mirrors test_agents.py)."""
+    return AsyncAnthropic(
+        api_key="test",
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(router.dispatch),
+            base_url="https://api.anthropic.com",
+        ),
+        max_retries=0,
+    )
+
+
+def _spec_agent_router(
+    *,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID | None,
+    agent_name: str,
+    agent_id: str = "ag_removal",
+    mcp_servers: list[dict[str, Any]] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    skills: list[dict[str, Any]] | None = None,
+) -> tuple[dict[str, Any], list[str], AsyncAnthropic]:
+    """MARouter + fake client for one agent; captures the PATCH body and a
+    request log (method+path) so tests can assert zero requests were issued."""
+    captured: dict[str, Any] = {}
+    request_log: list[str] = []
+    metadata = {"daimon_tenant": str(tenant_id), "daimon_name": agent_name}
+    if account_id is not None:
+        metadata["daimon_account"] = str(account_id)
+
+    def _agent_payload() -> dict[str, Any]:
+        return make_ma_agent(
+            id=agent_id,
+            name=agent_name,
+            mcp_servers=mcp_servers or [],
+            tools=tools or [],
+            skills=skills or [],
+            metadata=metadata,
+        ).model_dump(mode="json")
+
+    def on_list(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        request_log.append("GET /v1/agents")
+        return list_response([_agent_payload()])
+
+    def on_retrieve(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        request_log.append("GET /v1/agents/{id}")
+        return httpx.Response(200, json=_agent_payload())
+
+    def on_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        request_log.append("POST /v1/agents/{id}")
+        captured.update(json_body(req))
+        return httpx.Response(
+            200, json=make_ma_agent(id=agent_id, name=agent_name).model_dump(mode="json")
+        )
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", on_list)
+    router.add("GET", r"/v1/agents/([^/]+)", on_retrieve)
+    router.add("POST", r"/v1/agents/([^/]+)", on_update)
+    return captured, request_log, build_fake_anthropic(router.dispatch)
+
+
+async def _make_tenant_with_default_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    agent_name: str | None,
+) -> uuid.UUID:
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord")
+        if agent_name is not None:
+            await set_fields(
+                session,
+                scope=TenantScopeRef(tenant_id=tenant.id),
+                tenant_id=tenant.id,
+                agent_name=agent_name,
+                mode="agent",
+            )
+    return tenant.id
+
+
+# ---------------------------------------------------------------------------
+# detach_mcp_server
+# ---------------------------------------------------------------------------
+
+
+async def test_detach_mcp_server_impl_removes_server_and_matching_toolset() -> None:
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        agent_name="demo",
+        mcp_servers=[{"name": "ctx7", "type": "url", "url": "https://ctx7.example/mcp"}],
+        tools=[
+            {
+                "type": "mcp_toolset",
+                "mcp_server_name": "ctx7",
+                "configs": [],
+                "default_config": _ALLOW_ALL,
+            },
+            {
+                "type": "agent_toolset_20260401",
+                "configs": [],
+                "default_config": _ALLOW_ALL,
+            },
+        ],
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    result = await _detach_mcp_server_impl(
+        _runtime(client), auth, agent_name="demo", server_name="ctx7"
+    )
+
+    assert isinstance(result, AgentInfo)
+    assert captured.get("mcp_servers") == [], "the detached server must be gone from mcp_servers"
+    tool_types_and_names = [
+        (t.get("type"), t.get("mcp_server_name")) for t in captured.get("tools", [])
+    ]
+    assert ("mcp_toolset", "ctx7") not in tool_types_and_names, (
+        "the matching mcp_toolset entry must be removed alongside the server"
+    )
+    assert ("agent_toolset_20260401", None) in tool_types_and_names, "other tools must be preserved"
+
+
+async def test_detach_mcp_server_impl_raises_when_not_attached_and_issues_no_update() -> None:
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    _captured, request_log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        agent_name="demo",
+        mcp_servers=[{"name": "other", "type": "url", "url": "https://other.example/mcp"}],
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    with pytest.raises(ToolError, match="other"):
+        await _detach_mcp_server_impl(_runtime(client), auth, agent_name="demo", server_name="ctx7")
+    assert "POST /v1/agents/{id}" not in request_log, (
+        "a typo'd server name must not issue an update"
+    )
+
+
+async def test_detach_mcp_server_impl_rejects_reserved_server_before_any_request() -> None:
+    _captured, request_log, client = _spec_agent_router(
+        tenant_id=uuid.uuid4(), account_id=uuid.uuid4(), agent_name="demo"
+    )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.ADMIN, is_admin=True
+    )
+    with pytest.raises(ToolError, match="reserved"):
+        await _detach_mcp_server_impl(
+            _runtime(client), auth, agent_name="demo", server_name=DAIMON_MCP_SERVER_NAME
+        )
+    assert request_log == [], "the reserved-name guard must fire before any agent lookup"
+
+
+async def test_detach_mcp_server_impl_rejects_system_agent_no_daimon_account() -> None:
+    tenant_id = uuid.uuid4()
+    _captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=None,
+        agent_name="daimon",
+        mcp_servers=[{"name": "ctx7", "type": "url", "url": "https://ctx7.example/mcp"}],
+    )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.ADMIN, is_admin=True
+    )
+    with pytest.raises(ToolError, match="system agent"):
+        await _detach_mcp_server_impl(
+            _runtime(client), auth, agent_name="daimon", server_name="ctx7"
+        )
+
+
+async def test_detach_mcp_server_impl_rejects_non_admin_when_agent_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    _captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        agent_name="scoped-agent",
+        mcp_servers=[{"name": "ctx7", "type": "url", "url": "https://ctx7.example/mcp"}],
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    with pytest.raises(ToolError, match="Manage Server"):
+        await _detach_mcp_server_impl(
+            _runtime(client, session_factory=db_session_factory),
+            auth,
+            agent_name="scoped-agent",
+            server_name="ctx7",
+        )
+
+
+async def test_detach_mcp_server_impl_allows_non_admin_when_agent_unreachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name=None)
+    captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        agent_name="unscoped-agent",
+        mcp_servers=[{"name": "ctx7", "type": "url", "url": "https://ctx7.example/mcp"}],
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    await _detach_mcp_server_impl(
+        _runtime(client, session_factory=db_session_factory),
+        auth,
+        agent_name="unscoped-agent",
+        server_name="ctx7",
+    )
+    assert captured.get("mcp_servers") == [], "an unreachable agent's detach is not gated"
+
+
+async def test_detach_mcp_server_impl_retries_once_on_version_conflict() -> None:
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    metadata = {
+        "daimon_tenant": str(tenant_id),
+        "daimon_name": "demo",
+        "daimon_account": str(account_id),
+    }
+    update_calls: list[int] = []
+
+    def on_list(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        return list_response(
+            [
+                make_ma_agent(
+                    id="ag_conflict",
+                    name="demo",
+                    mcp_servers=[
+                        {"name": "ctx7", "type": "url", "url": "https://ctx7.example/mcp"}
+                    ],
+                    metadata=metadata,
+                ).model_dump(mode="json")
+            ]
+        )
+
+    def on_retrieve(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=make_ma_agent(
+                id="ag_conflict",
+                name="demo",
+                mcp_servers=[{"name": "ctx7", "type": "url", "url": "https://ctx7.example/mcp"}],
+                version=1,
+                metadata=metadata,
+            ).model_dump(mode="json"),
+        )
+
+    def on_update(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        update_calls.append(len(update_calls) + 1)
+        if len(update_calls) == 1:
+            return _conflict_response()
+        return httpx.Response(
+            200,
+            json=make_ma_agent(id="ag_conflict", name="demo", version=2).model_dump(mode="json"),
+        )
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", on_list)
+    router.add("GET", r"/v1/agents/([^/]+)", on_retrieve)
+    router.add("POST", r"/v1/agents/([^/]+)", on_update)
+    client = _build_no_retry_anthropic(router)
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    result = await _detach_mcp_server_impl(
+        _runtime(client), auth, agent_name="demo", server_name="ctx7"
+    )
+    assert isinstance(result, AgentInfo)
+    assert len(update_calls) == 2, "must retry exactly once after a version conflict"
+
+
+# ---------------------------------------------------------------------------
+# remove_skill
+# ---------------------------------------------------------------------------
+
+
+async def test_remove_skill_impl_detaches_by_raw_skill_id_preserving_others() -> None:
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        agent_name="demo",
+        skills=[
+            {"type": "anthropic", "skill_id": "skill_x", "version": "1"},
+            {"type": "anthropic", "skill_id": "skill_y", "version": "1"},
+        ],
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    result = await _remove_skill_impl(_runtime(client), auth, agent_name="demo", skill_id="skill_x")
+
+    assert isinstance(result, AgentInfo)
+    assert captured.get("skills") == [{"skill_id": "skill_y", "type": "anthropic"}]
+    assert "tools" not in captured, "remove_skill must not touch the base tool set"
+
+
+async def test_remove_skill_impl_detaches_by_resolved_display_name() -> None:
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    metadata = {
+        "daimon_tenant": str(tenant_id),
+        "daimon_name": "demo",
+        "daimon_account": str(account_id),
+    }
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _r, _m: list_response(
+            [
+                make_ma_agent(
+                    id="ag_removal",
+                    name="demo",
+                    skills=[{"type": "custom", "skill_id": "skill_build", "version": "1"}],
+                    metadata=metadata,
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add(
+        "GET",
+        r"/v1/skills",
+        lambda _r, _m: list_response(
+            [
+                SkillListResponse(
+                    id="skill_build",
+                    type="custom",
+                    display_title=f"{str(tenant_id)[:8]}-build-models",
+                    latest_version="1",
+                    created_at="2026-04-21T00:00:00Z",
+                    updated_at="2026-04-21T00:00:00Z",
+                    source="custom",
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    captured: dict[str, Any] = {}
+
+    def on_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        captured.update(json_body(req))
+        return httpx.Response(
+            200, json=make_ma_agent(id="ag_removal", name="demo").model_dump(mode="json")
+        )
+
+    router.add(
+        "GET",
+        r"/v1/agents/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            200,
+            json=make_ma_agent(
+                id="ag_removal",
+                name="demo",
+                skills=[{"type": "custom", "skill_id": "skill_build", "version": "1"}],
+                metadata=metadata,
+            ).model_dump(mode="json"),
+        ),
+    )
+    router.add("POST", r"/v1/agents/([^/]+)", on_update)
+    client = build_fake_anthropic(router.dispatch)
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    result = await _remove_skill_impl(
+        _runtime(client), auth, agent_name="demo", skill_id="build-models"
+    )
+    assert isinstance(result, AgentInfo)
+    assert captured.get("skills") == [], "resolved display name must match and detach the skill"
+
+
+async def test_remove_skill_impl_raises_when_nothing_matches_listing_attached() -> None:
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    _captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        agent_name="demo",
+        skills=[{"type": "anthropic", "skill_id": "skill_x", "version": "1"}],
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    with pytest.raises(ToolError, match="skill_x"):
+        await _remove_skill_impl(
+            _runtime(client), auth, agent_name="demo", skill_id="does-not-exist"
+        )
+
+
+async def test_remove_skill_impl_rejects_system_agent_no_daimon_account() -> None:
+    tenant_id = uuid.uuid4()
+    _captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=None,
+        agent_name="daimon",
+        skills=[{"type": "anthropic", "skill_id": "skill_x", "version": "1"}],
+    )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.ADMIN, is_admin=True
+    )
+    with pytest.raises(ToolError, match="system agent"):
+        await _remove_skill_impl(_runtime(client), auth, agent_name="daimon", skill_id="skill_x")
+
+
+async def test_remove_skill_impl_rejects_non_admin_when_agent_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    _captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        agent_name="scoped-agent",
+        skills=[{"type": "anthropic", "skill_id": "skill_x", "version": "1"}],
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    with pytest.raises(ToolError, match="Manage Server"):
+        await _remove_skill_impl(
+            _runtime(client, session_factory=db_session_factory),
+            auth,
+            agent_name="scoped-agent",
+            skill_id="skill_x",
+        )
+
+
+async def test_remove_skill_impl_allows_non_admin_when_agent_unreachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name=None)
+    captured, _log, client = _spec_agent_router(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        agent_name="unscoped-agent",
+        skills=[{"type": "anthropic", "skill_id": "skill_x", "version": "1"}],
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    await _remove_skill_impl(
+        _runtime(client, session_factory=db_session_factory),
+        auth,
+        agent_name="unscoped-agent",
+        skill_id="skill_x",
+    )
+    assert captured.get("skills") == [], "an unreachable agent's skill removal is not gated"

--- a/packages/adapters/mcp/tests/tools/test_agents.py
+++ b/packages/adapters/mcp/tests/tools/test_agents.py
@@ -40,10 +40,11 @@ from daimon.adapters.mcp.tools.agents import (
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
 from daimon.core.github_credentials import build_multifernet, get_pat, upsert_credential_encrypted
 from daimon.core.ma_identity import derive_agent_uuid
-from daimon.core.scope import DeploymentDefault
+from daimon.core.scope import DeploymentDefault, TenantScopeRef
 from daimon.core.specs import AgentSpec, SkillRef, SkillRepo
 from daimon.core.stores.agent_github_binding import set_agent_github_binding
 from daimon.core.stores.agent_repo_binding import set_binding
+from daimon.core.stores.scoped_config_write import set_fields
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import MARouter, build_fake_anthropic, json_body, list_response
 from factories import make_ma_agent
@@ -76,12 +77,15 @@ def _runtime(
     public_url: str | None = None,
     session_factory: async_sessionmaker[AsyncSession] | MagicMock | None = None,
     fernet: MultiFernet | None = None,
+    deployment_default: DeploymentDefault | None = None,
 ) -> McpRuntime:
     return McpRuntime(
         session_factory=session_factory if session_factory is not None else MagicMock(),
         client=client,  # type: ignore[arg-type]
         settings=_make_settings(public_url=public_url),  # type: ignore[arg-type]
-        deployment_default=DeploymentDefault(),
+        deployment_default=deployment_default
+        if deployment_default is not None
+        else DeploymentDefault(),
         fernet=fernet,
     )
 
@@ -3977,3 +3981,347 @@ async def test_attach_mcp_server_maps_residual_conflict_to_tool_error() -> None:
             server_name="ext-mcp",
             url="https://external.example/mcp",
         )
+
+
+# ---------------------------------------------------------------------------
+# Reachability gate: non-admin edits to a currently-reachable (non-seeded) agent
+#
+# blast radius = one agent -> open; blast radius = the tenant -> admin. A
+# stamped (non-seeded) agent nobody has scoped is a member's own scratchpad;
+# the moment it is a channel or workspace default, its name-visible
+# configuration fields (system/model/skills/mcp_servers/tools) require admin
+# at call time. description stays open regardless — it is a label, not a
+# spec field.
+# ---------------------------------------------------------------------------
+
+
+def _scoped_agent_router(
+    *, tenant_id: uuid.UUID, account_id: uuid.UUID, agent_name: str
+) -> tuple[dict[str, Any], AsyncAnthropic]:
+    """MARouter + fake client for one stamped (non-system) agent; captures PATCH bodies."""
+    captured: dict[str, Any] = {}
+
+    def on_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        captured.update(json_body(req))
+        return httpx.Response(
+            200,
+            json=make_ma_agent(id="ag_scoped", name=agent_name, mcp_servers=[]).model_dump(
+                mode="json"
+            ),
+        )
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _req, _m: list_response(
+            [
+                make_ma_agent(
+                    id="ag_scoped",
+                    name=agent_name,
+                    mcp_servers=[],
+                    metadata={
+                        "daimon_tenant": str(tenant_id),
+                        "daimon_name": agent_name,
+                        "daimon_account": str(account_id),
+                    },
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add(
+        "GET",
+        r"/v1/agents/([^/]+)",
+        lambda _req, _m: httpx.Response(
+            200,
+            json=make_ma_agent(id="ag_scoped", name=agent_name, mcp_servers=[]).model_dump(
+                mode="json"
+            ),
+        ),
+    )
+    router.add("POST", r"/v1/agents/([^/]+)", on_update)
+    return captured, build_fake_anthropic(router.dispatch)
+
+
+async def _make_tenant_with_default_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    agent_name: str | None,
+) -> uuid.UUID:
+    """Insert a real tenant; if `agent_name` is given, set it as the workspace default."""
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord")
+        if agent_name is not None:
+            await set_fields(
+                session,
+                scope=TenantScopeRef(tenant_id=tenant.id),
+                tenant_id=tenant.id,
+                agent_name=agent_name,
+                mode="agent",
+            )
+    return tenant.id
+
+
+async def test_update_agent_impl_rejects_non_admin_system_patch_when_agent_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    _, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="scoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    with pytest.raises(ToolError, match="Manage Server"):
+        await _update_agent_impl(
+            _runtime(client, session_factory=db_session_factory),
+            auth,
+            name="scoped-agent",
+            model=None,
+            description=None,
+            system="new system prompt",
+            tools=None,
+            mcp_servers=None,
+            skills=None,
+        )
+
+
+async def test_update_agent_impl_allows_non_admin_description_patch_when_agent_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    captured, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="scoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    await _update_agent_impl(
+        _runtime(client, session_factory=db_session_factory),
+        auth,
+        name="scoped-agent",
+        model=None,
+        description="a label, not a spec field",
+        system=None,
+        tools=None,
+        mcp_servers=None,
+        skills=None,
+    )
+    assert captured.get("description") == "a label, not a spec field", (
+        "description is not in the gated field set — it must reach MA even on a reachable agent"
+    )
+
+
+async def test_update_agent_impl_rejects_non_admin_skills_patch_when_agent_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    _, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="scoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    with pytest.raises(ToolError, match="Manage Server"):
+        await _update_agent_impl(
+            _runtime(client, session_factory=db_session_factory),
+            auth,
+            name="scoped-agent",
+            model=None,
+            description=None,
+            system=None,
+            tools=None,
+            mcp_servers=None,
+            skills=["some-skill"],
+        )
+
+
+async def test_update_agent_impl_rejects_non_admin_mcp_servers_patch_when_agent_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    _, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="scoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    with pytest.raises(ToolError, match="Manage Server"):
+        await _update_agent_impl(
+            _runtime(client, session_factory=db_session_factory),
+            auth,
+            name="scoped-agent",
+            model=None,
+            description=None,
+            system=None,
+            tools=None,
+            mcp_servers=[{"name": "ext", "type": "url", "url": "https://ext.example/mcp"}],
+            skills=None,
+        )
+
+
+async def test_update_agent_impl_rejects_non_admin_tools_patch_when_agent_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    _, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="scoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    with pytest.raises(ToolError, match="Manage Server"):
+        await _update_agent_impl(
+            _runtime(client, session_factory=db_session_factory),
+            auth,
+            name="scoped-agent",
+            model=None,
+            description=None,
+            system=None,
+            tools=[{"type": "agent_toolset_20260401"}],
+            mcp_servers=None,
+            skills=None,
+        )
+
+
+async def test_update_agent_impl_allows_non_admin_system_patch_when_agent_unreachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name=None)
+    captured, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="unscoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    await _update_agent_impl(
+        _runtime(client, session_factory=db_session_factory),
+        auth,
+        name="unscoped-agent",
+        model=None,
+        description=None,
+        system="new system prompt",
+        tools=None,
+        mcp_servers=None,
+        skills=None,
+    )
+    assert "new system prompt" in (captured.get("system") or ""), (
+        "an agent nobody has scoped is not gated — it's a member's own scratchpad"
+    )
+
+
+async def test_update_agent_impl_allows_admin_system_patch_when_agent_reachable_without_db_read() -> (
+    None
+):
+    """Admin short-circuits the reachability gate entirely — no config read required.
+
+    session_factory defaults to an unconfigured MagicMock(); if the gate tried
+    to open `async with runtime.session_factory()`, this test would error out
+    rather than merely fail an assertion.
+    """
+    account_id = uuid.uuid4()
+    tenant_id = uuid.uuid4()
+    _, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="scoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    result = await _update_agent_impl(
+        _runtime(client),
+        auth,
+        name="scoped-agent",
+        model=None,
+        description=None,
+        system="new system prompt",
+        tools=None,
+        mcp_servers=None,
+        skills=None,
+    )
+    assert isinstance(result, AgentInfo), "admin update must succeed without any config read"
+
+
+async def test_attach_mcp_server_impl_rejects_non_admin_when_agent_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name="scoped-agent")
+    _, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="scoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    with pytest.raises(ToolError, match="Manage Server"):
+        await _attach_mcp_server_impl(
+            _runtime(client, session_factory=db_session_factory),
+            auth,
+            agent_name="scoped-agent",
+            server_name="ctx7",
+            url="https://ctx7.example/mcp",
+        )
+
+
+async def test_attach_mcp_server_impl_allows_non_admin_when_agent_unreachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    account_id = uuid.uuid4()
+    tenant_id = await _make_tenant_with_default_agent(db_session_factory, agent_name=None)
+    captured, client = _scoped_agent_router(
+        tenant_id=tenant_id, account_id=account_id, agent_name="unscoped-agent"
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    await _attach_mcp_server_impl(
+        _runtime(client, session_factory=db_session_factory),
+        auth,
+        agent_name="unscoped-agent",
+        server_name="ctx7",
+        url="https://ctx7.example/mcp",
+    )
+    assert "mcp_servers" in captured, "an unreachable agent's MCP attachment is not gated"
+
+
+async def test_fork_agent_impl_allows_non_admin_source_with_no_daimon_account(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Forking the seeded (unstamped) agent is the sanctioned escape hatch — it
+    must work for a non-admin caller exactly as it does for an admin."""
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    def on_retrieve(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        body = make_ma_agent(id="ag_src", name="daimon")
+        return httpx.Response(200, json=body.model_dump(mode="json"))
+
+    def on_create(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        body = make_ma_agent(id="ag_new", name="my-fork")
+        return httpx.Response(200, json=body.model_dump(mode="json"))
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _req, _m: list_response(
+            [
+                make_ma_agent(
+                    id="ag_src",
+                    name="daimon",
+                    metadata={"daimon_tenant": str(tenant_id), "daimon_name": "daimon"},
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add("GET", r"/v1/agents/([^/]+)", on_retrieve)
+    router.add("POST", r"/v1/agents", on_create)
+    client = build_fake_anthropic(router.dispatch)
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+    result = await _fork_agent_impl(
+        _runtime(client, session_factory=db_session_factory, fernet=fernet),
+        auth,
+        source_name="daimon",
+        new_name="my-fork",
+    )
+    assert isinstance(result, AgentInfo), (
+        "non-admin fork of the unstamped seeded agent must succeed"
+    )

--- a/packages/adapters/mcp/tests/tools/test_reachability.py
+++ b/packages/adapters/mcp/tests/tools/test_reachability.py
@@ -1,0 +1,81 @@
+"""Tests for require_admin_for_reachable_agent — the per-target runtime gate."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from anthropic import AsyncAnthropic
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.reachability import require_admin_for_reachable_agent
+from daimon.core.scope import DeploymentDefault, TenantScopeRef
+from daimon.core.stores.domain import Role
+from daimon.core.stores.scoped_config_write import set_fields
+from daimon.testing.factories import make_tenant
+from fastmcp.exceptions import ToolError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+def _runtime(session_factory: async_sessionmaker[AsyncSession] | MagicMock) -> McpRuntime:
+    return McpRuntime(
+        session_factory=session_factory,
+        client=MagicMock(spec=AsyncAnthropic),  # type: ignore[arg-type]
+        settings=MagicMock(),  # type: ignore[arg-type]
+        deployment_default=DeploymentDefault(),
+    )
+
+
+async def test_admin_short_circuits_without_touching_session_factory() -> None:
+    """An admin caller returns immediately — the DB is never read."""
+    session_factory = MagicMock()
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.ADMIN, is_admin=True
+    )
+    result = await require_admin_for_reachable_agent(
+        _runtime(session_factory), auth, agent_name="daimon"
+    )
+    assert result is None, "admin caller passes the gate"
+    session_factory.assert_not_called()
+
+
+async def test_non_admin_reachable_agent_raises(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A non-admin caller patching a currently-reachable agent is refused."""
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord")
+        await set_fields(
+            session,
+            scope=TenantScopeRef(tenant_id=tenant.id),
+            tenant_id=tenant.id,
+            agent_name="daimon",
+            mode="agent",
+        )
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant.id, role=Role.USER, is_admin=False
+    )
+    with pytest.raises(ToolError, match="Manage Server"):
+        await require_admin_for_reachable_agent(
+            _runtime(db_session_factory), auth, agent_name="daimon"
+        )
+
+
+async def test_non_admin_unreachable_agent_returns_none(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A non-admin caller patching an agent nobody has scoped is not gated."""
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord")
+
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=tenant.id, role=Role.USER, is_admin=False
+    )
+    result = await require_admin_for_reachable_agent(
+        _runtime(db_session_factory), auth, agent_name="my-agent"
+    )
+    assert result is None, "unreachable agent must not be gated for a non-admin caller"

--- a/packages/adapters/mcp/tests/tools/test_require_admin.py
+++ b/packages/adapters/mcp/tests/tools/test_require_admin.py
@@ -11,13 +11,14 @@ import uuid
 from typing import Any
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import BetaEnvironment
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools._ctx import _require_admin
-from daimon.adapters.mcp.tools.agents import _create_agent_impl, _list_agents_impl
+from daimon.adapters.mcp.tools.agents import AgentInfo, _create_agent_impl, _list_agents_impl
 from daimon.adapters.mcp.tools.environments import (
     _archive_environment_impl,
     _create_environment_impl,
@@ -82,21 +83,39 @@ def _agents_runtime(client: AsyncAnthropic) -> McpRuntime:
     )
 
 
-async def test_create_agent_impl_raises_when_not_admin() -> None:
-    """Non-admin caller is rejected before any MA call."""
+async def test_create_agent_impl_does_not_raise_admin_gate_for_non_admin() -> None:
+    """create_agent is no longer admin-gated — a non-admin caller can create their
+    own agent, since a brand-new agent is never reachable (nothing to protect)."""
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda _req, _m: list_response([]))
+    router.add(
+        "POST",
+        r"/v1/agents",
+        lambda _req, _m: httpx.Response(
+            200, json=make_ma_agent(name="demo").model_dump(mode="json")
+        ),
+    )
+    router.add(
+        "GET",
+        r"/v1/agents/([^/]+)",
+        lambda _req, _m: httpx.Response(
+            200, json=make_ma_agent(name="demo").model_dump(mode="json")
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+
     auth = AuthIdentity(
-        account_id=uuid.uuid4(),
-        tenant_id=uuid.uuid4(),
+        account_id=account_id,
+        tenant_id=tenant_id,
         role=Role.USER,
         is_admin=False,
     )
-    runtime = _agents_runtime(MagicMock(spec=AsyncAnthropic))
-    spec = AgentSpec(name="my-agent", model="claude-opus-4-5")
-    with pytest.raises(ToolError) as exc_info:
-        await _create_agent_impl(runtime, auth, spec)
-    assert str(exc_info.value) == _D28_MESSAGE, (
-        "_create_agent_impl must refuse non-admin with admin-required message"
-    )
+    spec = AgentSpec(name="demo", model="claude-opus-4-5")
+    result = await _create_agent_impl(_agents_runtime(client), auth, spec)
+    assert isinstance(result, AgentInfo), "non-admin create must succeed and return AgentInfo"
 
 
 async def test_list_agents_impl_does_not_raise_for_non_admin() -> None:
@@ -134,26 +153,31 @@ async def test_list_agents_impl_does_not_raise_for_non_admin() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_self_write_file_impl_raises_when_not_admin() -> None:
-    """Non-admin agent caller is rejected before any DB call."""
+async def test_self_write_file_impl_does_not_raise_admin_gate_for_non_admin(
+    committing_sessionmaker: Any,
+) -> None:
+    """self_write_file is no longer admin-gated — a non-admin agent session can
+    write its own per-agent file (a per-agent attachment, not a spec field)."""
+    from factories import seed_tenant  # type: ignore[import-untyped]
+
+    async with committing_sessionmaker.begin() as session:
+        tenant_id = await seed_tenant(session)
+
     auth = AuthIdentity(
         account_id=uuid.uuid4(),
-        tenant_id=uuid.uuid4(),
+        tenant_id=tenant_id,
         role=Role.USER,
         agent_id=uuid.uuid4(),
         is_admin=False,
     )
     runtime = McpRuntime(
-        session_factory=MagicMock(),
+        session_factory=committing_sessionmaker,
         client=MagicMock(spec=AsyncAnthropic),  # type: ignore[arg-type]
         settings=MagicMock(),  # type: ignore[arg-type]
         deployment_default=DeploymentDefault(),
     )
-    with pytest.raises(ToolError) as exc_info:
-        await _self_write_file_impl(runtime, auth, key="config.yaml", content="hello")
-    assert str(exc_info.value) == _D28_MESSAGE, (
-        "_self_write_file_impl must refuse non-admin with admin-required message"
-    )
+    row = await _self_write_file_impl(runtime, auth, key="config.yaml", content="hello")
+    assert row.content == "hello", "non-admin write must succeed and persist content"
 
 
 async def test_self_read_file_impl_does_not_raise_admin_gate_for_non_admin(

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
@@ -559,7 +559,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
 
         # -----------------------------------------------------------------------
         # Edit button — push to L2 (the ONLY transition that pushes to L2)
-        # Open to every member (D-06/D-09): building/configuring an unscoped
+        # Open to every member: building/configuring an unscoped
         # agent needs no admin. can_edit_spec (admin, or the agent is not
         # currently reachable) decides whether the agent-spec controls render.
         # -----------------------------------------------------------------------
@@ -896,7 +896,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Remove skill — field-conditional (D-09): skills are part of the agent
+        # Remove skill — field-conditional: skills are part of the agent
         # spec, so this refuses a non-admin only when the target agent is
         # currently reachable. Re-resolves via the shared gate post-ack.
         # -----------------------------------------------------------------------
@@ -985,7 +985,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Remove MCP — field-conditional (D-09): MCP servers are part of the
+        # Remove MCP — field-conditional: MCP servers are part of the
         # agent spec, so this refuses a non-admin only when the target agent
         # is currently reachable. Re-resolves via the shared gate post-ack.
         # -----------------------------------------------------------------------
@@ -1073,7 +1073,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Remove secret — always open (D-09): env-variable credentials are a
+        # Remove secret — always open: env-variable credentials are a
         # per-agent attachment, not part of the agent spec. No refusal for any
         # caller; is_admin/can_edit_spec are resolved only for the L1 stale
         # fallback and the L2 re-render's build_l2_view kwargs.
@@ -1245,7 +1245,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # New Agent — push L3 new-agent form. Open to every member (D-06):
+        # New Agent — push L3 new-agent form. Open to every member:
         # creating an unscoped agent is not tenant-wide blast radius.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__new":
@@ -1259,7 +1259,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Fork Agent — push L3 fork-agent form. Open to every member (D-06):
+        # Fork Agent — push L3 fork-agent form. Open to every member:
         # forking is a new, unscoped agent, same as New.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__fork":
@@ -1299,7 +1299,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Edit Agent Form — push L3 edit-agent form. Field-conditional (D-09):
+        # Edit Agent Form — push L3 edit-agent form. Field-conditional:
         # touches system/model, part of the agent spec, so this refuses a
         # non-admin only when the target agent is currently reachable.
         # -----------------------------------------------------------------------
@@ -1363,7 +1363,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Edit Repo Form — push L3 edit-repo form. Always open (D-09): the
+        # Edit Repo Form — push L3 edit-repo form. Always open: the
         # repo binding is a per-agent attachment, not part of the agent spec.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__edit_repo_form":
@@ -1403,7 +1403,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Add Skill — push L3 add-skill form. Field-conditional (D-09): skills
+        # Add Skill — push L3 add-skill form. Field-conditional: skills
         # are part of the agent spec, so this refuses a non-admin only when
         # the target agent is currently reachable.
         # -----------------------------------------------------------------------
@@ -1455,7 +1455,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Add MCP Server — push L3 add-mcp form. Field-conditional (D-09):
+        # Add MCP Server — push L3 add-mcp form. Field-conditional:
         # MCP servers are part of the agent spec, so this refuses a
         # non-admin only when the target agent is currently reachable.
         # -----------------------------------------------------------------------
@@ -1507,7 +1507,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Paste Secrets — push L3 paste-secrets form. Always open (D-09):
+        # Paste Secrets — push L3 paste-secrets form. Always open:
         # env-variable credentials are a per-agent attachment, not part of
         # the agent spec.
         # -----------------------------------------------------------------------

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
@@ -16,9 +16,21 @@ Handler contract:
     discipline (app.py acks before spawning this handler). All I/O wrapped in
     the boundary catch.
 
-Security:
-  - Every mutating branch re-resolves is_admin server-side post-ack and refuses
-    on False ("hiding ≠ gating" principle).
+Security — the gate follows the blast radius of what each branch touches,
+never a blanket admin check ("hiding ≠ gating" principle: every refusal is
+decided post-ack, server-side, never trusted from the rendered view):
+  - Always open, no refusal for any caller: new, fork, edit (L1→L2 push),
+    edit_repo_form, paste_secrets, remove_secret. Repo bindings and env
+    variables are per-agent attachments that never enter the agent spec;
+    building/configuring an unscoped agent has no tenant-wide blast radius.
+  - Field-conditional via the shared reachability gate in ``agent_setup.gate``:
+    remove_skill, remove_mcp, edit_agent_form, add_skill, add_mcp. These touch
+    the agent spec (system/model/skills/mcp_servers), so a non-admin is
+    refused only when the target agent is currently reachable (a channel or
+    workspace default) — an unreachable agent has no live gate to defend.
+  - Admin-only unconditionally, unchanged: delete, the three scope:* branches,
+    connect_mcp (mints a bearer token; token issuance stays outside what
+    this phase opens).
   - JWT values for connect-mcp: never logged, last4/presence only.
   - Stale agent: re-fetch tolerates missing agent → no write, re-render L1 with
     warning notice.
@@ -41,6 +53,7 @@ from daimon.adapters.slack.admin import (
     _dev_allow_all_admin,  # pyright: ignore[reportPrivateUsage]
     resolve_is_admin,
 )
+from daimon.adapters.slack.agent_setup import gate
 from daimon.adapters.slack.agent_setup.read import (
     load_agent_channel_ids,
     load_scope_hint,
@@ -91,6 +104,7 @@ from daimon.core.scope import (
     TenantScopeRef,
 )
 from daimon.core.specs import AgentSpec
+from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
 from slack_sdk.errors import SlackApiError
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -221,11 +235,14 @@ def _build_section_blocks(
     section_data: object,
     agent_name: str,
     is_admin: bool,
+    can_edit_spec: bool,
 ) -> list[dict[str, Any]]:
     """Build the per-section blocks from ``load_section_data`` output.
 
     Handles type mapping from the heterogeneous ``load_section_data`` return
-    to the specific builder signatures.
+    to the specific builder signatures. ``can_edit_spec`` gates the
+    spec-touching sections (agent/skills/mcps); repo_auth and secrets are
+    per-agent attachments and render their mutation controls unconditionally.
     """
     if section == "agent":
         info: dict[str, Any] = dict(section_data) if isinstance(section_data, dict) else {}  # type: ignore[arg-type]
@@ -233,34 +250,65 @@ def _build_section_blocks(
             agent_name=agent_name,
             model_id=str(info.get("model_id") or ""),
             system_prompt=str(info.get("system_prompt") or ""),
-            is_admin=is_admin,
+            can_edit_spec=can_edit_spec,
         )
     elif section == "repo_auth":
         return build_repo_auth_section(
             repo=None,
             pat_last4=None,
-            is_admin=is_admin,
         )
     elif section == "skills":
         names: list[str] = list(section_data) if isinstance(section_data, list) else []  # type: ignore[arg-type]
         return build_skills_section(
             skill_names=names,
             sync_pending=False,
-            is_admin=is_admin,
+            can_edit_spec=can_edit_spec,
         )
     elif section == "mcps":
         mcp_names: list[str] = list(section_data) if isinstance(section_data, list) else []  # type: ignore[arg-type]
         mcps = [{"name": n, "url": ""} for n in mcp_names]
-        return build_mcps_section(mcps=mcps, is_admin=is_admin)
+        return build_mcps_section(mcps=mcps, can_edit_spec=can_edit_spec, is_admin=is_admin)
     elif section == "secrets":
         secret_names: list[str] = list(section_data) if isinstance(section_data, list) else []  # type: ignore[arg-type]
         return build_secrets_section(
             agent_name=agent_name,
             secret_names=secret_names,
-            is_admin=is_admin,
         )
     else:
         return []
+
+
+# ---------------------------------------------------------------------------
+# Spec-editability for un-gated renders (branches that don't call the shared
+# reachability gate but still need to know whether to render a section's
+# mutation controls -- e.g. `edit` and `remove_secret`, which are open to
+# every member and re-render a spec-touching section)
+# ---------------------------------------------------------------------------
+
+
+async def _compute_can_edit_spec(
+    runtime: SlackRuntime,
+    *,
+    is_admin: bool,
+    tenant_id: uuid.UUID,
+    agent_name: str,
+) -> bool:
+    """Whether the caller may change this agent's approved configuration.
+
+    True immediately for an admin (no DB read). Otherwise a single
+    reachability read decides: an unscoped agent has no live gate to
+    defend, so a member may still change its spec.
+    """
+    if is_admin:
+        return True
+    async with runtime.sessionmaker() as session:
+        reachable = await is_agent_reachable_in_tenant(
+            session,
+            tenant_id=tenant_id,
+            agent_name=agent_name,
+            default=runtime.deployment_default,
+        )
+    return not reachable
 
 
 # ---------------------------------------------------------------------------
@@ -474,6 +522,10 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 )
                 return
 
+            can_edit_spec = await _compute_can_edit_spec(
+                runtime, is_admin=is_admin, tenant_id=tenant_id, agent_name=agent_name_for_tab
+            )
+
             async with runtime.sessionmaker() as session:
                 section_data = await load_section_data(
                     session,
@@ -488,6 +540,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 section_data=section_data,
                 agent_name=agent_name_for_tab,
                 is_admin=is_admin,
+                can_edit_spec=can_edit_spec,
             )
 
             # views.update — NEVER views.push (3-level cap, Structural Guarantee #2)
@@ -499,12 +552,16 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     team_id=team_id,
                     channel_id=channel_id,
                     is_admin=is_admin,
+                    can_edit_spec=can_edit_spec,
                     section_blocks=section_blocks,
                 ),
             )
 
         # -----------------------------------------------------------------------
         # Edit button — push to L2 (the ONLY transition that pushes to L2)
+        # Open to every member (D-06/D-09): building/configuring an unscoped
+        # agent needs no admin. can_edit_spec (admin, or the agent is not
+        # currently reachable) decides whether the agent-spec controls render.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__edit":
             agent_name_for_edit = selected_agent_name or ""
@@ -514,13 +571,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
-                return
 
             # Stale check.
             agents_check = await list_agents_by_tenant(runtime.anthropic, tenant_id=tenant_id)
@@ -540,6 +590,10 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 )
                 return
 
+            can_edit_spec = await _compute_can_edit_spec(
+                runtime, is_admin=is_admin, tenant_id=tenant_id, agent_name=agent_name_for_edit
+            )
+
             async with runtime.sessionmaker() as session:
                 agent_data = await load_section_data(
                     session,
@@ -554,7 +608,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 agent_name=agent_name_for_edit,
                 model_id=str(agent_info.get("model_id") or ""),
                 system_prompt=str(agent_info.get("system_prompt") or ""),
-                is_admin=is_admin,
+                can_edit_spec=can_edit_spec,
             )
 
             # views.push — Edit is the ONLY action that pushes to L2.
@@ -566,6 +620,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     team_id=team_id,
                     channel_id=channel_id,
                     is_admin=is_admin,
+                    can_edit_spec=can_edit_spec,
                     section_blocks=section_blocks,
                 ),
             )
@@ -841,19 +896,14 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Remove skill — MUTATION: re-resolve is_admin (T-83-10)
+        # Remove skill — field-conditional (D-09): skills are part of the agent
+        # spec, so this refuses a non-admin only when the target agent is
+        # currently reachable. Re-resolves via the shared gate post-ack.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__remove_skill":
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
-                return
 
             skill_to_remove: str = action.get("selected_option", {}).get("value") or ""
             if not skill_to_remove or skill_to_remove == "__none__":
@@ -861,6 +911,17 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
 
             agent_name_for_remove = selected_agent_name or ""
             if not agent_name_for_remove:
+                return
+
+            if await gate.refuse_if_reachable_and_not_admin(
+                runtime,
+                client,
+                tenant_id=tenant_id,
+                agent_name=agent_name_for_remove,
+                channel_id=channel_id,
+                user_id=user_id,
+                dev_allow_all=_dev_allow_all_admin(runtime),
+            ):
                 return
 
             ma_agent = await find_agent_by_daimon_tag(
@@ -903,10 +964,12 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     section="skills",
                 )
             skill_names: list[str] = list(updated_data) if isinstance(updated_data, list) else []  # type: ignore[arg-type]
+            # Reaching here means the gate above proceeded: either admin, or
+            # the target was unreachable -- exactly can_edit_spec's definition.
             section_blocks = build_skills_section(
                 skill_names=skill_names,
                 sync_pending=False,
-                is_admin=is_admin,
+                can_edit_spec=True,
             )
             await client.views_update(  # pyright: ignore[reportUnknownMemberType]
                 view_id=view_id,
@@ -916,24 +979,20 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     team_id=team_id,
                     channel_id=channel_id,
                     is_admin=is_admin,
+                    can_edit_spec=True,
                     section_blocks=section_blocks,
                 ),
             )
 
         # -----------------------------------------------------------------------
-        # Remove MCP — MUTATION: re-resolve is_admin (T-83-10)
+        # Remove MCP — field-conditional (D-09): MCP servers are part of the
+        # agent spec, so this refuses a non-admin only when the target agent
+        # is currently reachable. Re-resolves via the shared gate post-ack.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__remove_mcp":
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
-                return
 
             mcp_to_remove: str = action.get("selected_option", {}).get("value") or ""
             if not mcp_to_remove or mcp_to_remove == "__none__":
@@ -941,6 +1000,17 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
 
             agent_name_for_remove = selected_agent_name or ""
             if not agent_name_for_remove:
+                return
+
+            if await gate.refuse_if_reachable_and_not_admin(
+                runtime,
+                client,
+                tenant_id=tenant_id,
+                agent_name=agent_name_for_remove,
+                channel_id=channel_id,
+                user_id=user_id,
+                dev_allow_all=_dev_allow_all_admin(runtime),
+            ):
                 return
 
             ma_agent = await find_agent_by_daimon_tag(
@@ -984,7 +1054,11 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 )
             mcp_names: list[str] = list(updated_data) if isinstance(updated_data, list) else []  # type: ignore[arg-type]
             mcps_dicts = [{"name": n, "url": ""} for n in mcp_names]
-            section_blocks = build_mcps_section(mcps=mcps_dicts, is_admin=is_admin)
+            # Reaching here means the gate above proceeded: either admin, or
+            # the target was unreachable -- exactly can_edit_spec's definition.
+            section_blocks = build_mcps_section(
+                mcps=mcps_dicts, can_edit_spec=True, is_admin=is_admin
+            )
             await client.views_update(  # pyright: ignore[reportUnknownMemberType]
                 view_id=view_id,
                 view=build_l2_view(
@@ -993,24 +1067,21 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     team_id=team_id,
                     channel_id=channel_id,
                     is_admin=is_admin,
+                    can_edit_spec=True,
                     section_blocks=section_blocks,
                 ),
             )
 
         # -----------------------------------------------------------------------
-        # Remove secret — MUTATION: re-resolve is_admin (T-83-10)
+        # Remove secret — always open (D-09): env-variable credentials are a
+        # per-agent attachment, not part of the agent spec. No refusal for any
+        # caller; is_admin/can_edit_spec are resolved only for the L1 stale
+        # fallback and the L2 re-render's build_l2_view kwargs.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__remove_secret":
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
-                return
 
             secret_key_to_remove: str = action.get("selected_option", {}).get("value") or ""
             if not secret_key_to_remove or secret_key_to_remove == "__none__":
@@ -1047,6 +1118,10 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     key=secret_key_to_remove,
                 )
 
+            can_edit_spec = await _compute_can_edit_spec(
+                runtime, is_admin=is_admin, tenant_id=tenant_id, agent_name=agent_name_for_remove
+            )
+
             async with runtime.sessionmaker() as session:
                 updated_data = await load_section_data(
                     session,
@@ -1059,7 +1134,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             section_blocks = build_secrets_section(
                 agent_name=agent_name_for_remove,
                 secret_names=secret_names,
-                is_admin=is_admin,
             )
             await client.views_update(  # pyright: ignore[reportUnknownMemberType]
                 view_id=view_id,
@@ -1069,6 +1143,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     team_id=team_id,
                     channel_id=channel_id,
                     is_admin=is_admin,
+                    can_edit_spec=can_edit_spec,
                     section_blocks=section_blocks,
                 ),
             )
@@ -1170,20 +1245,10 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # New Agent — push L3 new-agent form (T-83-20: re-resolve is_admin)
+        # New Agent — push L3 new-agent form. Open to every member (D-06):
+        # creating an unscoped agent is not tenant-wide blast radius.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__new":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
-                return
-
             await client.views_push(  # pyright: ignore[reportUnknownMemberType]
                 trigger_id=payload.get("trigger_id") or "",
                 view=build_l3_new_agent_form(
@@ -1194,23 +1259,17 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Fork Agent — push L3 fork-agent form (T-83-20/T-83-21)
+        # Fork Agent — push L3 fork-agent form. Open to every member (D-06):
+        # forking is a new, unscoped agent, same as New.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__fork":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
-                return
-
             fork_source = selected_agent_name or ""
             if not fork_source:
                 return
+
+            is_admin = await resolve_is_admin(
+                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
+            )
 
             # Stale check (T-83-21): verify source agent still exists.
             ma_agent = await find_agent_by_daimon_tag(
@@ -1240,7 +1299,9 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Edit Agent Form — push L3 edit-agent form (T-83-20/T-83-21)
+        # Edit Agent Form — push L3 edit-agent form. Field-conditional (D-09):
+        # touches system/model, part of the agent spec, so this refuses a
+        # non-admin only when the target agent is currently reachable.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__edit_agent_form":
             agent_name_for_edit = selected_agent_name or ""
@@ -1250,12 +1311,16 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
+
+            if await gate.refuse_if_reachable_and_not_admin(
+                runtime,
+                client,
+                tenant_id=tenant_id,
+                agent_name=agent_name_for_edit,
+                channel_id=channel_id,
+                user_id=user_id,
+                dev_allow_all=_dev_allow_all_admin(runtime),
+            ):
                 return
 
             # Stale check (T-83-21).
@@ -1298,7 +1363,8 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Edit Repo Form — push L3 edit-repo form (T-83-20/T-83-21)
+        # Edit Repo Form — push L3 edit-repo form. Always open (D-09): the
+        # repo binding is a per-agent attachment, not part of the agent spec.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__edit_repo_form":
             agent_name_for_repo = selected_agent_name or ""
@@ -1308,13 +1374,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
-                return
 
             # Stale check (T-83-21).
             ma_agent = await find_agent_by_daimon_tag(
@@ -1344,7 +1403,9 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Add Skill — push L3 add-skill form (T-83-20/T-83-21)
+        # Add Skill — push L3 add-skill form. Field-conditional (D-09): skills
+        # are part of the agent spec, so this refuses a non-admin only when
+        # the target agent is currently reachable.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__add_skill":
             agent_name_for_skill = selected_agent_name or ""
@@ -1354,12 +1415,16 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
+
+            if await gate.refuse_if_reachable_and_not_admin(
+                runtime,
+                client,
+                tenant_id=tenant_id,
+                agent_name=agent_name_for_skill,
+                channel_id=channel_id,
+                user_id=user_id,
+                dev_allow_all=_dev_allow_all_admin(runtime),
+            ):
                 return
 
             # Stale check (T-83-21).
@@ -1390,7 +1455,9 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Add MCP Server — push L3 add-mcp form (T-83-20/T-83-21)
+        # Add MCP Server — push L3 add-mcp form. Field-conditional (D-09):
+        # MCP servers are part of the agent spec, so this refuses a
+        # non-admin only when the target agent is currently reachable.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__add_mcp":
             agent_name_for_mcp = selected_agent_name or ""
@@ -1400,12 +1467,16 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
+
+            if await gate.refuse_if_reachable_and_not_admin(
+                runtime,
+                client,
+                tenant_id=tenant_id,
+                agent_name=agent_name_for_mcp,
+                channel_id=channel_id,
+                user_id=user_id,
+                dev_allow_all=_dev_allow_all_admin(runtime),
+            ):
                 return
 
             # Stale check (T-83-21).
@@ -1436,7 +1507,9 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Paste Secrets — push L3 paste-secrets form (T-83-20/T-83-21)
+        # Paste Secrets — push L3 paste-secrets form. Always open (D-09):
+        # env-variable credentials are a per-agent attachment, not part of
+        # the agent spec.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__paste_secrets":
             agent_name_for_secrets = selected_agent_name or ""
@@ -1446,13 +1519,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             is_admin = await resolve_is_admin(
                 client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
             )
-            if not is_admin:
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel_id or user_id,
-                    user=user_id,
-                    text=":x: You no longer have permission to change agent setup.",
-                )
-                return
 
             # Stale check (T-83-21).
             ma_agent = await find_agent_by_daimon_tag(

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
@@ -1,0 +1,93 @@
+"""Shared post-ack reachability refusal helper for Slack /agent-setup.
+
+Field-follows-the-gate rule for the next contributor wiring up a new
+mutating action: skills and MCP servers are part of the agent spec an
+admin approved when the agent became reachable (a channel or workspace
+default), so mutating those fields on a currently-reachable agent stays
+admin-only. Repo bindings and env-variable credentials are per-agent
+attachments that never enter the agent spec, so they stay open on every
+agent regardless of reachability -- callers touching only those fields
+must not route through this helper at all.
+
+``refuse_if_reachable_and_not_admin`` resolves admin status live via
+``resolve_is_admin`` (never trusts anything carried in the rendered view
+or in ``private_metadata``) and re-reads reachability fresh from the DB on
+every call -- no caching, matching the panel's existing re-resolve
+discipline for admin status.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from daimon.adapters.slack.admin import resolve_is_admin
+from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
+from slack_sdk.web.async_client import AsyncWebClient
+
+__all__ = ["refuse_if_reachable_and_not_admin"]
+
+
+async def refuse_if_reachable_and_not_admin(
+    runtime: SlackRuntime,
+    web_client: AsyncWebClient,
+    *,
+    tenant_id: uuid.UUID,
+    agent_name: str,
+    channel_id: str,
+    user_id: str,
+    dev_allow_all: bool = False,
+) -> bool:
+    """Refuse a spec-touching action against a currently-reachable agent.
+
+    Returns ``True`` when the caller must return early (refused); ``False``
+    when the caller should proceed.
+
+    An admin caller is never refused and never pays for a DB read --
+    ``resolve_is_admin`` is checked first and this function returns
+    immediately on ``True``. A non-admin caller is refused only when the
+    target agent is currently reachable (scoped as a channel or workspace
+    default); an unreachable agent has no live gate to defend, so any
+    member may still configure it.
+
+    Args:
+        runtime:       Injected ``SlackRuntime`` (sessionmaker, deployment
+                        default).
+        web_client:     Per-event ``AsyncWebClient``.
+        tenant_id:      Derived from the verified Socket Mode workspace id --
+                        never accepted from the interactive payload.
+        agent_name:     The target agent's name -- used only as a
+                        tenant-scoped lookup key.
+        channel_id:     Invoking channel, for the refusal ephemeral.
+        user_id:        Invoking user, for the admin check and the ephemeral.
+        dev_allow_all:  Testing-only admin-gate override, threaded through
+                        unchanged from ``_dev_allow_all_admin(runtime)``.
+
+    Returns:
+        ``True`` if the caller must refuse and return early, ``False`` to
+        proceed.
+    """
+    is_admin = await resolve_is_admin(web_client, user_id=user_id, dev_allow_all=dev_allow_all)
+    if is_admin:
+        return False
+
+    async with runtime.sessionmaker() as session:
+        reachable = await is_agent_reachable_in_tenant(
+            session,
+            tenant_id=tenant_id,
+            agent_name=agent_name,
+            default=runtime.deployment_default,
+        )
+    if not reachable:
+        return False
+
+    await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+        channel=channel_id or user_id,
+        user=user_id,
+        text=(
+            ":lock: This agent is currently the default for this workspace or a "
+            "channel, so changing its setup needs workspace-admin permission. "
+            "Creating or forking your own agent is not restricted."
+        ),
+    )
+    return True

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
@@ -8,15 +8,20 @@ Two responsibilities per form:
    payload and whether the background run should proceed. No I/O.
 
 2. ``run_*_submission`` (async, background):
-   Runs AFTER the ack. Re-checks ``is_admin`` server-side (fail-closed),
-   calls the appropriate write.py path, then ``views_update`` the parent or
-   posts an ephemeral for slow-failure reports.
+   Runs AFTER the ack. Re-checks authorization server-side against fresh
+   state (fail-closed), calls the appropriate write.py path, then posts an
+   ephemeral confirming the write or reporting a slow-failure.
 
 Pattern mirrors ``privacy_panel/submit.py`` exactly — same Decision dataclass
 shape, same evaluate-then-spawn discipline, same boundary catch tuple.
 
 Threat register:
-- Every run_* re-checks resolve_is_admin before any write.
+- Creation (new agent, fork) and per-agent attachments (repo binding, env
+  variables) are open to every workspace member — there is nothing an admin
+  has approved for a brand-new agent, and attachments never enter the agent
+  spec. Configuration that touches the agent spec an admin approved (model,
+  system prompt, skills, MCP servers) re-checks the shared ``agent_setup.gate``
+  helper fresh, after the ack, before any MA request or store write.
 - Secret VALUES are validated then passed to the
   write layer only; they never appear in response_action payloads, error
   strings, block_ids, action_ids, or log lines.
@@ -34,8 +39,8 @@ import anthropic
 import structlog
 from daimon.adapters.slack.admin import (
     _dev_allow_all_admin,  # pyright: ignore[reportPrivateUsage]
-    resolve_is_admin,
 )
+from daimon.adapters.slack.agent_setup import gate
 from daimon.adapters.slack.agent_setup.state import decode_private_metadata
 from daimon.adapters.slack.agent_setup.write import (
     call_reconcile_for_panel,
@@ -549,35 +554,6 @@ def _allowed_model_ids() -> frozenset[str]:
 
 
 # ---------------------------------------------------------------------------
-# Background run helpers
-# ---------------------------------------------------------------------------
-
-
-async def _refuse_non_admin(
-    web_client: AsyncWebClient,
-    *,
-    team_id: str,
-    channel_id: str,
-    user_id: str,
-    dev_allow_all: bool = False,
-) -> bool:
-    """Re-check is_admin server-side; send ephemeral and return True if non-admin.
-
-    T-83-14: every mutating run_* calls this first. Returns True = caller
-    should return early (refused). Returns False = admin confirmed, proceed.
-    """
-    is_admin = await resolve_is_admin(web_client, user_id=user_id, dev_allow_all=dev_allow_all)
-    if not is_admin:
-        await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
-            channel=channel_id,
-            user=user_id,
-            text=":x: You no longer have permission to change agent setup.",
-        )
-        return True
-    return False
-
-
-# ---------------------------------------------------------------------------
 # Background runs (post-ack I/O)
 # ---------------------------------------------------------------------------
 
@@ -594,20 +570,12 @@ async def run_new_agent_submission(
 ) -> None:
     """Post-ack: create a blank agent then refresh the L1 modal.
 
-    Re-checks is_admin before any write (T-83-14). Name-collision guard
-    lives in create_blank_agent (fast indexed MA read).
+    Creation is open to every workspace member: a new or forked agent has no
+    propagation row and no config tier pointing at it, so there is nothing
+    an admin has approved to protect. Name-collision guard lives in
+    create_blank_agent (fast indexed MA read).
     """
     try:
-        refused = await _refuse_non_admin(
-            web_client,
-            team_id=team_id,
-            channel_id=channel_id,
-            user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
-        )
-        if refused:
-            return
-
         tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
         account_id = derive_guild_account_uuid(tenant_id=tenant_id)
 
@@ -652,19 +620,11 @@ async def run_fork_agent_submission(
 ) -> None:
     """Post-ack: fork an existing agent then refresh the L1 modal.
 
-    Re-checks is_admin before any write (T-83-14).
+    Creation is open to every workspace member: the new fork has no
+    propagation row and no config tier pointing at it, so there is nothing
+    an admin has approved to protect.
     """
     try:
-        refused = await _refuse_non_admin(
-            web_client,
-            team_id=team_id,
-            channel_id=channel_id,
-            user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
-        )
-        if refused:
-            return
-
         tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
         account_id = derive_guild_account_uuid(tenant_id=tenant_id)
 
@@ -714,13 +674,20 @@ async def run_edit_agent_submission(
 ) -> None:
     """Post-ack: reconcile updated model/system for the agent.
 
-    Re-checks is_admin before any write (T-83-14). Name field is read-only
-    (rename-forbidden invariant, Structural Guarantee #6).
+    This form changes part of the configuration an admin approved (model,
+    system prompt), so it needs workspace-admin permission when the agent is
+    currently a default and is open otherwise — re-checked fresh against the
+    agent named by private_metadata, before any MA request. Name field is
+    read-only (rename-forbidden invariant, Structural Guarantee #6).
     """
     try:
-        refused = await _refuse_non_admin(
+        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        refused = await gate.refuse_if_reachable_and_not_admin(
+            runtime,
             web_client,
-            team_id=team_id,
+            tenant_id=tenant_id,
+            agent_name=agent_name,
             channel_id=channel_id,
             user_id=user_id,
             dev_allow_all=_dev_allow_all_admin(runtime),
@@ -728,7 +695,6 @@ async def run_edit_agent_submission(
         if refused:
             return
 
-        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
         account_id = derive_guild_account_uuid(tenant_id=tenant_id)
 
         ma_agent = await find_agent_by_daimon_tag(
@@ -750,12 +716,14 @@ async def run_edit_agent_submission(
             system_prompt=str(extra["system"]) if extra.get("system") else None,
         )
 
-        current_params = ma_agent.model_dump(mode="json")
         spec = AgentSpec.model_validate(
             {
                 "name": agent_name,
-                "model": updates.get("model") or current_params.get("model", "claude-sonnet-4-6"),
-                "system": updates.get("system") or current_params.get("system"),
+                # ma_agent.model.id, not a re-serialized dict — model is a
+                # nested {id, speed} object on the SDK response, not a bare
+                # string (mirrors the Discord panel's agent.model.id read).
+                "model": updates.get("model") or ma_agent.model.id,
+                "system": updates.get("system") or ma_agent.system,
             }
         )
         await call_reconcile_for_panel(
@@ -804,20 +772,12 @@ async def run_edit_repo_submission(
 ) -> None:
     """Post-ack: update repo binding and/or inline PAT for the agent.
 
-    Re-checks is_admin before any write (T-83-14).
-    Blank PAT field = keep stored token (never overwrites).
+    Repo binding and the inline PAT are per-agent attachments that never
+    enter the agent spec, so this form is open to every workspace member —
+    including against the workspace's current default agent. Blank PAT
+    field = keep stored token (never overwrites).
     """
     try:
-        refused = await _refuse_non_admin(
-            web_client,
-            team_id=team_id,
-            channel_id=channel_id,
-            user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
-        )
-        if refused:
-            return
-
         tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
         account_id = derive_guild_account_uuid(tenant_id=tenant_id)
 
@@ -952,13 +912,20 @@ async def run_add_skill_submission(
 ) -> None:
     """Post-ack: kick off skill sync for the given repo URL.
 
-    Re-checks is_admin before any write (T-83-14). Repo reachability is slow
-    I/O → accepted pre-ack; failures reported via ephemeral.
+    Skills are part of the configuration an admin approved, so this form
+    needs workspace-admin permission when the agent is currently a default
+    and is open otherwise — re-checked fresh, before the sync is queued.
+    Repo reachability is slow I/O → accepted pre-ack; failures reported via
+    ephemeral.
     """
     try:
-        refused = await _refuse_non_admin(
+        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        refused = await gate.refuse_if_reachable_and_not_admin(
+            runtime,
             web_client,
-            team_id=team_id,
+            tenant_id=tenant_id,
+            agent_name=agent_name,
             channel_id=channel_id,
             user_id=user_id,
             dev_allow_all=_dev_allow_all_admin(runtime),
@@ -966,7 +933,6 @@ async def run_add_skill_submission(
         if refused:
             return
 
-        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
         account_id = derive_guild_account_uuid(tenant_id=tenant_id)
 
         repo_url = str(extra.get("repo_url") or "")
@@ -1048,13 +1014,19 @@ async def run_add_mcp_submission(
 ) -> None:
     """Post-ack: add an MCP server entry to the agent and reconcile.
 
-    Re-checks is_admin before any write (T-83-14).
+    MCP servers are part of the configuration an admin approved, so this
+    form needs workspace-admin permission when the agent is currently a
+    default and is open otherwise — re-checked fresh, before the MA lookup.
     token: optional (write-only). Empty = keep stored credential.
     """
     try:
-        refused = await _refuse_non_admin(
+        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        refused = await gate.refuse_if_reachable_and_not_admin(
+            runtime,
             web_client,
-            team_id=team_id,
+            tenant_id=tenant_id,
+            agent_name=agent_name,
             channel_id=channel_id,
             user_id=user_id,
             dev_allow_all=_dev_allow_all_admin(runtime),
@@ -1062,7 +1034,6 @@ async def run_add_mcp_submission(
         if refused:
             return
 
-        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
         account_id = derive_guild_account_uuid(tenant_id=tenant_id)
 
         mcp_name = str(extra.get("mcp_name") or "")
@@ -1097,18 +1068,37 @@ async def run_add_mcp_submission(
             )
             return
 
-        current_params = ma_agent.model_dump(mode="json")  # pyright: ignore[reportUnknownMemberType]
-
-        existing_mcp_servers: list[dict[str, Any]] = list(current_params.get("mcp_servers") or [])
+        existing_mcp_servers: list[dict[str, Any]] = [
+            server.model_dump(mode="python") for server in ma_agent.mcp_servers
+        ]
         # BetaManagedAgentsURLMCPServerParams is a TypedDict — build the dict directly.
         existing_mcp_servers.append({"name": mcp_name, "type": "url", "url": mcp_url})
+
+        # AgentSpec requires a matching mcp_toolset entry for every declared
+        # mcp_servers name (otherwise MA's own update call 400s deep in the
+        # SDK) — carry the agent's existing tools forward and append the new
+        # server's toolset entry if it isn't already there.
+        existing_tools: list[dict[str, Any]] = [
+            tool.model_dump(mode="python") for tool in ma_agent.tools
+        ]
+        has_mcp_toolset_entry = any(
+            tool.get("type") == "mcp_toolset" and tool.get("mcp_server_name") == mcp_name
+            for tool in existing_tools
+        )
+        if not has_mcp_toolset_entry:
+            existing_tools.append({"type": "mcp_toolset", "mcp_server_name": mcp_name})
 
         spec = AgentSpec.model_validate(
             {
                 "name": agent_name,
-                "model": current_params.get("model", "claude-sonnet-4-6"),
-                "system": current_params.get("system"),
+                # ma_agent.model.id, not a re-serialized dict — model is a
+                # nested {id, speed} object on the SDK response, not a bare
+                # string (mirrors the edit-agent fix above and the Discord
+                # panel's agent.model.id read).
+                "model": ma_agent.model.id,
+                "system": ma_agent.system,
                 "mcp_servers": existing_mcp_servers,
+                "tools": existing_tools,
             }
         )
         await call_reconcile_for_panel(
@@ -1182,21 +1172,13 @@ async def run_paste_secrets_submission(
 ) -> None:
     """Post-ack: write validated secrets to agent_files store.
 
-    Re-checks is_admin before any write (T-83-14).
+    Env-variable credentials are a per-agent attachment that never enters
+    the agent spec, so this form is open to every workspace member —
+    including against the workspace's current default agent.
     CRITICAL: only key NAMES appear in logs and ephemeral.
     Secret values are consumed here and never propagated further.
     """
     try:
-        refused = await _refuse_non_admin(
-            web_client,
-            team_id=team_id,
-            channel_id=channel_id,
-            user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
-        )
-        if refused:
-            return
-
         tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
 
         ma_agent = await find_agent_by_daimon_tag(

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/views.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/views.py
@@ -122,15 +122,19 @@ def build_l1_view(
 ) -> dict[str, Any]:
     """Build the L1 entry modal: roster static_select + lifecycle + scope picker.
 
-    Admin rendering includes lifecycle (New/Fork/Edit/Delete) and scope
-    (workspace / channel / clear) blocks. Non-admin rendering omits both.
+    The lifecycle actions block always carries New/Fork/Edit — building and
+    configuring an unscoped agent is open to every member. Delete is
+    appended to that same block only for an admin viewer. The scope
+    (workspace / channel / clear) block stays admin-only: scoping and
+    archiving are the operations with tenant-wide blast radius.
 
     Zero-agents state, >25 overflow, and no-agent-selected state are all
     handled per the UI-SPEC block inventory.
 
     Args:
         state:                 Panel state carrying the capped roster rows.
-        is_admin:              Whether the invoking user has admin permissions.
+        is_admin:              Whether the invoking user has admin permissions
+                                (gates Delete and the scope block only).
         team_id:               Slack workspace ID.
         channel_id:            Invoking channel (default for scope channel picker).
         selected_agent_name:   Currently-selected agent name, or None.
@@ -153,14 +157,12 @@ def build_l1_view(
     # Block 2: divider
     blocks.append({"type": "divider"})
 
-    # Zero-agents state
+    # Zero-agents state — same copy for every viewer: New is unconditional now,
+    # so any member can create the first agent.
     if not state.rows:
-        if is_admin:
-            empty_text = (
-                "_No agents yet. Use *New* to create your first agent, or_ `@bot help me set up`_._"
-            )
-        else:
-            empty_text = "_No agents have been set up for this workspace yet._"
+        empty_text = (
+            "_No agents yet. Use *New* to create your first agent, or_ `@bot help me set up`_._"
+        )
         blocks.append(
             {
                 "type": "section",
@@ -220,37 +222,42 @@ def build_l1_view(
                 }
             )
 
-        # Block 4: lifecycle actions (admin-only)
+        # Block 4: lifecycle actions. New/Fork/Edit are unconditional — any
+        # member may build and configure an unscoped agent. Delete stays
+        # admin-only and is appended only for an admin viewer.
+        lifecycle_elements: list[dict[str, Any]] = [
+            {
+                "type": "button",
+                "action_id": "agent_setup__new",
+                "text": {"type": "plain_text", "text": "New"},
+            },
+            {
+                "type": "button",
+                "action_id": "agent_setup__fork",
+                "text": {"type": "plain_text", "text": "Fork"},
+            },
+            {
+                "type": "button",
+                "action_id": "agent_setup__edit",
+                "text": {"type": "plain_text", "text": "Edit"},
+            },
+        ]
         if is_admin:
-            blocks.append(
+            lifecycle_elements.append(
                 {
-                    "type": "actions",
-                    "block_id": "agent_setup__lifecycle_actions",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "action_id": "agent_setup__new",
-                            "text": {"type": "plain_text", "text": "New"},
-                        },
-                        {
-                            "type": "button",
-                            "action_id": "agent_setup__fork",
-                            "text": {"type": "plain_text", "text": "Fork"},
-                        },
-                        {
-                            "type": "button",
-                            "action_id": "agent_setup__edit",
-                            "text": {"type": "plain_text", "text": "Edit"},
-                        },
-                        {
-                            "type": "button",
-                            "action_id": "agent_setup__delete",
-                            "text": {"type": "plain_text", "text": "Delete"},
-                            "style": "danger",
-                        },
-                    ],
+                    "type": "button",
+                    "action_id": "agent_setup__delete",
+                    "text": {"type": "plain_text", "text": "Delete"},
+                    "style": "danger",
                 }
             )
+        blocks.append(
+            {
+                "type": "actions",
+                "block_id": "agent_setup__lifecycle_actions",
+                "elements": lifecycle_elements,
+            }
+        )
 
         # Block 5: divider before scope section
         blocks.append({"type": "divider"})
@@ -366,6 +373,7 @@ def build_l2_view(
     team_id: str,
     channel_id: str,
     is_admin: bool,
+    can_edit_spec: bool,
     section_blocks: list[dict[str, Any]],
 ) -> dict[str, Any]:
     """Build the L2 section editor: header + tabs + section content.
@@ -381,6 +389,12 @@ def build_l2_view(
         team_id:         Slack workspace ID.
         channel_id:      Invoking channel (for ephemeral deliveries).
         is_admin:        Whether the invoking user has admin permissions.
+        can_edit_spec:   Whether the invoking user may change this agent's
+                          approved configuration right now (admin, or the
+                          agent is not currently reachable). Carried on the
+                          signature for callers building the section content
+                          from this same authorization decision; the section
+                          blocks passed in already reflect it.
         section_blocks:  Pre-built blocks for the active section's content.
 
     Returns:
@@ -441,15 +455,21 @@ def build_agent_section(
     agent_name: str,
     model_id: str,
     system_prompt: str,
-    is_admin: bool,
+    can_edit_spec: bool,
 ) -> list[dict[str, Any]]:
     """Build the Agent section blocks for the L2 editor.
+
+    The Edit prompt & model action touches ``system``/``model`` — fields the
+    reachability gate covers on a currently-scoped agent (D-09) — so this
+    section's mutation control follows spec-editability, not admin-ness alone.
 
     Args:
         agent_name:    Name of the agent (read-only; rename = Fork + Delete).
         model_id:      MA model identifier.
         system_prompt: Full system prompt text (preview truncated to 200 chars).
-        is_admin:      Whether mutation actions should be included.
+        can_edit_spec: Whether the invoking user may change this agent's
+                       approved configuration right now (admin, or the agent
+                       is not currently reachable).
 
     Returns:
         List of Block Kit blocks for the Agent section.
@@ -485,7 +505,7 @@ def build_agent_section(
         },
     ]
 
-    if is_admin:
+    if can_edit_spec:
         blocks.append(
             {
                 "type": "actions",
@@ -510,14 +530,16 @@ def build_repo_auth_section(
     *,
     repo: str | None,
     pat_last4: str | None,
-    is_admin: bool,
 ) -> list[dict[str, Any]]:
     """Build the Repo+Auth section blocks for the L2 editor.
+
+    The repo binding and its PAT are a per-agent attachment, not part of the
+    agent spec an admin approves (D-09) — the edit control renders for every
+    member, on every agent, regardless of admin status or reachability.
 
     Args:
         repo:      Owner/repo string, or None if not configured.
         pat_last4: Pre-masked PAT display string (e.g. ``****abcd``), or None.
-        is_admin:  Whether mutation actions should be included.
 
     Returns:
         List of Block Kit blocks for the Repo+Auth section.
@@ -544,20 +566,19 @@ def build_repo_auth_section(
         },
     ]
 
-    if is_admin:
-        blocks.append(
-            {
-                "type": "actions",
-                "block_id": "agent_setup__repo_actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "action_id": "agent_setup__edit_repo_form",
-                        "text": {"type": "plain_text", "text": "Edit repo + auth"},
-                    },
-                ],
-            }
-        )
+    blocks.append(
+        {
+            "type": "actions",
+            "block_id": "agent_setup__repo_actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "action_id": "agent_setup__edit_repo_form",
+                    "text": {"type": "plain_text", "text": "Edit repo + auth"},
+                },
+            ],
+        }
+    )
 
     return blocks
 
@@ -566,14 +587,20 @@ def build_skills_section(
     *,
     skill_names: list[str],
     sync_pending: bool,
-    is_admin: bool,
+    can_edit_spec: bool,
 ) -> list[dict[str, Any]]:
     """Build the Skills section blocks for the L2 editor.
 
+    Skills are part of the agent spec an admin approves when the agent
+    becomes reachable (D-09), so the Add/Remove controls follow
+    spec-editability, not admin-ness alone.
+
     Args:
-        skill_names:  List of skill names currently attached to the agent.
-        sync_pending: Whether a skill-sync is in progress.
-        is_admin:     Whether mutation actions should be included.
+        skill_names:   List of skill names currently attached to the agent.
+        sync_pending:  Whether a skill-sync is in progress.
+        can_edit_spec: Whether the invoking user may change this agent's
+                       approved configuration right now (admin, or the agent
+                       is not currently reachable).
 
     Returns:
         List of Block Kit blocks for the Skills section.
@@ -605,7 +632,7 @@ def build_skills_section(
             }
         )
 
-    if is_admin:
+    if can_edit_spec:
         blocks.append(
             {
                 "type": "actions",
@@ -648,13 +675,27 @@ def build_skills_section(
 def build_mcps_section(
     *,
     mcps: list[dict[str, str]],
-    is_admin: bool,
+    can_edit_spec: bool,
+    is_admin: bool = False,
 ) -> list[dict[str, Any]]:
     """Build the MCPs section blocks for the L2 editor.
 
+    MCP servers are part of the agent spec an admin approves when the agent
+    becomes reachable (D-09), so Add MCP server / Remove MCP follow
+    spec-editability, not admin-ness alone. Connect via MCP is a distinct
+    operation — it mints a long-lived revocable bearer token, and token
+    issuance stays admin-only unconditionally (outside the set of operations
+    this gate opens), so it renders only for ``is_admin`` regardless of
+    ``can_edit_spec``: showing it to a member who would always be refused at
+    the dispatcher is worse UX than omitting it.
+
     Args:
-        mcps:     List of MCP server dicts with keys ``name`` and ``url``.
-        is_admin: Whether mutation actions should be included.
+        mcps:          List of MCP server dicts with keys ``name`` and ``url``.
+        can_edit_spec: Whether the invoking user may change this agent's
+                       approved configuration right now (admin, or the agent
+                       is not currently reachable). Gates Add/Remove.
+        is_admin:      Whether the invoking user has admin permissions.
+                       Gates Connect via MCP only.
 
     Returns:
         List of Block Kit blocks for the MCPs section.
@@ -674,45 +715,54 @@ def build_mcps_section(
         },
     ]
 
+    mcps_action_elements: list[dict[str, Any]] = []
+    if can_edit_spec:
+        mcps_action_elements.append(
+            {
+                "type": "button",
+                "action_id": "agent_setup__add_mcp",
+                "text": {"type": "plain_text", "text": "Add MCP server"},
+            }
+        )
+        mcps_action_elements.append(
+            {
+                "type": "static_select",
+                "action_id": "agent_setup__remove_mcp",
+                "placeholder": {"type": "plain_text", "text": "Remove MCP…"},
+                "options": [
+                    {
+                        "text": {
+                            "type": "plain_text",
+                            "text": m["name"],
+                        },
+                        "value": m["name"],
+                    }
+                    for m in mcps
+                ]
+                if mcps
+                else [
+                    {
+                        "text": {"type": "plain_text", "text": "(none)"},
+                        "value": "__none__",
+                    }
+                ],
+            }
+        )
     if is_admin:
+        mcps_action_elements.append(
+            {
+                "type": "button",
+                "action_id": "agent_setup__connect_mcp",
+                "text": {"type": "plain_text", "text": "Connect via MCP"},
+            }
+        )
+
+    if mcps_action_elements:
         blocks.append(
             {
                 "type": "actions",
                 "block_id": "agent_setup__mcps_actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "action_id": "agent_setup__add_mcp",
-                        "text": {"type": "plain_text", "text": "Add MCP server"},
-                    },
-                    {
-                        "type": "static_select",
-                        "action_id": "agent_setup__remove_mcp",
-                        "placeholder": {"type": "plain_text", "text": "Remove MCP…"},
-                        "options": [
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": m["name"],
-                                },
-                                "value": m["name"],
-                            }
-                            for m in mcps
-                        ]
-                        if mcps
-                        else [
-                            {
-                                "text": {"type": "plain_text", "text": "(none)"},
-                                "value": "__none__",
-                            }
-                        ],
-                    },
-                    {
-                        "type": "button",
-                        "action_id": "agent_setup__connect_mcp",
-                        "text": {"type": "plain_text", "text": "Connect via MCP"},
-                    },
-                ],
+                "elements": mcps_action_elements,
             }
         )
 
@@ -723,9 +773,12 @@ def build_secrets_section(
     *,
     agent_name: str,
     secret_names: list[str],
-    is_admin: bool,
 ) -> list[dict[str, Any]]:
     """Build the Secrets section blocks for the L2 editor.
+
+    Env-variable credentials are a per-agent attachment, not part of the
+    agent spec an admin approves (D-09) — Add/Remove render for every
+    member, on every agent, regardless of admin status or reachability.
 
     STRUCTURAL GUARANTEE: this function accepts
     ``secret_names: list[str]`` ONLY. Secret VALUES are never a parameter,
@@ -735,7 +788,6 @@ def build_secrets_section(
     Args:
         agent_name:   Name of the agent (used only for context, not rendered).
         secret_names: List of secret KEY NAMES (values never passed here).
-        is_admin:     Whether mutation actions should be included.
 
     Returns:
         List of Block Kit blocks for the Secrets section.
@@ -763,45 +815,44 @@ def build_secrets_section(
         },
     ]
 
-    if is_admin:
-        blocks.append(
-            {
-                "type": "actions",
-                "block_id": "agent_setup__secrets_actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "action_id": "agent_setup__paste_secrets",
-                        "text": {"type": "plain_text", "text": "Add secrets"},
+    blocks.append(
+        {
+            "type": "actions",
+            "block_id": "agent_setup__secrets_actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "action_id": "agent_setup__paste_secrets",
+                    "text": {"type": "plain_text", "text": "Add secrets"},
+                },
+                {
+                    "type": "static_select",
+                    "action_id": "agent_setup__remove_secret",
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "Remove secret…",
                     },
-                    {
-                        "type": "static_select",
-                        "action_id": "agent_setup__remove_secret",
-                        "placeholder": {
-                            "type": "plain_text",
-                            "text": "Remove secret…",
-                        },
-                        "options": [
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": name,
-                                },
-                                "value": name,
-                            }
-                            for name in secret_names
-                        ]
-                        if secret_names
-                        else [
-                            {
-                                "text": {"type": "plain_text", "text": "(none)"},
-                                "value": "__none__",
-                            }
-                        ],
-                    },
-                ],
-            }
-        )
+                    "options": [
+                        {
+                            "text": {
+                                "type": "plain_text",
+                                "text": name,
+                            },
+                            "value": name,
+                        }
+                        for name in secret_names
+                    ]
+                    if secret_names
+                    else [
+                        {
+                            "text": {"type": "plain_text", "text": "(none)"},
+                            "value": "__none__",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
 
     return blocks
 

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/views.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/views.py
@@ -460,7 +460,7 @@ def build_agent_section(
     """Build the Agent section blocks for the L2 editor.
 
     The Edit prompt & model action touches ``system``/``model`` — fields the
-    reachability gate covers on a currently-scoped agent (D-09) — so this
+    reachability gate covers on a currently-scoped agent — so this
     section's mutation control follows spec-editability, not admin-ness alone.
 
     Args:
@@ -534,7 +534,7 @@ def build_repo_auth_section(
     """Build the Repo+Auth section blocks for the L2 editor.
 
     The repo binding and its PAT are a per-agent attachment, not part of the
-    agent spec an admin approves (D-09) — the edit control renders for every
+    agent spec an admin approves — the edit control renders for every
     member, on every agent, regardless of admin status or reachability.
 
     Args:
@@ -592,7 +592,7 @@ def build_skills_section(
     """Build the Skills section blocks for the L2 editor.
 
     Skills are part of the agent spec an admin approves when the agent
-    becomes reachable (D-09), so the Add/Remove controls follow
+    becomes reachable, so the Add/Remove controls follow
     spec-editability, not admin-ness alone.
 
     Args:
@@ -681,7 +681,7 @@ def build_mcps_section(
     """Build the MCPs section blocks for the L2 editor.
 
     MCP servers are part of the agent spec an admin approves when the agent
-    becomes reachable (D-09), so Add MCP server / Remove MCP follow
+    becomes reachable, so Add MCP server / Remove MCP follow
     spec-editability, not admin-ness alone. Connect via MCP is a distinct
     operation — it mints a long-lived revocable bearer token, and token
     issuance stays admin-only unconditionally (outside the set of operations
@@ -777,7 +777,7 @@ def build_secrets_section(
     """Build the Secrets section blocks for the L2 editor.
 
     Env-variable credentials are a per-agent attachment, not part of the
-    agent spec an admin approves (D-09) — Add/Remove render for every
+    agent spec an admin approves — Add/Remove render for every
     member, on every agent, regardless of admin status or reachability.
 
     STRUCTURAL GUARANTEE: this function accepts

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
@@ -11,6 +11,14 @@ Covers the five required behaviors from 83-05 plan:
 - (connect_mcp) agent_setup__connect_mcp sends chat.postEphemeral and does
              NOT call views.update or views.push
 
+Also covers the field-follows-the-gate authorization matrix (10-06): the
+always-open branches (new/fork/edit/edit_repo_form/paste_secrets/remove_secret),
+the admin-only-unconditional branches (delete/scope:*/connect_mcp), and the
+field-conditional branches gated by ``refuse_if_reachable_and_not_admin``
+(remove_skill/remove_mcp/edit_agent_form/add_skill/add_mcp) — each proved for
+a non-admin caller against a real reachable-vs-unreachable agent, written via
+``scoped_config_write.set_fields``, never by patching the predicate.
+
 All cases use a real Postgres schema (db_session_factory) + the transport-level
 FakeSlackWebClient from conftest (no AsyncMock on client.* methods).
 """
@@ -37,6 +45,7 @@ from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.scope import ChannelConfigRow, ChannelScopeRef, TenantScopeRef
 from daimon.core.stores.scoped_config_read import get_scope
+from daimon.core.stores.scoped_config_write import set_fields
 from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import (
@@ -191,6 +200,80 @@ def _make_ma_handler_with_agents(
         return httpx.Response(404, json={"error": f"unhandled {method} {path}"})
 
     return handler
+
+
+def _make_ma_handler_with_agents_and_update(
+    agents: list[dict[str, object]],
+) -> Any:
+    """Like ``_make_ma_handler_with_agents``, plus PATCH/POST update on
+    ``/v1/agents/{id}`` — needed by removal-write branches (remove_skill,
+    remove_mcp) that call ``update_agent_with_version_retry``."""
+    agent_store: dict[str, dict[str, object]] = {
+        str(ag["id"]): ag
+        for ag in agents  # type: ignore[index]
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+
+        if method == "GET" and path == "/v1/agents":
+            return httpx.Response(
+                200,
+                json={"data": list(agent_store.values()), "has_more": False},
+            )
+        m = re.match(r"^/v1/agents/(?P<id>[^/]+)$", path)
+        if m and method == "GET":
+            agent_id_req = m.group("id")
+            if agent_id_req in agent_store:
+                return httpx.Response(200, json=agent_store[agent_id_req])
+            return httpx.Response(
+                404,
+                json={
+                    "type": "error",
+                    "error": {"type": "not_found_error", "message": "not found"},
+                },
+            )
+        if m and method in {"PATCH", "POST"}:
+            agent_id_req = m.group("id")
+            if agent_id_req not in agent_store:
+                return httpx.Response(
+                    404,
+                    json={
+                        "type": "error",
+                        "error": {"type": "not_found_error", "message": "not found"},
+                    },
+                )
+            body: dict[str, Any] = json.loads(request.content)
+            existing = agent_store[agent_id_req]
+            merged: dict[str, object] = {**existing, **body}
+            merged["version"] = int(existing.get("version", 1)) + 1  # type: ignore[arg-type]
+            agent_store[agent_id_req] = merged
+            return httpx.Response(200, json=merged)
+        if method == "GET" and path == "/v1/environments":
+            return httpx.Response(200, json={"data": [], "has_more": False})
+
+        return httpx.Response(404, json={"error": f"unhandled {method} {path}"})
+
+    return handler
+
+
+async def _mark_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: uuid.UUID,
+    agent_name: str,
+) -> None:
+    """Write a real tenant-scope propagation row (D-09) so the named agent is
+    currently reachable — never patch the reachability predicate."""
+    async with db_session_factory() as session, session.begin():
+        await set_fields(
+            session,
+            scope=TenantScopeRef(tenant_id=tenant_id),
+            tenant_id=tenant_id,
+            agent_name=agent_name,
+            mode="agent",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -737,64 +820,24 @@ async def test_handle_agent_setup_action_paste_secrets_pushes_paste_secrets_form
 
 
 # ---------------------------------------------------------------------------
-# Test: non-admin agent_setup__new is refused with no views.push (T-83-20)
+# Test: agent_setup__new is open to every member, admin or not (D-06/D-09)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_handle_agent_setup_action_new_with_non_admin_sends_ephemeral_no_push(
+async def test_handle_agent_setup_action_new_with_non_admin_pushes_form_no_ephemeral(
     db_session: AsyncSession,
     db_session_factory: async_sessionmaker[AsyncSession],
     fake_slack_web_client: object,
 ) -> None:
-    """Non-admin agent_setup__new must send the permission-refused ephemeral and NOT views_push.
+    """agent_setup__new is always-open (D-06): a non-admin still gets the form pushed,
+    with no refusal ephemeral. Building an unscoped agent is not tenant-wide blast radius.
 
-    The default FakeSlackWebClient users.info returns is_admin=False (fail-closed baseline).
-    T-83-20: every new L3-open branch re-resolves is_admin and refuses on False.
+    The default FakeSlackWebClient users.info returns is_admin=False (fail-closed baseline
+    for OTHER, still-gated branches) -- this branch no longer checks admin at all.
     """
     _, fernet_key, _ = await _seed_team(db_session)
     runtime = _build_runtime(fernet_key, db_session_factory)
-
-    payload = _action_payload("agent_setup__new")
-    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
-
-    client_fake: Any = fake_slack_web_client
-    push_calls = client_fake.mock.requests.get(
-        ("POST", yarl.URL(f"{_SLACK_API_BASE}/views.push")), []
-    )
-    assert not push_calls, (
-        "non-admin agent_setup__new must NOT call views.push (T-83-20 admin gate)"
-    )
-
-    ephemeral_calls = client_fake.mock.requests.get(
-        ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral")), []
-    )
-    assert ephemeral_calls, (
-        "non-admin agent_setup__new must send a permission-refused ephemeral (T-83-20)"
-    )
-    last_call = ephemeral_calls[-1]
-    body_json: dict[str, Any] = last_call.kwargs.get("json") or {}
-    body_text: str = body_json.get("text") or ""
-    assert "no longer have permission" in body_text, (
-        "ephemeral text must mention lack of permission (T-83-20 fail-closed re-check)"
-    )
-
-
-@pytest.mark.asyncio
-async def test_handle_agent_setup_action_new_with_non_admin_but_dev_allow_all_pushes_form(
-    db_session: AsyncSession,
-    db_session_factory: async_sessionmaker[AsyncSession],
-    fake_slack_web_client: object,
-) -> None:
-    """dev_allow_all_admin opens the gate for a non-admin: agent_setup__new pushes the form.
-
-    The default FakeSlackWebClient users.info returns is_admin=False, so the only
-    reason the new-agent form opens is the DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN
-    override threaded from settings — the testing escape hatch.
-    """
-    _, fernet_key, _ = await _seed_team(db_session)
-    runtime = _build_runtime(fernet_key, db_session_factory)
-    runtime.settings.slack.dev_allow_all_admin = True  # type: ignore[attr-defined]  # MagicMock settings
 
     payload = _action_payload("agent_setup__new")
     await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
@@ -802,7 +845,14 @@ async def test_handle_agent_setup_action_new_with_non_admin_but_dev_allow_all_pu
     client_fake: Any = fake_slack_web_client
     callback_id = _get_push_callback_id(client_fake)
     assert callback_id == "agent_setup__new_agent", (
-        f"non-admin with dev_allow_all_admin=True must push the new-agent form, got {callback_id!r}"
+        f"non-admin agent_setup__new must push the new-agent form, got {callback_id!r}"
+    )
+
+    ephemeral_calls = client_fake.mock.requests.get(
+        ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral")), []
+    )
+    assert not ephemeral_calls, (
+        "non-admin agent_setup__new must NOT send a refusal ephemeral (always open)"
     )
 
 
@@ -895,3 +945,567 @@ async def test_handle_agent_setup_action_scope_channel_writes_selected_channel_a
         f"#{_SELECTED_CHANNEL} (the selected/persisted channel), not #{_CHANNEL_ID} "
         f"(the invoking channel) — CR-03 regression guard"
     )
+
+
+# ---------------------------------------------------------------------------
+# Assertion helpers for the field-follows-the-gate matrix (10-06)
+# ---------------------------------------------------------------------------
+
+
+def _ephemeral_texts(client_fake: Any) -> list[str]:
+    calls = client_fake.mock.requests.get(
+        ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral")), []
+    )
+    texts: list[str] = []
+    for call in calls:
+        body: dict[str, Any] = call.kwargs.get("json") or {}
+        texts.append(str(body.get("text") or ""))
+    return texts
+
+
+def _has_push(client_fake: Any) -> bool:
+    return bool(
+        client_fake.mock.requests.get(("POST", yarl.URL(f"{_SLACK_API_BASE}/views.push")), [])
+    )
+
+
+def _has_update(client_fake: Any) -> bool:
+    return bool(
+        client_fake.mock.requests.get(("POST", yarl.URL(f"{_SLACK_API_BASE}/views.update")), [])
+    )
+
+
+def _assert_no_refusal(client_fake: Any) -> None:
+    texts = _ephemeral_texts(client_fake)
+    assert not any("no longer have permission" in t for t in texts), (
+        f"must NOT post the permission-refusal ephemeral, got ephemerals: {texts!r}"
+    )
+
+
+def _assert_reachability_refusal(client_fake: Any) -> None:
+    texts = _ephemeral_texts(client_fake)
+    assert any("workspace-admin" in t for t in texts), (
+        f"must post the reachability-refusal ephemeral naming why, got ephemerals: {texts!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Always-open branches (D-06/D-09): new, fork, edit, edit_repo_form,
+# paste_secrets, remove_secret -- no refusal for any caller, admin or not.
+# `new` is covered above; the remaining five follow.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_fork_non_admin_pushes_form_no_ephemeral(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload("agent_setup__fork", selected_agent_name=_AGENT_NAME)
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    assert _get_push_callback_id(client_fake) == "agent_setup__fork_agent", (
+        "non-admin agent_setup__fork must push the fork-agent form"
+    )
+    _assert_no_refusal(client_fake)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_edit_non_admin_pushes_l2_no_ephemeral(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload("agent_setup__edit", selected_agent_name=_AGENT_NAME)
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    assert _has_push(client_fake), "non-admin agent_setup__edit must push L2"
+    _assert_no_refusal(client_fake)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_edit_repo_form_non_admin_pushes_form_no_ephemeral(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload(
+        "agent_setup__edit_repo_form", selected_agent_name=_AGENT_NAME, active_section="repo_auth"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    assert _get_push_callback_id(client_fake) == "agent_setup__edit_repo", (
+        "non-admin agent_setup__edit_repo_form must push the edit-repo form"
+    )
+    _assert_no_refusal(client_fake)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_paste_secrets_non_admin_pushes_form_no_ephemeral(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload(
+        "agent_setup__paste_secrets", selected_agent_name=_AGENT_NAME, active_section="secrets"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    assert _get_push_callback_id(client_fake) == "agent_setup__paste_secrets", (
+        "non-admin agent_setup__paste_secrets must push the paste-secrets form"
+    )
+    _assert_no_refusal(client_fake)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_remove_secret_non_admin_writes_and_updates_no_ephemeral(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """remove_secret is always open (D-09): env variables are a per-agent
+    attachment, never part of the agent spec -- even on a reachable agent."""
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    payload = _action_payload(
+        "agent_setup__remove_secret",
+        selected_agent_name=_AGENT_NAME,
+        active_section="secrets",
+        action_extra={"selected_option": {"value": "SOME_KEY"}},
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    assert _has_update(client_fake), (
+        "non-admin remove_secret on a reachable agent must still re-render L2"
+    )
+    _assert_no_refusal(client_fake)
+
+
+# ---------------------------------------------------------------------------
+# Admin-only-unconditional branches: delete, scope:channel, scope:clear,
+# connect_mcp -- unchanged behavior, refused for a non-admin regardless of
+# reachability. scope:workspace is already covered above.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_delete_non_admin_refused_no_write(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload("agent_setup__delete", selected_agent_name=_AGENT_NAME)
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    texts = _ephemeral_texts(client_fake)
+    assert any("no longer have permission" in t for t in texts), (
+        "non-admin agent_setup__delete must be refused (admin-only, unconditional)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_scope_channel_non_admin_refused_no_write(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    payload = _action_payload(
+        "agent_setup__scope:channel",
+        selected_agent_name=_AGENT_NAME,
+        action_extra={"selected_channel": _CHANNEL_ID},
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    async with db_session_factory() as session:
+        row = await get_scope(
+            session, scope=ChannelScopeRef(tenant_id=tenant_id, channel_id=_CHANNEL_ID)
+        )
+    assert row is None, "non-admin scope:channel must not write a DB row (fail-closed)"
+
+    client_fake: Any = fake_slack_web_client
+    texts = _ephemeral_texts(client_fake)
+    assert any("no longer have permission" in t for t in texts), (
+        "non-admin agent_setup__scope:channel must be refused (admin-only, unconditional)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_scope_clear_non_admin_refused_no_write(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    payload = _action_payload("agent_setup__scope:clear", selected_agent_name=_AGENT_NAME)
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    async with db_session_factory() as session:
+        row = await get_scope(session, scope=TenantScopeRef(tenant_id=tenant_id))
+    assert row is not None and row.agent_name == _AGENT_NAME, (
+        "non-admin scope:clear must NOT clear the existing scope row (fail-closed)"
+    )
+
+    client_fake: Any = fake_slack_web_client
+    texts = _ephemeral_texts(client_fake)
+    assert any("no longer have permission" in t for t in texts), (
+        "non-admin agent_setup__scope:clear must be refused (admin-only, unconditional)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_connect_mcp_non_admin_refused_no_ephemeral_config(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """connect_mcp mints a bearer token and stays admin-only unconditionally (fact 5)."""
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+
+    settings = MagicMock()
+    settings.crypto.keys = (SecretStr(fernet_key),)
+    settings.mcp.public_url = "https://mcp.example.com"
+    settings.mcp.jwt_secret = SecretStr("test-secret-32-bytes-long-padding!")
+    settings.github = MagicMock()
+    settings.github.app_id = None
+    settings.slack.dev_allow_all_admin = False
+    runtime = SlackRuntime(
+        settings=settings,
+        anthropic=build_fake_anthropic(handler),
+        sessionmaker=db_session_factory,
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+    payload = _action_payload("agent_setup__connect_mcp", selected_agent_name=_AGENT_NAME)
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    texts = _ephemeral_texts(client_fake)
+    assert any("no longer have permission" in t for t in texts), (
+        "non-admin agent_setup__connect_mcp must be refused (admin-only, unconditional)"
+    )
+    assert not any(":link: *Connect via MCP" in t for t in texts), (
+        "non-admin agent_setup__connect_mcp must NOT receive the MCP config ephemeral"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field-conditional branches (D-09), gated by
+# refuse_if_reachable_and_not_admin: remove_skill, remove_mcp,
+# edit_agent_form, add_skill, add_mcp. Each proceeds for a non-admin when the
+# target agent is unreachable, and is refused when it is currently reachable
+# -- proved against a real propagation row (scoped_config_write.set_fields),
+# never by patching the predicate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_remove_skill_non_admin_unreachable_proceeds(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    agent_payload["skills"] = [{"type": "anthropic", "skill_id": "cli-auth"}]
+    handler = _make_ma_handler_with_agents_and_update([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload(
+        "agent_setup__remove_skill",
+        selected_agent_name=_AGENT_NAME,
+        active_section="skills",
+        action_extra={"selected_option": {"value": "cli-auth"}},
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    _assert_no_refusal(client_fake)
+    assert _has_update(client_fake), (
+        "non-admin remove_skill on an unreachable agent must proceed and re-render L2"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_remove_skill_non_admin_reachable_refused(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    payload = _action_payload(
+        "agent_setup__remove_skill",
+        selected_agent_name=_AGENT_NAME,
+        active_section="skills",
+        action_extra={"selected_option": {"value": "cli-auth"}},
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    _assert_reachability_refusal(client_fake)
+    assert not _has_update(client_fake), (
+        "non-admin remove_skill on a reachable agent must be refused before any re-render"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_remove_mcp_non_admin_unreachable_proceeds(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    agent_payload["mcp_servers"] = [{"name": "an-mcp", "url": "https://mcp.example.com"}]
+    handler = _make_ma_handler_with_agents_and_update([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload(
+        "agent_setup__remove_mcp",
+        selected_agent_name=_AGENT_NAME,
+        active_section="mcps",
+        action_extra={"selected_option": {"value": "an-mcp"}},
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    _assert_no_refusal(client_fake)
+    assert _has_update(client_fake), (
+        "non-admin remove_mcp on an unreachable agent must proceed and re-render L2"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_remove_mcp_non_admin_reachable_refused(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    payload = _action_payload(
+        "agent_setup__remove_mcp",
+        selected_agent_name=_AGENT_NAME,
+        active_section="mcps",
+        action_extra={"selected_option": {"value": "an-mcp"}},
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    _assert_reachability_refusal(client_fake)
+    assert not _has_update(client_fake), (
+        "non-admin remove_mcp on a reachable agent must be refused before any re-render"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_edit_agent_form_non_admin_unreachable_proceeds(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload(
+        "agent_setup__edit_agent_form", selected_agent_name=_AGENT_NAME, active_section="agent"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    assert _get_push_callback_id(client_fake) == "agent_setup__edit_agent", (
+        "non-admin edit_agent_form on an unreachable agent must push the edit-agent form"
+    )
+    _assert_no_refusal(client_fake)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_edit_agent_form_non_admin_reachable_refused(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    payload = _action_payload(
+        "agent_setup__edit_agent_form", selected_agent_name=_AGENT_NAME, active_section="agent"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    _assert_reachability_refusal(client_fake)
+    assert not _has_push(client_fake), (
+        "non-admin edit_agent_form on a reachable agent must be refused before any push"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_add_skill_non_admin_unreachable_proceeds(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload(
+        "agent_setup__add_skill", selected_agent_name=_AGENT_NAME, active_section="skills"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    assert _get_push_callback_id(client_fake) == "agent_setup__add_skill", (
+        "non-admin add_skill on an unreachable agent must push the add-skill form"
+    )
+    _assert_no_refusal(client_fake)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_add_skill_non_admin_reachable_refused(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    payload = _action_payload(
+        "agent_setup__add_skill", selected_agent_name=_AGENT_NAME, active_section="skills"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    _assert_reachability_refusal(client_fake)
+    assert not _has_push(client_fake), (
+        "non-admin add_skill on a reachable agent must be refused before any push"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_add_mcp_non_admin_unreachable_proceeds(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    payload = _action_payload(
+        "agent_setup__add_mcp", selected_agent_name=_AGENT_NAME, active_section="mcps"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    assert _get_push_callback_id(client_fake) == "agent_setup__add_mcp", (
+        "non-admin add_mcp on an unreachable agent must push the add-mcp form"
+    )
+    _assert_no_refusal(client_fake)
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_add_mcp_non_admin_reachable_refused(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    payload = _action_payload(
+        "agent_setup__add_mcp", selected_agent_name=_AGENT_NAME, active_section="mcps"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    _assert_reachability_refusal(client_fake)
+    assert not _has_push(client_fake), (
+        "non-admin add_mcp on a reachable agent must be refused before any push"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_add_mcp_admin_on_reachable_agent_unaffected(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """An admin caller is unaffected by reachability on a field-conditional branch."""
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
+
+    payload = _action_payload(
+        "agent_setup__add_mcp", selected_agent_name=_AGENT_NAME, active_section="mcps"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    assert _get_push_callback_id(client_fake) == "agent_setup__add_mcp", (
+        "admin add_mcp on a reachable agent must still push the add-mcp form"
+    )
+    _assert_no_refusal(client_fake)

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
@@ -264,7 +264,7 @@ async def _mark_reachable(
     tenant_id: uuid.UUID,
     agent_name: str,
 ) -> None:
-    """Write a real tenant-scope propagation row (D-09) so the named agent is
+    """Write a real tenant-scope propagation row so the named agent is
     currently reachable — never patch the reachability predicate."""
     async with db_session_factory() as session, session.begin():
         await set_fields(
@@ -820,7 +820,7 @@ async def test_handle_agent_setup_action_paste_secrets_pushes_paste_secrets_form
 
 
 # ---------------------------------------------------------------------------
-# Test: agent_setup__new is open to every member, admin or not (D-06/D-09)
+# Test: agent_setup__new is open to every member, admin or not
 # ---------------------------------------------------------------------------
 
 
@@ -830,7 +830,7 @@ async def test_handle_agent_setup_action_new_with_non_admin_pushes_form_no_ephem
     db_session_factory: async_sessionmaker[AsyncSession],
     fake_slack_web_client: object,
 ) -> None:
-    """agent_setup__new is always-open (D-06): a non-admin still gets the form pushed,
+    """agent_setup__new is always-open: a non-admin still gets the form pushed,
     with no refusal ephemeral. Building an unscoped agent is not tenant-wide blast radius.
 
     The default FakeSlackWebClient users.info returns is_admin=False (fail-closed baseline
@@ -990,7 +990,7 @@ def _assert_reachability_refusal(client_fake: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Always-open branches (D-06/D-09): new, fork, edit, edit_repo_form,
+# Always-open branches: new, fork, edit, edit_repo_form,
 # paste_secrets, remove_secret -- no refusal for any caller, admin or not.
 # `new` is covered above; the remaining five follow.
 # ---------------------------------------------------------------------------
@@ -1088,7 +1088,7 @@ async def test_handle_agent_setup_action_remove_secret_non_admin_writes_and_upda
     db_session_factory: async_sessionmaker[AsyncSession],
     fake_slack_web_client: object,
 ) -> None:
-    """remove_secret is always open (D-09): env variables are a per-agent
+    """remove_secret is always open: env variables are a per-agent
     attachment, never part of the agent spec -- even on a reachable agent."""
     tenant_id, fernet_key, _ = await _seed_team(db_session)
     agent_payload = _agent_payload(tenant_id=tenant_id)
@@ -1236,7 +1236,7 @@ async def test_handle_agent_setup_action_connect_mcp_non_admin_refused_no_epheme
 
 
 # ---------------------------------------------------------------------------
-# Field-conditional branches (D-09), gated by
+# Field-conditional branches, gated by
 # refuse_if_reachable_and_not_admin: remove_skill, remove_mcp,
 # edit_agent_form, add_skill, add_mcp. Each proceeds for a non-admin when the
 # target agent is unreachable, and is refused when it is currently reachable

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_gate.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_gate.py
@@ -1,0 +1,218 @@
+"""Tests for daimon.adapters.slack.agent_setup.gate.
+
+Covers refuse_if_reachable_and_not_admin's three behaviors:
+  - admin caller -> proceed, no DB session opened
+  - non-admin + unreachable agent -> proceed, no ephemeral posted
+  - non-admin + reachable agent -> refused, exactly one ephemeral posted
+
+All cases use a real Postgres schema (db_session_factory) + the
+transport-level FakeSlackWebClient from conftest (no AsyncMock on
+client.* methods) for the Slack side, and real scoped_config_write rows
+for reachability (never patching the predicate).
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import yarl
+from aioresponses import aioresponses as AioResponsesMock
+from daimon.adapters.slack.agent_setup.gate import refuse_if_reachable_and_not_admin
+from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.testing.factories import make_tenant, make_tenant_config
+from daimon.testing.ma import build_fake_anthropic, make_fake_ma_handler
+from slack_sdk.web.async_client import AsyncWebClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_TEAM_ID = "T_GATE_TESTS"
+_USER_ID = "U_GATE_TEST"
+_CHANNEL_ID = "C_GATE_TEST"
+_AGENT_NAME = "test-gate-agent"
+
+_USERS_INFO_PATTERN = re.compile(r"https://slack\.com/api/users\.info.*")
+_SLACK_API_BASE = "https://slack.com/api"
+
+
+def _admin_users_info_payload(user_id: str = _USER_ID) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "user": {
+            "id": user_id,
+            "name": "admin",
+            "is_admin": True,
+            "is_owner": False,
+            "is_primary_owner": False,
+        },
+    }
+
+
+def _non_admin_users_info_payload(user_id: str = _USER_ID) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "user": {
+            "id": user_id,
+            "name": "member",
+            "is_admin": False,
+            "is_owner": False,
+            "is_primary_owner": False,
+        },
+    }
+
+
+def _build_runtime(db_factory: async_sessionmaker[AsyncSession]) -> SlackRuntime:
+    """Construct a SlackRuntime with a fake Anthropic transport and real DB factory."""
+    settings = MagicMock()
+    settings.slack.dev_allow_all_admin = False
+    return SlackRuntime(
+        settings=settings,
+        anthropic=build_fake_anthropic(make_fake_ma_handler()),
+        sessionmaker=db_factory,
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+
+def _runtime_with_failing_sessionmaker() -> SlackRuntime:
+    """SlackRuntime whose sessionmaker raises if called -- proves the admin
+    short-circuit never opens a DB session."""
+
+    def _fail(*args: object, **kwargs: object) -> AsyncSession:
+        raise AssertionError("sessionmaker must not be called when the caller is already admin")
+
+    settings = MagicMock()
+    settings.slack.dev_allow_all_admin = False
+    return SlackRuntime(
+        settings=settings,
+        anthropic=build_fake_anthropic(make_fake_ma_handler()),
+        sessionmaker=MagicMock(side_effect=_fail),  # pyright: ignore[reportArgumentType]
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+
+@pytest.mark.asyncio
+async def test_refuse_if_reachable_and_not_admin_when_admin_returns_false_and_opens_no_session() -> (
+    None
+):
+    """Admin caller -> proceed (False), and the DB session is never opened."""
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _runtime_with_failing_sessionmaker()
+
+        refused = await refuse_if_reachable_and_not_admin(
+            runtime,
+            client,
+            tenant_id=uuid.uuid4(),
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is False, "an admin caller must never be refused"
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        assert post_key not in mock.requests, "admin path must not post any ephemeral"
+
+
+@pytest.mark.asyncio
+async def test_refuse_if_reachable_and_not_admin_when_non_admin_and_unreachable_returns_false(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Non-admin + unreachable target agent -> proceed (False), no ephemeral."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await session.commit()
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_non_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _build_runtime(db_session_factory)
+
+        refused = await refuse_if_reachable_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is False, "a non-admin acting on an unreachable agent must proceed"
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        assert post_key not in mock.requests, "pass-through case must not post any ephemeral"
+
+
+@pytest.mark.asyncio
+async def test_refuse_if_reachable_and_not_admin_when_non_admin_and_reachable_returns_true(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Non-admin + a reachable (workspace-default) target agent -> refused (True),
+    exactly one ephemeral posted."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await make_tenant_config(session, tenant=tenant, agent_name=_AGENT_NAME, mode="agent")
+        await session.commit()
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_non_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _build_runtime(db_session_factory)
+
+        refused = await refuse_if_reachable_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is True, "a non-admin acting on a reachable agent must be refused"
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        matches = mock.requests.get(post_key, [])
+        assert len(matches) == 1, f"expected exactly one ephemeral, got {len(matches)}"
+
+        _, kwargs = matches[0]
+        body = kwargs.get("json") or {}
+        assert "workspace-admin" in body.get("text", ""), (
+            "ephemeral should name why the action was refused"
+        )

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
@@ -7,7 +7,13 @@ Covers:
 - run_* handlers via FakeSlackWebClient:
   - run_new_agent_submission (admin, write succeeds) posts :white_check_mark: ephemeral; no views_update
   - run_paste_secrets_submission (admin, 2 pairs) posts count ephemeral without secret values; no views_update
-  - non-admin users.info → no write, :x: ephemeral sent (T-83-14)
+  - the four always-open paths (new/fork/edit_repo/paste_secrets): a non-admin
+    submission succeeds with no permission-refusal ephemeral, including against
+    the workspace's currently-default agent for the two per-agent attachments
+  - the three field-conditional paths (edit_agent/add_skill/add_mcp): a
+    non-admin submission proceeds on an unreachable agent and is refused
+    before any MA request on a reachable one, via the shared
+    ``agent_setup.gate`` helper
 """
 
 from __future__ import annotations
@@ -20,6 +26,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 import yarl
+from daimon.adapters.slack.agent_setup import submit as submit_mod
 from daimon.adapters.slack.agent_setup.submit import (
     _SECRET_CAP,
     SubmitDecision,
@@ -28,13 +35,22 @@ from daimon.adapters.slack.agent_setup.submit import (
     evaluate_fork_agent_submission,
     evaluate_new_agent_submission,
     evaluate_paste_secrets_submission,
+    run_add_mcp_submission,
+    run_add_skill_submission,
+    run_edit_agent_submission,
     run_edit_repo_submission,
+    run_fork_agent_submission,
     run_new_agent_submission,
     run_paste_secrets_submission,
 )
 from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.scope import TenantScopeRef
+from daimon.core.skill_sync import SyncReport
+from daimon.core.stores.scoped_config_write import set_fields
+from daimon.testing.factories import make_tenant
 from daimon.testing.ma import build_fake_anthropic, make_fake_ma_handler
 from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 # ---------------------------------------------------------------------------
 # Helpers for building minimal Slack view_submission payloads
@@ -388,123 +404,680 @@ def test_evaluate_paste_secrets_when_valid_extra_carries_pairs() -> None:
 # run_* handler tests via FakeSlackWebClient
 # ---------------------------------------------------------------------------
 # These tests require DAIMON_DATABASE__TEST_URL (real Postgres) for the DB write.
-# The non-admin refusal test needs no DB write — it only checks the ephemeral.
+# ---------------------------------------------------------------------------
+
+
+def _iso_now() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
+
+
+def _agent_payload_for_gate_tests(
+    *, tenant_id: Any, agent_id: str, agent_name: str = _AGENT_NAME
+) -> dict[str, object]:
+    """Build a minimal MA agent payload tagged for this tenant/name."""
+    from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
+
+    now = _iso_now()
+    return {
+        "id": agent_id,
+        "type": "agent",
+        "name": agent_name,
+        "version": 1,
+        "model": {"id": "claude-sonnet-4-6", "speed": "standard"},
+        "system": None,
+        "metadata": {
+            MA_METADATA_KEY_TENANT: str(tenant_id),
+            MA_METADATA_KEY_NAME: agent_name,
+        },
+        "mcp_servers": [],
+        "tools": [],
+        "skills": [],
+        "created_at": now,
+        "updated_at": now,
+        "archived_at": None,
+        "description": None,
+    }
+
+
+def _make_recording_ma_handler_with_agents_and_update(
+    agents: list[dict[str, object]],
+    calls: list[tuple[str, str]],
+) -> Any:
+    """Like a PATCH-capable fake MA handler, but records every (method, path)
+    it serves so a refusal test can assert zero MA traffic occurred."""
+    agent_store: dict[str, dict[str, object]] = {
+        str(ag["id"]): ag
+        for ag in agents  # type: ignore[index]
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+        calls.append((method, path))
+
+        if method == "GET" and path == "/v1/agents":
+            return httpx.Response(200, json={"data": list(agent_store.values()), "has_more": False})
+        m = re.match(r"^/v1/agents/(?P<id>[^/]+)$", path)
+        if m and method == "GET":
+            agent_id_req = m.group("id")
+            if agent_id_req in agent_store:
+                return httpx.Response(200, json=agent_store[agent_id_req])
+            return httpx.Response(
+                404,
+                json={
+                    "type": "error",
+                    "error": {"type": "not_found_error", "message": "not found"},
+                },
+            )
+        if m and method in {"PATCH", "POST"}:
+            agent_id_req = m.group("id")
+            if agent_id_req not in agent_store:
+                return httpx.Response(
+                    404,
+                    json={
+                        "type": "error",
+                        "error": {"type": "not_found_error", "message": "not found"},
+                    },
+                )
+            body: dict[str, Any] = json.loads(request.content)
+            existing = agent_store[agent_id_req]
+            merged: dict[str, object] = {**existing, **body}
+            merged["version"] = int(existing.get("version", 1)) + 1  # type: ignore[arg-type]
+            agent_store[agent_id_req] = merged
+            return httpx.Response(200, json=merged)
+        if method == "GET" and path == "/v1/environments":
+            return httpx.Response(200, json={"data": [], "has_more": False})
+
+        return httpx.Response(404, json={"error": f"unhandled {method} {path}"})
+
+    return handler
+
+
+def _build_runtime_with_db(
+    db_factory: async_sessionmaker[AsyncSession],
+    *,
+    fernet_key: str = "dummy",
+    anthropic_handler: Any = None,
+) -> SlackRuntime:
+    """Build a SlackRuntime with a real DB factory and a fake MA transport."""
+    handler = anthropic_handler or make_fake_ma_handler()
+    settings: MagicMock = MagicMock()
+    settings.crypto.keys = (SecretStr(fernet_key),)
+    settings.mcp.public_url = None
+    settings.mcp.jwt_secret = None
+    settings.github = MagicMock()
+    settings.github.app_id = None
+    settings.slack.dev_allow_all_admin = False
+    return SlackRuntime(
+        settings=settings,
+        anthropic=build_fake_anthropic(handler),
+        sessionmaker=db_factory,
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+
+async def _mark_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: Any,
+    agent_name: str,
+) -> None:
+    """Write a real tenant-scope propagation row (D-09) so the named agent is
+    currently reachable — never patch the reachability predicate."""
+    async with db_session_factory() as session, session.begin():
+        await set_fields(
+            session,
+            scope=TenantScopeRef(tenant_id=tenant_id),
+            tenant_id=tenant_id,
+            agent_name=agent_name,
+            mode="agent",
+        )
+
+
+def _ephemeral_texts(client_fake: Any) -> list[str]:
+    ephemeral_key = ("POST", yarl.URL("https://slack.com/api/chat.postEphemeral"))
+    return [
+        call.kwargs["json"]["text"] for call in client_fake.mock.requests.get(ephemeral_key, [])
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Task 1 — the four always-open paths: non-admin succeeds, no refusal ephemeral
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_run_paste_secrets_when_non_admin_sends_permission_denied_ephemeral(
-    fake_slack_web_client: Any,  # FakeSlackWebClient from conftest
+async def test_run_new_agent_submission_when_non_admin_creates_agent_with_no_refusal(
+    fake_slack_web_client: Any,
 ) -> None:
-    """Non-admin users.info default → no write, :x: ephemeral sent (T-83-14)."""
-    # conftest default users.info is non-admin (fail-closed baseline)
-    # We do NOT override admin here — this test verifies the fail-closed path.
+    """Creation is open to every workspace member — no admin re-check remains."""
+    client_fake: Any = fake_slack_web_client
+    # conftest default users.info is non-admin; no override needed.
+    runtime = _build_runtime_no_db()
 
-    # Build a decision with valid pairs (would succeed if admin).
-    _decision = SubmitDecision(
-        response_payload={"response_action": "clear"},
-        proceed=True,
+    await run_new_agent_submission(
+        runtime,
+        client_fake.client,
         team_id=_TEAM_ID,
         user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        extra={"name": "member-created-agent", "model": "claude-sonnet-4-6", "system": None},
+    )
+
+    texts = _ephemeral_texts(client_fake)
+    assert any(":white_check_mark:" in t for t in texts), (
+        "a non-admin's new-agent submission must succeed"
+    )
+    assert not any("permission" in t for t in texts), (
+        "creation must not post a permission-refusal ephemeral"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_new_agent_submission_when_duplicate_name_still_refused(
+    fake_slack_web_client: Any,
+) -> None:
+    """A name collision is still refused by create_blank_agent's own guard,
+    independent of the now-removed admin check."""
+    client_fake: Any = fake_slack_web_client
+    runtime = _build_runtime_no_db()
+
+    extra = {"name": "collide-agent", "model": "claude-sonnet-4-6", "system": None}
+    await run_new_agent_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V1",
+        extra=extra,
+    )
+    await run_new_agent_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V2",
+        extra=extra,
+    )
+
+    texts = _ephemeral_texts(client_fake)
+    assert any(":white_check_mark:" in t for t in texts), "the first create should succeed"
+    assert any("Failed to create agent" in t for t in texts), (
+        "the second, colliding create must still be refused by the collision guard"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_fork_agent_submission_when_non_admin_forks_agent_with_no_refusal(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Forking is open to every workspace member — no admin re-check remains."""
+    from cryptography.fernet import Fernet
+
+    client_fake: Any = fake_slack_web_client
+    runtime = _build_runtime_with_db(db_session_factory, fernet_key=Fernet.generate_key().decode())
+
+    await run_new_agent_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V1",
+        extra={"name": _AGENT_NAME, "model": "claude-sonnet-4-6", "system": None},
+    )
+    await run_fork_agent_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V2",
+        extra={"source_name": _AGENT_NAME, "new_name": "forked-agent"},
+    )
+
+    texts = _ephemeral_texts(client_fake)
+    assert any("Forked" in t for t in texts), "a non-admin's fork submission must succeed"
+    assert not any("permission" in t for t in texts), (
+        "fork must not post a permission-refusal ephemeral"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_edit_repo_submission_when_non_admin_and_agent_is_workspace_default_binds_repo(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Repo binding is a per-agent attachment, so it stays open for a
+    non-admin even against the workspace's currently-default agent (D-09)."""
+    from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
+    from daimon.core.stores.agent_repo_binding import get_binding
+
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=_TEAM_ID)
+    ma_agent_id = f"agent_{'f' * 24}"
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+
+    async with db_session_factory() as session:
+        await make_tenant(session, platform="slack", workspace_id=_TEAM_ID, id=tenant_id)
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    client_fake: Any = fake_slack_web_client
+    # conftest default users.info is non-admin; no override.
+
+    runtime = SlackRuntime(
+        settings=_build_edit_repo_settings(app_id=None),
+        anthropic=build_fake_anthropic(
+            _build_edit_repo_ma_handler(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+        ),
+        sessionmaker=db_session_factory,
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+    await run_edit_repo_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="repo",
+        extra={
+            "repo_url": "https://github.com/example/default-agent.git",
+            "pat": "",
+            "pat_replace": False,
+        },
+    )
+
+    async with db_session_factory() as session:
+        row = await get_binding(session, tenant_id=tenant_id, agent_id=agent_uuid)
+
+    assert row is not None, "binding should be written even against a workspace-default agent"
+    assert row.repo_url == "example/default-agent"
+
+    texts = _ephemeral_texts(client_fake)
+    assert any(":white_check_mark:" in t for t in texts), (
+        "repo binding must succeed for a non-admin on a workspace-default agent"
+    )
+    assert not any("workspace-admin" in t for t in texts), (
+        "no reachability refusal ephemeral should be posted for a per-agent attachment"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_paste_secrets_submission_when_non_admin_and_agent_is_workspace_default_writes_secrets(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Env variables are a per-agent attachment, so they stay open for a
+    non-admin even against the workspace's currently-default agent (D-09)."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        tenant_id = tenant.id
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    client_fake: Any = fake_slack_web_client
+    # conftest default users.info is non-admin; no override.
+
+    ma_agent_id = f"agent_{'g' * 24}"
+    agent_data = _agent_payload_for_gate_tests(tenant_id=tenant_id, agent_id=ma_agent_id)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+        if method == "GET" and path == "/v1/agents":
+            return httpx.Response(200, json={"data": [agent_data], "has_more": False})
+        if method == "GET" and path == "/v1/environments":
+            return httpx.Response(200, json={"data": [], "has_more": False})
+        return httpx.Response(404, json={"error": f"unhandled {method} {path}"})
+
+    runtime = _build_runtime_with_db(db_session_factory, anthropic_handler=_handler)
+
+    await run_paste_secrets_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
         agent_name=_AGENT_NAME,
         parent_section="secrets",
-        extra={"pairs": [("SOME_KEY", "some_val")]},
+        extra={"pairs": [("OPEN_KEY", "open_val")]},
     )
 
-    # run_paste_secrets needs a runtime with sessionmaker; we can't provide a
-    # full SlackRuntime without real settings. We test the fail-closed gate
-    # directly by calling _refuse_non_admin.
-    from daimon.adapters.slack.agent_setup.submit import _refuse_non_admin
+    texts = _ephemeral_texts(client_fake)
+    assert any(":white_check_mark:" in t for t in texts), (
+        "paste-secrets must succeed for a non-admin on a workspace-default agent"
+    )
+    assert not any("workspace-admin" in t for t in texts), (
+        "no reachability refusal ephemeral should be posted for a per-agent attachment"
+    )
 
-    refused = await _refuse_non_admin(
-        fake_slack_web_client.client,
+
+# ---------------------------------------------------------------------------
+# Task 2 — the three field-conditional paths: reachability-gated for non-admin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_edit_agent_submission_when_non_admin_and_unreachable_proceeds(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Editing model/prompt is open when nobody has scoped this agent."""
+    from daimon.core.ma_identity import derive_tenant_uuid
+
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=_TEAM_ID)
+    ma_agent_id = f"agent_{'h' * 24}"
+    calls: list[tuple[str, str]] = []
+    agent_payload = _agent_payload_for_gate_tests(tenant_id=tenant_id, agent_id=ma_agent_id)
+    handler = _make_recording_ma_handler_with_agents_and_update([agent_payload], calls)
+    runtime = _build_runtime_with_db(db_session_factory, anthropic_handler=handler)
+
+    client_fake: Any = fake_slack_web_client
+    # conftest default users.info is non-admin; no override.
+
+    await run_edit_agent_submission(
+        runtime,
+        client_fake.client,
         team_id=_TEAM_ID,
-        channel_id=_CHANNEL_ID,
         user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="agent",
+        extra={"model": None, "system": "You are helpful."},
     )
 
-    assert refused is True, "non-admin user should be refused (T-83-14 fail-closed)"
+    assert any(method in {"PATCH", "POST"} for method, path in calls if "/v1/agents/" in path), (
+        "an unreachable agent's edit must reach the MA update"
+    )
 
-    # Verify the :x: ephemeral was posted to the channel.
-    import yarl
-
-    post_key = ("POST", yarl.URL("https://slack.com/api/chat.postEphemeral"))
-    assert post_key in fake_slack_web_client.mock.requests, (
-        "non-admin refusal should post a chat.postEphemeral"
+    texts = _ephemeral_texts(client_fake)
+    assert any(":white_check_mark:" in t for t in texts), (
+        "edit-agent must succeed for a non-admin on an unreachable agent"
     )
 
 
 @pytest.mark.asyncio
-async def test_run_refuse_non_admin_when_admin_returns_false() -> None:
-    """Admin users.info → _refuse_non_admin returns False (T-83-14 admin pass-through).
+async def test_run_edit_agent_submission_when_non_admin_and_reachable_refused(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A non-admin editing a currently-default agent must be refused before
+    any MA request."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        tenant_id = tenant.id
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
 
-    Uses a fresh AioResponsesMock context (not the conftest fixture) so the
-    non-admin repeat=True default doesn't shadow the admin registration.
-    """
-    import re
+    calls: list[tuple[str, str]] = []
+    ma_agent_id = f"agent_{'i' * 24}"
+    agent_payload = _agent_payload_for_gate_tests(tenant_id=tenant_id, agent_id=ma_agent_id)
+    handler = _make_recording_ma_handler_with_agents_and_update([agent_payload], calls)
+    runtime = _build_runtime_with_db(db_session_factory, anthropic_handler=handler)
 
-    from aioresponses import aioresponses as AioResponsesMock
-    from daimon.adapters.slack.agent_setup.submit import _refuse_non_admin
-    from slack_sdk.web.async_client import AsyncWebClient
+    client_fake: Any = fake_slack_web_client
 
-    _USERS_INFO_PATTERN = re.compile(r"https://slack\.com/api/users\.info.*")
+    await run_edit_agent_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="agent",
+        extra={"model": None, "system": "Attempted change."},
+    )
 
-    with AioResponsesMock() as mock:
-        mock.get(  # pyright: ignore[reportUnknownMemberType]
-            _USERS_INFO_PATTERN,
-            payload={
-                "ok": True,
-                "user": {
-                    "id": _USER_ID,
-                    "is_admin": True,
-                    "is_owner": False,
-                    "is_primary_owner": False,
-                },
-            },
-            repeat=True,
-        )
-        # views.push fallback for the ephemeral that would be sent on refusal
-        # (not sent when admin, so this is just safety registration)
-        mock.post(  # pyright: ignore[reportUnknownMemberType]
-            "https://slack.com/api/chat.postEphemeral",
-            payload={"ok": True},
-            repeat=True,
-        )
-        client = AsyncWebClient(token="xoxb-test")
-        refused = await _refuse_non_admin(
-            client,
-            team_id=_TEAM_ID,
-            channel_id=_CHANNEL_ID,
-            user_id=_USER_ID,
-        )
+    assert calls == [], "a refused edit must never reach the MA"
 
-    assert refused is False, "admin user should NOT be refused (T-83-14 admin pass-through)"
+    texts = _ephemeral_texts(client_fake)
+    assert len(texts) == 1, "exactly one ephemeral should be posted on refusal"
+    assert "workspace-admin" in texts[0], (
+        "the refusal ephemeral should name why the write was refused"
+    )
 
 
 @pytest.mark.asyncio
-async def test_run_refuse_non_admin_with_dev_allow_all_returns_false_without_users_info() -> None:
-    """dev_allow_all opens the submit gate for a non-admin without any users.info I/O.
+async def test_run_add_skill_submission_when_non_admin_and_unreachable_proceeds(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adding a skill is open when nobody has scoped this agent."""
+    calls: list[str] = []
 
-    Mirrors the actions.py wiring: the write layer (submit.py) must honor the
-    DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN escape hatch too, else fork/edit submissions
-    are refused before the MA write and nothing persists. No users.info response
-    is registered — reaching False proves the short-circuit skipped the network.
-    """
-    from aioresponses import aioresponses as AioResponsesMock
-    from daimon.adapters.slack.agent_setup.submit import _refuse_non_admin
-    from slack_sdk.web.async_client import AsyncWebClient
+    async def fake_kickoff(
+        runtime: Any, *, tenant_id: Any, account_id: Any, agent_name: str, repo_url: str
+    ) -> SyncReport:
+        calls.append(repo_url)
+        return SyncReport(synced=1)
 
-    with AioResponsesMock():
-        client = AsyncWebClient(token="xoxb-test")
-        refused = await _refuse_non_admin(
-            client,
-            team_id=_TEAM_ID,
-            channel_id=_CHANNEL_ID,
-            user_id=_USER_ID,
-            dev_allow_all=True,
-        )
+    monkeypatch.setattr(submit_mod, "kick_off_skill_sync", fake_kickoff)
 
-    assert refused is False, "dev_allow_all=True must let a non-admin proceed (no refusal)"
+    runtime = _build_runtime_with_db(db_session_factory)
+    client_fake: Any = fake_slack_web_client
+    # conftest default users.info is non-admin; no override.
+
+    await run_add_skill_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="skills",
+        extra={"repo_url": "https://github.com/example/skills.git", "branch": "main"},
+    )
+
+    assert calls == ["https://github.com/example/skills.git"], (
+        "an unreachable agent's add-skill must reach kick_off_skill_sync"
+    )
+
+    texts = _ephemeral_texts(client_fake)
+    assert any(":white_check_mark:" in t for t in texts), (
+        "add-skill must succeed for a non-admin on an unreachable agent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_add_skill_submission_when_non_admin_and_reachable_refused_queues_no_sync(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-admin adding a skill to a currently-default agent must be
+    refused before the sync is queued."""
+
+    async def unexpected_kickoff(*args: Any, **kwargs: Any) -> SyncReport:
+        raise AssertionError("skill sync must not be kicked off when the write is refused")
+
+    monkeypatch.setattr(submit_mod, "kick_off_skill_sync", unexpected_kickoff)
+
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        tenant_id = tenant.id
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    runtime = _build_runtime_with_db(db_session_factory)
+    client_fake: Any = fake_slack_web_client
+
+    await run_add_skill_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="skills",
+        extra={"repo_url": "https://github.com/example/skills.git", "branch": "main"},
+    )
+
+    texts = _ephemeral_texts(client_fake)
+    assert len(texts) == 1, "exactly one ephemeral should be posted on refusal, no sync queued"
+    assert "workspace-admin" in texts[0], (
+        "the refusal ephemeral should name why the write was refused"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_add_mcp_submission_when_non_admin_and_unreachable_proceeds(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Adding an MCP server is open when nobody has scoped this agent."""
+    from daimon.core.ma_identity import derive_tenant_uuid
+
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=_TEAM_ID)
+    ma_agent_id = f"agent_{'j' * 24}"
+    calls: list[tuple[str, str]] = []
+    agent_payload = _agent_payload_for_gate_tests(tenant_id=tenant_id, agent_id=ma_agent_id)
+    handler = _make_recording_ma_handler_with_agents_and_update([agent_payload], calls)
+    runtime = _build_runtime_with_db(db_session_factory, anthropic_handler=handler)
+
+    client_fake: Any = fake_slack_web_client
+    # conftest default users.info is non-admin; no override.
+
+    await run_add_mcp_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="mcps",
+        extra={
+            "mcp_name": "an-mcp",
+            "mcp_url": "https://mcp.example.com",
+            "token": None,
+            "token_replace": False,
+        },
+    )
+
+    assert any(method in {"PATCH", "POST"} for method, path in calls if "/v1/agents/" in path), (
+        "an unreachable agent's add-mcp must reach the MA update"
+    )
+
+    texts = _ephemeral_texts(client_fake)
+    assert any(":white_check_mark:" in t for t in texts), (
+        "add-mcp must succeed for a non-admin on an unreachable agent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_add_mcp_submission_when_non_admin_and_reachable_refused(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A non-admin adding an MCP server to a currently-default agent must be
+    refused before any MA request."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        tenant_id = tenant.id
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    ma_agent_id = f"agent_{'k' * 24}"
+    calls: list[tuple[str, str]] = []
+    agent_payload = _agent_payload_for_gate_tests(tenant_id=tenant_id, agent_id=ma_agent_id)
+    handler = _make_recording_ma_handler_with_agents_and_update([agent_payload], calls)
+    runtime = _build_runtime_with_db(db_session_factory, anthropic_handler=handler)
+
+    client_fake: Any = fake_slack_web_client
+
+    await run_add_mcp_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="mcps",
+        extra={
+            "mcp_name": "an-mcp",
+            "mcp_url": "https://mcp.example.com",
+            "token": None,
+            "token_replace": False,
+        },
+    )
+
+    assert calls == [], "a refused add-mcp must never reach the MA"
+
+    texts = _ephemeral_texts(client_fake)
+    assert len(texts) == 1, "exactly one ephemeral should be posted on refusal"
+    assert "workspace-admin" in texts[0], (
+        "the refusal ephemeral should name why the write was refused"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_add_mcp_submission_when_admin_and_reachable_proceeds(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An admin caller is unaffected by reachability on a field-conditional branch."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        tenant_id = tenant.id
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    ma_agent_id = f"agent_{'l' * 24}"
+    calls: list[tuple[str, str]] = []
+    agent_payload = _agent_payload_for_gate_tests(tenant_id=tenant_id, agent_id=ma_agent_id)
+    handler = _make_recording_ma_handler_with_agents_and_update([agent_payload], calls)
+    runtime = _build_runtime_with_db(db_session_factory, anthropic_handler=handler)
+
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
+
+    await run_add_mcp_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="mcps",
+        extra={
+            "mcp_name": "an-mcp",
+            "mcp_url": "https://mcp.example.com",
+            "token": None,
+            "token_replace": False,
+        },
+    )
+
+    assert any(method in {"PATCH", "POST"} for method, path in calls if "/v1/agents/" in path), (
+        "an admin's add-mcp must still reach the MA update even on a reachable agent"
+    )
+
+    texts = _ephemeral_texts(client_fake)
+    assert any(":white_check_mark:" in t for t in texts), (
+        "add-mcp must succeed for an admin regardless of reachability"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
@@ -527,7 +527,7 @@ async def _mark_reachable(
     tenant_id: Any,
     agent_name: str,
 ) -> None:
-    """Write a real tenant-scope propagation row (D-09) so the named agent is
+    """Write a real tenant-scope propagation row so the named agent is
     currently reachable — never patch the reachability predicate."""
     async with db_session_factory() as session, session.begin():
         await set_fields(
@@ -658,7 +658,7 @@ async def test_run_edit_repo_submission_when_non_admin_and_agent_is_workspace_de
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     """Repo binding is a per-agent attachment, so it stays open for a
-    non-admin even against the workspace's currently-default agent (D-09)."""
+    non-admin even against the workspace's currently-default agent."""
     from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
     from daimon.core.stores.agent_repo_binding import get_binding
 
@@ -723,7 +723,7 @@ async def test_run_paste_secrets_submission_when_non_admin_and_agent_is_workspac
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     """Env variables are a per-agent attachment, so they stay open for a
-    non-admin even against the workspace's currently-default agent (D-09)."""
+    non-admin even against the workspace's currently-default agent."""
     async with db_session_factory() as session:
         tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
         tenant_id = tenant.id

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_views.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_views.py
@@ -135,7 +135,8 @@ def test_build_l1_view_admin_includes_roster_select_block() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_build_l1_view_non_admin_omits_lifecycle_actions() -> None:
+def test_build_l1_view_non_admin_includes_new_fork_edit_but_not_delete() -> None:
+    """Non-admin view keeps the lifecycle block but omits Delete (D-06/D-09)."""
     state = _roster_state("agent-a", "agent-b")
     view = build_l1_view(
         state,
@@ -146,9 +147,38 @@ def test_build_l1_view_non_admin_omits_lifecycle_actions() -> None:
         scope_hint="_(no default set)_",
     )
     block_ids = _block_ids(view)
-    assert "agent_setup__lifecycle_actions" not in block_ids, (
-        "non-admin view must NOT include agent_setup__lifecycle_actions (omission contract)"
+    assert "agent_setup__lifecycle_actions" in block_ids, (
+        "non-admin view must still include agent_setup__lifecycle_actions (New/Fork/Edit)"
     )
+
+    lifecycle_block = next(
+        b for b in view["blocks"] if b.get("block_id") == "agent_setup__lifecycle_actions"
+    )
+    action_ids = [e.get("action_id") for e in lifecycle_block["elements"]]
+    assert "agent_setup__new" in action_ids, "non-admin lifecycle row must include New"
+    assert "agent_setup__fork" in action_ids, "non-admin lifecycle row must include Fork"
+    assert "agent_setup__edit" in action_ids, "non-admin lifecycle row must include Edit"
+    assert "agent_setup__delete" not in action_ids, (
+        "non-admin lifecycle row must NOT include Delete (admin-only, D-06)"
+    )
+
+
+def test_build_l1_view_admin_lifecycle_includes_delete() -> None:
+    """Admin view's lifecycle row carries Delete alongside New/Fork/Edit."""
+    state = _roster_state("agent-a")
+    view = build_l1_view(
+        state,
+        is_admin=True,
+        team_id="T123",
+        channel_id="C456",
+        selected_agent_name="agent-a",
+        scope_hint="_(no default set)_",
+    )
+    lifecycle_block = next(
+        b for b in view["blocks"] if b.get("block_id") == "agent_setup__lifecycle_actions"
+    )
+    action_ids = [e.get("action_id") for e in lifecycle_block["elements"]]
+    assert "agent_setup__delete" in action_ids, "admin lifecycle row must include Delete"
 
 
 def test_build_l1_view_non_admin_omits_scope_actions() -> None:
@@ -164,6 +194,43 @@ def test_build_l1_view_non_admin_omits_scope_actions() -> None:
     block_ids = _block_ids(view)
     assert "agent_setup__scope_actions" not in block_ids, (
         "non-admin view must NOT include agent_setup__scope_actions (omission contract)"
+    )
+
+
+def test_build_l1_view_non_admin_has_no_scope_action_ids_anywhere() -> None:
+    """No `agent_setup__scope:*` action id anywhere in a non-admin payload."""
+    state = _roster_state("agent-a")
+    view = build_l1_view(
+        state,
+        is_admin=False,
+        team_id="T123",
+        channel_id="C456",
+        selected_agent_name="agent-a",
+        scope_hint="_(no default set)_",
+    )
+    serialized = json.dumps(view)
+    assert "agent_setup__scope:" not in serialized, (
+        "non-admin payload must contain no agent_setup__scope:* action id anywhere"
+    )
+
+
+def test_build_l1_view_non_admin_empty_roster_invites_creating_first_agent() -> None:
+    """Zero-agents copy is audience-neutral -- New is unconditional now."""
+    state = AgentSetupState(rows=[], over_cap_count=0)
+    view = build_l1_view(
+        state,
+        is_admin=False,
+        team_id="T123",
+        channel_id="C456",
+        selected_agent_name=None,
+        scope_hint="_(no default set)_",
+    )
+    serialized = json.dumps(view)
+    assert "No agents yet" in serialized, (
+        "empty-roster copy must invite creating the first agent for every viewer"
+    )
+    assert "have been set up for this workspace yet" not in serialized, (
+        "the old admin-only-creation copy must not appear for a non-admin"
     )
 
 
@@ -246,6 +313,7 @@ def test_build_l2_view_active_skills_tab_has_primary_style() -> None:
         team_id="T123",
         channel_id="C456",
         is_admin=True,
+        can_edit_spec=True,
         section_blocks=[],
     )
     # Find the section_tabs actions block
@@ -273,6 +341,7 @@ def test_build_l2_view_inactive_tabs_have_no_primary_style() -> None:
         team_id="T123",
         channel_id="C456",
         is_admin=True,
+        can_edit_spec=True,
         section_blocks=[],
     )
     tabs_block = next(
@@ -301,6 +370,7 @@ def test_build_l2_view_active_agent_tab_has_primary_style() -> None:
         team_id="T123",
         channel_id="C456",
         is_admin=True,
+        can_edit_spec=True,
         section_blocks=[],
     )
     tabs_block = next(
@@ -328,6 +398,7 @@ def test_build_l2_view_private_metadata_under_3000_chars() -> None:
         team_id="T" + "0" * 10,
         channel_id="C" + "0" * 10,
         is_admin=True,
+        can_edit_spec=True,
         section_blocks=[],
     )
     pm = view["private_metadata"]
@@ -341,6 +412,7 @@ def test_build_l2_view_private_metadata_has_no_tenant_id() -> None:
         team_id="T123",
         channel_id="C456",
         is_admin=False,
+        can_edit_spec=False,
         section_blocks=[],
     )
     pm = json.loads(view["private_metadata"])
@@ -357,7 +429,6 @@ def test_secrets_section_renders_key_names_as_chips_when_names_provided() -> Non
     blocks = build_secrets_section(
         agent_name="my-agent",
         secret_names=["XERO_API_KEY", "TOGGL_TOKEN"],
-        is_admin=True,
     )
     serialized = json.dumps(blocks)
     assert "XERO_API_KEY" in serialized, (
@@ -372,7 +443,6 @@ def test_secrets_section_never_renders_fictional_secret_value() -> None:
     blocks = build_secrets_section(
         agent_name="my-agent",
         secret_names=["XERO_API_KEY", "TOGGL_TOKEN"],
-        is_admin=True,
     )
     serialized = json.dumps(blocks)
     assert sentinel_value not in serialized, (
@@ -386,7 +456,6 @@ def test_secrets_section_empty_names_renders_empty_state() -> None:
     blocks = build_secrets_section(
         agent_name="my-agent",
         secret_names=[],
-        is_admin=True,
     )
     serialized = json.dumps(blocks)
     # The empty state copy is: "_-# + add your first secret_"
@@ -409,29 +478,167 @@ def test_secrets_section_keys_only_no_values_parameter_in_signature() -> None:
     )
 
 
-def test_secrets_section_non_admin_omits_mutation_actions() -> None:
-    """Non-admin secret section omits Add/Remove buttons."""
+def test_secrets_section_always_includes_mutation_actions() -> None:
+    """Secrets are a per-agent attachment (D-09): Add/Remove render for every
+    caller, regardless of admin status or reachability -- build_secrets_section
+    takes no is_admin/can_edit_spec parameter at all."""
     blocks = build_secrets_section(
         agent_name="my-agent",
         secret_names=["XERO_API_KEY"],
-        is_admin=False,
-    )
-    block_ids = [b.get("block_id", "") for b in blocks]
-    assert "agent_setup__secrets_actions" not in block_ids, (
-        "non-admin secrets section must not include agent_setup__secrets_actions"
-    )
-
-
-def test_secrets_section_admin_includes_mutation_actions() -> None:
-    """Admin secret section includes Add secrets / Remove secret buttons."""
-    blocks = build_secrets_section(
-        agent_name="my-agent",
-        secret_names=["XERO_API_KEY"],
-        is_admin=True,
     )
     block_ids = [b.get("block_id", "") for b in blocks]
     assert "agent_setup__secrets_actions" in block_ids, (
-        "admin secrets section must include agent_setup__secrets_actions"
+        "secrets section must always include agent_setup__secrets_actions"
+    )
+
+
+def test_repo_auth_section_always_includes_edit_action_id() -> None:
+    """Repo binding is a per-agent attachment (D-09): the edit action id
+    renders regardless of admin status or reachability -- build_repo_auth_section
+    takes no is_admin/can_edit_spec parameter at all."""
+    blocks = build_repo_auth_section(repo=None, pat_last4=None)
+    action_ids = [
+        e.get("action_id", "")
+        for block in blocks
+        if block.get("type") == "actions"
+        for e in block.get("elements", [])
+    ]
+    assert "agent_setup__edit_repo_form" in action_ids, (
+        "repo-auth section must always include the edit-repo action id"
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_skills_section / build_mcps_section — can_edit_spec gate (D-09)
+# ---------------------------------------------------------------------------
+
+
+def test_build_skills_section_can_edit_spec_false_omits_add_and_remove() -> None:
+    blocks = build_skills_section(skill_names=["a-skill"], sync_pending=False, can_edit_spec=False)
+    action_ids = [
+        e.get("action_id", "")
+        for block in blocks
+        if block.get("type") == "actions"
+        for e in block.get("elements", [])
+    ]
+    assert "agent_setup__add_skill" not in action_ids, (
+        "can_edit_spec=False must omit the add-skill action id"
+    )
+    assert "agent_setup__remove_skill" not in action_ids, (
+        "can_edit_spec=False must omit the remove-skill action id"
+    )
+
+
+def test_build_skills_section_can_edit_spec_true_includes_add_and_remove() -> None:
+    blocks = build_skills_section(skill_names=["a-skill"], sync_pending=False, can_edit_spec=True)
+    action_ids = [
+        e.get("action_id", "")
+        for block in blocks
+        if block.get("type") == "actions"
+        for e in block.get("elements", [])
+    ]
+    assert "agent_setup__add_skill" in action_ids, (
+        "can_edit_spec=True must include the add-skill action id"
+    )
+    assert "agent_setup__remove_skill" in action_ids, (
+        "can_edit_spec=True must include the remove-skill action id"
+    )
+
+
+def test_build_mcps_section_can_edit_spec_false_omits_add_and_remove() -> None:
+    mcps = [{"name": "an-mcp", "url": "https://mcp.example.com"}]
+    blocks = build_mcps_section(mcps=mcps, can_edit_spec=False)
+    action_ids = [
+        e.get("action_id", "")
+        for block in blocks
+        if block.get("type") == "actions"
+        for e in block.get("elements", [])
+    ]
+    assert "agent_setup__add_mcp" not in action_ids, (
+        "can_edit_spec=False must omit the add-mcp action id"
+    )
+    assert "agent_setup__remove_mcp" not in action_ids, (
+        "can_edit_spec=False must omit the remove-mcp action id"
+    )
+
+
+def test_build_mcps_section_can_edit_spec_true_includes_add_and_remove() -> None:
+    mcps = [{"name": "an-mcp", "url": "https://mcp.example.com"}]
+    blocks = build_mcps_section(mcps=mcps, can_edit_spec=True)
+    action_ids = [
+        e.get("action_id", "")
+        for block in blocks
+        if block.get("type") == "actions"
+        for e in block.get("elements", [])
+    ]
+    assert "agent_setup__add_mcp" in action_ids, (
+        "can_edit_spec=True must include the add-mcp action id"
+    )
+    assert "agent_setup__remove_mcp" in action_ids, (
+        "can_edit_spec=True must include the remove-mcp action id"
+    )
+
+
+def test_build_mcps_section_connect_via_mcp_follows_is_admin_not_can_edit_spec() -> None:
+    """Connect via MCP mints a bearer token and stays admin-only unconditionally
+    (fact 5) -- a non-admin member editing an unreachable agent (can_edit_spec=True)
+    must not see it, since the dispatcher would always refuse the click."""
+    mcps = [{"name": "an-mcp", "url": "https://mcp.example.com"}]
+    blocks = build_mcps_section(mcps=mcps, can_edit_spec=True, is_admin=False)
+    action_ids = [
+        e.get("action_id", "")
+        for block in blocks
+        if block.get("type") == "actions"
+        for e in block.get("elements", [])
+    ]
+    assert "agent_setup__connect_mcp" not in action_ids, (
+        "connect_mcp must not render for a non-admin even when can_edit_spec is True"
+    )
+
+
+def test_build_l2_view_renders_agent_form_action_for_member_when_spec_editable() -> None:
+    """A member (is_admin=False) editing an unreachable agent (can_edit_spec=True)
+    still sees the agent-form action; an admin-only rule would hide it wrongly."""
+    section_blocks = build_agent_section(
+        agent_name="my-agent",
+        model_id="claude-sonnet-4-6",
+        system_prompt="hello",
+        can_edit_spec=True,
+    )
+    view = build_l2_view(
+        agent_name="my-agent",
+        active_section="agent",
+        team_id="T123",
+        channel_id="C456",
+        is_admin=False,
+        can_edit_spec=True,
+        section_blocks=section_blocks,
+    )
+    serialized = json.dumps(view)
+    assert "agent_setup__edit_agent_form" in serialized, (
+        "L2 view must render the agent-form action for a member when spec-editable"
+    )
+
+
+def test_build_l2_view_omits_agent_form_action_when_not_spec_editable() -> None:
+    section_blocks = build_agent_section(
+        agent_name="my-agent",
+        model_id="claude-sonnet-4-6",
+        system_prompt="hello",
+        can_edit_spec=False,
+    )
+    view = build_l2_view(
+        agent_name="my-agent",
+        active_section="agent",
+        team_id="T123",
+        channel_id="C456",
+        is_admin=False,
+        can_edit_spec=False,
+        section_blocks=section_blocks,
+    )
+    serialized = json.dumps(view)
+    assert "agent_setup__edit_agent_form" not in serialized, (
+        "L2 view must omit the agent-form action when the agent is not spec-editable"
     )
 
 
@@ -604,7 +811,7 @@ def test_build_agent_section_admin_uses_edit_agent_form_action_id() -> None:
         agent_name="my-agent",
         model_id="claude-sonnet-4-6",
         system_prompt="You are helpful.",
-        is_admin=True,
+        can_edit_spec=True,
     )
     all_action_ids = [
         element.get("action_id", "")
@@ -631,7 +838,6 @@ def test_build_repo_auth_section_admin_uses_edit_repo_form_action_id() -> None:
     blocks = build_repo_auth_section(
         repo="owner/repo",
         pat_last4="****abcd",
-        is_admin=True,
     )
     all_action_ids = [
         element.get("action_id", "")
@@ -705,7 +911,7 @@ def test_build_skills_section_remove_option_plain_text_carries_raw_name() -> Non
     appear verbatim in the option label.
     """
     raw_name = "a&b<c>"
-    blocks = build_skills_section(skill_names=[raw_name], sync_pending=False, is_admin=True)
+    blocks = build_skills_section(skill_names=[raw_name], sync_pending=False, can_edit_spec=True)
     # Find the remove-skill static_select
     remove_options: list[dict[str, object]] = []
     for block in blocks:
@@ -726,7 +932,7 @@ def test_build_mcps_section_remove_option_plain_text_carries_raw_name() -> None:
     """remove-mcp static_select option label must carry the raw MCP name verbatim."""
     raw_name = "a&b<c>"
     mcps = [{"name": raw_name, "url": "https://mcp.example.com"}]
-    blocks = build_mcps_section(mcps=mcps, is_admin=True)
+    blocks = build_mcps_section(mcps=mcps, can_edit_spec=True)
     remove_options: list[dict[str, object]] = []
     for block in blocks:
         if block.get("type") == "actions":
@@ -745,7 +951,7 @@ def test_build_mcps_section_remove_option_plain_text_carries_raw_name() -> None:
 def test_build_secrets_section_remove_option_plain_text_carries_raw_name() -> None:
     """remove-secret static_select option label must carry the raw secret key name verbatim."""
     raw_name = "a&b<c>"
-    blocks = build_secrets_section(agent_name="test-agent", secret_names=[raw_name], is_admin=True)
+    blocks = build_secrets_section(agent_name="test-agent", secret_names=[raw_name])
     remove_options: list[dict[str, object]] = []
     for block in blocks:
         if block.get("type") == "actions":

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_views.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_views.py
@@ -136,7 +136,7 @@ def test_build_l1_view_admin_includes_roster_select_block() -> None:
 
 
 def test_build_l1_view_non_admin_includes_new_fork_edit_but_not_delete() -> None:
-    """Non-admin view keeps the lifecycle block but omits Delete (D-06/D-09)."""
+    """Non-admin view keeps the lifecycle block but omits Delete."""
     state = _roster_state("agent-a", "agent-b")
     view = build_l1_view(
         state,
@@ -159,7 +159,7 @@ def test_build_l1_view_non_admin_includes_new_fork_edit_but_not_delete() -> None
     assert "agent_setup__fork" in action_ids, "non-admin lifecycle row must include Fork"
     assert "agent_setup__edit" in action_ids, "non-admin lifecycle row must include Edit"
     assert "agent_setup__delete" not in action_ids, (
-        "non-admin lifecycle row must NOT include Delete (admin-only, D-06)"
+        "non-admin lifecycle row must NOT include Delete (admin-only)"
     )
 
 
@@ -479,7 +479,7 @@ def test_secrets_section_keys_only_no_values_parameter_in_signature() -> None:
 
 
 def test_secrets_section_always_includes_mutation_actions() -> None:
-    """Secrets are a per-agent attachment (D-09): Add/Remove render for every
+    """Secrets are a per-agent attachment: Add/Remove render for every
     caller, regardless of admin status or reachability -- build_secrets_section
     takes no is_admin/can_edit_spec parameter at all."""
     blocks = build_secrets_section(
@@ -493,7 +493,7 @@ def test_secrets_section_always_includes_mutation_actions() -> None:
 
 
 def test_repo_auth_section_always_includes_edit_action_id() -> None:
-    """Repo binding is a per-agent attachment (D-09): the edit action id
+    """Repo binding is a per-agent attachment: the edit action id
     renders regardless of admin status or reachability -- build_repo_auth_section
     takes no is_admin/can_edit_spec parameter at all."""
     blocks = build_repo_auth_section(repo=None, pat_last4=None)
@@ -509,7 +509,7 @@ def test_repo_auth_section_always_includes_edit_action_id() -> None:
 
 
 # ---------------------------------------------------------------------------
-# build_skills_section / build_mcps_section — can_edit_spec gate (D-09)
+# build_skills_section / build_mcps_section — can_edit_spec gate
 # ---------------------------------------------------------------------------
 
 

--- a/packages/core/daimon/core/scope.py
+++ b/packages/core/daimon/core/scope.py
@@ -6,6 +6,7 @@ No I/O, no SQLAlchemy imports. Imported by stores and adapters alike.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Literal
 
@@ -162,6 +163,38 @@ def _pick_environment(
     if default.environment_name:
         return default.environment_name, "deployment"
     return None, None
+
+
+def is_agent_reachable(
+    agent_name: str,
+    *,
+    tenant: TenantConfigRow | None,
+    channels: Sequence[ChannelConfigRow],
+    default: DeploymentDefault,
+) -> bool:
+    """Answer whether any user in the tenant can currently reach the named agent.
+
+    Reachability includes the deployment tier: on a fresh install with no
+    config rows at all, the agent named by the deployment default is reachable,
+    because that is what every mention resolves to via `_pick_agent`'s
+    fall-through. A tenant row in mode='agent' with a non-empty agent_name
+    overrides that fall-through for the whole tenant; a channel row only ever
+    overrides for its own channel and never suppresses the deployment tier
+    for the rest.
+
+    Deliberately blind to the agent's name, to any seeded/managed marker, and
+    to ownership stamps — it answers only whether the name is reachable
+    through the channel/tenant/deployment cascade, nothing about what the
+    agent is or who created it.
+    """
+    if any(row.mode == "agent" and row.agent_name == agent_name for row in channels):
+        return True
+    if tenant is not None and tenant.mode == "agent" and tenant.agent_name == agent_name:
+        return True
+    tenant_consumes_fallthrough = (
+        tenant is not None and tenant.mode == "agent" and bool(tenant.agent_name)
+    )
+    return default.agent_name == agent_name and not tenant_consumes_fallthrough
 
 
 def merge(

--- a/packages/core/daimon/core/stores/scoped_config_read.py
+++ b/packages/core/daimon/core/stores/scoped_config_read.py
@@ -16,6 +16,7 @@ from daimon.core.scope import (
     TenantConfigRow,
     UserConfigRow,
     UserScopeRef,
+    is_agent_reachable,
     merge,
 )
 from sqlalchemy import select
@@ -89,6 +90,24 @@ async def list_propagations_for_tenant(
         for ch in ch_orms
     ]
     return tenant_row, ch_rows
+
+
+async def is_agent_reachable_in_tenant(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    agent_name: str,
+    default: DeploymentDefault,
+) -> bool:
+    """Shell half of the reachability rule: answer for one tenant from the DB.
+
+    Reads the tenant's config rows via `list_propagations_for_tenant` and feeds
+    them straight into the pure `is_agent_reachable` predicate. Callers that
+    already hold the config rows in memory (the Discord panel's cascade view)
+    should call the pure predicate directly instead of paying for this read.
+    """
+    tenant_row, channel_rows = await list_propagations_for_tenant(session, tenant_id=tenant_id)
+    return is_agent_reachable(agent_name, tenant=tenant_row, channels=channel_rows, default=default)
 
 
 async def _fetch_user(session: AsyncSession, *, account_id: uuid.UUID) -> UserConfigRow | None:

--- a/packages/core/tests/defaults/test_defaults_dir.py
+++ b/packages/core/tests/defaults/test_defaults_dir.py
@@ -62,20 +62,30 @@ def test_defaults_skills_parse() -> None:
 
 
 def test_defaults_daimon_agent_guidance_routes_credentials_to_request_tools() -> None:
-    """The daimon agent's guidance must name both credential-request tools and
-    no longer route credential entry to the /agent-setup panel — replacing the
-    setup-panel redirect was the whole point of the request_env_credential /
-    request_mcp_credential tools."""
+    """The daimon agent's guidance — its system prompt plus its referenced
+    skills — must name both credential-request tools and no line anywhere in
+    that combined guidance may route credential *entry* to the /agent-setup
+    panel — replacing the setup-panel redirect was the whole point of the
+    request_env_credential / request_mcp_credential tools. The mechanism now
+    lives in the workspace-setup skill rather than the system prompt itself
+    (the prompt keeps only the no-plaintext rule), so this checks the union
+    of both, not the system prompt alone."""
     specs = load_agent_specs(DEFAULTS / "agents")
     daimon = next(s for s in specs if s.name == "daimon")
-    system = daimon.system or ""
-    assert "request_env_credential" in system, (
+    skill_names = {ref.skill_id for ref in daimon.skills if ref.type == "custom"}
+    skill_bodies = [
+        load_skill_spec(d)[1]
+        for d in load_skill_paths(DEFAULTS / "skills")
+        if load_skill_spec(d)[0].name in skill_names
+    ]
+    combined = "\n".join([daimon.system or "", *skill_bodies])
+    assert "request_env_credential" in combined, (
         "guidance must name request_env_credential for ad hoc env secrets"
     )
-    assert "request_mcp_credential" in system, (
+    assert "request_mcp_credential" in combined, (
         "guidance must name request_mcp_credential for auth-required MCP servers"
     )
-    for line in system.splitlines():
+    for line in combined.splitlines():
         if "/agent-setup" not in line:
             continue
         lowered = line.lower()

--- a/packages/core/tests/stores/test_scoped_config_read.py
+++ b/packages/core/tests/stores/test_scoped_config_read.py
@@ -16,6 +16,7 @@ from daimon.core.scope import (
 )
 from daimon.core.stores.scoped_config_read import (
     get_scope,
+    is_agent_reachable_in_tenant,
     list_propagations_for_tenant,
     resolve,
 )
@@ -435,3 +436,96 @@ async def test_cross_tenant_isolation(db_session: AsyncSession) -> None:
     assert result_a.agent_name == "agent-for-a", (
         "resolving tenant A must return its own tenant_config agent_name"
     )
+
+
+# ---------------------------------------------------------------------------
+# is_agent_reachable_in_tenant tests
+# ---------------------------------------------------------------------------
+
+
+async def test_is_agent_reachable_in_tenant_true_for_deployment_default_on_fresh_tenant(
+    db_session: AsyncSession,
+) -> None:
+    """A tenant with no config rows at all still answers True for the deployment default."""
+    t = await make_tenant(db_session)
+    reachable = await is_agent_reachable_in_tenant(
+        db_session, tenant_id=t.id, agent_name="daimon", default=_DEFAULT
+    )
+    assert reachable, (
+        "the deployment-default agent must be reachable on a tenant with no config rows"
+    )
+
+
+async def test_is_agent_reachable_in_tenant_false_for_unrelated_name(
+    db_session: AsyncSession,
+) -> None:
+    """A fresh tenant answers False for a name that is neither scoped nor the default."""
+    t = await make_tenant(db_session)
+    reachable = await is_agent_reachable_in_tenant(
+        db_session, tenant_id=t.id, agent_name="scratch", default=_DEFAULT
+    )
+    assert not reachable, "an unscoped, non-default agent name must be unreachable"
+
+
+async def test_is_agent_reachable_in_tenant_true_after_channel_propagation(
+    db_session: AsyncSession,
+) -> None:
+    """After scoping an agent to one channel, that agent answers True for the tenant."""
+    from daimon.core.stores.scoped_config_write import set_fields  # noqa: PLC0415
+
+    t = await make_tenant(db_session)
+    await set_fields(
+        db_session,
+        scope=ChannelScopeRef(tenant_id=t.id, channel_id="c1"),
+        tenant_id=t.id,
+        agent_name="Y",
+    )
+    reachable = await is_agent_reachable_in_tenant(
+        db_session, tenant_id=t.id, agent_name="Y", default=_DEFAULT
+    )
+    assert reachable, "an agent scoped to a channel row must be reachable in the tenant"
+
+
+async def test_is_agent_reachable_in_tenant_false_for_default_after_tenant_propagation(
+    db_session: AsyncSession,
+) -> None:
+    """After scoping the tenant to a different agent, the deployment default stops answering True."""
+    from daimon.core.stores.scoped_config_write import set_fields  # noqa: PLC0415
+
+    t = await make_tenant(db_session)
+    await set_fields(
+        db_session,
+        scope=TenantScopeRef(tenant_id=t.id),
+        tenant_id=t.id,
+        agent_name="Y",
+    )
+    reachable = await is_agent_reachable_in_tenant(
+        db_session, tenant_id=t.id, agent_name=_DEFAULT.agent_name or "", default=_DEFAULT
+    )
+    assert not reachable, (
+        "a tenant-scope propagation to a different agent must consume the deployment fall-through"
+    )
+
+
+async def test_is_agent_reachable_in_tenant_is_isolated_per_tenant(
+    db_session: AsyncSession,
+) -> None:
+    """One tenant scoping an agent must not make it reachable in a sibling tenant."""
+    from daimon.core.stores.scoped_config_write import set_fields  # noqa: PLC0415
+
+    t1 = await make_tenant(db_session)
+    t2 = await make_tenant(db_session)
+    await set_fields(
+        db_session,
+        scope=ChannelScopeRef(tenant_id=t1.id, channel_id="c1"),
+        tenant_id=t1.id,
+        agent_name="Y",
+    )
+    reachable_t1 = await is_agent_reachable_in_tenant(
+        db_session, tenant_id=t1.id, agent_name="Y", default=DeploymentDefault()
+    )
+    reachable_t2 = await is_agent_reachable_in_tenant(
+        db_session, tenant_id=t2.id, agent_name="Y", default=DeploymentDefault()
+    )
+    assert reachable_t1, "the tenant that scoped agent Y must answer True for Y"
+    assert not reachable_t2, "a sibling tenant that never scoped agent Y must answer False for Y"

--- a/packages/core/tests/test_scope.py
+++ b/packages/core/tests/test_scope.py
@@ -15,6 +15,7 @@ from daimon.core.scope import (
     ScopeContext,
     TenantConfigRow,
     _pick_agent,  # pyright: ignore[reportPrivateUsage]  # test seam
+    is_agent_reachable,
     merge,
 )
 
@@ -276,3 +277,110 @@ def test_scope_context_accepts_all_fields() -> None:
     assert ctx.tenant_id == tid
     assert ctx.channel_id == "c1"
     assert ctx.account_id == aid
+
+
+# ---------------------------------------------------------------------------
+# is_agent_reachable — reachability predicate over channel/tenant/deployment
+# ---------------------------------------------------------------------------
+
+
+def test_is_agent_reachable_true_for_deployment_default_on_fresh_install() -> None:
+    """No tenant row, no channel rows: the seeded deployment default is reachable."""
+    default = DeploymentDefault(agent_name="daimon", environment_name="default")
+    assert is_agent_reachable("daimon", tenant=None, channels=[], default=default), (
+        "the deployment-default agent must be reachable on a fresh install with no config rows"
+    )
+
+
+def test_is_agent_reachable_false_for_unrelated_name_on_fresh_install() -> None:
+    """No tenant row, no channel rows: an agent nobody named is not reachable."""
+    default = DeploymentDefault(agent_name="daimon", environment_name="default")
+    assert not is_agent_reachable("scratch", tenant=None, channels=[], default=default), (
+        "an agent that is neither scoped nor the deployment default must be unreachable"
+    )
+
+
+def test_is_agent_reachable_true_when_tenant_row_names_it() -> None:
+    """A tenant row in mode='agent' naming the agent makes it reachable."""
+    tid = uuid.uuid4()
+    tenant = TenantConfigRow(tenant_id=tid, agent_name="alpha", mode="agent")
+    assert is_agent_reachable("alpha", tenant=tenant, channels=[], default=DeploymentDefault()), (
+        "a tenant row naming the agent in mode='agent' must make it reachable"
+    )
+
+
+def test_is_agent_reachable_false_for_deployment_default_when_tenant_overrides() -> None:
+    """A tenant row that names a different agent consumes the fall-through."""
+    tid = uuid.uuid4()
+    tenant = TenantConfigRow(tenant_id=tid, agent_name="alpha", mode="agent")
+    default = DeploymentDefault(agent_name="daimon")
+    assert not is_agent_reachable("daimon", tenant=tenant, channels=[], default=default), (
+        "a tenant row overriding the agent must consume the deployment fall-through"
+    )
+
+
+def test_is_agent_reachable_true_for_default_when_tenant_row_is_user_active() -> None:
+    """A tenant row in mode='user_active' does not consume the fall-through."""
+    tid = uuid.uuid4()
+    tenant = TenantConfigRow(tenant_id=tid, agent_name="alpha", mode="user_active")
+    default = DeploymentDefault(agent_name="daimon")
+    assert is_agent_reachable("daimon", tenant=tenant, channels=[], default=default), (
+        "a non-agent-mode tenant row must not consume the deployment fall-through"
+    )
+
+
+def test_is_agent_reachable_true_for_default_when_tenant_agent_name_empty() -> None:
+    """A tenant row in mode='agent' with no agent_name does not consume the fall-through."""
+    tid = uuid.uuid4()
+    tenant = TenantConfigRow(tenant_id=tid, agent_name=None, mode="agent")
+    default = DeploymentDefault(agent_name="daimon")
+    assert is_agent_reachable("daimon", tenant=tenant, channels=[], default=default), (
+        "an empty agent_name on an agent-mode tenant row must not consume the fall-through, "
+        "matching _pick_agent's truthiness test"
+    )
+
+
+def test_is_agent_reachable_true_when_channel_row_names_it() -> None:
+    """A channel row in mode='agent' naming the agent makes it reachable."""
+    tid = uuid.uuid4()
+    channel = ChannelConfigRow(tenant_id=tid, channel_id="c1", agent_name="beta", mode="agent")
+    assert is_agent_reachable(
+        "beta", tenant=None, channels=[channel], default=DeploymentDefault()
+    ), "a channel row naming the agent in mode='agent' must make it reachable"
+
+
+def test_is_agent_reachable_true_for_default_alongside_a_channel_row() -> None:
+    """A channel row scoping one agent does not suppress the deployment default for others."""
+    tid = uuid.uuid4()
+    channel = ChannelConfigRow(tenant_id=tid, channel_id="c1", agent_name="beta", mode="agent")
+    default = DeploymentDefault(agent_name="daimon")
+    assert is_agent_reachable("daimon", tenant=None, channels=[channel], default=default), (
+        "a channel row cannot suppress the deployment tier for other channels"
+    )
+
+
+def test_is_agent_reachable_false_when_channel_row_is_user_active() -> None:
+    """A channel row in mode='user_active' does not make its agent_name reachable."""
+    tid = uuid.uuid4()
+    channel = ChannelConfigRow(
+        tenant_id=tid, channel_id="c1", agent_name="beta", mode="user_active"
+    )
+    assert not is_agent_reachable(
+        "beta", tenant=None, channels=[channel], default=DeploymentDefault()
+    ), "a user_active channel row must not make its agent_name reachable"
+
+
+def test_is_agent_reachable_false_when_no_default_and_no_rows() -> None:
+    """No deployment default and no rows at all: nothing is reachable."""
+    assert not is_agent_reachable(
+        "anything", tenant=None, channels=[], default=DeploymentDefault()
+    ), "with no default and no rows, no agent name should be reachable"
+
+
+def test_is_agent_reachable_is_case_sensitive() -> None:
+    """Matching is exact and case-sensitive."""
+    tid = uuid.uuid4()
+    tenant = TenantConfigRow(tenant_id=tid, agent_name="alpha", mode="agent")
+    assert not is_agent_reachable(
+        "Alpha", tenant=tenant, channels=[], default=DeploymentDefault()
+    ), "matching must be case-sensitive: 'Alpha' must not match a row named 'alpha'"

--- a/tests/integration/test_seeded_prompt_tool_claims.py
+++ b/tests/integration/test_seeded_prompt_tool_claims.py
@@ -1,0 +1,322 @@
+"""The drift gate between the seeded prompt/skill's tool claims and the live
+tool registry.
+
+This is the structural fix for how the routines lie got into the seeded
+prompt in the first place: prose drifts from the live tool surface over
+time, but tool names do not — so tool names are what gets checked, against a
+real chat-turn-shaped session driven through the real MCP handshake, every
+time this suite runs.
+
+Every identifier-shaped token in the seeded `daimon` agent's system prompt,
+and in every skill it references (not just `workspace-setup`), is checked:
+
+- If the token is not a real, currently-registered tool name (an ordinary
+  parameter name or other prose that merely looks identifier-shaped), it is
+  ignored — UNLESS it's written in call syntax (immediately followed by
+  `(`), which is an unambiguous claim that the model should invoke it. A
+  call-syntax reference to a name that turns out not to exist at all fails
+  as "unregistered".
+- If it is a real tool, it must be discoverable by a chat-turn-shaped
+  session (the same shape wave 2's `test_chat_session_tool_reachability.py`
+  built: an account subject, no `agent_id` claim, no `is_admin` claim, a
+  Discord-shaped platform claim) — unless it is in the short, commented
+  exception list below, for the handful of names the skill names *only* to
+  warn the model away from them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import datetime as dt
+import itertools
+import json
+import re
+from collections.abc import AsyncIterator, Awaitable, Callable
+from pathlib import Path
+
+import httpx
+import pytest
+from daimon.adapters.mcp.server import create_mcp_app
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    McpSettings,
+    Settings,
+)
+from daimon.core.defaults.loader import (
+    load_agent_specs,
+    load_skill_paths,
+    load_skill_spec,
+)
+from daimon.core.mcp_auth import mint_jwt
+from daimon.core.stores import accounts
+from daimon.core.stores.domain import Role
+from daimon.testing.factories import make_account, make_platform_principal, make_tenant
+from daimon.testing.ma import MARouter, build_fake_anthropic
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.types import ASGIApp, Message
+
+pytestmark = pytest.mark.asyncio
+
+SECRET = "a" * 32
+_NOW = dt.datetime(2026, 4, 24, tzinfo=dt.UTC)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULTS = REPO_ROOT / "defaults"
+
+# Identifier-shaped candidate tokens: lowercase snake_case with at least one
+# underscore. Every real MCP tool name in this codebase is multi-word, so
+# this shape is a cheap, effective first filter before anything hits the
+# network — plain English words in the surrounding prose never match it.
+_TOKEN_RE = re.compile(r"\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b")
+
+# Names the skill deliberately introduces ONLY to warn the model away from
+# them (a real, registered tool that is NOT reachable from a chat turn,
+# named on purpose to distinguish it from a chat-reachable sibling). Keep
+# this short — each entry needs a reason.
+_INTENTIONAL_NON_CHAT_MENTIONS: dict[str, str] = {
+    # named only to distinguish it from remove_skill, its chat-reachable sibling
+    "delete_skill": "tenant-wide destructive skill delete; admin-only, panel-only",
+    # named only to say it is NOT available from chat, unlike most roster ops
+    "archive_agent": "destructive agent delete; admin-only, panel/CLI-only",
+}
+
+
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def _strip_fenced_code_blocks(text: str) -> str:
+    """Drop ```-fenced example code (bash/python usage snippets) before any
+    extraction. A genuine MCP tool reference in this codebase's skills is
+    always given as inline single-backtick prose (`tool_name` or
+    `tool_name(args)`); a fenced block is illustrative library usage
+    (`pd.read_csv(...)`, `az.from_netcdf(...)`, a user-defined helper inside
+    a worked example) that would otherwise look identical, in shape, to a
+    real tool call."""
+    return _FENCED_CODE_RE.sub("", text)
+
+
+def _extract_candidates(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text))
+
+
+def _is_call_syntax(token: str, text: str) -> bool:
+    """True if `token` appears immediately followed by '(' anywhere in `text`,
+    as a BARE call — not attribute-qualified.
+
+    An unambiguous tool-invocation shape (`create_routine(...)`), as opposed
+    to a bare parameter-name mention inside another tool's own argument list
+    (e.g. `cron_expr` documented as one of create_routine's arguments), or a
+    qualified call into an ordinary Python library used in worked examples
+    (`az.from_netcdf(...)`, `pd.read_csv(...)`) — every real MCP tool call in
+    this codebase's skills is a bare name, never `module.tool_name(...)`.
+    """
+    return re.search(rf"(?<!\.)\b{re.escape(token)}\(", text) is not None
+
+
+def _collect_texts() -> tuple[str, dict[str, str]]:
+    """Return (system prompt text, {skill name: skill body}) for the seeded
+    `daimon` agent and every custom skill its `skills:` block references —
+    not a hardcoded single skill path, so a second seeded skill is covered
+    automatically."""
+    specs = load_agent_specs(DEFAULTS / "agents")
+    daimon = next(s for s in specs if s.name == "daimon")
+    system = _strip_fenced_code_blocks(daimon.system or "")
+    referenced_skill_ids = {ref.skill_id for ref in daimon.skills if ref.type == "custom"}
+    bodies: dict[str, str] = {}
+    for skill_dir in load_skill_paths(DEFAULTS / "skills"):
+        spec, body = load_skill_spec(skill_dir)
+        if spec.name in referenced_skill_ids:
+            bodies[spec.name] = _strip_fenced_code_blocks(body)
+    return system, bodies
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
+    send_queue: asyncio.Queue[Message] = asyncio.Queue()
+    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await receive_queue.get()
+
+    async def send(message: Message) -> None:
+        await send_queue.put(message)
+
+    async def run_lifespan() -> None:
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+
+    task = asyncio.create_task(run_lifespan())
+
+    await receive_queue.put({"type": "lifespan.startup"})
+    msg = await send_queue.get()
+    assert msg["type"] == "lifespan.startup.complete", msg
+    try:
+        yield
+    finally:
+        await receive_queue.put({"type": "lifespan.shutdown"})
+        msg = await send_queue.get()
+        assert msg["type"] == "lifespan.shutdown.complete", msg
+        await task
+
+
+def _parse_jsonrpc_response(resp: httpx.Response) -> dict[str, object]:
+    content_type = resp.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        for line in resp.text.splitlines():
+            if line.startswith("data: "):
+                return json.loads(line[6:])  # type: ignore[return-value]
+        raise AssertionError(f"No data line in SSE response: {resp.text!r}")
+    return resp.json()  # type: ignore[return-value]
+
+
+@contextlib.asynccontextmanager
+async def _open_session(
+    app: ASGIApp, *, token: str
+) -> AsyncIterator[Callable[[str, dict[str, object] | None], Awaitable[dict[str, object]]]]:
+    """Initialize one real MCP session and yield a caller for repeated
+    JSON-RPC calls against it — the handshake runs once, not per query."""
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        init_resp = await c.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0"},
+                },
+            },
+            headers=headers,
+        )
+        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
+        session_id = init_resp.headers.get("mcp-session-id")
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+        counter = itertools.count(2)
+
+        async def _call(method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+            body = {"jsonrpc": "2.0", "id": next(counter), "method": method, "params": params or {}}
+            resp = await c.post("/mcp", json=body, headers=headers)
+            assert resp.status_code == 200, f"{method} failed ({resp.status_code}): {resp.text}"
+            return _parse_jsonrpc_response(resp)
+
+        yield _call
+
+
+async def _search_text(
+    call: Callable[[str, dict[str, object] | None], Awaitable[dict[str, object]]],
+    query: str,
+) -> str:
+    result = await call("tools/call", {"name": "search_tools", "arguments": {"query": query}})
+    payload = result.get("result", result)
+    content = payload.get("content", [])  # type: ignore[union-attr]
+    return " ".join(item.get("text", "") for item in content if isinstance(item, dict))
+
+
+def _make_app(sessionmaker: async_sessionmaker[AsyncSession]) -> ASGIApp:
+    return create_mcp_app(
+        settings=Settings(
+            database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+            anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+            mcp=McpSettings(jwt_secret=SecretStr(SECRET), public_url=HttpUrl("https://x/mcp")),
+        ),
+        sessionmaker=sessionmaker,
+        anthropic=build_fake_anthropic(MARouter().dispatch),
+    )
+
+
+async def _seed_admin_token(sessionmaker: async_sessionmaker[AsyncSession]) -> str:
+    async with sessionmaker() as s, s.begin():
+        tenant = await make_tenant(s, platform="discord", workspace_id="prompt-claims-admin")
+        account = await make_account(s, tenant=tenant)
+        await accounts.set_role(s, account.id, Role.ADMIN)
+        account_id = account.id
+    return mint_jwt(account_id=account_id, secret=SECRET.encode(), now=_NOW)
+
+
+async def _seed_chat_turn_token(sessionmaker: async_sessionmaker[AsyncSession]) -> str:
+    """A token shaped exactly like a Discord chat turn: account subject, no
+    `agent_id` claim, no `is_admin` claim, a Discord-bound platform identity —
+    the same shape wave 2's `test_chat_session_tool_reachability.py` built."""
+    async with sessionmaker() as s, s.begin():
+        tenant = await make_tenant(s, platform="discord", workspace_id="prompt-claims-chat-turn")
+        account = await make_account(s, tenant=tenant)
+        await make_platform_principal(
+            s,
+            platform="discord",
+            external_id="discord-user-1",
+            tenant=tenant,
+            account=account,
+        )
+        account_id = account.id
+    return mint_jwt(account_id=account_id, secret=SECRET.encode(), now=_NOW)
+
+
+async def test_seeded_prompt_and_skill_tool_claims_are_chat_turn_reachable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Every tool-name-shaped token the seeded prompt or its referenced
+    skills name must be one a chat-turn-shaped session can actually reach.
+
+    Regression coverage note (verified manually, not asserted here — the
+    check needs a live edit to prove): temporarily appending a fabricated
+    tool name, or a real admin-only tool name like `sync_skills`, to
+    `defaults/agents/daimon.yaml`'s system block makes this test fail and
+    names the offending token in the failure message. Both were confirmed
+    during development and reverted before this file was committed.
+    """
+    system_text, skill_bodies = _collect_texts()
+
+    candidates: dict[str, str] = {}
+    for token in _extract_candidates(system_text):
+        candidates.setdefault(token, "the seeded system prompt")
+    for skill_name, body in skill_bodies.items():
+        for token in _extract_candidates(body):
+            candidates.setdefault(token, f"the {skill_name!r} skill")
+
+    app = _make_app(db_session_factory)
+    admin_token = await _seed_admin_token(db_session_factory)
+    chat_token = await _seed_chat_turn_token(db_session_factory)
+
+    admin_search_text: dict[str, str] = {}
+    async with _open_session(app, token=admin_token) as admin_call:
+        for token in candidates:
+            admin_search_text[token] = await _search_text(admin_call, token.replace("_", " "))
+
+    chat_search_text: dict[str, str] = {}
+    async with _open_session(app, token=chat_token) as chat_call:
+        for token in candidates:
+            chat_search_text[token] = await _search_text(chat_call, token.replace("_", " "))
+
+    all_text = "\n".join([system_text, *skill_bodies.values()])
+    offending: list[str] = []
+    for token, source in sorted(candidates.items()):
+        if token in _INTENTIONAL_NON_CHAT_MENTIONS:
+            continue
+        is_registered = token in admin_search_text[token]
+        if not is_registered and not _is_call_syntax(token, all_text):
+            # Not a real tool, and not written as a call — an ordinary
+            # identifier-shaped word (a parameter name, a YAML key, ...).
+            continue
+        is_chat_discoverable = token in chat_search_text[token]
+        if not is_chat_discoverable:
+            reason = (
+                "registered but not reachable from a chat turn"
+                if is_registered
+                else "unregistered — no such tool exists"
+            )
+            offending.append(f"{token!r} (named in {source}): {reason}")
+
+    assert not offending, (
+        "the seeded prompt/skill names a tool a chat turn cannot reach:\n" + "\n".join(offending)
+    )


### PR DESCRIPTION
A fresh install now lands on a working default agent whose job is onboarding, and anyone can build an agent while only admins can make one reachable.

## Why

Three problems, all reachable from a first-time server:

1. **The seeded agent introduced itself as a CLI tool.** Its prompt opened with "a local development assistant embedded in the `daimon` CLI … help the operator … in the repo at the working directory" — which is not what a Discord or Slack workspace just installed.
2. **The prompt claimed capabilities the tool surface denied.** It refused to create routines and pointed users at a `/routines` "+ New Routine" button; `create_routine` is ungated and works, and that button exists only on Slack — Discord's routines panel has no creation path at all. It also told the agent to call `set_repo_binding`, which is not callable from a chat-shaped session.
3. **Configuring anything required being an admin.** A member could not bring their own agent, even though nothing about *building* one is dangerous. Only *reachability* is.

## What changed

**Authorization.** Creating, forking, updating, attaching MCP servers, and binding a repo are open to every member. Scoping an agent to a channel or workspace, archiving, environment management, and skill sync stay admin-only. The rule is blast radius: affects one agent → open; affects the tenant → admin.

**The gate that opening it required.** An agent that is *currently* a channel or workspace default can only have its identity and behaviour changed by an admin — name, system prompt, model, skills, tools, MCP servers. An agent nobody has scoped is editable by anyone, because nobody can reach it. Per-agent attachments (repo binding, environment variables) stay open either way. This is enforced at three layers rather than by hiding buttons: a pure predicate in core, a runtime check inside each tool implementation, and a click-time/submit-time re-check on both panels that re-reads state instead of trusting what was rendered.

**Chat-reachable removal.** `detach_mcp_server`, `remove_skill`, `remove_env_credential`, and a key-name listing. Credential *entry* still goes through the private button flow — the listing returns names only, never values, with a test asserting a stored value cannot appear anywhere in the response.

**A first-run install can no longer lie about itself.** The provisioning status flip now confirms the configured default agent actually exists upstream before reporting ready, and `/agent-setup` reports "being set up" or "hit a snag" from the persisted status instead of "this server has no agents yet".

**The seeded agent.** Rewritten from 146 lines to 83: identity, orientation posture, and the credentials rule stay in the prompt; the setup walkthrough and roster-operation mechanics move into a new seeded `workspace-setup` skill. It orients a first-time workspace and proposes next steps rather than waiting to be asked. Model pin bumped to `claude-sonnet-5`.

**A drift gate so this class of bug cannot return silently.** `tests/integration/test_seeded_prompt_tool_claims.py` boots the MCP app, derives a chat-turn-shaped session, and fails if the prompt or skill names a tool that session cannot actually reach. It was verified red against both a fabricated tool name and a real admin-only one before being committed.

## Two bugs found on the way

- **Slack's "Add MCP server" was broken outright.** The submit path never carried the agent's existing tools forward or added the required toolset cross-reference, so spec validation rejected every submission. Found by writing success-path tests, not just refusal tests.
- **Several authorization tests were passing vacuously.** They invoked the tool proxy with the wrong parameter names, so the call never reached the tool — "non-admin is denied" was being proven by a malformed request. Relatedly, assertions that a tool is absent from `tools/list` prove nothing here, because a search transform collapses the catalogue into three meta-tools for every session; visibility is now asserted through the search tool instead.

## Not included

Adapter log durability (shipping container logs to the cloud logging sink, plus the missing writer grant) is prepared but not in this PR — it needs a live staging apply and an operator-pasted query result to verify, and nothing else depends on it.

## Verification

Full suite green: 3716 passed, 4 skipped. `pyright` strict 0 errors, `ruff` clean, all six import-linter contracts kept, repo lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
