### PR TITLE
fix(slack): refuse panel edits to the built-in agent, admins included

### DIFF
--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
@@ -14,6 +14,19 @@ must not route through this helper at all.
 or in ``private_metadata``) and re-reads reachability fresh from the DB on
 every call -- no caching, matching the panel's existing re-resolve
 discipline for admin status.
+
+It refuses in two cases, checked in this order:
+
+1. The target is a defaults-managed agent -- refused unconditionally, for
+   admins too. Editing one from a panel never stamps the reconciler's spec
+   hash, so the edit would survive every later reconcile and drift the agent
+   from the shipped defaults with no way back. Forking is the editable path.
+2. The caller is not a workspace admin and the target is currently
+   reachable (a channel or workspace default). An unreachable agent has no
+   live gate to defend, so any member may configure it.
+
+Both checks live here rather than at the call sites so a newly-wired
+mutating action inherits them by routing through this one helper.
 """
 
 from __future__ import annotations
@@ -22,10 +35,17 @@ import uuid
 
 from daimon.adapters.slack.admin import resolve_is_admin
 from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
+from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
 from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
 from slack_sdk.web.async_client import AsyncWebClient
 
 __all__ = ["refuse_if_reachable_and_not_admin"]
+
+_SEEDED_AGENT_MESSAGE = (
+    ":lock: This is the workspace's built-in agent, so its setup cannot be changed "
+    "from here — not even by an admin. Fork it to get an editable copy you own."
+)
 
 
 async def refuse_if_reachable_and_not_admin(
@@ -38,17 +58,17 @@ async def refuse_if_reachable_and_not_admin(
     user_id: str,
     dev_allow_all: bool = False,
 ) -> bool:
-    """Refuse a spec-touching action against a currently-reachable agent.
+    """Refuse a spec-touching action against a built-in or reachable agent.
 
     Returns ``True`` when the caller must return early (refused); ``False``
     when the caller should proceed.
 
-    An admin caller is never refused and never pays for a DB read --
-    ``resolve_is_admin`` is checked first and this function returns
-    immediately on ``True``. A non-admin caller is refused only when the
-    target agent is currently reachable (scoped as a channel or workspace
-    default); an unreachable agent has no live gate to defend, so any
-    member may still configure it.
+    A defaults-managed agent is refused first and unconditionally, admins
+    included, so that check precedes the admin short-circuit. Otherwise an
+    admin caller is never refused and never pays for a DB read. A non-admin
+    caller is refused only when the target agent is currently reachable
+    (scoped as a channel or workspace default); an unreachable agent has no
+    live gate to defend, so any member may still configure it.
 
     Args:
         runtime:       Injected ``SlackRuntime`` (sessionmaker, deployment
@@ -67,6 +87,22 @@ async def refuse_if_reachable_and_not_admin(
         ``True`` if the caller must refuse and return early, ``False`` to
         proceed.
     """
+    # Defaults-managed agents are off-limits to everyone, admins included, and
+    # this check therefore runs BEFORE the admin short-circuit. A panel edit
+    # never stamps the reconciler's spec hash, so an edited seeded agent would
+    # be skipped by the hash short-circuit on every subsequent reconcile and
+    # drift from the shipped defaults permanently. Forking is the editable path.
+    # Read fresh from the roster rather than from anything the rendered view or
+    # private_metadata carried, matching this module's re-resolve discipline.
+    seeded = await find_agent_by_daimon_tag(runtime.anthropic, tenant_id=tenant_id, name=agent_name)
+    if seeded is not None and seeded.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
+        await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+            channel=channel_id or user_id,
+            user=user_id,
+            text=_SEEDED_AGENT_MESSAGE,
+        )
+        return True
+
     is_admin = await resolve_is_admin(web_client, user_id=user_id, dev_allow_all=dev_allow_all)
     if is_admin:
         return False

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_gate.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_gate.py
@@ -1,9 +1,11 @@
 """Tests for daimon.adapters.slack.agent_setup.gate.
 
-Covers refuse_if_reachable_and_not_admin's three behaviors:
+Covers refuse_if_reachable_and_not_admin's four behaviors:
   - admin caller -> proceed, no DB session opened
   - non-admin + unreachable agent -> proceed, no ephemeral posted
   - non-admin + reachable agent -> refused, exactly one ephemeral posted
+  - any caller, including an admin, against a defaults-managed agent ->
+    refused, pointing at forking as the editable path
 
 All cases use a real Postgres schema (db_session_factory) + the
 transport-level FakeSlackWebClient from conftest (no AsyncMock on
@@ -15,6 +17,7 @@ from __future__ import annotations
 
 import re
 import uuid
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -22,8 +25,14 @@ import httpx
 import pytest
 import yarl
 from aioresponses import aioresponses as AioResponsesMock
+from anthropic.types.beta import BetaManagedAgentsAgent
 from daimon.adapters.slack.agent_setup.gate import refuse_if_reachable_and_not_admin
 from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.defaults.metadata import (
+    MA_METADATA_KEY_MANAGED,
+    MA_METADATA_KEY_NAME,
+    MA_METADATA_KEY_TENANT,
+)
 from daimon.testing.factories import make_tenant, make_tenant_config
 from daimon.testing.ma import build_fake_anthropic, make_fake_ma_handler
 from slack_sdk.web.async_client import AsyncWebClient
@@ -216,3 +225,93 @@ async def test_refuse_if_reachable_and_not_admin_when_non_admin_and_reachable_re
         assert "workspace-admin" in body.get("text", ""), (
             "ephemeral should name why the action was refused"
         )
+
+
+def _seeded_agent_handler(
+    *, tenant_id: uuid.UUID, agent_name: str
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Serve a single defaults-managed agent from the agent-list endpoint."""
+    payload = BetaManagedAgentsAgent(
+        id="agent_seeded_0000000000",
+        type="agent",
+        name=agent_name,
+        model={"id": "claude-sonnet-5"},  # type: ignore[arg-type]
+        metadata={
+            MA_METADATA_KEY_TENANT: str(tenant_id),
+            MA_METADATA_KEY_NAME: agent_name,
+            MA_METADATA_KEY_MANAGED: "true",
+        },
+        description=None,
+        archived_at=None,
+        created_at="2026-05-01T00:00:00Z",  # type: ignore[arg-type]
+        updated_at="2026-05-01T00:00:00Z",  # type: ignore[arg-type]
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    ).model_dump(mode="json")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/agents":
+            return httpx.Response(200, json={"data": [payload], "has_more": False})
+        return httpx.Response(404, json={"error": {"message": "unexpected route"}})
+
+    return handler
+
+
+async def test_gate_refuses_a_workspace_admin_editing_the_defaults_managed_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A defaults-managed agent is off-limits to everyone, admins included.
+
+    Editing one from the panel never stamps the reconciler's spec hash, so the
+    edit would survive every later reconcile and drift the agent from the
+    shipped defaults permanently. The admin short-circuit must not reach it.
+    """
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await session.commit()
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _build_runtime(db_session_factory)
+        object.__setattr__(
+            runtime,
+            "anthropic",
+            build_fake_anthropic(
+                _seeded_agent_handler(tenant_id=tenant.id, agent_name=_AGENT_NAME)
+            ),
+        )
+
+        refused = await refuse_if_reachable_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is True, (
+            "an admin must still be refused against the workspace's built-in agent"
+        )
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        matches = mock.requests.get(post_key, [])
+        assert len(matches) == 1, f"expected exactly one ephemeral, got {len(matches)}"
+
+        _, kwargs = matches[0]
+        text = (kwargs.get("json") or {}).get("text", "")
+        assert "built-in agent" in text, "ephemeral should say the agent is built in"
+        assert "Fork" in text, "ephemeral should point at forking as the editable path"

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
@@ -846,7 +846,8 @@ async def test_run_edit_agent_submission_when_non_admin_and_reachable_refused(
         extra={"model": None, "system": "Attempted change."},
     )
 
-    assert calls == [], "a refused edit must never reach the MA"
+    writes = [c for c in calls if c[0] != "GET"]
+    assert writes == [], "a refused edit must never write to the MA"
 
     texts = _ephemeral_texts(client_fake)
     assert len(texts) == 1, "exactly one ephemeral should be posted on refusal"
@@ -1023,7 +1024,8 @@ async def test_run_add_mcp_submission_when_non_admin_and_reachable_refused(
         },
     )
 
-    assert calls == [], "a refused add-mcp must never reach the MA"
+    writes = [c for c in calls if c[0] != "GET"]
+    assert writes == [], "a refused add-mcp must never write to the MA"
 
     texts = _ephemeral_texts(client_fake)
     assert len(texts) == 1, "exactly one ephemeral should be posted on refusal"


### PR DESCRIPTION
A Slack workspace admin could overwrite the built-in agent's system prompt through the `/agent-setup` edit modal. This closes that path.

## Why it matters

The built-in agent is meant to be un-editable from chat or panel by *anyone*, admins included. That is not a permissions preference — it is a data-integrity constraint. A panel edit never stamps the reconciler's spec hash, so an edited built-in agent is skipped by the hash short-circuit on every subsequent reconcile and drifts from the shipped defaults permanently, with no path back short of manual intervention. The reconciler's own comments name this failure mode as the reason the guard exists.

Two of the three surfaces already enforced it:

- **MCP** — `_reject_system_agent`, unconditional, and correctly reused by the chat-side removal tools.
- **Discord** — the `is_system` branch in the panel's click-time authorization helper, which deliberately runs *before* the admin check.
- **Slack** — nothing. `RosterEntry` carried no provenance field at all, and the shared refusal helper only asked "is the caller an admin, or is the agent unreachable?". A workspace admin sailed straight through both.

Reproduced before fixing: an admin's edit submission against an agent stamped as defaults-managed overwrote its system prompt and returned a success ephemeral. No refusal.

## The fix

The check goes **inside** the shared refusal helper rather than at the call sites, so all eight mutating entry points inherit it and a ninth added later cannot forget it. It runs **before** the admin short-circuit, mirroring the ordering Discord already uses.

The agent's provenance is read fresh from the roster on each call rather than taken from the rendered view or `private_metadata` — the same re-resolve discipline this helper already applies to admin status and reachability, and the reason a stale open modal cannot be used to bypass it.

Forking remains the editable path, and the refusal message says so.

## Verification

The regression test was confirmed to **fail** with the guard removed and pass with it restored — it exercises the real refusal, not a tautology.

Full Slack suite: 402 passed. `pyright` strict 0 errors, `ruff` clean, import contracts kept, repo lints clean.

## Two incidental corrections

- Two existing tests asserted `calls == []` for a refused edit — "must never reach the MA". The guard adds one authorization *read*, so those assertions are narrowed to writes. Their intent, that no mutation occurs, is unchanged and still enforced.
- The helper's docstring claimed the admin check runs first. That is no longer true, and a stale ordering claim inside an authorization function is precisely the kind of drift worth not shipping. Corrected alongside the change it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
