### PR TITLE
Discord wizard: structured mid-turn forms with typed answers

### DIFF
--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -88,6 +88,15 @@ system: |
   added via either tool, the credential becomes usable by everyone who
   talks to this agent — say so when you post the button.
 
+  When a question has a small set of answers, or several linked questions
+  need answering, post a form with `post_wizard(prompt, steps, channel_id)`
+  instead of asking one at a time in prose — steps can be single-choice,
+  multi-select, or free-text, and one step may carry a single finished image.
+  After calling `post_wizard`, END THE TURN IMMEDIATELY: do not narrate the
+  form, do not continue the conversation, and do not call another tool. The
+  user's answers come back later as a brand-new message carrying a keyed
+  block — that is when you resume, with the full history of having asked.
+
   You can also perform agent roster operations on your tenant via MCP:
 
   - `fork_agent(source_name, new_name)` clones an existing agent.

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -248,6 +248,14 @@ class DaimonBot(commands.Bot):
 
         self.add_dynamic_items(CredentialRequestButton)
 
+        # Same rationale as CredentialRequestButton above: the wizard's
+        # first screen is posted by the MCP process, and every tap on it
+        # lands here. wizard.py imports DaimonBot at module level -- local
+        # import avoids the same cycle credential_button.py would hit.
+        from daimon.adapters.discord.wizard import WizardNavButton, WizardSelect
+
+        self.add_dynamic_items(WizardNavButton, WizardSelect)
+
     async def _post_to_guild(self, guild: discord.Guild, embed: discord.Embed) -> None:
         """Post an embed via the fallback chain: text channel → DM owner → skip."""
         channel = _pick_post_channel(guild)

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -256,6 +256,14 @@ class DaimonBot(commands.Bot):
 
         self.add_dynamic_items(WizardNavButton, WizardSelect)
 
+        # The Submit button gets its own dispatch class (claiming the
+        # submission and starting a billed turn) rather than sharing
+        # WizardNavButton/WizardSelect's registration -- see
+        # wizard_submit.py's module docstring. Same local-import rationale.
+        from daimon.adapters.discord.wizard_submit import WizardSubmitButton
+
+        self.add_dynamic_items(WizardSubmitButton)
+
     async def _post_to_guild(self, guild: discord.Guild, embed: discord.Embed) -> None:
         """Post an embed via the fallback chain: text channel → DM owner → skip."""
         channel = _pick_post_channel(guild)

--- a/packages/adapters/discord/daimon/adapters/discord/views.py
+++ b/packages/adapters/discord/daimon/adapters/discord/views.py
@@ -6,14 +6,17 @@ CancelView for interrupting running turns (no timeout -- lifecycle manages remov
 All Views are non-persistent (VIEW-04): no custom_id, no bot.add_view(). CancelView uses
 timeout=None -- lifecycle manages removal.
 
-The one documented exception: the chat-initiated credential-request button
-(`daimon.adapters.discord.credential_button.CredentialRequestButton`) IS
-persistent -- it carries a custom_id and is registered as a
-`discord.ui.DynamicItem` class in `setup_hook`. This is necessary because the
-process that posts that button (the MCP server) is not the process that
-dispatches its click (this bot) -- there is no live in-memory View instance
-to attach a non-persistent handler to. Every other interactive component in
-this adapter stays non-persistent.
+The documented exceptions: the chat-initiated credential-request button
+(`daimon.adapters.discord.credential_button.CredentialRequestButton`) and the
+wizard's navigation button and multi-select
+(`daimon.adapters.discord.wizard.WizardNavButton`,
+`daimon.adapters.discord.wizard.WizardSelect`) ARE persistent -- each carries
+a custom_id and is registered as a `discord.ui.DynamicItem` class in
+`setup_hook`. This is necessary because the process that posts the message
+(the MCP server, for both the credential button and the wizard's first
+screen) is not the process that dispatches its click (this bot) -- there is
+no live in-memory View instance to attach a non-persistent handler to. Every
+other interactive component in this adapter stays non-persistent.
 """
 
 from __future__ import annotations

--- a/packages/adapters/discord/daimon/adapters/discord/wizard.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard.py
@@ -141,6 +141,12 @@ async def _apply_and_render(
     predicated UPDATE and is not bounded by the 3s ack budget. Raises
     `ValueError` when `build_action`/`apply` reject the action (e.g. empty
     typed text) -- callers that can produce that case catch it narrowly.
+
+    `row` is both the state the transition is computed from and the
+    optimistic-concurrency token the write is predicated on (`row.updated_at`),
+    so a second tap that lands between this one's read and write loses
+    instead of silently erasing the first's answer. Callers must therefore
+    pass a freshly read row, never a snapshot held across a user-paced wait.
     """
     spec = WizardSpec.model_validate(row.spec)
     state = WizardState(
@@ -158,12 +164,13 @@ async def _apply_and_render(
             short_id=row.id,
             answers=new_state.answers,
             current_step=new_state.current_step,
+            expected_updated_at=row.updated_at,
             now=now,
         )
     if rowcount == 0:
-        # The row changed under this tap (expired, erased, or submitted
-        # elsewhere) -- leave the message alone rather than re-rendering a
-        # screen that no longer matches the row's real status.
+        # The row changed under this tap (expired, erased, submitted, or
+        # written by a tap that landed first) -- leave the message alone
+        # rather than re-rendering a screen that no longer matches the row.
         await interaction.followup.send(_STALE, ephemeral=True)
         return
     await interaction.edit_original_response(view=build_wizard_view(to_screen(spec, new_state)))
@@ -388,6 +395,12 @@ class WizardCustomTextModal(discord.ui.Modal):
     `CredentialRequestButton.callback`. Its own `on_submit` runs the same
     rebuild / `build_action` / `apply` / `update_wizard_state` /
     `edit_original_response` sequence as the dynamic items above.
+
+    The row captured at modal-open time is kept only for its short id: the
+    window between opening this modal and submitting it is user-paced and
+    unbounded, so `on_submit` re-reads the row rather than writing from a
+    snapshot that every select and nav tap made in the meantime has already
+    invalidated.
     """
 
     def __init__(
@@ -410,11 +423,15 @@ class WizardCustomTextModal(discord.ui.Modal):
             # For a component-originated modal submit, the deferred update
             # and `edit_original_response` target the wizard message itself.
             await interaction.response.defer()
+            row = await _load_row(self._bot, self._row.id)
+            if row is None:
+                await interaction.followup.send(_NOT_AVAILABLE, ephemeral=True)
+                return
             text = str(self.answer_input.value or "")
             action = f"s{self._step_index}_custom"
             try:
                 await _apply_and_render(
-                    interaction, bot=self._bot, row=self._row, action=action, values=[], text=text
+                    interaction, bot=self._bot, row=row, action=action, values=[], text=text
                 )
             except ValueError:
                 # The pure transition already refuses empty/whitespace text

--- a/packages/adapters/discord/daimon/adapters/discord/wizard.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard.py
@@ -1,0 +1,425 @@
+"""Persistent dispatch for wizard navigation, options, multi-select taps, and
+typed answers -- `WizardNavButton`, `WizardSelect`, `WizardCustomTextModal`.
+
+The process that posts a wizard's first screen (the MCP server) is never the
+process that dispatches a tap on it (this bot) -- there is no live in-memory
+`View` instance in this process to attach an ordinary non-persistent handler
+to. `discord.ui.DynamicItem` is the primitive that matches a template regex
+against an arbitrary future `custom_id` and reconstructs per-tap state via
+`from_custom_id`, so `WizardNavButton` and `WizardSelect` are two more
+entries in this adapter's short list of persistent dynamic items (see
+`views.py`'s module docstring for the first, `CredentialRequestButton`).
+`WizardCustomTextModal` is not itself a dynamic item -- it is opened
+directly, mid-callback, exactly like `EnvCredentialModal`/`McpCredentialModal`
+are opened from `CredentialRequestButton.callback`.
+
+Authorization is requester-only, with no admin gate: `interaction_check`
+compares `str(interaction.user.id)` against the row's stored
+`requester_platform_user_id` and fails closed on any lookup miss, an
+already-submitted row, or an abandoned/expired row. That comparison is the
+ONLY authorization on this write path -- mirroring `CredentialRequestButton`,
+the one existing precedent.
+
+`from_custom_id`, `interaction_check`, and `callback` (on both dynamic-item
+classes) each catch broadly and log via structlog, because discord.py's own
+dispatcher swallows any exception raised inside those three methods --
+verified against the installed `discord/ui/view.py`. Propagating would mean
+the exception vanishes into a dispatcher we don't control and the user is
+left with a permanently stuck interaction and nothing in our own logs. That
+is a deliberate, documented suspension of the ordinary let-failures-
+propagate rule at exactly this boundary, not a general license to swallow
+exceptions elsewhere in this module.
+
+The Submit button is deliberately NOT dispatched here. It gets its own
+dispatch class in a later plan, because the path it opens -- claiming the
+submission and starting a billed turn -- needs an isolated entry point
+rather than sharing one with ordinary navigation.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any, Self, cast
+
+import structlog
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.wizard_render import build_wizard_view
+from daimon.core.stores.domain import WizardSessionRow
+from daimon.core.stores.wizard_session import get_wizard_session, update_wizard_state
+from daimon.core.wizard.apply import apply, build_action
+from daimon.core.wizard.render import to_screen
+from daimon.core.wizard.spec import WizardSpec
+from daimon.core.wizard.state import (
+    NAV_CUSTOM_ID_TEMPLATE,
+    SELECT_CUSTOM_ID_TEMPLATE,
+    WizardState,
+    WizardStatus,
+    build_custom_id,
+)
+from sqlalchemy.exc import SQLAlchemyError
+
+import discord
+from discord.ext import commands
+
+_log = structlog.get_logger()
+
+_NOT_AVAILABLE = "This form is no longer available."
+_WRONG_REQUESTER = "This form was for someone else."
+_ALREADY_SUBMITTED = "This form was already submitted."
+_EXPIRED = "This form has expired."
+_STALE = "This form changed before your tap landed."
+_CHECK_FAILED = "Something went wrong checking this form -- please try again."
+_CALLBACK_FAILED = "Something went wrong updating this form -- please try again."
+_EMPTY_TEXT = "Your answer can't be empty -- try again."
+
+_OPENER_ACTION_RE = re.compile(r"^s(?P<step>\d{1,2})_(?:enter|custom)$")
+
+
+async def _load_row(bot: DaimonBot, short_id: str) -> WizardSessionRow | None:
+    """One indexed primary-key read through `bot.runtime.sessionmaker()`.
+
+    Runs before the 3s ack budget starts (called from `from_custom_id`).
+    Never raises: discord.py logs and discards any exception raised from
+    `from_custom_id`, so a raised DB error here would leave the user with a
+    permanently stuck interaction and nothing in our own logs.
+    """
+    try:
+        async with bot.runtime.sessionmaker() as session:
+            return await get_wizard_session(session, short_id=short_id)
+    except SQLAlchemyError:
+        _log.exception("wizard.lookup_failed", short_id=short_id)
+        return None
+
+
+async def _authorize_tap(row: WizardSessionRow | None, interaction: discord.Interaction) -> bool:
+    """Shared requester/lifecycle gate for `WizardNavButton` and `WizardSelect`.
+
+    Sends the matching ephemeral rejection and returns False for: a missing
+    row, a non-requester tap, an already-submitted row, or an abandoned or
+    past-expiry row. This replaces what would otherwise be a silent no-op on
+    a stale form. Returns True only for the requester tapping an open,
+    unexpired row.
+    """
+    if row is None:
+        await interaction.response.send_message(_NOT_AVAILABLE, ephemeral=True)
+        return False
+    if str(interaction.user.id) != row.requester_platform_user_id:
+        await interaction.response.send_message(_WRONG_REQUESTER, ephemeral=True)
+        return False
+    if row.status == WizardStatus.SUBMITTED:
+        await interaction.response.send_message(_ALREADY_SUBMITTED, ephemeral=True)
+        return False
+    if row.status == WizardStatus.ABANDONED or row.expires_at < datetime.now(UTC):
+        await interaction.response.send_message(_EXPIRED, ephemeral=True)
+        return False
+    return True
+
+
+async def _reply_or_followup(interaction: discord.Interaction, message: str) -> None:
+    """Send `message` ephemerally, via the response if it is still open or
+    via the followup once it has already been used (deferred or replied)."""
+    if interaction.response.is_done():
+        await interaction.followup.send(message, ephemeral=True)
+    else:
+        await interaction.response.send_message(message, ephemeral=True)
+
+
+async def _apply_and_render(
+    interaction: discord.Interaction,
+    *,
+    bot: DaimonBot,
+    row: WizardSessionRow,
+    action: str,
+    values: list[str],
+    text: str | None,
+) -> None:
+    """Rebuild state, run the pure transition, persist, and re-render.
+
+    Must run AFTER the interaction has already been acknowledged (a deferred
+    component tap, or a modal's already-deferred `on_submit`) -- this does a
+    predicated UPDATE and is not bounded by the 3s ack budget. Raises
+    `ValueError` when `build_action`/`apply` reject the action (e.g. empty
+    typed text) -- callers that can produce that case catch it narrowly.
+    """
+    spec = WizardSpec.model_validate(row.spec)
+    state = WizardState(
+        short_id=row.id,
+        current_step=row.current_step,
+        answers=row.answers,
+        status=WizardStatus(row.status),
+    )
+    action_obj = build_action(action, spec=spec, values=values, text=text)
+    new_state = apply(state, spec, action_obj)
+    now = datetime.now(UTC)
+    async with bot.runtime.sessionmaker() as session, session.begin():
+        rowcount = await update_wizard_state(
+            session,
+            short_id=row.id,
+            answers=new_state.answers,
+            current_step=new_state.current_step,
+            now=now,
+        )
+    if rowcount == 0:
+        # The row changed under this tap (expired, erased, or submitted
+        # elsewhere) -- leave the message alone rather than re-rendering a
+        # screen that no longer matches the row's real status.
+        await interaction.followup.send(_STALE, ephemeral=True)
+        return
+    await interaction.edit_original_response(view=build_wizard_view(to_screen(spec, new_state)))
+
+
+class WizardNavButton(
+    discord.ui.DynamicItem[discord.ui.Button[discord.ui.LayoutView]],
+    template=NAV_CUSTOM_ID_TEMPLATE,
+):
+    """Dispatches Back/Next/choice-option/opener taps. Registered ONCE as a
+    class (not per-button) via `client.add_dynamic_items` in `bot.py`'s
+    `setup_hook`. See the module docstring for the authorization model and
+    why `from_custom_id`/`interaction_check`/`callback` catch their own
+    exceptions."""
+
+    def __init__(
+        self,
+        *,
+        short_id: str,
+        action: str,
+        label: str,
+        style: discord.ButtonStyle,
+        wizard_row: WizardSessionRow | None,
+        row: int | None = None,
+    ) -> None:
+        button: discord.ui.Button[discord.ui.LayoutView] = discord.ui.Button(
+            style=style,
+            label=label,
+            custom_id=build_custom_id(short_id, action),
+            row=row,
+        )
+        super().__init__(button, row=row)
+        self.short_id = short_id
+        self.action = action
+        self.wizard_row = wizard_row
+
+    @classmethod
+    async def from_custom_id(  # type: ignore[override]  # discord.py's ClientT is a free TypeVar; this adapter only ever runs DaimonBot
+        cls,
+        interaction: discord.Interaction[commands.Bot],
+        item: discord.ui.Item[Any],
+        match: re.Match[str],
+        /,
+    ) -> Self:
+        short_id = match["short_id"]
+        action = match["action"]
+        bot = cast(DaimonBot, interaction.client)
+        wizard_row = await _load_row(bot, short_id)
+        label = item.label if isinstance(item, discord.ui.Button) and item.label else action
+        style = item.style if isinstance(item, discord.ui.Button) else discord.ButtonStyle.secondary
+        return cls(
+            short_id=short_id, action=action, label=label, style=style, wizard_row=wizard_row
+        )
+
+    async def interaction_check(  # type: ignore[override]  # see from_custom_id
+        self, interaction: discord.Interaction[commands.Bot], /
+    ) -> bool:
+        try:
+            return await _authorize_tap(self.wizard_row, interaction)
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("wizard.nav_interaction_check_failed", err_type=type(err).__name__)
+            await interaction.response.send_message(_CHECK_FAILED, ephemeral=True)
+            return False
+
+    async def callback(  # type: ignore[override]  # see from_custom_id
+        self, interaction: discord.Interaction[commands.Bot]
+    ) -> None:
+        try:
+            row = self.wizard_row
+            if row is None:
+                return
+            bot = cast(DaimonBot, interaction.client)
+
+            opener_match = _OPENER_ACTION_RE.match(self.action)
+            if opener_match is not None:
+                # A modal cannot follow a defer -- it must be the FIRST
+                # response to this interaction.
+                step_index = int(opener_match["step"])
+                step = WizardSpec.model_validate(row.spec).steps[step_index]
+                await interaction.response.send_modal(
+                    WizardCustomTextModal(
+                        bot=bot, row=row, step_index=step_index, question=step.question
+                    )
+                )
+                return
+
+            # This handler needs an indexed read, a pure transition, and an
+            # indexed write before it could otherwise answer -- more work
+            # inside the 3s ack budget than any other handler in this
+            # adapter does, so the deferral is unconditionally the first
+            # statement on every non-opener path.
+            await interaction.response.defer()
+            await _apply_and_render(
+                interaction, bot=bot, row=row, action=self.action, values=[], text=None
+            )
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("wizard.nav_callback_failed", err_type=type(err).__name__)
+            await _reply_or_followup(interaction, _CALLBACK_FAILED)
+
+
+class WizardSelect(
+    discord.ui.DynamicItem[discord.ui.Select[discord.ui.LayoutView]],
+    template=SELECT_CUSTOM_ID_TEMPLATE,
+):
+    """Dispatches a multi-select change. See `WizardNavButton`'s docstring
+    for the shared authorization and exception-boundary rationale."""
+
+    def __init__(
+        self,
+        *,
+        short_id: str,
+        action: str,
+        placeholder: str,
+        min_values: int,
+        max_values: int,
+        options: list[discord.SelectOption],
+        wizard_row: WizardSessionRow | None,
+        row: int | None = None,
+    ) -> None:
+        select: discord.ui.Select[discord.ui.LayoutView] = discord.ui.Select(
+            custom_id=build_custom_id(short_id, action),
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            options=options or [discord.SelectOption(label="unavailable", value="_")],
+            row=row,
+        )
+        super().__init__(select, row=row)
+        self.short_id = short_id
+        self.action = action
+        self.wizard_row = wizard_row
+
+    @classmethod
+    async def from_custom_id(  # type: ignore[override]  # see WizardNavButton.from_custom_id
+        cls,
+        interaction: discord.Interaction[commands.Bot],
+        item: discord.ui.Item[Any],
+        match: re.Match[str],
+        /,
+    ) -> Self:
+        short_id = match["short_id"]
+        action = match["action"]
+        bot = cast(DaimonBot, interaction.client)
+        wizard_row = await _load_row(bot, short_id)
+
+        # Rebuilt from the row's spec/answers, not from the raw component on
+        # the message, so the reconstructed widget's options and defaults
+        # always reflect the state a tap will actually be evaluated against.
+        placeholder = ""
+        min_values, max_values = 0, 1
+        options: list[discord.SelectOption] = []
+        if wizard_row is not None:
+            spec = WizardSpec.model_validate(wizard_row.spec)
+            state = WizardState(
+                short_id=short_id,
+                current_step=wizard_row.current_step,
+                answers=wizard_row.answers,
+                status=WizardStatus(wizard_row.status),
+            )
+            screen_select = to_screen(spec, state).select
+            if screen_select is not None:
+                placeholder = screen_select.placeholder
+                min_values = screen_select.min_values
+                max_values = screen_select.max_values
+                options = [
+                    discord.SelectOption(
+                        label=option.label,
+                        value=option.value,
+                        description=option.description,
+                        default=option.default,
+                    )
+                    for option in screen_select.options
+                ]
+        return cls(
+            short_id=short_id,
+            action=action,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            options=options,
+            wizard_row=wizard_row,
+        )
+
+    async def interaction_check(  # type: ignore[override]  # see WizardNavButton.interaction_check
+        self, interaction: discord.Interaction[commands.Bot], /
+    ) -> bool:
+        try:
+            return await _authorize_tap(self.wizard_row, interaction)
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("wizard.select_interaction_check_failed", err_type=type(err).__name__)
+            await interaction.response.send_message(_CHECK_FAILED, ephemeral=True)
+            return False
+
+    async def callback(  # type: ignore[override]  # see WizardNavButton.callback
+        self, interaction: discord.Interaction[commands.Bot]
+    ) -> None:
+        try:
+            row = self.wizard_row
+            if row is None:
+                return
+            bot = cast(DaimonBot, interaction.client)
+            await interaction.response.defer()
+            await _apply_and_render(
+                interaction,
+                bot=bot,
+                row=row,
+                action=self.action,
+                values=list(self.item.values),
+                text=None,
+            )
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("wizard.select_callback_failed", err_type=type(err).__name__)
+            await _reply_or_followup(interaction, _CALLBACK_FAILED)
+
+
+class WizardCustomTextModal(discord.ui.Modal):
+    """The 'type your own' opener's text form.
+
+    Not itself a dynamic item -- opened directly from `WizardNavButton.callback`
+    for the interaction that triggered it, exactly like
+    `EnvCredentialModal`/`McpCredentialModal` are opened from
+    `CredentialRequestButton.callback`. Its own `on_submit` runs the same
+    rebuild / `build_action` / `apply` / `update_wizard_state` /
+    `edit_original_response` sequence as the dynamic items above.
+    """
+
+    def __init__(
+        self, *, bot: DaimonBot, row: WizardSessionRow, step_index: int, question: str
+    ) -> None:
+        super().__init__(title=question[:45])
+        self._bot = bot
+        self._row = row
+        self._step_index = step_index
+        self.answer_input: discord.ui.TextInput[WizardCustomTextModal] = discord.ui.TextInput(
+            label="Your answer",
+            style=discord.TextStyle.short,
+            required=True,
+            max_length=200,
+        )
+        self.add_item(self.answer_input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        try:
+            # For a component-originated modal submit, the deferred update
+            # and `edit_original_response` target the wizard message itself.
+            await interaction.response.defer()
+            text = str(self.answer_input.value or "")
+            action = f"s{self._step_index}_custom"
+            try:
+                await _apply_and_render(
+                    interaction, bot=self._bot, row=self._row, action=action, values=[], text=text
+                )
+            except ValueError:
+                # The pure transition already refuses empty/whitespace text
+                # -- surface that as an ephemeral notice, not a state change.
+                await interaction.followup.send(_EMPTY_TEXT, ephemeral=True)
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("wizard.modal_submit_failed", err_type=type(err).__name__)
+            await _reply_or_followup(interaction, _CALLBACK_FAILED)

--- a/packages/adapters/discord/daimon/adapters/discord/wizard.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard.py
@@ -173,7 +173,12 @@ async def _apply_and_render(
         # rather than re-rendering a screen that no longer matches the row.
         await interaction.followup.send(_STALE, ephemeral=True)
         return
-    await interaction.edit_original_response(view=build_wizard_view(to_screen(spec, new_state)))
+    # A re-render carries the agent-authored prompt and question verbatim in
+    # its head text; nothing in a form legitimately needs to mention anyone.
+    await interaction.edit_original_response(
+        view=build_wizard_view(to_screen(spec, new_state)),
+        allowed_mentions=discord.AllowedMentions.none(),
+    )
 
 
 class WizardNavButton(

--- a/packages/adapters/discord/daimon/adapters/discord/wizard.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard.py
@@ -18,7 +18,10 @@ compares `str(interaction.user.id)` against the row's stored
 `requester_platform_user_id` and fails closed on any lookup miss, an
 already-submitted row, or an abandoned/expired row. That comparison is the
 ONLY authorization on this write path -- mirroring `CredentialRequestButton`,
-the one existing precedent.
+the one existing precedent. It is joined by one binding check: the tap must
+come from the message the row was posted as, so a stateless custom_id cannot
+be replayed against a component on some other message, in some other channel
+or guild.
 
 `from_custom_id`, `interaction_check`, and `callback` (on both dynamic-item
 classes) each catch broadly and log via structlog, because discord.py's own
@@ -96,12 +99,28 @@ async def _authorize_tap(row: WizardSessionRow | None, interaction: discord.Inte
     """Shared requester/lifecycle gate for `WizardNavButton` and `WizardSelect`.
 
     Sends the matching ephemeral rejection and returns False for: a missing
-    row, a non-requester tap, an already-submitted row, or an abandoned or
-    past-expiry row. This replaces what would otherwise be a silent no-op on
-    a stale form. Returns True only for the requester tapping an open,
-    unexpired row.
+    row, a tap that did not come from the row's own message, a non-requester
+    tap, an already-submitted row, or an abandoned or past-expiry row. This
+    replaces what would otherwise be a silent no-op on a stale form. Returns
+    True only for the requester tapping an open, unexpired row on the message
+    the form was posted as.
     """
     if row is None:
+        await interaction.response.send_message(_NOT_AVAILABLE, ephemeral=True)
+        return False
+    message = interaction.message
+    if message is not None and str(message.id) != row.message_id:
+        # A custom_id carries no state, so nothing else stops the requester
+        # replaying their own form's id against a component on some other
+        # message -- in another channel or another guild -- which would run
+        # and bill the turn somewhere the form never was. The row records the
+        # message it was posted as; fail closed when they disagree.
+        _log.warning(
+            "wizard.message_mismatch",
+            short_id=row.id,
+            expected_message_id=row.message_id,
+            actual_message_id=str(message.id),
+        )
         await interaction.response.send_message(_NOT_AVAILABLE, ephemeral=True)
         return False
     if str(interaction.user.id) != row.requester_platform_user_id:

--- a/packages/adapters/discord/daimon/adapters/discord/wizard_render.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard_render.py
@@ -1,0 +1,109 @@
+"""Screen-to-`discord.ui` renderer for the bot process.
+
+This is the SECOND copy of the Screen-to-`LayoutView` translation --
+`daimon.adapters.mcp.tools.discord._wizard`'s `build_wizard_view` is the
+first, run by the process that posts a wizard's first screen. The two
+processes cannot import each other (import-linter's independence contract),
+and the layer they share -- `daimon.core.wizard.render` -- deliberately
+carries no Discord SDK type, so each side owns a thin, from-scratch
+translation of the platform-neutral `Screen` into its own component tree.
+A change to component order, style mapping, or spacing in one renderer
+without the matching change in the other would silently desync what a user
+sees after a tap from what they saw on the original post -- a later test
+(`test_wizard_render.py`) asserts the two renderers agree component-for-
+component on the same `Screen`, so any change here must be mirrored there.
+
+The one deliberate divergence: this process cannot attach files -- there is
+no local `discord.File` handle to re-upload on a re-render, since the bot
+process never touched the MCP process's file store. A `Screen.image` is
+therefore resolved from `screen.image.url` only (the persisted
+content-delivery address `_post_wizard_impl` captured on first post); when
+only a `handle` is present and no `url`, the image is simply omitted rather
+than raising -- that combination should not occur for a step already posted
+(the posting side always resolves and stores a url for every image it
+uploads), but a re-render must degrade gracefully rather than crash a tap.
+
+Component order is a contract: head text, a small separator, an optional
+media gallery, optional body text, an optional select row, then (after a
+large invisible separator gap) one action row per button row.
+"""
+
+from __future__ import annotations
+
+from daimon.core.wizard.render import Screen, ScreenButton
+from daimon.core.wizard.state import build_custom_id
+
+import discord
+
+_ACCENT_COLOURS: dict[str, int] = {
+    "blurple": 0x5865F2,
+    "green": 0x57F287,
+}
+
+_BUTTON_STYLES: dict[str, discord.ButtonStyle] = {
+    "primary": discord.ButtonStyle.primary,
+    "secondary": discord.ButtonStyle.secondary,
+    "success": discord.ButtonStyle.success,
+}
+
+
+def _build_button(short_id: str, button: ScreenButton) -> discord.ui.Button[discord.ui.LayoutView]:
+    return discord.ui.Button(
+        style=_BUTTON_STYLES[button.style],
+        label=button.label,
+        custom_id=build_custom_id(short_id, button.action),
+        disabled=button.disabled,
+    )
+
+
+def build_wizard_view(screen: Screen) -> discord.ui.LayoutView:
+    """Translate a `Screen` into a real `LayoutView`, matching the posting
+    process's component order exactly. See the module docstring for the one
+    deliberate divergence (image resolution from `url` only, no `files`)."""
+    container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container(
+        accent_colour=_ACCENT_COLOURS[screen.accent]
+    )
+    container.add_item(discord.ui.TextDisplay(screen.head_text))
+    container.add_item(discord.ui.Separator(visible=True, spacing=discord.SeparatorSpacing.small))
+
+    if screen.image is not None and screen.image.url is not None:
+        gallery: discord.ui.MediaGallery[discord.ui.LayoutView] = discord.ui.MediaGallery()
+        gallery.add_item(media=screen.image.url)
+        container.add_item(gallery)
+
+    if screen.body_text is not None:
+        container.add_item(discord.ui.TextDisplay(screen.body_text))
+
+    if screen.select is not None:
+        select: discord.ui.Select[discord.ui.LayoutView] = discord.ui.Select(
+            custom_id=build_custom_id(screen.short_id, screen.select.action),
+            placeholder=screen.select.placeholder,
+            min_values=screen.select.min_values,
+            max_values=screen.select.max_values,
+            options=[
+                discord.SelectOption(
+                    label=option.label,
+                    value=option.value,
+                    description=option.description,
+                    default=option.default,
+                )
+                for option in screen.select.options
+            ],
+        )
+        select_row: discord.ui.ActionRow[discord.ui.LayoutView] = discord.ui.ActionRow()
+        select_row.add_item(select)
+        container.add_item(select_row)
+
+    if screen.button_rows:
+        container.add_item(
+            discord.ui.Separator(visible=False, spacing=discord.SeparatorSpacing.large)
+        )
+        for row in screen.button_rows:
+            action_row: discord.ui.ActionRow[discord.ui.LayoutView] = discord.ui.ActionRow()
+            for button in row:
+                action_row.add_item(_build_button(screen.short_id, button))
+            container.add_item(action_row)
+
+    view = discord.ui.LayoutView(timeout=None)
+    view.add_item(container)
+    return view

--- a/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
@@ -20,10 +20,15 @@ Three things are load-bearing about `callback`'s shape:
    "submitted". `DaimonBot._spawn` gives the turn its own tracked
    background task with its own failure logging instead.
 
-2. **The claim is one predicated UPDATE statement, not a read-then-write.**
-   `try_claim_submit`'s own row lock is what makes two concurrent Submit
-   taps produce exactly one winner -- the loser's WHERE clause simply
-   matches zero rows. No advisory lock, no read-your-own-write race window.
+2. **The claim is one predicated UPDATE statement, not a read-then-write,
+   and the spawn follows it immediately.** `try_claim_submit`'s own row lock
+   is what makes two concurrent Submit taps produce exactly one winner --
+   the loser's WHERE clause simply matches zero rows. No advisory lock, no
+   read-your-own-write race window. The claim is also irreversible, which is
+   why nothing that can fail is allowed between it and the spawn: the
+   collapse re-render runs AFTER the hand-off and swallows its own
+   `HTTPException`, so a transient Discord failure on a cosmetic edit can
+   never consume a submission without running the turn it claimed.
 
 3. **The collapsed screen carries no interactive components.** Once a row's
    status flips to submitted, `to_screen` returns the collapsed screen
@@ -186,24 +191,31 @@ class WizardSubmitButton(
                     now=now,
                 )
 
+            if claimed is not None:
+                # The claim is the point of no return, so the turn it paid
+                # for is handed off IMMEDIATELY after it -- nothing that can
+                # fail may sit between the two. A concurrent tap that lost
+                # the claim spawns nothing: a second turn here would be a
+                # second billed turn.
+                bot._spawn(  # pyright: ignore[reportPrivateUsage]  # DaimonBot's tracked fire-and-forget helper; see module docstring point 1 for why the turn must never be awaited here
+                    run_wizard_submit_turn(
+                        bot=bot, interaction=interaction, row=claimed, spec=spec, state=submitted
+                    )
+                )
+
             # Collapse to the read-only, button-free summary regardless of
             # who won the claim -- see the module docstring, point 2. Both a
             # winning and a losing concurrent tapper must see the SAME
-            # consistent, submitted-looking result.
-            await interaction.edit_original_response(
-                view=build_wizard_view(to_screen(spec, submitted))
-            )
-
-            if claimed is None:
-                # A concurrent tap already claimed this submission -- a
-                # second turn here would be a second billed turn.
-                return
-
-            bot._spawn(  # pyright: ignore[reportPrivateUsage]  # DaimonBot's tracked fire-and-forget helper; see module docstring point 1 for why the turn must never be awaited here
-                run_wizard_submit_turn(
-                    bot=bot, interaction=interaction, row=claimed, spec=spec, state=submitted
+            # consistent, submitted-looking result. Purely cosmetic, and
+            # caught here rather than at the callback's outer boundary: the
+            # row is already claimed, so the outer handler's "please try
+            # again" would invite a retry that can only ever be rejected.
+            try:
+                await interaction.edit_original_response(
+                    view=build_wizard_view(to_screen(spec, submitted))
                 )
-            )
+            except discord.HTTPException:
+                _log.exception("wizard_submit.collapse_edit_failed", short_id=row.id)
         except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
             _log.exception("wizard_submit.callback_failed", err_type=type(err).__name__)
             await _reply_or_followup(interaction, _CALLBACK_FAILED)

--- a/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
@@ -35,6 +35,12 @@ Three things are load-bearing about `callback`'s shape:
    (`button_rows=()`), so a submitted form's message can never be tapped
    again -- there is nothing left on it to dispatch a tap to.
 
+The two gates a wizard turn DOES share with the mention path: `bot.draining`
+(checked in `callback`, before the one-shot claim, so a refused submit leaves
+a form that is still tappable after the restart) and the per-tenant
+`_inflight` cap (claimed and released in `run_wizard_submit_turn`, because a
+wizard turn costs the same upstream capacity as a mention turn).
+
 Accepted limitation, deliberately not addressed here: a submit-spawned turn
 does not participate in the mention path's per-thread `_processing`/`_pending`
 queueing (`bot.py`'s `_drain_pending_for_thread`). That queue only mention
@@ -42,7 +48,9 @@ turns feed and drain; half-registering a wizard turn into it would strand
 mentions that arrive while the wizard turn runs, with nothing left to drain
 them. The practical effect is that a wizard turn and a mention turn can run
 concurrently against the same thread's session -- an accepted trade-off, not
-a bug, for the first cut of this feature.
+a bug, for the first cut of this feature. It also means `_drain_and_close`
+(which polls `_processing`) does not wait for an already-running wizard turn;
+the drain gate above is what keeps new ones from starting.
 """
 
 from __future__ import annotations
@@ -79,6 +87,7 @@ from daimon.core.stores.domain import Role, WizardSessionRow
 from daimon.core.stores.thread_sessions import update_watermark
 from daimon.core.stores.wizard_session import try_claim_submit
 from daimon.core.turn.admission import AdmissionDenied, MissingTurnConfigError, admit
+from daimon.core.turn.gating import should_admit_turn
 from daimon.core.turn.lifecycle import TurnLifecycle
 from daimon.core.turn.prepare import bind_session
 from daimon.core.turn.run import run_prepared_turn
@@ -103,6 +112,11 @@ _log = structlog.get_logger()
 
 _CALLBACK_FAILED = "Something went wrong submitting this form -- please try again."
 _CHECK_FAILED = "Something went wrong checking this form -- please try again."
+_DRAINING = "I'm restarting right now -- submit this form again in a moment."
+_OVER_CAP = (
+    "Your answers were recorded, but this server has too many chats in flight "
+    "right now -- ask again in the thread in a moment."
+)
 
 
 class WizardSubmitButton(
@@ -180,6 +194,14 @@ class WizardSubmitButton(
                     view=build_wizard_view(to_screen(spec, submitted)),
                     allowed_mentions=discord.AllowedMentions.none(),
                 )
+                return
+
+            if bot.draining:
+                # Checked BEFORE the claim: the claim is one-shot, so
+                # refusing here leaves the form intact and tappable once a
+                # fresh process picks it up. The mention path rejects the
+                # same way in `on_message`.
+                await _reply_or_followup(interaction, _DRAINING)
                 return
 
             now = datetime.now(UTC)
@@ -276,9 +298,15 @@ async def run_wizard_submit_turn(
     boundary (the same one `_handle_mention` uses) because nothing above a
     fire-and-forget background task will otherwise report a failure to the
     user.
+
+    Claims a per-tenant in-flight slot the same way `on_message` does, and
+    releases it in the same `finally` that unbinds the log context: a wizard
+    turn costs the same upstream capacity as a mention turn, so it must count
+    against the same cap.
     """
     rid = generate_request_id()
     structlog.contextvars.bind_contextvars(rid=rid)
+    inflight_claimed = False
     try:
         # The form lives in the conversation the resumed turn should
         # continue -- no new thread is created here.
@@ -292,6 +320,27 @@ async def run_wizard_submit_turn(
         else:
             parent_channel_id = str(channel.id)
         thread_id = str(channel.id)
+
+        discord_settings = bot.runtime.settings.discord
+        assert discord_settings is not None, (
+            "run_wizard_submit_turn called without discord settings -- entrypoint must "
+            "validate at boot"
+        )
+
+        # --- Per-tenant concurrency cap, claimed exactly as `on_message`
+        # claims it: read-check-increment with no await in between, and one
+        # matching release in this function's `finally`. The claim already
+        # committed, so an over-cap submit says the answers were recorded
+        # rather than pretending nothing happened. ---
+        count = bot._inflight.get(row.tenant_id, 0)  # pyright: ignore[reportPrivateUsage]  # the per-tenant cap bookkeeping DaimonBot owns; a wizard turn must count against the same cap the mention path claims
+        if not should_admit_turn(
+            current_in_flight=count, cap=discord_settings.max_concurrent_turns_per_tenant
+        ):
+            _log.info("wizard_submit.skipped.over_cap", tenant_id=str(row.tenant_id))
+            await channel.send(_OVER_CAP)
+            return
+        bot._inflight[row.tenant_id] = count + 1  # pyright: ignore[reportPrivateUsage]  # see the read above
+        inflight_claimed = True
 
         # --- Stage one: admission -- D-01 admit(). Same three branches
         # _orchestrate has, prefixed with a sentence saying the answers were
@@ -373,11 +422,6 @@ async def run_wizard_submit_turn(
             )
             await role_session.commit()
 
-        discord_settings = bot.runtime.settings.discord
-        assert discord_settings is not None, (
-            "run_wizard_submit_turn called without discord settings -- entrypoint must "
-            "validate at boot"
-        )
         if discord_settings.per_caller_thread_sessions:
             session_account_id = admission.account_id
         else:
@@ -499,4 +543,6 @@ async def run_wizard_submit_turn(
         _log.exception("wizard_submit.turn_failed_unexpected", error=str(exc), short_id=row.id)
         await _render_wizard_turn_error(interaction, tenant_id=row.tenant_id, rid=rid, exc=exc)
     finally:
+        if inflight_claimed:
+            bot._release_inflight(row.tenant_id)  # pyright: ignore[reportPrivateUsage]  # the matching release for the claim above
         structlog.contextvars.unbind_contextvars("rid")

--- a/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
@@ -1,0 +1,488 @@
+"""`WizardSubmitButton` -- the isolated dispatch entry point for a wizard's
+Submit tap, plus `run_wizard_submit_turn`, the resumed turn it spawns.
+
+This is the only part of the wizard feature that spends the operator's money,
+and the only part that can double-spend it. Every other tap in this feature
+(`daimon.adapters.discord.wizard`) writes state and re-renders; a Submit tap
+additionally claims the row exactly once and starts a billed turn, so it gets
+its own `discord.ui.DynamicItem` template (`SUBMIT_CUSTOM_ID_TEMPLATE`) and
+its own module rather than sharing `WizardNavButton`'s dispatch.
+
+Three things are load-bearing about `callback`'s shape:
+
+1. **The acknowledgement comes first, the turn second, and the turn is never
+   awaited from inside `callback`.** discord.py wraps a `DynamicItem`
+   callback in a bare catch-and-log (verified against the installed
+   `discord/ui/view.py`, same as every other class in this adapter's short
+   list of persistent dynamic items). A turn can run for minutes; awaiting
+   it here would hold the interaction open until it finished and would let
+   any failure inside it vanish silently behind a message that already says
+   "submitted". `DaimonBot._spawn` gives the turn its own tracked
+   background task with its own failure logging instead.
+
+2. **The claim is one predicated UPDATE statement, not a read-then-write.**
+   `try_claim_submit`'s own row lock is what makes two concurrent Submit
+   taps produce exactly one winner -- the loser's WHERE clause simply
+   matches zero rows. No advisory lock, no read-your-own-write race window.
+
+3. **The collapsed screen carries no interactive components.** Once a row's
+   status flips to submitted, `to_screen` returns the collapsed screen
+   (`button_rows=()`), so a submitted form's message can never be tapped
+   again -- there is nothing left on it to dispatch a tap to.
+
+Accepted limitation, deliberately not addressed here: a submit-spawned turn
+does not participate in the mention path's per-thread `_processing`/`_pending`
+queueing (`bot.py`'s `_drain_pending_for_thread`). That queue only mention
+turns feed and drain; half-registering a wizard turn into it would strand
+mentions that arrive while the wizard turn runs, with nothing left to drain
+them. The practical effect is that a wizard turn and a mention turn can run
+concurrently against the same thread's session -- an accepted trade-off, not
+a bug, for the first cut of this feature.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Self, cast
+
+import anthropic as _anthropic
+import sentry_sdk
+import structlog
+from daimon.adapters.discord.bot import (
+    DaimonBot,
+    _credit_depleted_message,  # pyright: ignore[reportPrivateUsage]  # reused verbatim: the same balance-depleted copy the mention path shows
+    _resolve_bot_display_name,  # pyright: ignore[reportPrivateUsage]  # reused verbatim: the same bot-display-name resolution the mention path uses
+)
+from daimon.adapters.discord.checks import is_member_guild_admin
+from daimon.adapters.discord.errors import generate_request_id, render_error
+from daimon.adapters.discord.lifecycle import DiscordTurnLifecycle
+from daimon.adapters.discord.thread_send import safe_thread_send
+from daimon.adapters.discord.views import CancelView
+from daimon.adapters.discord.wizard import (
+    _authorize_tap,  # pyright: ignore[reportPrivateUsage]  # shared requester-only gate the sibling dispatch classes use -- reused verbatim so authorization logic exists in exactly one place
+    _load_row,  # pyright: ignore[reportPrivateUsage]  # shared row loader the sibling dispatch classes use -- reused verbatim
+    _reply_or_followup,  # pyright: ignore[reportPrivateUsage]  # shared is_done()-gated reply helper the sibling dispatch classes use -- reused verbatim
+)
+from daimon.adapters.discord.wizard_render import build_wizard_view
+from daimon.core.errors import DaimonError
+from daimon.core.ma_resolver import MAResolverMissError
+from daimon.core.stores.accounts import set_role
+from daimon.core.stores.domain import Role, WizardSessionRow
+from daimon.core.stores.thread_sessions import update_watermark
+from daimon.core.stores.wizard_session import try_claim_submit
+from daimon.core.turn.admission import AdmissionDenied, MissingTurnConfigError, admit
+from daimon.core.turn.lifecycle import TurnLifecycle
+from daimon.core.turn.prepare import bind_session
+from daimon.core.turn.run import run_prepared_turn
+from daimon.core.wizard.answers import format_answer_block
+from daimon.core.wizard.apply import apply
+from daimon.core.wizard.render import to_screen
+from daimon.core.wizard.spec import WizardSpec
+from daimon.core.wizard.state import (
+    SUBMIT_CUSTOM_ID_TEMPLATE,
+    ActionKind,
+    WizardAction,
+    WizardState,
+    WizardStatus,
+    build_custom_id,
+)
+from sqlalchemy.exc import SQLAlchemyError
+
+import discord
+from discord.ext import commands
+
+_log = structlog.get_logger()
+
+_CALLBACK_FAILED = "Something went wrong submitting this form -- please try again."
+_CHECK_FAILED = "Something went wrong checking this form -- please try again."
+
+
+class WizardSubmitButton(
+    discord.ui.DynamicItem[discord.ui.Button[discord.ui.LayoutView]],
+    template=SUBMIT_CUSTOM_ID_TEMPLATE,
+):
+    """Dispatches the Submit tap. Registered ONCE as a class (not per-button)
+    via `client.add_dynamic_items` in `bot.py`'s `setup_hook`, alongside
+    `WizardNavButton`/`WizardSelect`. Authorization and lifecycle rejection
+    are the SAME requester-only gate `WizardNavButton`/`WizardSelect` use
+    (imported from `wizard.py`, not re-implemented) -- see this module's and
+    `wizard.py`'s docstrings for why `from_custom_id`/`interaction_check`/
+    `callback` each catch their own exceptions."""
+
+    def __init__(self, *, short_id: str, wizard_row: WizardSessionRow | None) -> None:
+        button: discord.ui.Button[discord.ui.LayoutView] = discord.ui.Button(
+            style=discord.ButtonStyle.success,
+            label="Submit",
+            custom_id=build_custom_id(short_id, "submit"),
+        )
+        super().__init__(button)
+        self.short_id = short_id
+        self.wizard_row = wizard_row
+
+    @classmethod
+    async def from_custom_id(  # type: ignore[override]  # discord.py's ClientT is a free TypeVar; this adapter only ever runs DaimonBot
+        cls,
+        interaction: discord.Interaction[commands.Bot],
+        item: discord.ui.Item[Any],
+        match: re.Match[str],
+        /,
+    ) -> Self:
+        short_id = match["short_id"]
+        bot = cast(DaimonBot, interaction.client)
+        wizard_row = await _load_row(bot, short_id)
+        return cls(short_id=short_id, wizard_row=wizard_row)
+
+    async def interaction_check(  # type: ignore[override]  # see from_custom_id
+        self, interaction: discord.Interaction[commands.Bot], /
+    ) -> bool:
+        try:
+            return await _authorize_tap(self.wizard_row, interaction)
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("wizard_submit.interaction_check_failed", err_type=type(err).__name__)
+            await interaction.response.send_message(_CHECK_FAILED, ephemeral=True)
+            return False
+
+    async def callback(  # type: ignore[override]  # see from_custom_id
+        self, interaction: discord.Interaction[commands.Bot]
+    ) -> None:
+        try:
+            row = self.wizard_row
+            if row is None:
+                return
+            bot = cast(DaimonBot, interaction.client)
+
+            # The acknowledgement is unconditionally the FIRST statement --
+            # see the module docstring, point 1.
+            await interaction.response.defer()
+
+            spec = WizardSpec.model_validate(row.spec)
+            state = WizardState(
+                short_id=row.id,
+                current_step=row.current_step,
+                answers=row.answers,
+                status=WizardStatus(row.status),
+            )
+            submitted = apply(state, spec, WizardAction(kind=ActionKind.SUBMIT))
+
+            if submitted.status is not WizardStatus.SUBMITTED:
+                # A stale tap that is not at the review screen -- `apply`
+                # already refused it (returned `state` unchanged). Re-render
+                # whatever screen the row is actually on; no claim, no turn.
+                await interaction.edit_original_response(
+                    view=build_wizard_view(to_screen(spec, submitted))
+                )
+                return
+
+            now = datetime.now(UTC)
+            async with bot.runtime.sessionmaker() as session, session.begin():
+                claimed = await try_claim_submit(
+                    session,
+                    short_id=row.id,
+                    answers=submitted.answers,
+                    current_step=submitted.current_step,
+                    now=now,
+                )
+
+            # Collapse to the read-only, button-free summary regardless of
+            # who won the claim -- see the module docstring, point 2. Both a
+            # winning and a losing concurrent tapper must see the SAME
+            # consistent, submitted-looking result.
+            await interaction.edit_original_response(
+                view=build_wizard_view(to_screen(spec, submitted))
+            )
+
+            if claimed is None:
+                # A concurrent tap already claimed this submission -- a
+                # second turn here would be a second billed turn.
+                return
+
+            bot._spawn(  # pyright: ignore[reportPrivateUsage]  # DaimonBot's tracked fire-and-forget helper; see module docstring point 1 for why the turn must never be awaited here
+                run_wizard_submit_turn(
+                    bot=bot, interaction=interaction, row=claimed, spec=spec, state=submitted
+                )
+            )
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("wizard_submit.callback_failed", err_type=type(err).__name__)
+            await _reply_or_followup(interaction, _CALLBACK_FAILED)
+
+
+async def _render_wizard_turn_error(
+    interaction: discord.Interaction[commands.Bot],
+    *,
+    tenant_id: uuid.UUID,
+    rid: str,
+    exc: Exception,
+) -> None:
+    """Sentry-tag + post a rendered error for a turn failure caught in
+    `run_wizard_submit_turn`. Mirrors `bot.py`'s `_render_turn_error`.
+
+    Takes `interaction` (not a pre-narrowed channel) because the caller sits
+    inside an `except` block, where a value assigned earlier in the `try` is
+    "possibly unbound" from pyright's perspective (an exception could, in
+    principle, have been raised before that assignment ran) -- re-deriving
+    the channel from a function parameter, which is always bound, sidesteps
+    that without a runtime-meaningless `assert`.
+    """
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag("rid", rid)
+        scope.set_tag("tenant_id", str(tenant_id))
+        scope.set_tag(
+            "guild_id", str(interaction.guild_id) if interaction.guild_id is not None else ""
+        )
+        sentry_sdk.capture_exception(exc)
+    error_text = render_error(exc, request_id=rid)
+    channel = interaction.channel
+    if channel is None or not isinstance(channel, discord.abc.Messageable):
+        return
+    if isinstance(channel, discord.Thread):
+        await safe_thread_send(channel, error_text)
+    else:
+        await channel.send(error_text)
+
+
+async def run_wizard_submit_turn(
+    *,
+    bot: DaimonBot,
+    interaction: discord.Interaction[commands.Bot],
+    row: WizardSessionRow,
+    spec: WizardSpec,
+    state: WizardState,
+) -> None:
+    """The background task `WizardSubmitButton.callback` spawns after winning
+    the claim. An ordinary caller of the shared admission/session-binding/run
+    chokepoint (`daimon.core.turn.admission.admit`,
+    `daimon.core.turn.prepare.bind_session`,
+    `daimon.core.turn.run.run_prepared_turn`) -- never a private turn path --
+    resuming the thread's existing session so the agent continues with the
+    full history of having asked. Mirrors `bot.py`'s `_orchestrate` sequence
+    rather than inventing a parallel one; carries its OWN two-tier error
+    boundary (the same one `_handle_mention` uses) because nothing above a
+    fire-and-forget background task will otherwise report a failure to the
+    user.
+    """
+    rid = generate_request_id()
+    structlog.contextvars.bind_contextvars(rid=rid)
+    try:
+        # The form lives in the conversation the resumed turn should
+        # continue -- no new thread is created here.
+        channel = interaction.channel
+        if channel is None or not isinstance(channel, discord.abc.Messageable):
+            _log.warning("wizard_submit.no_messageable_channel", short_id=row.id)
+            return
+
+        if isinstance(channel, discord.Thread):
+            parent_channel_id = str(channel.parent_id)
+        else:
+            parent_channel_id = str(channel.id)
+        thread_id = str(channel.id)
+
+        # --- Stage one: admission -- D-01 admit(). Same three branches
+        # _orchestrate has, prefixed with a sentence saying the answers were
+        # already recorded (the claim committed before this runs). ---
+        try:
+            admission = await admit(
+                bot.runtime.turn_deps,
+                tenant_id=row.tenant_id,
+                platform="discord",
+                external_user_id=str(interaction.user.id),
+                channel_id=parent_channel_id,
+                now=datetime.now(UTC),
+            )
+        except MissingTurnConfigError as err:
+            _log.info(
+                "wizard_submit.missing_config",
+                short_id=row.id,
+                missing=list(err.missing),
+            )
+            hints: list[str] = []
+            if "agent" in err.missing:
+                hints.append(
+                    "An admin can set the default agent in `/agent-setup` -> "
+                    "**Set as default...** -> [This channel] or [Whole server]."
+                )
+            if "environment" in err.missing:
+                hints.append(
+                    "Environment is operator-only -- an operator can set it via the CLI "
+                    "(`daimon config set environment_name=...`)."
+                )
+            await channel.send(
+                "Your answers were recorded, but no "
+                f"{' or '.join(err.missing)} configured for this channel -- ask again "
+                "in the thread once it's set up. " + " ".join(hints)
+            )
+            return
+        except MAResolverMissError as err:
+            _log.warning(
+                "wizard_submit.resolver_miss",
+                kind=err.kind,
+                daimon_tag=err.daimon_tag,
+                tenant_id=str(err.tenant_id),
+            )
+            await channel.send(
+                "Your answers were recorded, but the configured agent or environment "
+                "no longer exists -- ask again in the thread. An admin can re-set the "
+                "agent in `/agent-setup` -> **Set as default...**; the environment is "
+                "operator-only via the CLI (`daimon config set environment_name=...`)."
+            )
+            return
+        except AdmissionDenied as err:
+            if err.reason == "balance_depleted":
+                _log.info("wizard_submit.skipped.over_balance", tenant_id=str(row.tenant_id))
+                await channel.send(
+                    "Your answers were recorded, but "
+                    + _credit_depleted_message(_resolve_bot_display_name(bot.runtime.settings))
+                )
+            else:
+                _log.info("wizard_submit.skipped.over_cap", user_id=str(interaction.user.id))
+                await channel.send(
+                    "Your answers were recorded, but the monthly usage cap was reached "
+                    "for this guild -- ask again in the thread. An admin can adjust the "
+                    "cap with `/billing` (when available)."
+                )
+            return
+
+        agent = admission.agent
+
+        # --- Per-turn role upsert -- unconditional, same rationale as
+        # _orchestrate: the live-role gate the resumed turn's MCP calls hit
+        # must read a fresh value. ---
+        author = interaction.user
+        is_admin = isinstance(author, discord.Member) and is_member_guild_admin(
+            author, guild_owner_id=interaction.guild.owner_id if interaction.guild else None
+        )
+        async with bot.runtime.sessionmaker() as role_session:
+            await set_role(
+                role_session, admission.account_id, Role.ADMIN if is_admin else Role.USER
+            )
+            await role_session.commit()
+
+        discord_settings = bot.runtime.settings.discord
+        assert discord_settings is not None, (
+            "run_wizard_submit_turn called without discord settings -- entrypoint must "
+            "validate at boot"
+        )
+        if discord_settings.per_caller_thread_sessions:
+            session_account_id = admission.account_id
+        else:
+            session_account_id = uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                f"legacy-thread-sentinel:{row.tenant_id}:{channel.id}",
+            )
+
+        # --- Stage two: bind_session -- D-01 bind_session(). Always reuses
+        # the thread's existing session: the form lives in the conversation
+        # the turn should continue, so the agent resumes with the history of
+        # having asked. ---
+        prepared = await bind_session(
+            bot.runtime.turn_deps,
+            admission,
+            tenant_id=row.tenant_id,
+            platform="discord",
+            external_user_id=str(interaction.user.id),
+            thread_id=thread_id,
+            session_account_id=session_account_id,
+            reuse_existing=True,
+        )
+
+        _log.info(
+            "wizard_submit.session_ready",
+            session_id=prepared.ma_session_id,
+            thread_id=thread_id,
+            reused=prepared.reused,
+        )
+
+        user_message = format_answer_block(spec, state)
+
+        async def _send_embed(**kwargs: Any) -> discord.Message:
+            return await channel.send(**kwargs)
+
+        async def _edit_message(msg: discord.Message, **kwargs: Any) -> None:
+            await msg.edit(**kwargs)
+
+        cancel = asyncio.Event()
+        cancel_view = CancelView(allowed_user_id=interaction.user.id, cancel=cancel)
+        lifecycle = DiscordTurnLifecycle(
+            send=_send_embed,
+            edit=_edit_message,
+            agent_name=agent.name,
+            model_id=agent.model.id,
+            cancel_view=cancel_view,
+        )
+        await lifecycle.post_initial()
+
+        # lifecycle_holder tracks whichever DiscordTurnLifecycle actually
+        # completed the turn -- recovery_lifecycle rebuilds a fresh one
+        # against a recreated session, and the watermark write below must
+        # read final_message_id off THAT lifecycle, not the pre-recovery one.
+        lifecycle_holder: list[DiscordTurnLifecycle] = [lifecycle]
+
+        async def _reseed_user_message() -> str:
+            """The answer block IS the full message -- re-seeding a
+            dead-session recovery cycle sends the same block again."""
+            return format_answer_block(spec, state)
+
+        def _recovery_lifecycle(cancel_event: asyncio.Event) -> TurnLifecycle:
+            new_lifecycle = DiscordTurnLifecycle(
+                send=_send_embed,
+                edit=_edit_message,
+                agent_name=agent.name,
+                model_id=agent.model.id,
+                cancel_view=CancelView(allowed_user_id=interaction.user.id, cancel=cancel_event),
+            )
+            lifecycle_holder[0] = new_lifecycle
+            return new_lifecycle
+
+        _log.info(
+            "wizard_submit.turn_started",
+            thread_id=thread_id,
+            session_id=prepared.ma_session_id,
+        )
+        outcome = await run_prepared_turn(
+            bot.runtime.turn_deps,
+            prepared,
+            tenant_id=row.tenant_id,
+            platform="discord",
+            thread_id=thread_id,
+            external_user_id=str(interaction.user.id),
+            user_message=user_message,
+            lifecycle=lifecycle,
+            cancel=cancel,
+            reseed_user_message=_reseed_user_message,
+            recovery_lifecycle=_recovery_lifecycle,
+            render_interval_s=2.0,
+        )
+        turn_state = outcome.state
+        mapping_id = outcome.mapping_id
+        final_lifecycle = lifecycle_holder[0]
+
+        if turn_state.error is not None:
+            _log.warning(
+                "wizard_submit.turn_error",
+                thread_id=thread_id,
+                session_id=outcome.ma_session_id,
+                kind=turn_state.error.kind,
+            )
+        else:
+            _log.info(
+                "wizard_submit.turn_completed",
+                thread_id=thread_id,
+                session_id=outcome.ma_session_id,
+            )
+            if mapping_id is not None and final_lifecycle.final_message_id is not None:
+                async with bot.runtime.sessionmaker() as wm_session:
+                    await update_watermark(
+                        wm_session,
+                        id=mapping_id,
+                        watermark_message_id=final_lifecycle.final_message_id,
+                    )
+    except (DaimonError, _anthropic.APIError, discord.HTTPException, SQLAlchemyError) as exc:
+        _log.warning("wizard_submit.turn_failed", error=str(exc), short_id=row.id)
+        await _render_wizard_turn_error(interaction, tenant_id=row.tenant_id, rid=rid, exc=exc)
+    except Exception as exc:  # noqa: BLE001 -- background-task adapter boundary (see module docstring); nothing above this task will otherwise report the failure
+        _log.exception("wizard_submit.turn_failed_unexpected", error=str(exc), short_id=row.id)
+        await _render_wizard_turn_error(interaction, tenant_id=row.tenant_id, rid=rid, exc=exc)
+    finally:
+        structlog.contextvars.unbind_contextvars("rid")

--- a/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
@@ -177,7 +177,8 @@ class WizardSubmitButton(
                 # already refused it (returned `state` unchanged). Re-render
                 # whatever screen the row is actually on; no claim, no turn.
                 await interaction.edit_original_response(
-                    view=build_wizard_view(to_screen(spec, submitted))
+                    view=build_wizard_view(to_screen(spec, submitted)),
+                    allowed_mentions=discord.AllowedMentions.none(),
                 )
                 return
 
@@ -212,7 +213,8 @@ class WizardSubmitButton(
             # again" would invite a retry that can only ever be rejected.
             try:
                 await interaction.edit_original_response(
-                    view=build_wizard_view(to_screen(spec, submitted))
+                    view=build_wizard_view(to_screen(spec, submitted)),
+                    allowed_mentions=discord.AllowedMentions.none(),
                 )
             except discord.HTTPException:
                 _log.exception("wizard_submit.collapse_edit_failed", short_id=row.id)

--- a/packages/adapters/discord/tests/privacy_panel/conftest.py
+++ b/packages/adapters/discord/tests/privacy_panel/conftest.py
@@ -35,6 +35,7 @@ def _make_preview(**overrides: Any) -> PurgePreview:
         "slack_user_tokens": PurgePreviewRow(count=0, example=None),
         "slack_turn_contexts": PurgePreviewRow(count=0, example=None),
         "credential_requests": PurgePreviewRow(count=0, example=None),
+        "wizard_sessions": PurgePreviewRow(count=0, example=None),
     }
     base.update(overrides)
     return PurgePreview(**base)

--- a/packages/adapters/discord/tests/test_branding.py
+++ b/packages/adapters/discord/tests/test_branding.py
@@ -88,6 +88,7 @@ def _make_preview() -> PurgePreview:
         slack_user_tokens=zero,
         slack_turn_contexts=zero,
         credential_requests=zero,
+        wizard_sessions=zero,
     )
 
 

--- a/packages/adapters/discord/tests/test_wizard.py
+++ b/packages/adapters/discord/tests/test_wizard.py
@@ -1,0 +1,447 @@
+"""Tests for WizardNavButton / WizardSelect / WizardCustomTextModal --
+authorization, expiry, defer-then-edit ordering, and state persistence.
+
+Driven directly against real seeded `wizard_session` rows (`make_wizard_session`),
+following `test_credential_button.py`'s interaction stand-in shape. Only the
+interaction is a stand-in -- the store, the pure transition, and the renderer
+all run for real.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from daimon.adapters.discord.wizard import (
+    WizardCustomTextModal,
+    WizardNavButton,
+    WizardSelect,
+)
+from daimon.core.stores.domain import WizardSessionRow
+from daimon.core.stores.wizard_session import (
+    delete_wizard_sessions_for_platform_user,
+    get_wizard_session,
+    update_wizard_state,
+)
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import build_custom_id
+from daimon.testing.factories import make_wizard_session
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+_REQUESTER_ID = "100000000000000001"
+_OTHER_USER_ID = "200000000000000002"
+
+
+def _two_step_spec() -> dict[str, Any]:
+    """A choice step (allow_custom) followed by a multi step -- enough steps
+    to exercise Next/Back/option/select/opener transitions distinctly."""
+    return WizardSpec(
+        prompt="Plan the picnic",
+        steps=[
+            Step(
+                key="colour",
+                question="Favourite colour?",
+                kind=StepKind.CHOICE,
+                options=[Option(label="Red", value="red"), Option(label="Blue", value="blue")],
+            ),
+            Step(
+                key="toppings",
+                question="Which toppings?",
+                kind=StepKind.MULTI,
+                options=[
+                    Option(label="Cheese", value="cheese"),
+                    Option(label="Olives", value="olives"),
+                ],
+            ),
+        ],
+    ).model_dump(mode="json")
+
+
+def _fake_bot(sessionmaker: async_sessionmaker[AsyncSession]) -> Any:
+    """A minimal stand-in for DaimonBot -- only `.runtime.sessionmaker` is read."""
+    return SimpleNamespace(runtime=SimpleNamespace(sessionmaker=sessionmaker))
+
+
+def _interaction(*, user_id: str, client: Any) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user.id = int(user_id)
+    interaction.client = client
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.edit_original_response = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _nav_match(short_id: str, action: str) -> Any:
+    custom_id = build_custom_id(short_id, action)
+    matched = WizardNavButton.__discord_ui_compiled_template__.fullmatch(custom_id)
+    assert matched is not None, "test action must satisfy WizardNavButton's own template"
+    return matched
+
+
+def _select_match(short_id: str, action: str) -> Any:
+    custom_id = build_custom_id(short_id, action)
+    matched = WizardSelect.__discord_ui_compiled_template__.fullmatch(custom_id)
+    assert matched is not None, "test action must satisfy WizardSelect's own template"
+    return matched
+
+
+async def _seed(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    current_step: int = 0,
+    answers: dict[str, list[str]] | None = None,
+    status: str = "open",
+    requester_platform_user_id: str = _REQUESTER_ID,
+    expires_at: datetime | None = None,
+) -> WizardSessionRow:
+    async with db_session_factory() as session, session.begin():
+        return await make_wizard_session(
+            session,
+            requester_platform_user_id=requester_platform_user_id,
+            spec=_two_step_spec(),
+            answers=answers,
+            current_step=current_step,
+            status=status,
+            expires_at=expires_at,
+        )
+
+
+# --- interaction_check: authorization and lifecycle -------------------------
+
+
+async def test_interaction_check_allows_the_requester(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "next")
+    )
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is True, "the requester tapping an open, unexpired form must be allowed"
+    interaction.response.send_message.assert_not_awaited()
+
+
+async def test_interaction_check_rejects_a_different_user_with_no_state_change(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_OTHER_USER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "next")
+    )
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "a non-requester tap must be rejected"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "someone else" in message, "rejection must say the form was for someone else"
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after == row, "a rejected tap must leave the row byte-identical -- no state change"
+
+
+async def test_interaction_check_rejects_unknown_short_id(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+    unknown_short_id = "zzzzzzz9"
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(unknown_short_id, "next")
+    )
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "an unknown short id must be rejected"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "no longer available" in message
+
+
+async def test_interaction_check_rejects_an_already_submitted_row(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, status="submitted", current_step=2)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "back")
+    )
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "a submitted row must reject further taps"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "already submitted" in message
+
+
+async def test_interaction_check_rejects_an_expired_row(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, expires_at=datetime.now(UTC) - timedelta(minutes=1))
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "next")
+    )
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, (
+        "an expired form must say so -- this replaces what would otherwise be "
+        "a silent no-op on a stale form"
+    )
+    message = interaction.response.send_message.call_args.args[0]
+    assert "expired" in message
+
+
+# --- callback: transitions ----------------------------------------------------
+
+
+async def test_next_tap_defers_before_any_write_or_render(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+    call_order: list[str] = []
+    interaction.response.defer = AsyncMock(side_effect=lambda *a, **k: call_order.append("defer"))
+    interaction.edit_original_response = AsyncMock(
+        side_effect=lambda *a, **k: call_order.append("edit")
+    )
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "next")
+    )
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    assert call_order == ["defer", "edit"], (
+        "the deferral must land before the database write and the re-render"
+    )
+
+
+async def test_next_tap_advances_current_step_and_edits_with_a_new_view(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "next")
+    )
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    interaction.edit_original_response.assert_awaited_once()
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.current_step == 1, "Next must advance current_step in the database"
+
+
+async def test_option_tap_on_choice_step_records_the_value_and_advances(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "s0_c0")
+    )
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.answers["colour"] == ["red"], "the tapped option's value must be recorded"
+    assert after.current_step == 1, "a choice tap must advance to the next step"
+
+
+async def test_select_change_records_every_chosen_value_and_does_not_advance(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=1)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardSelect.from_custom_id(
+        interaction, MagicMock(), _select_match(row.id, "s1_sel")
+    )
+    item.item._values = ["cheese", "olives"]  # pyright: ignore[reportPrivateUsage]  # simulates a real dispatch's _refresh_state without running the full ViewStore machinery
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.answers["toppings"] == ["cheese", "olives"], "every chosen value must be recorded"
+    assert after.current_step == 1, "a multi-select change must not advance the step"
+
+
+async def test_back_tap_from_step_one_returns_to_step_zero(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=1)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "back")
+    )
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.current_step == 0, "Back from step 1 must return to step 0"
+
+
+async def test_tap_on_a_row_deleted_between_read_and_write_edits_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "next")
+    )
+    assert await item.interaction_check(interaction) is True
+
+    async with db_session_factory() as session, session.begin():
+        deleted = await delete_wizard_sessions_for_platform_user(
+            session, platform_user_id=_REQUESTER_ID, tenant_id=row.tenant_id
+        )
+    assert deleted == 1, "the row must actually be gone before the write races it"
+
+    await item.callback(interaction)
+
+    interaction.edit_original_response.assert_not_awaited()
+    interaction.followup.send.assert_awaited_once()
+
+
+async def test_opener_action_responds_with_a_modal_and_performs_no_write(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "s0_custom")
+    )
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    interaction.response.send_modal.assert_awaited_once()
+    sent_modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(sent_modal, WizardCustomTextModal), "an opener must open the text modal"
+    interaction.response.defer.assert_not_awaited()
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after == row, "opening the modal must not write anything"
+
+
+async def test_modal_submit_records_typed_text_and_re_renders(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    modal = WizardCustomTextModal(bot=bot, row=row, step_index=0, question="Favourite colour?")
+    modal.answer_input._value = "chartreuse"  # pyright: ignore[reportPrivateUsage]  # simulates the user's typed text
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    await modal.on_submit(interaction)
+
+    interaction.edit_original_response.assert_awaited_once()
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.answers["colour"] == ["chartreuse"], "the typed text must be recorded"
+    assert after.current_step == 1, "a choice step's custom text must advance to the next step"
+
+
+async def test_whitespace_only_modal_text_writes_nothing_and_replies(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    modal = WizardCustomTextModal(bot=bot, row=row, step_index=0, question="Favourite colour?")
+    modal.answer_input._value = "   "  # pyright: ignore[reportPrivateUsage]  # whitespace-only
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    await modal.on_submit(interaction)
+
+    interaction.edit_original_response.assert_not_awaited()
+    interaction.followup.send.assert_awaited_once()
+    message = interaction.followup.send.call_args.args[0]
+    assert "empty" in message.lower()
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after == row, "whitespace-only text must not change the row"
+
+
+# --- state durability ---------------------------------------------------------
+
+
+async def test_reconstructing_from_custom_id_reflects_a_write_by_another_session(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """This is the restart-survival property: a fresh `from_custom_id` call
+    carries no in-memory view, so it must read whatever the LAST session
+    wrote -- exactly what lets Back/Next survive a bot restart."""
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+
+    # Simulate a different process's earlier tap: advance the row directly
+    # through the store, with no WizardNavButton instance involved.
+    async with db_session_factory() as session, session.begin():
+        rowcount = await update_wizard_state(
+            session,
+            short_id=row.id,
+            answers=row.answers,
+            current_step=1,
+            now=datetime.now(UTC),
+        )
+    assert rowcount == 1
+
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "back")
+    )
+
+    assert item.wizard_row is not None
+    assert item.wizard_row.current_step == 1, (
+        "a fresh from_custom_id call must read the current_step the OTHER "
+        "session wrote, not any value cached from when this row was first seeded "
+        "-- this is what lets Back/Next survive a bot restart (D-12)"
+    )
+
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.current_step == 0, "Back from the externally-written step 1 must reach step 0"

--- a/packages/adapters/discord/tests/test_wizard.py
+++ b/packages/adapters/discord/tests/test_wizard.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 from daimon.adapters.discord.wizard import (
     WizardCustomTextModal,
@@ -337,6 +338,27 @@ async def test_tap_on_a_row_deleted_between_read_and_write_edits_nothing(
 
     interaction.edit_original_response.assert_not_awaited()
     interaction.followup.send.assert_awaited_once()
+
+
+async def test_re_render_suppresses_every_mention(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Head text and the review summary interpolate agent-authored prompt and
+    question text verbatim, so every re-render has to suppress mentions."""
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "next")
+    )
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    allowed = interaction.edit_original_response.call_args.kwargs["allowed_mentions"]
+    assert allowed.to_dict() == discord.AllowedMentions.none().to_dict(), (
+        "a wizard re-render must ping nobody"
+    )
 
 
 async def test_second_tap_computed_from_the_same_base_row_is_refused_as_stale(

--- a/packages/adapters/discord/tests/test_wizard.py
+++ b/packages/adapters/discord/tests/test_wizard.py
@@ -297,6 +297,28 @@ async def test_select_change_records_every_chosen_value_and_does_not_advance(
     assert after.current_step == 1, "a multi-select change must not advance the step"
 
 
+async def test_select_change_carrying_an_undeclared_value_writes_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A modified client can put anything in a select's values -- the tap must
+    be refused rather than recorded under the step's key."""
+    row = await _seed(db_session_factory, current_step=1)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item = await WizardSelect.from_custom_id(
+        interaction, MagicMock(), _select_match(row.id, "s1_sel")
+    )
+    item.item._values = ["cheese", "anchovies"]  # pyright: ignore[reportPrivateUsage]  # simulates a real dispatch's _refresh_state without running the full ViewStore machinery
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after == row, "a forged select value must leave the row byte-identical"
+    interaction.edit_original_response.assert_not_awaited()
+
+
 async def test_back_tap_from_step_one_returns_to_step_zero(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/packages/adapters/discord/tests/test_wizard.py
+++ b/packages/adapters/discord/tests/test_wizard.py
@@ -339,6 +339,40 @@ async def test_tap_on_a_row_deleted_between_read_and_write_edits_nothing(
     interaction.followup.send.assert_awaited_once()
 
 
+async def test_second_tap_computed_from_the_same_base_row_is_refused_as_stale(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A double-click: both taps read the row before either writes. The
+    second one's answers/step predate the first's write, so it must be
+    refused rather than silently erasing what the first recorded."""
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    interaction_a = _interaction(user_id=_REQUESTER_ID, client=bot)
+    interaction_b = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    option_tap = await WizardNavButton.from_custom_id(
+        interaction_a, MagicMock(), _nav_match(row.id, "s0_c0")
+    )
+    next_tap = await WizardNavButton.from_custom_id(
+        interaction_b, MagicMock(), _nav_match(row.id, "next")
+    )
+    assert await option_tap.interaction_check(interaction_a) is True
+    assert await next_tap.interaction_check(interaction_b) is True
+
+    await option_tap.callback(interaction_a)
+    await next_tap.callback(interaction_b)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.answers["colour"] == ["red"], (
+        "the second tap must not erase the answer the first tap recorded"
+    )
+    interaction_b.edit_original_response.assert_not_awaited()
+    stale_message = interaction_b.followup.send.call_args.args[0]
+    assert "changed" in stale_message, "the losing tap must say the form changed under it"
+
+
 async def test_opener_action_responds_with_a_modal_and_performs_no_write(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
@@ -402,6 +436,38 @@ async def test_whitespace_only_modal_text_writes_nothing_and_replies(
     assert after == row, "whitespace-only text must not change the row"
 
 
+async def test_modal_submit_writes_from_a_re_read_row_not_its_open_time_snapshot(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The modal-open-to-submit window is user-paced and unbounded, so every
+    tap that lands in it must survive the eventual typed answer."""
+    row = await _seed(db_session_factory, current_step=0)
+    bot = _fake_bot(db_session_factory)
+    modal = WizardCustomTextModal(bot=bot, row=row, step_index=1, question="Which toppings?")
+    modal.answer_input._value = "pineapple"  # pyright: ignore[reportPrivateUsage]  # simulates the user's typed text
+
+    # While the modal sits open, an ordinary tap records the choice step's
+    # answer and advances -- the snapshot the modal holds is now stale.
+    tap_interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+    tap = await WizardNavButton.from_custom_id(
+        tap_interaction, MagicMock(), _nav_match(row.id, "s0_c0")
+    )
+    assert await tap.interaction_check(tap_interaction) is True
+    await tap.callback(tap_interaction)
+
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot)
+    await modal.on_submit(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.answers["colour"] == ["red"], (
+        "the modal's write must not erase the answer recorded while it was open"
+    )
+    assert after.answers["toppings"] == ["pineapple"], "the typed text must still be recorded"
+    interaction.edit_original_response.assert_awaited_once()
+
+
 # --- state durability ---------------------------------------------------------
 
 
@@ -422,6 +488,7 @@ async def test_reconstructing_from_custom_id_reflects_a_write_by_another_session
             short_id=row.id,
             answers=row.answers,
             current_step=1,
+            expected_updated_at=row.updated_at,
             now=datetime.now(UTC),
         )
     assert rowcount == 1

--- a/packages/adapters/discord/tests/test_wizard.py
+++ b/packages/adapters/discord/tests/test_wizard.py
@@ -36,6 +36,7 @@ pytestmark = pytest.mark.asyncio
 
 _REQUESTER_ID = "100000000000000001"
 _OTHER_USER_ID = "200000000000000002"
+_MESSAGE_ID = "900000000000000001"
 
 
 def _two_step_spec() -> dict[str, Any]:
@@ -68,10 +69,11 @@ def _fake_bot(sessionmaker: async_sessionmaker[AsyncSession]) -> Any:
     return SimpleNamespace(runtime=SimpleNamespace(sessionmaker=sessionmaker))
 
 
-def _interaction(*, user_id: str, client: Any) -> MagicMock:
+def _interaction(*, user_id: str, client: Any, message_id: str = _MESSAGE_ID) -> MagicMock:
     interaction = MagicMock()
     interaction.user.id = int(user_id)
     interaction.client = client
+    interaction.message.id = int(message_id)
     interaction.response.send_message = AsyncMock()
     interaction.response.send_modal = AsyncMock()
     interaction.response.defer = AsyncMock()
@@ -108,6 +110,7 @@ async def _seed(
         return await make_wizard_session(
             session,
             requester_platform_user_id=requester_platform_user_id,
+            message_id=_MESSAGE_ID,
             spec=_two_step_spec(),
             answers=answers,
             current_step=current_step,
@@ -150,6 +153,31 @@ async def test_interaction_check_rejects_a_different_user_with_no_state_change(
     assert allowed is False, "a non-requester tap must be rejected"
     message = interaction.response.send_message.call_args.args[0]
     assert "someone else" in message, "rejection must say the form was for someone else"
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after == row, "a rejected tap must leave the row byte-identical -- no state change"
+
+
+async def test_interaction_check_rejects_a_tap_from_a_different_message(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A custom_id carries no state, so the requester replaying their own
+    form's id against a component on another message -- in another channel or
+    guild -- would otherwise bind and bill the turn wherever they replayed
+    it."""
+    row = await _seed(db_session_factory)
+    bot = _fake_bot(db_session_factory)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, message_id="800000000000000009")
+
+    item = await WizardNavButton.from_custom_id(
+        interaction, MagicMock(), _nav_match(row.id, "next")
+    )
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "a tap that did not come from the form's own message must be rejected"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "no longer available" in message
 
     async with db_session_factory() as session:
         after = await get_wizard_session(session, short_id=row.id)

--- a/packages/adapters/discord/tests/test_wizard_render.py
+++ b/packages/adapters/discord/tests/test_wizard_render.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import discord
 import pytest
 from daimon.adapters.discord.wizard_render import build_wizard_view
+from daimon.core.wizard.apply import apply
 from daimon.core.wizard.render import to_screen
 from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
 from daimon.core.wizard.state import (
     NAV_CUSTOM_ID_PATTERN,
     SELECT_CUSTOM_ID_PATTERN,
     SUBMIT_CUSTOM_ID_PATTERN,
+    ActionKind,
+    WizardAction,
     WizardState,
 )
 
@@ -132,8 +137,6 @@ def test_image_with_only_a_handle_and_no_url_renders_no_gallery() -> None:
 def test_collapsed_screen_renders_no_action_rows_at_all() -> None:
     spec = _choice_spec()
     state = WizardState(short_id=_SHORT_ID, current_step=1, answers={"colour": ["red"]})
-    from daimon.core.wizard.apply import apply
-    from daimon.core.wizard.state import ActionKind, WizardAction
 
     submitted = apply(state, spec, WizardAction(kind=ActionKind.SUBMIT))
     screen = to_screen(spec, submitted)
@@ -151,9 +154,9 @@ def test_collapsed_screen_renders_no_action_rows_at_all() -> None:
     [_choice_spec, _multi_spec],
 )
 def test_has_components_v2_is_true_for_every_produced_view(
-    spec_factory: object,
+    spec_factory: Callable[[], WizardSpec],
 ) -> None:
-    spec = spec_factory()  # type: ignore[operator]  # parametrized factory callables
+    spec = spec_factory()
     screen = to_screen(spec, WizardState(short_id=_SHORT_ID))
 
     view = build_wizard_view(screen)

--- a/packages/adapters/discord/tests/test_wizard_render.py
+++ b/packages/adapters/discord/tests/test_wizard_render.py
@@ -1,0 +1,184 @@
+"""Tests for wizard_render.build_wizard_view -- Screen to LayoutView translation."""
+
+from __future__ import annotations
+
+import discord
+import pytest
+from daimon.adapters.discord.wizard_render import build_wizard_view
+from daimon.core.wizard.render import to_screen
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import (
+    NAV_CUSTOM_ID_PATTERN,
+    SELECT_CUSTOM_ID_PATTERN,
+    SUBMIT_CUSTOM_ID_PATTERN,
+    WizardState,
+)
+
+_SHORT_ID = "abcd1234"
+
+
+def _choice_spec(*, image_handle: str | None = None, image_url: str | None = None) -> WizardSpec:
+    return WizardSpec(
+        prompt="Pick a favourite",
+        steps=[
+            Step(
+                key="colour",
+                question="Which colour?",
+                kind=StepKind.CHOICE,
+                options=[Option(label="Red", value="red"), Option(label="Blue", value="blue")],
+                image_handle=image_handle,
+                image_url=image_url,
+            )
+        ],
+    )
+
+
+def _multi_spec() -> WizardSpec:
+    return WizardSpec(
+        prompt="Pick some toppings",
+        steps=[
+            Step(
+                key="toppings",
+                question="Which toppings?",
+                kind=StepKind.MULTI,
+                options=[
+                    Option(label="Cheese", value="cheese"),
+                    Option(label="Olives", value="olives"),
+                ],
+            )
+        ],
+    )
+
+
+def _container(view: discord.ui.LayoutView) -> discord.ui.Container[discord.ui.LayoutView]:
+    children = view.children
+    assert len(children) == 1, "a wizard view must hold exactly one top-level item"
+    container = children[0]
+    assert isinstance(container, discord.ui.Container), "the one top-level item must be a Container"
+    return container
+
+
+def test_choice_screen_renders_one_container_with_expected_child_ordering() -> None:
+    spec = _choice_spec()
+    screen = to_screen(spec, WizardState(short_id=_SHORT_ID))
+
+    view = build_wizard_view(screen)
+
+    container = _container(view)
+    kinds = [type(item) for item in container.children]
+    assert kinds[0] is discord.ui.TextDisplay, "head text must render first"
+    assert kinds[1] is discord.ui.Separator, "a small separator must follow the head text"
+    # Choice step: no image, no select, no body text -> next is the pre-nav
+    # gap separator, then one ActionRow per button row (options + nav).
+    assert kinds[2] is discord.ui.Separator, (
+        "a large invisible separator must precede the button rows"
+    )
+    assert all(kind is discord.ui.ActionRow for kind in kinds[3:]), (
+        "every remaining child must be an ActionRow of buttons"
+    )
+
+
+def test_select_screen_renders_exactly_one_action_row_before_nav_row() -> None:
+    spec = _multi_spec()
+    screen = to_screen(spec, WizardState(short_id=_SHORT_ID))
+    assert screen.select is not None, "a multi step's screen must carry a select"
+
+    view = build_wizard_view(screen)
+
+    container = _container(view)
+    kinds = [type(item) for item in container.children]
+    select_row_indices = [
+        index
+        for index, item in enumerate(container.children)
+        if isinstance(item, discord.ui.ActionRow)
+        and any(isinstance(c, discord.ui.Select) for c in item.children)
+    ]
+    assert len(select_row_indices) == 1, "exactly one action row must hold the select"
+    action_row_indices = [index for index, kind in enumerate(kinds) if kind is discord.ui.ActionRow]
+    assert action_row_indices[0] == select_row_indices[0], (
+        "the select's action row must come before the nav row's action row"
+    )
+    assert len(action_row_indices) == 2, "a multi step renders the select row plus one nav row"
+
+
+def test_image_with_url_renders_a_media_gallery() -> None:
+    spec = _choice_spec(image_url="https://cdn.example.com/step0.png")
+    screen = to_screen(spec, WizardState(short_id=_SHORT_ID))
+    assert screen.image is not None and screen.image.url is not None
+
+    view = build_wizard_view(screen)
+
+    container = _container(view)
+    galleries = [item for item in container.children if isinstance(item, discord.ui.MediaGallery)]
+    assert len(galleries) == 1, "a screen image with a url must render exactly one media gallery"
+
+
+def test_image_with_only_a_handle_and_no_url_renders_no_gallery() -> None:
+    spec = _choice_spec(image_handle="handle-only-no-url")
+    screen = to_screen(spec, WizardState(short_id=_SHORT_ID))
+    assert screen.image is not None and screen.image.handle is not None
+    assert screen.image.url is None, "this test's premise is a handle with no persisted url"
+
+    view = build_wizard_view(screen)
+
+    container = _container(view)
+    galleries = [item for item in container.children if isinstance(item, discord.ui.MediaGallery)]
+    assert galleries == [], (
+        "this process cannot resolve a bare handle to media -- it never touches "
+        "the posting process's file store, so the image must be omitted"
+    )
+
+
+def test_collapsed_screen_renders_no_action_rows_at_all() -> None:
+    spec = _choice_spec()
+    state = WizardState(short_id=_SHORT_ID, current_step=1, answers={"colour": ["red"]})
+    from daimon.core.wizard.apply import apply
+    from daimon.core.wizard.state import ActionKind, WizardAction
+
+    submitted = apply(state, spec, WizardAction(kind=ActionKind.SUBMIT))
+    screen = to_screen(spec, submitted)
+    assert screen.button_rows == (), "a submitted run's screen must carry no button rows"
+
+    view = build_wizard_view(screen)
+
+    container = _container(view)
+    action_rows = [item for item in container.children if isinstance(item, discord.ui.ActionRow)]
+    assert action_rows == [], "a collapsed (submitted) screen must render no action rows"
+
+
+@pytest.mark.parametrize(
+    "spec_factory",
+    [_choice_spec, _multi_spec],
+)
+def test_has_components_v2_is_true_for_every_produced_view(
+    spec_factory: object,
+) -> None:
+    spec = spec_factory()  # type: ignore[operator]  # parametrized factory callables
+    screen = to_screen(spec, WizardState(short_id=_SHORT_ID))
+
+    view = build_wizard_view(screen)
+
+    assert view.has_components_v2(), "every wizard view must carry the components-v2 flag"
+
+
+def test_custom_id_on_every_button_and_select_fullmatches_a_core_pattern() -> None:
+    spec = _multi_spec()
+    screen = to_screen(spec, WizardState(short_id=_SHORT_ID))
+
+    view = build_wizard_view(screen)
+
+    container = _container(view)
+    for item in container.children:
+        if isinstance(item, discord.ui.ActionRow):
+            for child in item.children:
+                custom_id = getattr(child, "custom_id", None)
+                assert custom_id is not None, "every dispatchable item must carry a custom_id"
+                matched = (
+                    NAV_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+                    or SELECT_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+                    or SUBMIT_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+                )
+                assert matched is not None, (
+                    f"custom_id {custom_id!r} must fullmatch one of the three core "
+                    "wizard dispatch grammars"
+                )

--- a/packages/adapters/discord/tests/test_wizard_submit.py
+++ b/packages/adapters/discord/tests/test_wizard_submit.py
@@ -30,6 +30,7 @@ pytestmark = pytest.mark.asyncio
 
 _REQUESTER_ID = "300000000000000001"
 _OTHER_USER_ID = "400000000000000002"
+_MESSAGE_ID = "900000000000000002"
 
 
 def _one_step_spec() -> dict[str, Any]:
@@ -74,10 +75,17 @@ def _fake_bot(
     return bot
 
 
-def _interaction(*, user_id: str, client: Any, call_order: list[str] | None = None) -> MagicMock:
+def _interaction(
+    *,
+    user_id: str,
+    client: Any,
+    call_order: list[str] | None = None,
+    message_id: str = _MESSAGE_ID,
+) -> MagicMock:
     interaction = MagicMock()
     interaction.user.id = int(user_id)
     interaction.client = client
+    interaction.message.id = int(message_id)
     interaction.response.send_message = AsyncMock()
 
     # is_done() tracks the deferral the way a real InteractionResponse does,
@@ -118,6 +126,7 @@ async def _seed(
         return await make_wizard_session(
             session,
             requester_platform_user_id=requester_platform_user_id,
+            message_id=_MESSAGE_ID,
             spec=_one_step_spec(),
             answers=answers if answers is not None else {"colour": ["red"]},
             current_step=current_step,
@@ -294,6 +303,32 @@ async def test_submit_by_a_non_requester_is_rejected_writes_nothing_spawns_nothi
         after = await get_wizard_session(session, short_id=row.id)
     assert after == row, "a rejected tap must leave the row byte-identical -- no state change"
     assert bot.spawned == [], "a rejected tap must never spawn a turn"
+
+
+async def test_submit_from_a_different_message_is_rejected_and_claims_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Replaying the form's custom_id against a component on another message
+    would bind and bill the turn in that message's channel while charging the
+    tenant the form belongs to."""
+    row = await _seed(db_session_factory, current_step=1)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order)
+    interaction = _interaction(
+        user_id=_REQUESTER_ID, client=bot, call_order=call_order, message_id="800000000000000009"
+    )
+
+    item = await WizardSubmitButton.from_custom_id(interaction, MagicMock(), _submit_match(row.id))
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "a submit that did not come from the form's own message is rejected"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "no longer available" in message
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after == row, "a rejected submit must leave the row byte-identical"
+    assert bot.spawned == [], "a rejected submit must never spawn a turn"
 
 
 # --- ordering --------------------------------------------------------------------

--- a/packages/adapters/discord/tests/test_wizard_submit.py
+++ b/packages/adapters/discord/tests/test_wizard_submit.py
@@ -256,7 +256,7 @@ async def test_submit_by_a_non_requester_is_rejected_writes_nothing_spawns_nothi
 # --- ordering --------------------------------------------------------------------
 
 
-async def test_defer_precedes_the_claim_write_and_the_spawn(
+async def test_defer_precedes_the_spawn_which_precedes_the_collapse_edit(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     row = await _seed(db_session_factory, current_step=1)
@@ -268,7 +268,38 @@ async def test_defer_precedes_the_claim_write_and_the_spawn(
     assert await item.interaction_check(interaction) is True
     await item.callback(interaction)
 
-    assert call_order == ["defer", "edit", "spawn"], (
-        "the acknowledgement must land before the claim's collapsed re-render, which must "
-        "land before the turn is handed to the tracked background task"
+    assert call_order == ["defer", "spawn", "edit"], (
+        "the acknowledgement must land first, and the claimed turn must be handed to the "
+        "tracked background task before the cosmetic collapsed re-render -- nothing that "
+        "can fail may sit between the irreversible claim and the hand-off"
     )
+
+
+async def test_a_failing_collapse_edit_still_spawns_the_claimed_turn(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The claim is irreversible: once it commits, the user can never
+    resubmit, so a transient Discord failure on the purely cosmetic collapse
+    re-render must not cost them the turn they already paid for."""
+    row = await _seed(db_session_factory, current_step=1)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, call_order=call_order)
+    interaction.edit_original_response = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=500, reason="Server Error"), "boom")
+    )
+
+    item = await WizardSubmitButton.from_custom_id(interaction, MagicMock(), _submit_match(row.id))
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.status == "submitted", "the claim still commits when the re-render fails"
+
+    assert len(bot.spawned) == 1, (
+        "a failed collapse edit must not prevent the claimed turn from being spawned"
+    )
+    interaction.followup.send.assert_not_awaited()
+    interaction.response.send_message.assert_not_awaited()

--- a/packages/adapters/discord/tests/test_wizard_submit.py
+++ b/packages/adapters/discord/tests/test_wizard_submit.py
@@ -1,0 +1,274 @@
+"""Tests for `WizardSubmitButton` -- the single-claim gate, the
+acknowledge-then-collapse-then-spawn ordering, and reuse of `wizard.py`'s
+shared requester-only authorization.
+
+Driven directly against real seeded `wizard_session` rows (`make_wizard_session`),
+following `test_wizard.py`'s interaction stand-in shape. The bot stand-in's
+`_spawn` records the coroutine and closes it without running it -- what
+`run_wizard_submit_turn` actually does is covered end-to-end by
+`tests/integration/test_wizard_submit_turn.py`; this file only proves the
+button dispatches (or doesn't) correctly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from daimon.adapters.discord.wizard_submit import WizardSubmitButton
+from daimon.core.stores.domain import WizardSessionRow
+from daimon.core.stores.wizard_session import get_wizard_session
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import build_custom_id
+from daimon.testing.factories import make_wizard_session
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+_REQUESTER_ID = "300000000000000001"
+_OTHER_USER_ID = "400000000000000002"
+
+
+def _one_step_spec() -> dict[str, Any]:
+    """A single choice step -- current_step=1 is one past the last step
+    index, i.e. the review screen (`daimon.core.wizard.render.to_screen`)."""
+    return WizardSpec(
+        prompt="Plan the picnic",
+        steps=[
+            Step(
+                key="colour",
+                question="Favourite colour?",
+                kind=StepKind.CHOICE,
+                options=[Option(label="Red", value="red"), Option(label="Blue", value="blue")],
+            ),
+        ],
+    ).model_dump(mode="json")
+
+
+def _fake_bot(sessionmaker: async_sessionmaker[AsyncSession], call_order: list[str]) -> Any:
+    """A minimal stand-in for DaimonBot -- `.runtime.sessionmaker` is real,
+    `._spawn` records the coroutine (appending to `call_order`) and closes it
+    without running it, so `run_wizard_submit_turn`'s own behaviour is never
+    exercised here (see `tests/integration/test_wizard_submit_turn.py`)."""
+    spawned: list[Any] = []
+
+    def _spawn(coro: Any) -> None:
+        call_order.append("spawn")
+        spawned.append(coro)
+        coro.close()
+
+    bot = SimpleNamespace(
+        runtime=SimpleNamespace(sessionmaker=sessionmaker), _spawn=_spawn, spawned=spawned
+    )
+    return bot
+
+
+def _interaction(*, user_id: str, client: Any, call_order: list[str] | None = None) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user.id = int(user_id)
+    interaction.client = client
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock(
+        side_effect=(lambda *a, **k: call_order.append("defer")) if call_order is not None else None
+    )
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.edit_original_response = AsyncMock(
+        side_effect=(lambda *a, **k: call_order.append("edit")) if call_order is not None else None
+    )
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _submit_match(short_id: str) -> Any:
+    custom_id = build_custom_id(short_id, "submit")
+    matched = WizardSubmitButton.__discord_ui_compiled_template__.fullmatch(custom_id)
+    assert matched is not None, "test action must satisfy WizardSubmitButton's own template"
+    return matched
+
+
+async def _seed(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    current_step: int,
+    status: str = "open",
+    answers: dict[str, list[str]] | None = None,
+    requester_platform_user_id: str = _REQUESTER_ID,
+) -> WizardSessionRow:
+    async with db_session_factory() as session, session.begin():
+        return await make_wizard_session(
+            session,
+            requester_platform_user_id=requester_platform_user_id,
+            spec=_one_step_spec(),
+            answers=answers if answers is not None else {"colour": ["red"]},
+            current_step=current_step,
+            status=status,
+        )
+
+
+def _container(view: discord.ui.LayoutView) -> Any:
+    children = view.children
+    assert len(children) == 1, "a wizard view must hold exactly one top-level item"
+    return children[0]
+
+
+# --- claim, collapse, spawn --------------------------------------------------
+
+
+async def test_submit_at_review_claims_the_row_and_spawns_exactly_one_turn(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=1)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, call_order=call_order)
+
+    item = await WizardSubmitButton.from_custom_id(interaction, MagicMock(), _submit_match(row.id))
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.status == "submitted", "a review-screen submit must claim the row"
+
+    assert len(bot.spawned) == 1, "a winning claim must spawn exactly one background task"
+    assert bot.spawned[0].__qualname__ == "run_wizard_submit_turn", (
+        "the spawned coroutine must be run_wizard_submit_turn, never awaited inline"
+    )
+    interaction.edit_original_response.assert_awaited_once()
+
+
+async def test_collapsed_view_has_no_interactive_components(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=1)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, call_order=call_order)
+
+    item = await WizardSubmitButton.from_custom_id(interaction, MagicMock(), _submit_match(row.id))
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    view = interaction.edit_original_response.call_args.kwargs["view"]
+    container = _container(view)
+    action_rows = [child for child in container.children if isinstance(child, discord.ui.ActionRow)]
+    assert action_rows == [], (
+        "a submitted form's collapsed screen must carry no interactive components -- "
+        "it must never be re-drivable"
+    )
+    text_children = [
+        child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
+    ]
+    assert any("Submitted" in text for text in text_children), (
+        "the collapsed screen must visibly say the form was submitted"
+    )
+
+
+async def test_a_tap_not_at_the_review_screen_re_renders_and_neither_claims_nor_spawns(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    # current_step=0 is the first (and only) real step -- not the review
+    # screen -- so apply(SUBMIT) refuses it (returns state unchanged).
+    row = await _seed(db_session_factory, current_step=0)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, call_order=call_order)
+
+    item = await WizardSubmitButton.from_custom_id(interaction, MagicMock(), _submit_match(row.id))
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.status == "open", "a stale tap not at the review screen must not claim the row"
+    assert after.current_step == 0
+
+    assert bot.spawned == [], "a stale tap must never spawn a turn"
+    interaction.edit_original_response.assert_awaited_once()
+
+
+async def test_two_sequential_submits_the_second_claims_nothing_and_spawns_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Simulates a double-tap: both taps reconstruct their `WizardSubmitButton`
+    from the row while it is still open (both `from_custom_id` calls land
+    before either write), then are dispatched one after the other. The first
+    callback wins the claim; the second's `try_claim_submit` call finds the
+    row no longer `open` and returns None -- proving the claim gate itself
+    (not just `interaction_check`) is what makes a double submit safe."""
+    row = await _seed(db_session_factory, current_step=1)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order)
+    interaction_a = _interaction(user_id=_REQUESTER_ID, client=bot)
+    interaction_b = _interaction(user_id=_REQUESTER_ID, client=bot)
+
+    item_a = await WizardSubmitButton.from_custom_id(
+        interaction_a, MagicMock(), _submit_match(row.id)
+    )
+    item_b = await WizardSubmitButton.from_custom_id(
+        interaction_b, MagicMock(), _submit_match(row.id)
+    )
+    assert await item_a.interaction_check(interaction_a) is True
+    assert await item_b.interaction_check(interaction_b) is True
+
+    await item_a.callback(interaction_a)
+    await item_b.callback(interaction_b)
+
+    assert len(bot.spawned) == 1, "only the winning tap may spawn a background turn"
+    interaction_a.edit_original_response.assert_awaited_once()
+    interaction_b.edit_original_response.assert_awaited_once()
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.status == "submitted"
+
+
+# --- authorization -------------------------------------------------------------
+
+
+async def test_submit_by_a_non_requester_is_rejected_writes_nothing_spawns_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=1)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order)
+    interaction = _interaction(user_id=_OTHER_USER_ID, client=bot, call_order=call_order)
+
+    item = await WizardSubmitButton.from_custom_id(interaction, MagicMock(), _submit_match(row.id))
+    allowed = await item.interaction_check(interaction)
+
+    assert allowed is False, "a non-requester submit tap must be rejected"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "someone else" in message
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after == row, "a rejected tap must leave the row byte-identical -- no state change"
+    assert bot.spawned == [], "a rejected tap must never spawn a turn"
+
+
+# --- ordering --------------------------------------------------------------------
+
+
+async def test_defer_precedes_the_claim_write_and_the_spawn(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed(db_session_factory, current_step=1)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, call_order=call_order)
+
+    item = await WizardSubmitButton.from_custom_id(interaction, MagicMock(), _submit_match(row.id))
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    assert call_order == ["defer", "edit", "spawn"], (
+        "the acknowledgement must land before the claim's collapsed re-render, which must "
+        "land before the turn is handed to the tracked background task"
+    )

--- a/packages/adapters/discord/tests/test_wizard_submit.py
+++ b/packages/adapters/discord/tests/test_wizard_submit.py
@@ -48,7 +48,12 @@ def _one_step_spec() -> dict[str, Any]:
     ).model_dump(mode="json")
 
 
-def _fake_bot(sessionmaker: async_sessionmaker[AsyncSession], call_order: list[str]) -> Any:
+def _fake_bot(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    call_order: list[str],
+    *,
+    draining: bool = False,
+) -> Any:
     """A minimal stand-in for DaimonBot -- `.runtime.sessionmaker` is real,
     `._spawn` records the coroutine (appending to `call_order`) and closes it
     without running it, so `run_wizard_submit_turn`'s own behaviour is never
@@ -61,7 +66,10 @@ def _fake_bot(sessionmaker: async_sessionmaker[AsyncSession], call_order: list[s
         coro.close()
 
     bot = SimpleNamespace(
-        runtime=SimpleNamespace(sessionmaker=sessionmaker), _spawn=_spawn, spawned=spawned
+        runtime=SimpleNamespace(sessionmaker=sessionmaker),
+        _spawn=_spawn,
+        spawned=spawned,
+        draining=draining,
     )
     return bot
 
@@ -71,10 +79,19 @@ def _interaction(*, user_id: str, client: Any, call_order: list[str] | None = No
     interaction.user.id = int(user_id)
     interaction.client = client
     interaction.response.send_message = AsyncMock()
-    interaction.response.defer = AsyncMock(
-        side_effect=(lambda *a, **k: call_order.append("defer")) if call_order is not None else None
-    )
-    interaction.response.is_done = MagicMock(return_value=False)
+
+    # is_done() tracks the deferral the way a real InteractionResponse does,
+    # so `_reply_or_followup` picks the followup once the callback has
+    # acknowledged -- which is the only route a post-defer reply can take.
+    deferred: list[bool] = []
+
+    def _defer(*_args: Any, **_kwargs: Any) -> None:
+        deferred.append(True)
+        if call_order is not None:
+            call_order.append("defer")
+
+    interaction.response.defer = AsyncMock(side_effect=_defer)
+    interaction.response.is_done = MagicMock(side_effect=lambda: bool(deferred))
     interaction.edit_original_response = AsyncMock(
         side_effect=(lambda *a, **k: call_order.append("edit")) if call_order is not None else None
     )
@@ -227,6 +244,32 @@ async def test_two_sequential_submits_the_second_claims_nothing_and_spawns_nothi
         after = await get_wizard_session(session, short_id=row.id)
     assert after is not None
     assert after.status == "submitted"
+
+
+async def test_a_submit_during_drain_claims_nothing_and_leaves_the_form_tappable(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The claim is one-shot, so refusing before it (unlike the mention path,
+    which has nothing to preserve) leaves a form the user can submit again
+    once a fresh process picks it up."""
+    row = await _seed(db_session_factory, current_step=1)
+    call_order: list[str] = []
+    bot = _fake_bot(db_session_factory, call_order, draining=True)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, call_order=call_order)
+
+    item = await WizardSubmitButton.from_custom_id(interaction, MagicMock(), _submit_match(row.id))
+    assert await item.interaction_check(interaction) is True
+    await item.callback(interaction)
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.status == "open", "a submit refused during drain must not consume the claim"
+
+    assert bot.spawned == [], "no turn may start while the process is draining"
+    interaction.edit_original_response.assert_not_awaited()
+    message = interaction.followup.send.call_args.args[0]
+    assert "restarting" in message, "the refusal must say the bot is restarting"
 
 
 # --- authorization -------------------------------------------------------------

--- a/packages/adapters/mcp/daimon/adapters/mcp/server.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/server.py
@@ -52,6 +52,7 @@ from daimon.adapters.mcp.tools.credential_requests import register_credential_re
 from daimon.adapters.mcp.tools.media import register_media_tools
 from daimon.adapters.mcp.tools.notebook import register_notebook_tools
 from daimon.adapters.mcp.tools.propagation import register_propagation_tools
+from daimon.adapters.mcp.tools.wizard import register_wizard_tools
 from daimon.adapters.mcp.webhooks import build_github_webhook, build_stripe_webhook
 from daimon.core.billing import BillingConfig, load_billing_config
 from daimon.core.config import Settings, load_settings
@@ -259,6 +260,7 @@ def create_mcp_app(
     environments.register_environment_tools(mcp, runtime)
     vault.register_vault_tools(mcp, runtime)
     register_credential_request_tools(mcp, runtime)
+    register_wizard_tools(mcp, runtime)
     skills.register_skill_tools(mcp, runtime)
     sessions.register_sessions_tools(mcp, runtime)
     agent_chat.register_agent_chat_tools(mcp, runtime)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/__init__.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/__init__.py
@@ -82,3 +82,12 @@ from daimon.adapters.mcp.tools.discord._send import (
 from daimon.adapters.mcp.tools.discord._send import (
     _send_message_impl as _send_message_impl,  # pyright: ignore[reportPrivateUsage]
 )
+from daimon.adapters.mcp.tools.discord._wizard import (
+    PostedWizard as PostedWizard,
+)
+from daimon.adapters.mcp.tools.discord._wizard import (
+    _post_wizard_impl as _post_wizard_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.discord._wizard import (
+    build_wizard_view as build_wizard_view,
+)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_wizard.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_wizard.py
@@ -1,0 +1,119 @@
+"""Screen-to-`discord.ui` renderer, and the REST post that opens a wizard run.
+
+Posted from the MCP process (Cloud Run); every tap on the posted message is
+dispatched later by the Discord bot process (worker VM). The two processes
+cannot import each other (import-linter's independence contract), and the
+layer they share -- `daimon.core.wizard` -- deliberately carries no Discord
+SDK type, so each side owns a thin translation of the platform-neutral
+`Screen` (`daimon.core.wizard.render`) into its own component tree. This
+module is that translation for the posting side; a divergent copy here (a
+button built in a different order, a different style mapping) would silently
+desync the two renderers without either side raising, so the two are held to
+producing byte-identical `to_components()` output for the same `Screen`.
+
+A plain `discord.ui.View` cannot hold a `Container`, `TextDisplay`,
+`Separator`, or `MediaGallery` -- those are components-v2 items, and
+`View.add_item` raises `ValueError` for any of them unless the view is a
+`discord.ui.LayoutView`. `LayoutView` is therefore the only view type built
+here. The components-v2 message flag is never set by this module: the HTTP
+layer sets it automatically from the view's own contents. A components-v2
+message also cannot carry `content`, `embed`, `embeds`, `stickers`, or
+`poll` -- which is why the screen's head text is rendered as a `TextDisplay`
+component instead of message content.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import discord
+from daimon.core.wizard.render import Screen, ScreenButton
+from daimon.core.wizard.state import build_custom_id
+
+_ACCENT_COLOURS: dict[str, int] = {
+    "blurple": 0x5865F2,
+    "green": 0x57F287,
+}
+
+_BUTTON_STYLES: dict[str, discord.ButtonStyle] = {
+    "primary": discord.ButtonStyle.primary,
+    "secondary": discord.ButtonStyle.secondary,
+    "success": discord.ButtonStyle.success,
+}
+
+
+def _build_button(short_id: str, button: ScreenButton) -> discord.ui.Button[discord.ui.LayoutView]:
+    return discord.ui.Button(
+        style=_BUTTON_STYLES[button.style],
+        label=button.label,
+        custom_id=build_custom_id(short_id, button.action),
+        disabled=button.disabled,
+    )
+
+
+def build_wizard_view(
+    screen: Screen, *, files: Mapping[str, discord.File] | None = None
+) -> discord.ui.LayoutView:
+    """Translate a `Screen` into a real `LayoutView`.
+
+    Component order is a contract: head text, a small separator, an optional
+    media gallery, optional body text, an optional select row, then (after a
+    large invisible separator gap) one action row per button row. A screen's
+    image is resolved by preferring the matching `discord.File` in `files`
+    (keyed by handle) over its persisted `url`, and is omitted entirely when
+    neither resolves -- this is how a later step's already-uploaded image
+    rides the first post's attachment set without being displayed on it.
+    """
+    container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container(
+        accent_colour=_ACCENT_COLOURS[screen.accent]
+    )
+    container.add_item(discord.ui.TextDisplay(screen.head_text))
+    container.add_item(discord.ui.Separator(visible=True, spacing=discord.SeparatorSpacing.small))
+
+    if screen.image is not None:
+        media: str | discord.File | None = None
+        if files is not None and screen.image.handle is not None and screen.image.handle in files:
+            media = files[screen.image.handle]
+        elif screen.image.url is not None:
+            media = screen.image.url
+        if media is not None:
+            gallery: discord.ui.MediaGallery[discord.ui.LayoutView] = discord.ui.MediaGallery()
+            gallery.add_item(media=media)
+            container.add_item(gallery)
+
+    if screen.body_text is not None:
+        container.add_item(discord.ui.TextDisplay(screen.body_text))
+
+    if screen.select is not None:
+        select: discord.ui.Select[discord.ui.LayoutView] = discord.ui.Select(
+            custom_id=build_custom_id(screen.short_id, screen.select.action),
+            placeholder=screen.select.placeholder,
+            min_values=screen.select.min_values,
+            max_values=screen.select.max_values,
+            options=[
+                discord.SelectOption(
+                    label=option.label,
+                    value=option.value,
+                    description=option.description,
+                    default=option.default,
+                )
+                for option in screen.select.options
+            ],
+        )
+        select_row: discord.ui.ActionRow[discord.ui.LayoutView] = discord.ui.ActionRow()
+        select_row.add_item(select)
+        container.add_item(select_row)
+
+    if screen.button_rows:
+        container.add_item(
+            discord.ui.Separator(visible=False, spacing=discord.SeparatorSpacing.large)
+        )
+        for row in screen.button_rows:
+            action_row: discord.ui.ActionRow[discord.ui.LayoutView] = discord.ui.ActionRow()
+            for button in row:
+                action_row.add_item(_build_button(screen.short_id, button))
+            container.add_item(action_row)
+
+    view = discord.ui.LayoutView(timeout=None)
+    view.add_item(container)
+    return view

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_wizard.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_wizard.py
@@ -215,7 +215,13 @@ async def _post_wizard_impl(  # pyright: ignore[reportUnusedFunction]
         _check_send_permission(channel, member)
         if not isinstance(channel, discord.abc.Messageable):
             raise ToolError("channel does not support sending messages")
-        sent = await channel.send(view=view, files=files)
+        # The head text carries the agent-authored prompt and question
+        # verbatim (only user-typed answers go through the summary's escape
+        # pass), so an injected `@everyone` in a form would ping the channel.
+        # Nothing in a form legitimately needs to mention anyone.
+        sent = await channel.send(
+            view=view, files=files, allowed_mentions=discord.AllowedMentions.none()
+        )
 
     # Mapped by position, not by filename: a file's display name is slugged
     # from the agent-supplied image title, so two steps titled the same thing

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_wizard.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_wizard.py
@@ -20,15 +20,52 @@ layer sets it automatically from the view's own contents. A components-v2
 message also cannot carry `content`, `embed`, `embeds`, `stickers`, or
 `poll` -- which is why the screen's head text is rendered as a `TextDisplay`
 component instead of message content.
+
+Reuses `_credential_button.py`'s exact require/resolve/permission-check
+order (itself borrowed from `_send.py`'s `_send_message_impl`) rather than
+re-implementing any of it, so posting a wizard carries the same
+channel-visibility discipline as every other message this adapter sends.
+
+The invariant that makes cross-process re-rendering possible: the process
+that redraws a later step runs elsewhere (the bot, on a tap) and cannot read
+this process's file store, so whatever a later render needs has to be
+resolvable from anywhere. That is what the content-delivery addresses this
+module captures are for -- every step's image is therefore uploaded exactly
+once, here, on the first post, even though only step one's image is
+referenced by a component on this message.
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
+from dataclasses import dataclass
 
 import discord
-from daimon.core.wizard.render import Screen, ScreenButton
-from daimon.core.wizard.state import build_custom_id
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.discord._client import (
+    _require_bot_token,  # pyright: ignore[reportPrivateUsage]
+    _require_discord_identity,  # pyright: ignore[reportPrivateUsage]
+    _require_guild_channel,  # pyright: ignore[reportPrivateUsage]
+    _require_guild_id,  # pyright: ignore[reportPrivateUsage]
+    _resolve_channel,  # pyright: ignore[reportPrivateUsage]
+    _resolve_member,  # pyright: ignore[reportPrivateUsage]
+    rest_client,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.discord._send import (
+    _build_files_from_handles,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.discord._visibility import (
+    _check_send_permission,  # pyright: ignore[reportPrivateUsage]
+    _ensure_thread_parent_cached,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.wizard.render import Screen, ScreenButton, to_screen
+from daimon.core.wizard.spec import WizardSpec
+from daimon.core.wizard.state import WizardState, build_custom_id
+from fastmcp.exceptions import ToolError
+
+logger = logging.getLogger(__name__)
 
 _ACCENT_COLOURS: dict[str, int] = {
     "blurple": 0x5865F2,
@@ -117,3 +154,80 @@ def build_wizard_view(
     view = discord.ui.LayoutView(timeout=None)
     view.add_item(container)
     return view
+
+
+@dataclass(frozen=True)
+class PostedWizard:
+    """What posting a wizard's first screen returns to its caller.
+
+    `image_urls` maps every uploaded step's `image_handle` to the
+    content-delivery address Discord minted for it -- the durable reference
+    a later re-render (running in the other process, on a tap) resolves the
+    image from, since it never sees this process's file store.
+    """
+
+    message_id: str
+    image_urls: dict[str, str]
+
+
+async def _post_wizard_impl(  # pyright: ignore[reportUnusedFunction]
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    spec: WizardSpec,
+    short_id: str,
+) -> PostedWizard:
+    """Post a wizard's first screen, uploading every step's image.
+
+    Only step one's image is referenced by a component; every other step's
+    image still rides this same attachment set so its content-delivery
+    address is captured now, before any tap, since a later render cannot
+    reach this process's file store.
+    """
+    _require_discord_identity(auth)
+    guild_id = _require_guild_id(auth)
+    bot_token = _require_bot_token(runtime)
+
+    handles = [step.image_handle for step in spec.steps if step.image_handle is not None]
+    files: list[discord.File] = []
+    if handles:
+        file_store = runtime.file_store
+        if file_store is None:
+            raise ToolError(
+                "file_handles requires the media file store to be configured "
+                "(set DAIMON_GEMINI__API_KEY on the mcp process)"
+            )
+        files = await _build_files_from_handles(handles, store=file_store)
+    files_by_handle = dict(zip(handles, files, strict=True))
+
+    rendered_screen = to_screen(spec, WizardState(short_id=short_id))
+    view = build_wizard_view(rendered_screen, files=files_by_handle)
+
+    async with rest_client(bot_token) as c:
+        _, member = await _resolve_member(c, guild_id, _require_discord_identity(auth))
+        raw_channel = await _resolve_channel(c, channel_id)
+        channel = _require_guild_channel(raw_channel, guild_id)
+        if isinstance(channel, discord.Thread):
+            # Thread.permissions_for needs the parent in the guild cache;
+            # the per-call REST client starts with an empty one.
+            await _ensure_thread_parent_cached(channel)
+        _check_send_permission(channel, member)
+        if not isinstance(channel, discord.abc.Messageable):
+            raise ToolError("channel does not support sending messages")
+        sent = await channel.send(view=view, files=files)
+
+    url_by_filename = {attachment.filename: attachment.url for attachment in sent.attachments}
+    image_urls: dict[str, str] = {}
+    for handle, file in files_by_handle.items():
+        url = url_by_filename.get(file.filename)
+        if url is None:
+            logger.warning(
+                "wizard post %s: no attachment url returned for image handle %r",
+                sent.id,
+                handle,
+            )
+            continue
+        image_urls[handle] = url
+
+    return PostedWizard(message_id=str(sent.id), image_urls=image_urls)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_wizard.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_wizard.py
@@ -217,17 +217,21 @@ async def _post_wizard_impl(  # pyright: ignore[reportUnusedFunction]
             raise ToolError("channel does not support sending messages")
         sent = await channel.send(view=view, files=files)
 
-    url_by_filename = {attachment.filename: attachment.url for attachment in sent.attachments}
-    image_urls: dict[str, str] = {}
-    for handle, file in files_by_handle.items():
-        url = url_by_filename.get(file.filename)
-        if url is None:
-            logger.warning(
-                "wizard post %s: no attachment url returned for image handle %r",
-                sent.id,
-                handle,
-            )
-            continue
-        image_urls[handle] = url
+    # Mapped by position, not by filename: a file's display name is slugged
+    # from the agent-supplied image title, so two steps titled the same thing
+    # upload under one filename and would both resolve to whichever
+    # attachment came last. discord.py sends files in list order and Discord
+    # returns attachments in that same order, so index i belongs to handle i.
+    image_urls = {
+        handle: attachment.url
+        for handle, attachment in zip(handles, sent.attachments, strict=False)
+    }
+    missing = [handle for handle in handles if handle not in image_urls]
+    if missing:
+        logger.warning(
+            "wizard post %s: no attachment url returned for image handles %r",
+            sent.id,
+            missing,
+        )
 
     return PostedWizard(message_id=str(sent.id), image_urls=image_urls)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/wizard.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/wizard.py
@@ -1,0 +1,140 @@
+"""post_wizard: the agent-facing tool that posts a multi-step form.
+
+Deliberately NOT admin-gated — a form is an ordinary conversational
+capability, not a chat-mutation admin action, mirroring
+``credential_requests.py``'s rationale for the same omission.
+
+No other tool in this server carries an end-your-turn contract. Everywhere
+else, the tool's return value is simply data and the agent decides what to
+do next. Here, the return value IS an instruction: posting a wizard means
+the agent's turn is over, because the user's answers arrive later as a
+brand-new message (a keyed block resolved by the turn pipeline), not as
+anything this tool call can return synchronously. In the system this
+behaviour is ported from, the tool result's instruction alone was found
+insufficient — models kept narrating past it or calling another tool — which
+is why the seeded agent prompt (``defaults/agents/daimon.yaml``) carries a
+matching, reinforcing line rather than relying on this docstring alone.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Final
+
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools._ctx import _auth  # pyright: ignore[reportPrivateUsage]
+from daimon.adapters.mcp.tools.discord import (
+    _post_wizard_impl as _post_wizard_discord_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.stores.wizard_session import create_wizard_session
+from daimon.core.wizard.expiry import derive_expires_at
+from daimon.core.wizard.spec import Step, WizardSpec
+from daimon.core.wizard.state import WizardStatus, new_short_id
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+
+_STOP_SIGNAL: Final[str] = (
+    "WIZARD_POSTED: the form is now live in the channel. End your turn "
+    "immediately — do not narrate, do not continue, and do not call another "
+    "tool. The user's answers will arrive later as a brand-new message "
+    "carrying a keyed block; that is when you resume, with the full history "
+    "of having asked."
+)
+
+
+async def _post_wizard_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    prompt: str,
+    steps: list[Step],
+    channel_id: str,
+) -> str:
+    if auth.platform == "slack":
+        raise ToolError("post_wizard is not supported on Slack yet")
+    if auth.platform_user_id is None:
+        raise ToolError("post_wizard requires a platform-bound identity")
+
+    # `image_url` is server-populated: a caller-supplied value must never
+    # reach the renderer, so it is stripped before validation even runs.
+    stripped_steps = [step.model_copy(update={"image_url": None}) for step in steps]
+    try:
+        spec = WizardSpec(prompt=prompt, steps=stripped_steps)
+    except ValueError as err:
+        raise ToolError(
+            f"Invalid wizard form: {err} Split it into a shorter follow-up form."
+        ) from err
+
+    short_id = new_short_id()
+
+    # Post before insert: a failed post must leave no stored row nobody can
+    # tap. `_post_wizard_discord_impl`'s ToolErrors already name the
+    # channel/permission/handle problem, so they propagate unchanged.
+    posted = await _post_wizard_discord_impl(
+        runtime, auth, channel_id=channel_id, spec=spec, short_id=short_id
+    )
+
+    rebuilt_steps = [
+        step.model_copy(update={"image_url": posted.image_urls[step.image_handle]})
+        if step.image_handle is not None and step.image_handle in posted.image_urls
+        else step
+        for step in spec.steps
+    ]
+    rebuilt_spec = spec.model_copy(update={"steps": rebuilt_steps})
+
+    now = datetime.now(UTC)
+    expires_at = derive_expires_at(now=now, attachment_urls=list(posted.image_urls.values()))
+
+    # If this insert fails after a successful post, let it propagate: the
+    # agent sees an error, and the orphaned message is inert because no row
+    # backs its custom_ids.
+    async with runtime.session_factory.begin() as session:
+        await create_wizard_session(
+            session,
+            short_id=short_id,
+            tenant_id=auth.tenant_id,
+            account_id=auth.account_id,
+            requester_platform_user_id=auth.platform_user_id,
+            channel_id=channel_id,
+            message_id=posted.message_id,
+            spec=rebuilt_spec.model_dump(mode="json"),
+            answers={},
+            current_step=0,
+            status=WizardStatus.OPEN.value,
+            expires_at=expires_at,
+            now=now,
+        )
+
+    return _STOP_SIGNAL
+
+
+def register_wizard_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
+    @mcp.tool
+    async def post_wizard(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        prompt: str,
+        steps: list[Step],
+        channel_id: str,
+    ) -> str:
+        """Post a multi-step form in the channel instead of asking in prose.
+
+        Each entry in ``steps`` is single-choice, multi-select, or free-text.
+        A step may carry one finished image by passing the file-store handle
+        returned by the image-generation tool — never a URL, never a diagram
+        source. Server channels and threads are supported; direct messages
+        are not. A form that exceeds a platform ceiling (too many steps, too
+        many options, too large a label) raises an error naming the offending
+        step — split the form into a shorter follow-up and retry.
+
+        AFTER CALLING THIS TOOL YOU MUST END YOUR TURN IMMEDIATELY. Do not
+        narrate the form, do not continue the conversation, and do not call
+        another tool. The user's answers arrive later as a brand-new message.
+        """
+        return await _post_wizard_impl(
+            runtime,
+            await _auth(ctx),
+            prompt=prompt,
+            steps=steps,
+            channel_id=channel_id,
+        )

--- a/packages/adapters/mcp/tests/tools/test_discord_wizard.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_wizard.py
@@ -389,6 +389,68 @@ async def test_post_wizard_returns_a_url_for_every_uploaded_handle(
     ), "the later step's handle must also resolve, even though it isn't displayed"
 
 
+async def test_post_wizard_maps_same_named_attachments_to_distinct_handles(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A file's display name is slugged from the agent-supplied title, so two
+    steps whose images share a title upload under one filename -- each handle
+    must still resolve to its own attachment."""
+    store = FileStore(base_dir=tmp_path)
+    handle1 = store.put(data=b"PNGDATA1", mime_type="image/png", title="chart")
+    handle2 = store.put(data=b"PNGDATA2", mime_type="image/png", title="chart")
+    assert store.get(handle1.id).display_filename == store.get(handle2.id).display_filename, (
+        "the two handles must genuinely collide on filename for this test to mean anything"
+    )
+    spec = _two_image_spec_for(handle1.id, handle2.id)
+
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            return _message_payload(
+                message_id="9203",
+                attachments=[
+                    {
+                        "id": "8001",
+                        "filename": "chart.png",
+                        "url": "https://cdn.discordapp.com/attachments/1/2/chart.png?ex=first",
+                        "proxy_url": "https://media.discordapp.net/attachments/1/2/chart.png?ex=first",
+                        "size": 8,
+                    },
+                    {
+                        "id": "8002",
+                        "filename": "chart.png",
+                        "url": "https://cdn.discordapp.com/attachments/1/3/chart.png?ex=second",
+                        "proxy_url": "https://media.discordapp.net/attachments/1/3/chart.png?ex=second",
+                        "size": 8,
+                    },
+                ],
+            )
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    posted_wizard = await _post_wizard_impl(
+        _runtime_with_discord_token(file_store=store),
+        _auth(),
+        channel_id="222",
+        spec=spec,
+        short_id="abcd1234",
+    )
+
+    assert posted_wizard.image_urls[handle1.id] == (
+        "https://cdn.discordapp.com/attachments/1/2/chart.png?ex=first"
+    ), "the first step's handle must resolve to the first uploaded attachment"
+    assert posted_wizard.image_urls[handle2.id] == (
+        "https://cdn.discordapp.com/attachments/1/3/chart.png?ex=second"
+    ), "the second step must not inherit the first step's image"
+
+
 async def test_post_wizard_rejects_a_missing_file_handle(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/packages/adapters/mcp/tests/tools/test_discord_wizard.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_wizard.py
@@ -1,0 +1,484 @@
+"""Transport-level tests for _post_wizard_impl (posting a wizard's first screen).
+
+Each test calls `_post_wizard_impl` directly with a hand-built `AuthIdentity`
+and a transport-level patched `discord.http.HTTPClient` (`patch_discord_http`),
+exactly like `test_discord.py`'s credential-button tests. Inline route
+handlers and payload builders per call site (no DRY across tests) so SDK-
+payload drift breaks the relevant test, per guideline:testing.
+
+discord.py sends the create-message request as `json=payload` when the
+message carries no files, or as multipart (`files=..., form=[...]`) when it
+does -- the wizard post always attaches at least the view, and attaches real
+files whenever any step declares an `image_handle`. `_payload_from_kwargs`
+reads whichever transport the captured kwargs carry.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import discord
+import discord.http
+import pytest
+from anthropic import AsyncAnthropic
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.file_store import FileStore
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.discord import (
+    _post_wizard_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.config import AnthropicSettings, DatabaseSettings, DiscordSettings, Settings
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.domain import Role
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from fastmcp.exceptions import ToolError
+from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+# Load patch_discord_http directly from the sibling conftest.py by file path,
+# matching test_discord.py's workaround for the "from conftest import ..."
+# collision with the parent tests/conftest.py.
+_conftest_path = Path(__file__).parent / "conftest.py"
+_spec = importlib.util.spec_from_file_location("_tools_conftest", _conftest_path)
+assert _spec is not None and _spec.loader is not None
+_tools_conftest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_tools_conftest)
+patch_discord_http = _tools_conftest.patch_discord_http
+
+pytestmark = pytest.mark.asyncio
+
+# Permission flag constants (Discord docs).
+_VIEW_CHANNEL = 1 << 10  # 1024
+_SEND_MESSAGES = 1 << 11  # 2048
+
+
+def _payload_from_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Return the parsed JSON payload regardless of json vs multipart transport."""
+    if "json" in kwargs:
+        return kwargs["json"]  # type: ignore[no-any-return]
+    for part in kwargs["form"]:
+        if part["name"] == "payload_json":
+            return json.loads(part["value"])  # type: ignore[no-any-return]
+    raise AssertionError(f"no payload_json part in multipart form: {kwargs!r}")
+
+
+def _runtime_with_discord_token(*, file_store: FileStore | None) -> McpRuntime:
+    """Build an McpRuntime with a Settings carrying a discord.bot_token.
+
+    `session_factory` and `client` are real (unbound/unrouted) SDK objects
+    the impl never touches in these tests -- `rest_client` opens its own
+    per-call Discord HTTP client instead of reusing either.
+    """
+    settings = Settings(
+        database=DatabaseSettings(url="postgresql+asyncpg://x/y"),  # pyright: ignore[reportArgumentType]
+        anthropic=AnthropicSettings(api_key=SecretStr("k")),
+        discord=DiscordSettings(bot_token=SecretStr("test-bot-token")),
+    )
+    session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker()  # type: ignore[call-arg]
+    return McpRuntime(
+        session_factory=session_factory,
+        client=AsyncAnthropic(api_key="k"),
+        settings=settings,
+        deployment_default=DeploymentDefault(),
+        file_store=file_store,
+    )
+
+
+def _auth(*, external_id: str = "111", platform_user_id: str = "42") -> AuthIdentity:
+    return AuthIdentity(
+        account_id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+        role=Role.USER,
+        platform="discord",
+        external_id=external_id,
+        platform_user_id=platform_user_id,
+    )
+
+
+def _guild_payload(*, guild_id: str = "111", owner_id: str = "1") -> dict[str, Any]:
+    return {
+        "id": guild_id,
+        "name": "test-guild",
+        "owner_id": owner_id,
+        "afk_timeout": 0,
+        "verification_level": 0,
+        "default_message_notifications": 0,
+        "explicit_content_filter": 0,
+        "roles": [],
+        "emojis": [],
+        "features": [],
+        "mfa_level": 0,
+        "system_channel_flags": 0,
+        "premium_tier": 0,
+        "preferred_locale": "en-US",
+        "nsfw_level": 0,
+        "premium_progress_bar_enabled": False,
+        "stickers": [],
+        "region": "us-east",
+    }
+
+
+def _everyone_role(guild_id: str, perms: int) -> dict[str, Any]:
+    return {
+        "id": guild_id,
+        "name": "@everyone",
+        "permissions": str(perms),
+        "position": 0,
+        "color": 0,
+        "hoist": False,
+        "managed": False,
+        "mentionable": False,
+        "flags": 0,
+    }
+
+
+def _member_payload(user_id: str = "42") -> dict[str, Any]:
+    return {
+        "user": {
+            "id": user_id,
+            "username": "caller",
+            "discriminator": "0001",
+            "global_name": "caller",
+            "avatar": None,
+            "bot": False,
+            "flags": 0,
+        },
+        "roles": [],
+        "joined_at": "2024-01-01T00:00:00+00:00",
+        "deaf": False,
+        "mute": False,
+        "flags": 0,
+    }
+
+
+def _text_channel_payload(*, channel_id: str = "222", guild_id: str = "111") -> dict[str, Any]:
+    return {
+        "id": channel_id,
+        "type": 0,
+        "guild_id": guild_id,
+        "name": "general",
+        "position": 0,
+        "permission_overwrites": [],
+        "nsfw": False,
+        "rate_limit_per_user": 0,
+        "parent_id": None,
+    }
+
+
+def _author_payload(author_id: str = "42") -> dict[str, Any]:
+    return {
+        "id": author_id,
+        "username": "caller",
+        "discriminator": "0001",
+        "global_name": "caller",
+        "avatar": None,
+        "bot": False,
+        "flags": 0,
+    }
+
+
+def _message_payload(
+    *,
+    message_id: str,
+    channel_id: str = "222",
+    attachments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": message_id,
+        "channel_id": channel_id,
+        "author": _author_payload(),
+        "content": None,
+        "timestamp": "2026-05-09T00:00:00+00:00",
+        "edited_timestamp": None,
+        "tts": False,
+        "mention_everyone": False,
+        "mentions": [],
+        "mention_roles": [],
+        "attachments": attachments or [],
+        "embeds": [],
+        "type": 0,
+        "pinned": False,
+        "flags": 32768,
+    }
+
+
+def _two_image_spec_for(handle1: str, handle2: str) -> WizardSpec:
+    return WizardSpec(
+        prompt="Configure the pipeline",
+        steps=[
+            Step(
+                key="stage",
+                question="Pick a stage",
+                kind=StepKind.CHOICE,
+                options=[Option(label="dev", value="dev")],
+                image_handle=handle1,
+            ),
+            Step(
+                key="region",
+                question="Pick a region",
+                kind=StepKind.CHOICE,
+                options=[Option(label="us", value="us")],
+                image_handle=handle2,
+            ),
+        ],
+    )
+
+
+def _happy_path_handler(
+    posted: dict[str, Any], *, attachments: list[dict[str, Any]] | None = None
+) -> Any:
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            posted.update(kwargs)
+            return _message_payload(message_id="9201", attachments=attachments)
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    return handler
+
+
+async def test_post_wizard_sets_the_components_v2_flag_from_the_view(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted))
+    spec = WizardSpec(
+        prompt="p",
+        steps=[
+            Step(
+                key="k", question="q", kind=StepKind.CHOICE, options=[Option(label="a", value="a")]
+            )
+        ],
+    )
+    await _post_wizard_impl(
+        _runtime_with_discord_token(file_store=None),
+        _auth(),
+        channel_id="222",
+        spec=spec,
+        short_id="abcd1234",
+    )
+    payload = _payload_from_kwargs(posted)
+    assert payload["flags"] == discord.MessageFlags(components_v2=True).value, (
+        "the sent flags value must equal the library's own components_v2 flag value"
+    )
+
+
+async def test_post_wizard_sends_no_message_content(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted))
+    spec = WizardSpec(
+        prompt="p",
+        steps=[
+            Step(
+                key="k", question="q", kind=StepKind.CHOICE, options=[Option(label="a", value="a")]
+            )
+        ],
+    )
+    await _post_wizard_impl(
+        _runtime_with_discord_token(file_store=None),
+        _auth(),
+        channel_id="222",
+        spec=spec,
+        short_id="abcd1234",
+    )
+    payload = _payload_from_kwargs(posted)
+    assert payload.get("content") is None, (
+        "a components-v2 message cannot carry content; the sent payload must "
+        "have no content or a null one"
+    )
+
+
+async def test_post_wizard_uploads_every_step_image_but_references_only_the_first(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    store = FileStore(base_dir=tmp_path)
+    handle1 = store.put(data=b"PNGDATA1", mime_type="image/png", title="step1")
+    handle2 = store.put(data=b"PNGDATA2", mime_type="image/png", title="step2")
+    spec = _two_image_spec_for(handle1.id, handle2.id)
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted))
+    await _post_wizard_impl(
+        _runtime_with_discord_token(file_store=store),
+        _auth(),
+        channel_id="222",
+        spec=spec,
+        short_id="abcd1234",
+    )
+    assert posted["files"] is not None and len(posted["files"]) == 2, (
+        "both step images must upload even though only step one's shows"
+    )
+    payload = _payload_from_kwargs(posted)
+    serialized = json.dumps(payload["components"])
+    assert serialized.count("attachment://") == 1, (
+        "later steps' images must mint content-delivery addresses without "
+        "being displayed -- only step one's image may be referenced by a "
+        "rendered component"
+    )
+
+
+async def test_post_wizard_returns_a_url_for_every_uploaded_handle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    store = FileStore(base_dir=tmp_path)
+    handle1 = store.put(data=b"PNGDATA1", mime_type="image/png", title="step1")
+    handle2 = store.put(data=b"PNGDATA2", mime_type="image/png", title="step2")
+    spec = _two_image_spec_for(handle1.id, handle2.id)
+    posted: dict[str, Any] = {}
+
+    def handler_factory() -> Any:
+        async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+            if route.path == "/guilds/{guild_id}":
+                return _guild_payload()
+            if route.path == "/guilds/{guild_id}/roles":
+                return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+            if route.path == "/guilds/{guild_id}/members/{member_id}":
+                return _member_payload()
+            if route.path == "/channels/{channel_id}":
+                return _text_channel_payload()
+            if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+                posted.update(kwargs)
+                return _message_payload(
+                    message_id="9202",
+                    attachments=[
+                        {
+                            "id": "8001",
+                            "filename": "step1.png",
+                            "url": "https://cdn.discordapp.com/attachments/1/2/step1.png?ex=abc123",
+                            "proxy_url": "https://media.discordapp.net/attachments/1/2/step1.png?ex=abc123",
+                            "size": 8,
+                        },
+                        {
+                            "id": "8002",
+                            "filename": "step2.png",
+                            "url": "https://cdn.discordapp.com/attachments/1/2/step2.png?ex=def456",
+                            "proxy_url": "https://media.discordapp.net/attachments/1/2/step2.png?ex=def456",
+                            "size": 8,
+                        },
+                    ],
+                )
+            raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+        return handler
+
+    patch_discord_http(monkeypatch, handler_factory())
+    posted_wizard = await _post_wizard_impl(
+        _runtime_with_discord_token(file_store=store),
+        _auth(),
+        channel_id="222",
+        spec=spec,
+        short_id="abcd1234",
+    )
+    assert posted_wizard.image_urls[handle1.id] == (
+        "https://cdn.discordapp.com/attachments/1/2/step1.png?ex=abc123"
+    ), "each handle must map to the durable url the platform minted for it"
+    assert posted_wizard.image_urls[handle2.id] == (
+        "https://cdn.discordapp.com/attachments/1/2/step2.png?ex=def456"
+    ), "the later step's handle must also resolve, even though it isn't displayed"
+
+
+async def test_post_wizard_rejects_a_missing_file_handle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    store = FileStore(base_dir=tmp_path)
+    spec = WizardSpec(
+        prompt="p",
+        steps=[
+            Step(
+                key="k",
+                question="q",
+                kind=StepKind.CHOICE,
+                options=[Option(label="a", value="a")],
+                image_handle="nope.png",
+            )
+        ],
+    )
+
+    async def handler(_route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        raise AssertionError("Discord HTTP must not be hit before the handle resolves")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="nope.png"):
+        await _post_wizard_impl(
+            _runtime_with_discord_token(file_store=store),
+            _auth(),
+            channel_id="222",
+            spec=spec,
+            short_id="abcd1234",
+        )
+
+
+async def test_post_wizard_refuses_a_channel_the_requester_cannot_see(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    spec = WizardSpec(
+        prompt="p",
+        steps=[
+            Step(
+                key="k", question="q", kind=StepKind.CHOICE, options=[Option(label="a", value="a")]
+            )
+        ],
+    )
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]  # no send_messages
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            raise AssertionError("must not POST when send permission denied")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="send_messages"):
+        await _post_wizard_impl(
+            _runtime_with_discord_token(file_store=None),
+            _auth(),
+            channel_id="222",
+            spec=spec,
+            short_id="abcd1234",
+        )
+
+
+async def test_post_wizard_posts_a_form_with_no_images(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted))
+    spec = WizardSpec(
+        prompt="p",
+        steps=[
+            Step(
+                key="k", question="q", kind=StepKind.CHOICE, options=[Option(label="a", value="a")]
+            )
+        ],
+    )
+    posted_wizard = await _post_wizard_impl(
+        _runtime_with_discord_token(file_store=None),
+        _auth(),
+        channel_id="222",
+        spec=spec,
+        short_id="abcd1234",
+    )
+    assert posted_wizard.image_urls == {}, "a form with no images uploads nothing"
+    payload = _payload_from_kwargs(posted)
+    assert len(payload["components"]) == 1, "still exactly one top-level container"
+    assert payload["flags"] == discord.MessageFlags(components_v2=True).value, (
+        "the v2 flag must still be set even with zero attachments"
+    )

--- a/packages/adapters/mcp/tests/tools/test_discord_wizard.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_wizard.py
@@ -301,6 +301,37 @@ async def test_post_wizard_sends_no_message_content(
     )
 
 
+async def test_post_wizard_suppresses_every_mention(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The head text carries the agent-authored prompt and question verbatim,
+    so an injected mass mention would ping the whole channel."""
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted))
+    spec = WizardSpec(
+        prompt="@everyone pick one",
+        steps=[
+            Step(
+                key="k",
+                question="<@&999> which?",
+                kind=StepKind.CHOICE,
+                options=[Option(label="a", value="a")],
+            )
+        ],
+    )
+    await _post_wizard_impl(
+        _runtime_with_discord_token(file_store=None),
+        _auth(),
+        channel_id="222",
+        spec=spec,
+        short_id="abcd1234",
+    )
+    payload = _payload_from_kwargs(posted)
+    assert payload["allowed_mentions"] == discord.AllowedMentions.none().to_dict(), (
+        "a wizard post must suppress every mention -- nothing in a form needs to ping"
+    )
+
+
 async def test_post_wizard_uploads_every_step_image_but_references_only_the_first(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/packages/adapters/mcp/tests/tools/test_wizard_tool.py
+++ b/packages/adapters/mcp/tests/tools/test_wizard_tool.py
@@ -1,0 +1,592 @@
+"""DB-backed unit tests for post_wizard's tool-level impl.
+
+Drives `_post_wizard_impl` (the tool-level one in `tools/wizard.py`, which
+delegates to the Discord-side `_post_wizard_impl` from `tools/discord/`) with
+a real `committing_sessionmaker` (real Postgres, per guideline:testing), a
+real `FileStore`, and a transport-level patched Discord `HTTPClient`
+(`patch_discord_http`, loaded from the sibling conftest.py by file path —
+same trick `test_discord_wizard.py`/`test_credential_requests.py` use).
+
+The short_id the tool mints internally is never returned to the caller (the
+tool's return value is the stop signal), so tests recover it the same way
+`test_credential_requests.py` recovers a minted token: by parsing it back out
+of the posted message payload's own `wz:{short_id}:{action}` custom_ids.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import discord
+import discord.http
+import pytest
+from anthropic import AsyncAnthropic
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.file_store import FileStore
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.wizard import _STOP_SIGNAL, _post_wizard_impl
+from daimon.core.config import AnthropicSettings, DatabaseSettings, DiscordSettings, Settings
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.domain import Role
+from daimon.core.stores.wizard_session import (
+    count_wizard_sessions_for_platform_user,
+    get_wizard_session,
+)
+from daimon.core.wizard.expiry import DEFAULT_TTL
+from daimon.core.wizard.spec import Option, Step, StepKind
+from daimon.testing.factories import make_account, make_tenant
+from fastmcp.exceptions import ToolError
+from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+# Load patch_discord_http directly from the sibling conftest.py by file path —
+# same workaround test_discord_wizard.py / test_credential_requests.py use to
+# dodge the "from conftest import ..." collision with the parent tests/conftest.py.
+_conftest_path = Path(__file__).parent / "conftest.py"
+_spec = importlib.util.spec_from_file_location("_tools_conftest", _conftest_path)
+assert _spec is not None and _spec.loader is not None
+_tools_conftest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_tools_conftest)
+patch_discord_http = _tools_conftest.patch_discord_http
+
+pytestmark = pytest.mark.asyncio
+
+_VIEW_CHANNEL = 1 << 10
+_SEND_MESSAGES = 1 << 11
+
+_SHORT_ID_RE = re.compile(r"wz:([A-Za-z0-9]{8}):")
+
+
+def _runtime(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    file_store: FileStore | None = None,
+    with_discord: bool = True,
+) -> McpRuntime:
+    settings = Settings(
+        database=DatabaseSettings(url="postgresql+asyncpg://x/y"),  # pyright: ignore[reportArgumentType]
+        anthropic=AnthropicSettings(api_key=SecretStr("k")),
+        discord=DiscordSettings(bot_token=SecretStr("test-bot-token")) if with_discord else None,
+    )
+    return McpRuntime(
+        session_factory=sessionmaker,
+        client=AsyncAnthropic(api_key="k"),
+        settings=settings,
+        deployment_default=DeploymentDefault(),
+        file_store=file_store,
+    )
+
+
+def _auth_identity(
+    *,
+    platform: str | None = "discord",
+    external_id: str | None = "111",
+    platform_user_id: str | None = "42",
+    tenant_id: uuid.UUID | None = None,
+    account_id: uuid.UUID | None = None,
+) -> AuthIdentity:
+    return AuthIdentity(
+        account_id=account_id if account_id is not None else uuid.uuid4(),
+        tenant_id=tenant_id if tenant_id is not None else uuid.uuid4(),
+        role=Role.USER,
+        platform=platform,
+        external_id=external_id,
+        platform_user_id=platform_user_id,
+    )
+
+
+def _guild_payload(*, guild_id: str = "111") -> dict[str, Any]:
+    return {
+        "id": guild_id,
+        "name": "test-guild",
+        "owner_id": "1",
+        "afk_timeout": 0,
+        "verification_level": 0,
+        "default_message_notifications": 0,
+        "explicit_content_filter": 0,
+        "roles": [],
+        "emojis": [],
+        "features": [],
+        "mfa_level": 0,
+        "system_channel_flags": 0,
+        "premium_tier": 0,
+        "preferred_locale": "en-US",
+        "nsfw_level": 0,
+        "premium_progress_bar_enabled": False,
+        "stickers": [],
+        "region": "us-east",
+    }
+
+
+def _everyone_role(guild_id: str, perms: int) -> dict[str, Any]:
+    return {
+        "id": guild_id,
+        "name": "@everyone",
+        "permissions": str(perms),
+        "position": 0,
+        "color": 0,
+        "hoist": False,
+        "managed": False,
+        "mentionable": False,
+        "flags": 0,
+    }
+
+
+def _member_payload(user_id: str = "42") -> dict[str, Any]:
+    return {
+        "user": {
+            "id": user_id,
+            "username": "caller",
+            "discriminator": "0001",
+            "global_name": "caller",
+            "avatar": None,
+            "bot": False,
+            "flags": 0,
+        },
+        "roles": [],
+        "joined_at": "2024-01-01T00:00:00+00:00",
+        "deaf": False,
+        "mute": False,
+        "flags": 0,
+    }
+
+
+def _text_channel_payload(*, channel_id: str = "222", guild_id: str = "111") -> dict[str, Any]:
+    return {
+        "id": channel_id,
+        "type": 0,
+        "guild_id": guild_id,
+        "name": "general",
+        "position": 0,
+        "permission_overwrites": [],
+        "nsfw": False,
+        "rate_limit_per_user": 0,
+        "parent_id": None,
+    }
+
+
+def _author_payload(author_id: str = "1") -> dict[str, Any]:
+    return {
+        "id": author_id,
+        "username": "bot",
+        "discriminator": "0001",
+        "global_name": "bot",
+        "avatar": None,
+        "bot": True,
+        "flags": 0,
+    }
+
+
+def _message_payload(
+    *,
+    message_id: str,
+    channel_id: str = "222",
+    attachments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": message_id,
+        "channel_id": channel_id,
+        "author": _author_payload(),
+        "content": None,
+        "timestamp": "2026-05-09T00:00:00+00:00",
+        "edited_timestamp": None,
+        "tts": False,
+        "mention_everyone": False,
+        "mentions": [],
+        "mention_roles": [],
+        "attachments": attachments or [],
+        "embeds": [],
+        "type": 0,
+        "pinned": False,
+        "flags": 32768,
+    }
+
+
+def _happy_path_handler(
+    posted: dict[str, Any],
+    *,
+    message_id: str = "9301",
+    attachments: list[dict[str, Any]] | None = None,
+) -> Any:
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            posted.update(kwargs)
+            return _message_payload(message_id=message_id, attachments=attachments)
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    return handler
+
+
+def _payload_from_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    if "json" in kwargs:
+        return kwargs["json"]  # type: ignore[no-any-return]
+    for part in kwargs["form"]:
+        if part["name"] == "payload_json":
+            return json.loads(part["value"])  # type: ignore[no-any-return]
+    raise AssertionError(f"no payload_json part in multipart form: {kwargs!r}")
+
+
+def _short_id_from_posted(posted: dict[str, Any]) -> str:
+    payload = _payload_from_kwargs(posted)
+    match = _SHORT_ID_RE.search(json.dumps(payload["components"]))
+    assert match is not None, f"no wz: custom_id found in posted components: {payload!r}"
+    return match.group(1)
+
+
+def _one_choice_step(**kwargs: Any) -> Step:
+    return Step(
+        key=kwargs.pop("key", "k"),
+        question="q",
+        kind=StepKind.CHOICE,
+        options=[Option(label="a", value="a")],
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. The stop signal
+# ---------------------------------------------------------------------------
+
+
+async def test_post_wizard_returns_the_stop_signal(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await db_session.commit()
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted))
+    result = await _post_wizard_impl(
+        _runtime(committing_sessionmaker),
+        _auth_identity(tenant_id=tenant.id, account_id=account.id),
+        prompt="Configure the pipeline",
+        steps=[_one_choice_step()],
+        channel_id="222",
+    )
+    assert result == _STOP_SIGNAL, "the tool must return exactly the module's stop-signal constant"
+    assert "end your turn" in result.lower(), "the stop signal must tell the agent to end its turn"
+
+
+# ---------------------------------------------------------------------------
+# 2. The stored row
+# ---------------------------------------------------------------------------
+
+
+async def test_post_wizard_stores_the_form_with_its_message_id(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await db_session.commit()
+    auth = _auth_identity(tenant_id=tenant.id, account_id=account.id)
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted, message_id="9302"))
+
+    await _post_wizard_impl(
+        _runtime(committing_sessionmaker),
+        auth,
+        prompt="Configure the pipeline",
+        steps=[_one_choice_step()],
+        channel_id="222",
+    )
+
+    short_id = _short_id_from_posted(posted)
+    row = await get_wizard_session(db_session, short_id=short_id)
+    assert row is not None, "the row minted by the post must be readable back through the store"
+    assert row.status == "open"
+    assert row.current_step == 0
+    assert row.answers == {}
+    assert row.message_id == "9302"
+    assert row.tenant_id == tenant.id
+    assert row.account_id == auth.account_id
+    assert row.requester_platform_user_id == auth.platform_user_id
+    assert row.channel_id == "222"
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-step content-delivery addresses persist
+# ---------------------------------------------------------------------------
+
+
+async def test_post_wizard_persists_a_content_address_for_every_step_image(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await db_session.commit()
+    store = FileStore(base_dir=tmp_path)
+    handle1 = store.put(data=b"PNGDATA1", mime_type="image/png", title="step1")
+    handle2 = store.put(data=b"PNGDATA2", mime_type="image/png", title="step2")
+    posted: dict[str, Any] = {}
+    patch_discord_http(
+        monkeypatch,
+        _happy_path_handler(
+            posted,
+            message_id="9303",
+            attachments=[
+                {
+                    "id": "8001",
+                    "filename": "step1.png",  # matches store.put(title="step1") below
+                    "url": "https://cdn.discordapp.com/attachments/1/2/step1.png?ex=abc123",
+                    "proxy_url": "https://media.discordapp.net/attachments/1/2/step1.png?ex=abc123",
+                    "size": 8,
+                },
+                {
+                    "id": "8002",
+                    "filename": "step2.png",  # matches store.put(title="step2") below
+                    "url": "https://cdn.discordapp.com/attachments/1/2/step2.png?ex=def456",
+                    "proxy_url": "https://media.discordapp.net/attachments/1/2/step2.png?ex=def456",
+                    "size": 8,
+                },
+            ],
+        ),
+    )
+
+    await _post_wizard_impl(
+        _runtime(committing_sessionmaker, file_store=store),
+        _auth_identity(tenant_id=tenant.id, account_id=account.id),
+        prompt="Configure the pipeline",
+        steps=[
+            _one_choice_step(key="stage", image_handle=handle1.id),
+            _one_choice_step(key="region", image_handle=handle2.id),
+        ],
+        channel_id="222",
+    )
+
+    short_id = _short_id_from_posted(posted)
+    row = await get_wizard_session(db_session, short_id=short_id)
+    assert row is not None
+    steps_by_key = {step["key"]: step for step in row.spec["steps"]}
+    assert steps_by_key["stage"]["image_url"] == (
+        "https://cdn.discordapp.com/attachments/1/2/step1.png?ex=abc123"
+    ), "the stored spec must resolve step one's image url so another process can re-render it"
+    assert steps_by_key["region"]["image_url"] == (
+        "https://cdn.discordapp.com/attachments/1/2/step2.png?ex=def456"
+    ), "the stored spec must resolve every step's image url, not just the displayed one"
+
+
+# ---------------------------------------------------------------------------
+# 4. Expiry follows the image signature
+# ---------------------------------------------------------------------------
+
+
+async def test_post_wizard_expiry_follows_the_image_signature(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await db_session.commit()
+    store = FileStore(base_dir=tmp_path)
+    handle = store.put(data=b"PNGDATA", mime_type="image/png", title="x")
+    an_hour_out = int((datetime.now(UTC) + timedelta(hours=1)).timestamp())
+    posted: dict[str, Any] = {}
+    patch_discord_http(
+        monkeypatch,
+        _happy_path_handler(
+            posted,
+            message_id="9304",
+            attachments=[
+                {
+                    "id": "8001",
+                    "filename": "x.png",  # matches store.put(title="x") above
+                    "url": f"https://cdn.discordapp.com/attachments/1/2/x.png?ex={an_hour_out:x}",
+                    "proxy_url": f"https://media.discordapp.net/attachments/1/2/x.png?ex={an_hour_out:x}",
+                    "size": 7,
+                }
+            ],
+        ),
+    )
+    before = datetime.now(UTC)
+
+    await _post_wizard_impl(
+        _runtime(committing_sessionmaker, file_store=store),
+        _auth_identity(tenant_id=tenant.id, account_id=account.id),
+        prompt="Configure the pipeline",
+        steps=[_one_choice_step(image_handle=handle.id)],
+        channel_id="222",
+    )
+
+    short_id = _short_id_from_posted(posted)
+    row = await get_wizard_session(db_session, short_id=short_id)
+    assert row is not None
+    assert row.expires_at < before + timedelta(hours=1), (
+        "a form whose image signature expires in an hour must expire under that hour"
+    )
+
+
+async def test_post_wizard_expiry_defaults_with_no_images(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await db_session.commit()
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted, message_id="9305"))
+    before = datetime.now(UTC)
+
+    await _post_wizard_impl(
+        _runtime(committing_sessionmaker),
+        _auth_identity(tenant_id=tenant.id, account_id=account.id),
+        prompt="Configure the pipeline",
+        steps=[_one_choice_step()],
+        channel_id="222",
+    )
+
+    short_id = _short_id_from_posted(posted)
+    row = await get_wizard_session(db_session, short_id=short_id)
+    assert row is not None
+    assert row.expires_at >= before + DEFAULT_TTL - timedelta(seconds=5), (
+        "with no images, the stored expiry must be the default TTL window"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. A caller-supplied image_url never survives
+# ---------------------------------------------------------------------------
+
+
+async def test_post_wizard_strips_a_caller_supplied_image_url(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await db_session.commit()
+    posted: dict[str, Any] = {}
+    patch_discord_http(monkeypatch, _happy_path_handler(posted, message_id="9306"))
+
+    await _post_wizard_impl(
+        _runtime(committing_sessionmaker),
+        _auth_identity(tenant_id=tenant.id, account_id=account.id),
+        prompt="Configure the pipeline",
+        steps=[_one_choice_step(image_url="https://evil.example.com/x.png")],
+        channel_id="222",
+    )
+
+    short_id = _short_id_from_posted(posted)
+    row = await get_wizard_session(db_session, short_id=short_id)
+    assert row is not None
+    assert row.spec["steps"][0]["image_url"] is None, (
+        "a caller-supplied image_url with no image_handle must never be persisted"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Over-ceiling forms raise an actionable error
+# ---------------------------------------------------------------------------
+
+
+async def test_post_wizard_rejects_an_over_ceiling_form(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    async def handler(_route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        raise AssertionError("an over-ceiling form must never reach the Discord HTTP layer")
+
+    step = Step(
+        key="too_many",
+        question="q",
+        kind=StepKind.CHOICE,
+        options=[Option(label=f"opt{n}", value=f"v{n}") for n in range(26)],
+    )
+    with pytest.raises(ToolError, match=r"too_many.*(?s:.*)split the form") as excinfo:
+        await _post_wizard_impl(
+            _runtime(committing_sessionmaker),
+            _auth_identity(),
+            prompt="Configure the pipeline",
+            steps=[step],
+            channel_id="222",
+        )
+    assert "too_many" in str(excinfo.value), "the error must name the offending step's key"
+
+
+# ---------------------------------------------------------------------------
+# 7. A failed post leaves no row
+# ---------------------------------------------------------------------------
+
+
+async def test_post_wizard_writes_no_row_when_the_post_fails(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await db_session.commit()
+    auth = _auth_identity(tenant_id=tenant.id, account_id=account.id)
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]  # no send_messages
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.method == "POST" and route.path == "/channels/{channel_id}/messages":
+            raise AssertionError("must not POST when send permission is denied")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+
+    with pytest.raises(ToolError, match="send_messages"):
+        await _post_wizard_impl(
+            _runtime(committing_sessionmaker),
+            auth,
+            prompt="Configure the pipeline",
+            steps=[_one_choice_step()],
+            channel_id="222",
+        )
+
+    assert (
+        await count_wizard_sessions_for_platform_user(
+            db_session, platform_user_id=auth.platform_user_id or "", tenant_id=tenant.id
+        )
+        == 0
+    ), "a failed post must leave no stored form nobody can tap"
+
+
+# ---------------------------------------------------------------------------
+# 8. Slack is refused
+# ---------------------------------------------------------------------------
+
+
+async def test_post_wizard_refuses_on_slack(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
+    with pytest.raises(ToolError, match="not supported on Slack"):
+        await _post_wizard_impl(
+            _runtime(committing_sessionmaker),
+            auth,
+            prompt="Configure the pipeline",
+            steps=[_one_choice_step()],
+            channel_id="222",
+        )

--- a/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
+++ b/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
@@ -61,6 +61,7 @@ from daimon.core.stores.tenants import get_tenant
 from daimon.core.tenant_balance import is_over_balance
 from daimon.core.usage_recording import record_turn_usage
 from daimon.core.usage_sweep import sweep_headless_usage
+from daimon.core.wizard_sweep import sweep_expired_wizard_sessions
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
@@ -310,6 +311,18 @@ async def _sweep_headless_usage(
         log.exception("scheduler.usage_sweep.failed")
 
 
+async def _sweep_wizard_sessions(sm: async_sessionmaker[AsyncSession]) -> None:
+    """Abandon expired open wizard_session rows once. Boundary catch: a sweep
+    failure must not kill the scheduler loop — the next tick retries.
+
+    No `anthropic.APIError` in the catch: this sweep makes no upstream call.
+    """
+    try:
+        await sweep_expired_wizard_sessions(sm, now=datetime.now(UTC))
+    except SQLAlchemyError:
+        log.exception("scheduler.wizard_sweep.failed")
+
+
 def _validate_mcp_settings(settings: Settings) -> None:
     """Single-tenant deployments require both ``settings.mcp.jwt_secret`` and
     ``settings.mcp.public_url`` so each routine fire can bind the daimon-mcp
@@ -426,6 +439,7 @@ async def run(
             )
             await _sweep_pending_files(client, sm)
             await _sweep_headless_usage(client, sm, markup=settings.billing.markup)
+            await _sweep_wizard_sessions(sm)
             return 0
 
         while not stop_event.is_set():
@@ -440,6 +454,7 @@ async def run(
             )
             await _sweep_pending_files(client, sm)
             await _sweep_headless_usage(client, sm, markup=settings.billing.markup)
+            await _sweep_wizard_sessions(sm)
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(
                     stop_event.wait(), timeout=scheduler_settings.tick_interval_s

--- a/packages/adapters/scheduler/tests/test_main.py
+++ b/packages/adapters/scheduler/tests/test_main.py
@@ -26,6 +26,7 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
 from daimon.adapters.scheduler.main import (
     _build_fire,  # pyright: ignore[reportPrivateUsage]  # test seam for balance gate + debit binding
     _CapsAdapter,  # pyright: ignore[reportPrivateUsage]  # named test seam for cap wiring
+    _sweep_wizard_sessions,  # pyright: ignore[reportPrivateUsage]  # test seam for the wizard sweep wrapper
     _validate_mcp_settings,  # pyright: ignore[reportPrivateUsage]  # boot-validation seam
 )
 from daimon.core.billing import BillingConfig
@@ -41,6 +42,7 @@ from daimon.core.stores.routines import create_routine, get_routine
 from daimon.core.usage_recording import record_turn_usage
 from daimon.testing.factories import make_tenant
 from pydantic import SecretStr
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 _TEST_BILLING = BillingConfig(
@@ -752,3 +754,39 @@ async def test_fire_closure_threads_public_url_from_settings(
         )
 
     await fake_client.close()
+
+
+async def test_sweep_wizard_sessions_swallows_sqlalchemy_error(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A SQLAlchemyError from the core sweep must not propagate — the wrapper's
+    named boundary catch exists so a DB hiccup cannot kill the scheduler loop."""
+    with unittest.mock.patch(
+        "daimon.adapters.scheduler.main.sweep_expired_wizard_sessions",
+        side_effect=SQLAlchemyError("boom"),
+    ):
+        await _sweep_wizard_sessions(db_session_factory)  # must not raise
+
+
+async def test_sweep_wizard_sessions_forwards_sessionmaker_and_returns_cleanly(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Happy path: the wrapper forwards the injected sessionmaker to the core
+    sweep and returns without raising."""
+    captured_sm: list[async_sessionmaker[AsyncSession]] = []
+
+    async def fake_sweep(
+        sm: async_sessionmaker[AsyncSession], *, now: datetime, limit: int = 500
+    ) -> int:
+        captured_sm.append(sm)
+        return 0
+
+    with unittest.mock.patch(
+        "daimon.adapters.scheduler.main.sweep_expired_wizard_sessions",
+        side_effect=fake_sweep,
+    ):
+        await _sweep_wizard_sessions(db_session_factory)
+
+    assert captured_sm == [db_session_factory], (
+        "wrapper must forward the injected sessionmaker to the core sweep unchanged"
+    )

--- a/packages/adapters/slack/tests/test_privacy_panel.py
+++ b/packages/adapters/slack/tests/test_privacy_panel.py
@@ -308,6 +308,7 @@ def _make_preview(**overrides: Any) -> PurgePreview:
         "slack_user_tokens": PurgePreviewRow(count=0, example=None),
         "slack_turn_contexts": PurgePreviewRow(count=0, example=None),
         "credential_requests": PurgePreviewRow(count=0, example=None),
+        "wizard_sessions": PurgePreviewRow(count=0, example=None),
     }
     base.update(overrides)
     return PurgePreview(**base)

--- a/packages/core/alembic/versions/0004_wizard_session.py
+++ b/packages/core/alembic/versions/0004_wizard_session.py
@@ -1,0 +1,75 @@
+"""wizard_session — durable state for the multi-step Discord wizard.
+
+One row per wizard run, keyed by its short id (the value carried in every
+tap's `custom_id`). `tenant_id` cascades on tenant teardown. `account_id` is
+a nullable FK to `accounts.id` kept purely so the schema-reflecting purge
+drift guard sees this table — `SET NULL` rather than `CASCADE` because
+erasure is actually driven by the platform-user-scoped delete helper in
+`daimon.core.stores.wizard_session`, not by this FK. No cleanup sweep in
+this migration — `abandon_expired_wizard_sessions` is a store-level helper a
+scheduler tick calls separately.
+
+downgrade: safe
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision: str = "0004_wizard_session"
+down_revision: str | None = "0003_credential_requests"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "wizard_session",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("tenant_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("account_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("requester_platform_user_id", sa.Text(), nullable=False),
+        sa.Column("channel_id", sa.Text(), nullable=False),
+        sa.Column("message_id", sa.Text(), nullable=False),
+        sa.Column("spec", JSONB(), nullable=False),
+        sa.Column("answers", JSONB(), nullable=False),
+        sa.Column("current_step", sa.Integer(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_wizard_session"),
+        sa.ForeignKeyConstraint(
+            ["tenant_id"],
+            ["tenants.id"],
+            ondelete="CASCADE",
+            name="fk_wizard_session_tenant_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["account_id"],
+            ["accounts.id"],
+            ondelete="SET NULL",
+            name="fk_wizard_session_account_id",
+        ),
+    )
+    op.create_index(
+        "ix_wizard_session_tenant_requester",
+        "wizard_session",
+        ["tenant_id", "requester_platform_user_id"],
+    )
+    op.create_index(
+        "ix_wizard_session_status_expires_at",
+        "wizard_session",
+        ["status", "expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("wizard_session")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from decimal import Decimal
+from typing import Any
 
 from sqlalchemy import (
     BigInteger,
@@ -28,7 +29,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -852,6 +853,72 @@ class CredentialRequest(Base):
     )
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class WizardSession(Base):
+    """Durable state for one multi-step wizard form (`daimon.core.wizard`).
+
+    The process that posts a wizard's first screen (the MCP tool handler) is
+    never the process that receives its taps (the Discord bot's interaction
+    dispatcher), and a bot restart can land between any two taps on the same
+    form — so `answers` and `current_step` are read from and written to this
+    row on every tap. They are never derived from the message content and
+    never held in process memory; the row IS the state.
+
+    `account_id` deliberately carries a real (nullable) FK to `accounts.id`,
+    unlike the neighbouring handshake table `credential_requests`, whose
+    `account_id` has no FK at all. The schema-reflecting purge drift guard
+    (`test_purge_covers_every_account_or_principal_scoped_table`) only
+    notices a table if it has an `accounts.id` FK or a `principal_id`
+    column — being invisible to it means nothing mechanically forces a
+    future refactor to keep erasing these rows. Nullability does not exempt
+    a column from being a foreign key for that check. `ondelete="SET NULL"`
+    rather than `CASCADE` because erasure is actually driven by
+    `delete_wizard_sessions_for_platform_user` (a platform-user-scoped
+    delete, mirroring `credential_requests`), not by an accounts.id cascade;
+    the FK exists for the drift guard's visibility, not as the deletion
+    mechanism.
+
+    `requester_platform_user_id` is the actual authorization key for every
+    tap: the dispatcher compares it exactly against the tapping user's
+    platform id before honouring any button or select on this row.
+    """
+
+    __tablename__ = "wizard_session"
+    __table_args__ = (
+        Index(
+            "ix_wizard_session_tenant_requester",
+            "tenant_id",
+            "requester_platform_user_id",
+        ),
+        Index("ix_wizard_session_status_expires_at", "status", "expires_at"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    account_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("accounts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    requester_platform_user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    channel_id: Mapped[str] = mapped_column(Text, nullable=False)
+    message_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # dict[str, Any]: a serialized WizardSpec, validated back into the real
+    # Pydantic model at read time — not a typing shortcut.
+    spec: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    answers: Mapped[dict[str, list[str]]] = mapped_column(JSONB, nullable=False)
+    current_step: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
 class SlackEventDedup(Base):

--- a/packages/core/daimon/core/privacy.py
+++ b/packages/core/daimon/core/privacy.py
@@ -27,6 +27,7 @@ from daimon.core.stores import slack_turn_contexts as slack_turn_contexts_store
 from daimon.core.stores import slack_user_tokens as slack_user_tokens_store
 from daimon.core.stores import tenants as tenants_store
 from daimon.core.stores import user_skills as user_skills_store
+from daimon.core.stores import wizard_session as wizard_session_store
 from daimon.core.stores.domain import CliPrincipalRow, PlatformPrincipalRow
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -66,6 +67,7 @@ class PurgePreview(BaseModel):
     slack_user_tokens: PurgePreviewRow
     slack_turn_contexts: PurgePreviewRow
     credential_requests: PurgePreviewRow
+    wizard_sessions: PurgePreviewRow
 
 
 def _format_platform_principal(p: PlatformPrincipalRow) -> str:
@@ -284,6 +286,28 @@ async def collect_purge_preview(
             )
         credential_requests = PurgePreviewRow(count=credential_requests_total, example=None)
 
+        # 14. wizard_sessions — requester_platform_user_id-scoped, same shape as
+        # credential_requests above. Keyed by (platform_user_id, tenant_id),
+        # mirroring _purge_principal_in_session's actual tenant-scoped delete
+        # call exactly, so this preview agrees field-for-field with what
+        # purge_account actually deletes. Dedup avoids double-counting when two
+        # principals under the account share a (platform_user_id, tenant_id) key.
+        wizard_session_keys: set[tuple[str, uuid.UUID]] = set()
+        for pp in pp_list:
+            wizard_session_keys.add((pp.external_id, pp.tenant_id))
+        for cli in cli_list:
+            wizard_session_keys.add((cli.os_user, cli.tenant_id))
+        wizard_sessions_total = 0
+        for platform_user_id, key_tenant_id in wizard_session_keys:
+            wizard_sessions_total += (
+                await wizard_session_store.count_wizard_sessions_for_platform_user(
+                    session,
+                    platform_user_id=platform_user_id,
+                    tenant_id=key_tenant_id,
+                )
+            )
+        wizard_sessions = PurgePreviewRow(count=wizard_sessions_total, example=None)
+
     return PurgePreview(
         linked_principals=linked_principals,
         principal_links=principal_links,
@@ -298,4 +322,5 @@ async def collect_purge_preview(
         slack_user_tokens=slack_user_tokens,
         slack_turn_contexts=slack_turn_contexts,
         credential_requests=credential_requests,
+        wizard_sessions=wizard_sessions,
     )

--- a/packages/core/daimon/core/purge.py
+++ b/packages/core/daimon/core/purge.py
@@ -9,11 +9,18 @@ Registry note: the per-store delete sequence is hardcoded inside
 appending one helper call here plus one int field on `PurgeReport`. Current
 sequence: user_skills -> github_credentials -> agent_github_binding ->
 github_oauth_states (both kinds where the table permits) -> credential_requests
-(both kinds, platform-user-scoped like github_oauth_states) -> routines
+(both kinds, platform-user-scoped like github_oauth_states) -> wizard_session
+(both kinds, platform-user-scoped like credential_requests) -> routines
 (platform only) -> principal_links -> principal row. Account-level deletes
 (mcp_tokens, user_configs, accounts) run in `purge_account` after all principal
 rows are gone; mcp_tokens is keyed by account_id and is deleted before
 delete_account so its NO-ACTION/CASCADE FK to accounts.id is satisfied.
+
+wizard_session rides the platform-user-scoped delete path rather than an
+accounts.id cascade: the row's identity key is the requester's platform user
+id (a Discord/Slack tap must resolve back to a form regardless of whether an
+account row exists yet), and the nullable accounts FK on the table exists only
+to make the schema-reflecting drift guard see the table, not to delete through.
 
 credential_requests carries a Discord snowflake in requester_platform_user_id
 with no cleanup sweep by design (the table is one row per credential request,
@@ -64,6 +71,7 @@ from daimon.core.stores import slack_turn_contexts as slack_turn_contexts_store
 from daimon.core.stores import slack_user_tokens as slack_user_tokens_store
 from daimon.core.stores import tenants as tenants_store
 from daimon.core.stores import user_skills as user_skills_store
+from daimon.core.stores import wizard_session as wizard_session_store
 from daimon.core.stores.domain import CliPrincipalRow, PlatformPrincipalRow
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -92,6 +100,7 @@ class PurgeReport(BaseModel):
     slack_user_tokens: int = 0
     slack_turn_contexts: int = 0
     credential_requests: int = 0
+    wizard_sessions: int = 0
 
     def merge(self, other: PurgeReport) -> PurgeReport:
         return PurgeReport(
@@ -109,6 +118,7 @@ class PurgeReport(BaseModel):
             slack_user_tokens=self.slack_user_tokens + other.slack_user_tokens,
             slack_turn_contexts=self.slack_turn_contexts + other.slack_turn_contexts,
             credential_requests=self.credential_requests + other.credential_requests,
+            wizard_sessions=self.wizard_sessions + other.wizard_sessions,
         )
 
 
@@ -161,6 +171,13 @@ async def _purge_principal_in_session(
                 tenant_id=principal.tenant_id,
             )
         )
+        # wizard_session carries the same non-globally-unique platform_user_id
+        # caveat as credential_requests above — always tenant-scoped.
+        wizard_sessions_count = await wizard_session_store.delete_wizard_sessions_for_platform_user(
+            session,
+            platform_user_id=principal.external_id,
+            tenant_id=principal.tenant_id,
+        )
     else:
         routines_count = 0
         kind = "cli"
@@ -189,6 +206,14 @@ async def _purge_principal_in_session(
                 platform_user_id=principal.os_user,
                 tenant_id=principal.tenant_id,
             )
+        )
+        # CLI principals never own wizard_session rows in practice (the wizard
+        # flow is Discord/Slack-only), so this always reports 0 — kept for
+        # symmetry with the platform branch and future-proofing.
+        wizard_sessions_count = await wizard_session_store.delete_wizard_sessions_for_platform_user(
+            session,
+            platform_user_id=principal.os_user,
+            tenant_id=principal.tenant_id,
         )
 
     # user_skills and github_credentials are keyed by principal_id alone — both
@@ -233,6 +258,7 @@ async def _purge_principal_in_session(
         agent_github_binding=agent_github_binding_count,
         slack_user_tokens=slack_user_tokens_count,
         credential_requests=credential_requests_count,
+        wizard_sessions=wizard_sessions_count,
     )
 
 

--- a/packages/core/daimon/core/stores/domain.py
+++ b/packages/core/daimon/core/stores/domain.py
@@ -11,7 +11,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
@@ -411,6 +411,26 @@ class CredentialRequestRow(BaseModel):
     created_at: datetime
     expires_at: datetime
     used_at: datetime | None
+
+
+class WizardSessionRow(BaseModel):
+    """Pydantic row for WizardSession — one multi-step wizard form's durable state."""
+
+    model_config = ConfigDict(from_attributes=True, frozen=True)
+
+    id: str
+    tenant_id: uuid.UUID
+    account_id: uuid.UUID | None
+    requester_platform_user_id: str
+    channel_id: str
+    message_id: str
+    spec: dict[str, Any]
+    answers: dict[str, list[str]]
+    current_step: int
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
 
 
 class McpTokenRow(BaseModel):

--- a/packages/core/daimon/core/stores/wizard_session.py
+++ b/packages/core/daimon/core/stores/wizard_session.py
@@ -1,0 +1,214 @@
+"""Async store for wizard_session — the multi-step wizard's durable state.
+
+No try/except anywhere in this module — exceptions propagate to the adapter
+boundary. `try_claim_submit`'s single atomic UPDATE is the entire
+double-submit gate: its own row lock serializes concurrent taps, so no
+advisory lock (unlike the vault get-or-create critical section in
+`mcp_vault.py`, which needs one because it spans a read-then-create) is
+needed here — nothing in this module spans a read-then-write.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, cast
+
+from daimon.core._models import WizardSession
+from daimon.core.stores.domain import WizardSessionRow
+from sqlalchemy import CursorResult, delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def create_wizard_session(
+    session: AsyncSession,
+    *,
+    short_id: str,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID | None,
+    requester_platform_user_id: str,
+    channel_id: str,
+    message_id: str,
+    spec: dict[str, Any],
+    answers: dict[str, list[str]],
+    current_step: int,
+    status: str,
+    expires_at: datetime,
+    now: datetime,
+) -> WizardSessionRow:
+    """Insert a fresh wizard_session row and return it. `now` is injected,
+    never read from a clock inside the store."""
+    orm = WizardSession(
+        id=short_id,
+        tenant_id=tenant_id,
+        account_id=account_id,
+        requester_platform_user_id=requester_platform_user_id,
+        channel_id=channel_id,
+        message_id=message_id,
+        spec=spec,
+        answers=answers,
+        current_step=current_step,
+        status=status,
+        updated_at=now,
+        expires_at=expires_at,
+    )
+    session.add(orm)
+    await session.flush()
+    return WizardSessionRow.model_validate(orm)
+
+
+async def get_wizard_session(
+    session: AsyncSession,
+    *,
+    short_id: str,
+) -> WizardSessionRow | None:
+    """Return the row for `short_id`, or None if it was never minted.
+
+    Deliberately applies no lifecycle filter — mirrors
+    `credential_requests.peek_credential_request`'s rationale: the caller
+    needs to tell "unknown", "expired", and "already submitted" apart, which
+    requires the full row, not a filtered read that collapses all three into
+    None.
+    """
+    orm = await session.get(WizardSession, short_id)
+    if orm is None:
+        return None
+    return WizardSessionRow.model_validate(orm)
+
+
+async def update_wizard_state(
+    session: AsyncSession,
+    *,
+    short_id: str,
+    answers: dict[str, list[str]],
+    current_step: int,
+    now: datetime,
+) -> int:
+    """Persist a tap's new answers/step, iff the row is open and unexpired.
+
+    Deliberately not a read-modify-write: one UPDATE statement predicated on
+    `id == short_id AND status == "open" AND expires_at > now`. A tap on a
+    row that was already purged, submitted, or expired therefore writes
+    nothing and reports a rowcount of 0 — the caller decides what to tell
+    the user, rather than this store assuming the row still exists.
+    """
+    stmt = (
+        update(WizardSession)
+        .where(
+            WizardSession.id == short_id,
+            WizardSession.status == "open",
+            WizardSession.expires_at > now,
+        )
+        .values(answers=answers, current_step=current_step, updated_at=now)
+    )
+    result = await session.execute(stmt)
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
+async def try_claim_submit(
+    session: AsyncSession,
+    *,
+    short_id: str,
+    answers: dict[str, list[str]],
+    current_step: int,
+    now: datetime,
+) -> WizardSessionRow | None:
+    """Atomically flip `short_id` to submitted, iff it is open and unexpired.
+
+    One statement is the authoritative single-use gate: the UPDATE's own row
+    lock serializes concurrent Submit taps, so the loser's WHERE clause
+    simply matches zero rows — no advisory lock needed, because nothing here
+    spans a read-then-write. Returns the claimed row, or None when the claim
+    was lost (a second claim winning would mean a second billed turn).
+    """
+    stmt = (
+        update(WizardSession)
+        .where(
+            WizardSession.id == short_id,
+            WizardSession.status == "open",
+            WizardSession.expires_at > now,
+        )
+        .values(status="submitted", answers=answers, current_step=current_step, updated_at=now)
+        .returning(WizardSession)
+    )
+    result = await session.execute(stmt)
+    orm = result.scalar_one_or_none()
+    await session.flush()
+    if orm is None:
+        return None
+    return WizardSessionRow.model_validate(orm)
+
+
+async def abandon_expired_wizard_sessions(
+    session: AsyncSession,
+    *,
+    now: datetime,
+    limit: int = 500,
+) -> int:
+    """Flip up to `limit` open, past-expiry rows to `abandoned`. Returns the
+    rowcount.
+
+    Selects the target ids first with a `LIMIT`, then updates by that id
+    set, so one sweep tick cannot lock the whole table.
+    """
+    id_stmt = (
+        select(WizardSession.id)
+        .where(WizardSession.status == "open", WizardSession.expires_at <= now)
+        .limit(limit)
+    )
+    ids = (await session.execute(id_stmt)).scalars().all()
+    if not ids:
+        return 0
+    stmt = (
+        update(WizardSession)
+        .where(WizardSession.id.in_(ids))
+        .values(status="abandoned", updated_at=now)
+    )
+    result = await session.execute(stmt)
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
+async def delete_wizard_sessions_for_platform_user(
+    session: AsyncSession,
+    *,
+    platform_user_id: str,
+    tenant_id: uuid.UUID | None = None,
+) -> int:
+    """Delete ALL wizard_session rows for `platform_user_id`. Idempotent.
+
+    Deliberately applies no lifecycle filter — submitted and abandoned rows
+    still carry the user's typed answers and must be erased, mirroring
+    `credential_requests.delete_credential_requests_for_platform_user`.
+
+    Callers should always pass `tenant_id`: a platform user id is not
+    globally unique across installs, so a tenant-agnostic delete risks
+    erasing another tenant's rows.
+    """
+    predicates = [WizardSession.requester_platform_user_id == platform_user_id]
+    if tenant_id is not None:
+        predicates.append(WizardSession.tenant_id == tenant_id)
+    result = await session.execute(delete(WizardSession).where(*predicates))
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
+async def count_wizard_sessions_for_platform_user(
+    session: AsyncSession,
+    *,
+    platform_user_id: str,
+    tenant_id: uuid.UUID | None = None,
+) -> int:
+    """Count wizard_session rows that `delete_wizard_sessions_for_platform_user`
+    would delete. Read-only. Pass the SAME `tenant_id` the delete caller uses,
+    or the preview diverges from the purge (parity contract in daimon.core.privacy).
+    """
+    predicates = [WizardSession.requester_platform_user_id == platform_user_id]
+    if tenant_id is not None:
+        predicates.append(WizardSession.tenant_id == tenant_id)
+    stmt = select(func.count()).select_from(WizardSession).where(*predicates)
+    return int((await session.execute(stmt)).scalar_one())

--- a/packages/core/daimon/core/stores/wizard_session.py
+++ b/packages/core/daimon/core/stores/wizard_session.py
@@ -82,15 +82,26 @@ async def update_wizard_state(
     short_id: str,
     answers: dict[str, list[str]],
     current_step: int,
+    expected_updated_at: datetime,
     now: datetime,
 ) -> int:
-    """Persist a tap's new answers/step, iff the row is open and unexpired.
+    """Persist a tap's new answers/step, iff the row is open, unexpired, and
+    unchanged since the caller read it.
 
     Deliberately not a read-modify-write: one UPDATE statement predicated on
-    `id == short_id AND status == "open" AND expires_at > now`. A tap on a
-    row that was already purged, submitted, or expired therefore writes
-    nothing and reports a rowcount of 0 — the caller decides what to tell
-    the user, rather than this store assuming the row still exists.
+    `id == short_id AND status == "open" AND expires_at > now AND
+    updated_at == expected_updated_at`. A tap on a row that was already
+    purged, submitted, or expired therefore writes nothing and reports a
+    rowcount of 0 — the caller decides what to tell the user, rather than
+    this store assuming the row still exists.
+
+    `expected_updated_at` is the optimistic-concurrency token, and it is what
+    makes the predicate cover content as well as lifecycle: every caller
+    computes its new answers/step from a row it read earlier, so without it
+    two near-simultaneous taps both write from the same base row and the
+    second silently erases the first's effect. `updated_at` advances on every
+    write here (and on the submit claim), so a losing tap matches zero rows
+    and gets the same rowcount 0 a lifecycle miss produces.
     """
     stmt = (
         update(WizardSession)
@@ -98,6 +109,7 @@ async def update_wizard_state(
             WizardSession.id == short_id,
             WizardSession.status == "open",
             WizardSession.expires_at > now,
+            WizardSession.updated_at == expected_updated_at,
         )
         .values(answers=answers, current_step=current_step, updated_at=now)
     )

--- a/packages/core/daimon/core/wizard/__init__.py
+++ b/packages/core/daimon/core/wizard/__init__.py
@@ -1,0 +1,22 @@
+"""Platform-neutral core for agent-authored, multi-step interactive forms.
+
+This package lives in `daimon.core`, not in an adapter, because the two
+processes that need it cannot import each other: the MCP server posts a
+form on behalf of an agent, while the Discord bot later dispatches the
+taps on that form's buttons and selects. Import-linter's independence
+contract forbids `daimon.adapters.mcp` from importing
+`daimon.adapters.discord` (or vice versa), so the shared schema, state,
+and wire grammar have to sit one level up, in core. This layer emits a
+platform-neutral screen description; each of the two processes owns a
+thin renderer that turns that description into real platform components.
+
+The wizard is deliberately Discord-only for now. The platform-neutral
+screen description this package produces is the seam a future Slack
+renderer would attach to — the pure core underneath does not change,
+only a new renderer would be added. `tests/parity/test_wizard_discord_only.py`
+is the executable record of that exemption: it fails the day a Slack
+wizard renderer appears without being updated alongside it, rather than
+silently going stale as a comment would.
+"""
+
+from __future__ import annotations

--- a/packages/core/daimon/core/wizard/answers.py
+++ b/packages/core/daimon/core/wizard/answers.py
@@ -32,6 +32,14 @@ from daimon.core.wizard.state import WizardState
 _MARKDOWN_CONTROL_CHARS = "*_~`|>#-[]()"
 _UNANSWERED_DISPLAY = "—"  # em dash
 
+# A summary is rendered into one TextDisplay, which Discord caps at 4000
+# characters. A 20-step form with long typed answers can exceed that, and an
+# oversized body makes the review AND the post-submit collapse re-render fail
+# — the latter on a form whose submission has already been claimed. Truncate
+# with headroom instead.
+MAX_SUMMARY_CHARS = 3800
+_TRUNCATION_MARKER = "\n… (answers truncated for display)"
+
 
 _ZERO_WIDTH_SPACE = "​"
 
@@ -66,7 +74,13 @@ def _label_for_value(spec_step_options: list[tuple[str, str]], value: str) -> st
 
 
 def summarize_answers(spec: WizardSpec, state: WizardState) -> str:
-    """Return a human-readable, escaped, one-line-per-step summary."""
+    """Return a human-readable, escaped, one-line-per-step summary, truncated
+    to `MAX_SUMMARY_CHARS`.
+
+    Truncation is display-only: the full answers still reach the agent
+    through `format_answer_block`, which carries no ceiling because it is
+    message text, not a component.
+    """
     lines: list[str] = []
     for step in spec.steps:
         recorded = state.answers.get(step.key)
@@ -78,7 +92,13 @@ def summarize_answers(spec: WizardSpec, state: WizardState) -> str:
             escape_discord_markup(_label_for_value(option_pairs, value)) for value in recorded
         ]
         lines.append(f"**{step.question}**: {', '.join(display_values)}")
-    return "\n".join(lines)
+    summary = "\n".join(lines)
+    if len(summary) <= MAX_SUMMARY_CHARS:
+        return summary
+    # rstrip("\\") so the cut cannot end on a lone backslash that would then
+    # escape the marker's own newline.
+    head = summary[: MAX_SUMMARY_CHARS - len(_TRUNCATION_MARKER)].rstrip("\\")
+    return f"{head}{_TRUNCATION_MARKER}"
 
 
 def format_answer_block(spec: WizardSpec, state: WizardState) -> str:

--- a/packages/core/daimon/core/wizard/answers.py
+++ b/packages/core/daimon/core/wizard/answers.py
@@ -1,0 +1,91 @@
+"""Answer serialization for the resumed turn and for rendered screens.
+
+`format_answer_block` and `summarize_answers` deliberately disagree on
+escaping and on values-vs-labels, because they serve different readers.
+
+`format_answer_block` is what the resumed turn's user message carries. The
+agent that authored the `WizardSpec` already knows the question text and the
+option labels — restating them as prose would make the agent re-derive
+information it already has. So this emits raw, unescaped option *values*
+(the machine identifiers the agent itself assigned), one JSON array per step
+key inside a fenced code block. JSON-encoding each step's value list is what
+makes a value containing a colon, a newline or a bracket unambiguous to
+parse back out — the agent does not have to guess where one answer ends and
+the next begins.
+
+`summarize_answers` is what a human reads on the review and submitted
+screens. It substitutes each recorded value back to its option's label
+(falling back to the raw value for user-typed custom text, which has no
+label), and every substituted string passes through
+`escape_discord_markup` — display text a user only partially controls
+(their own typed answers) must never be interpreted as markdown or as a
+mass-mention by Discord's renderer.
+"""
+
+from __future__ import annotations
+
+import json
+
+from daimon.core.wizard.spec import WizardSpec
+from daimon.core.wizard.state import WizardState
+
+_MARKDOWN_CONTROL_CHARS = "*_~`|>#-[]()"
+_UNANSWERED_DISPLAY = "—"  # em dash
+
+
+_ZERO_WIDTH_SPACE = "​"
+
+
+def escape_discord_markup(text: str) -> str:
+    """Backslash-escape Discord markdown control characters and neutralize
+    mass mentions (`@everyone`, `@here`, `<@id>`, `<@&role_id>`) with a
+    zero-width space inserted right after the `@`.
+
+    Mass-mention neutralization runs before markdown escaping so the `<@`
+    prefix `<@&role_id>` also starts with is matched exactly once, regardless
+    of how many of `*_~`|>#-[]()` the surrounding text also contains.
+    """
+    neutralized = text.replace("@everyone", f"@{_ZERO_WIDTH_SPACE}everyone")
+    neutralized = neutralized.replace("@here", f"@{_ZERO_WIDTH_SPACE}here")
+    neutralized = neutralized.replace("<@", f"<@{_ZERO_WIDTH_SPACE}")
+
+    escaped_chars: list[str] = []
+    for char in neutralized:
+        if char in _MARKDOWN_CONTROL_CHARS:
+            escaped_chars.append(f"\\{char}")
+        else:
+            escaped_chars.append(char)
+    return "".join(escaped_chars)
+
+
+def _label_for_value(spec_step_options: list[tuple[str, str]], value: str) -> str:
+    for option_value, option_label in spec_step_options:
+        if option_value == value:
+            return option_label
+    return value
+
+
+def summarize_answers(spec: WizardSpec, state: WizardState) -> str:
+    """Return a human-readable, escaped, one-line-per-step summary."""
+    lines: list[str] = []
+    for step in spec.steps:
+        recorded = state.answers.get(step.key)
+        if not recorded:
+            lines.append(f"**{step.question}**: {_UNANSWERED_DISPLAY}")
+            continue
+        option_pairs = [(option.value, option.label) for option in step.options]
+        display_values = [
+            escape_discord_markup(_label_for_value(option_pairs, value)) for value in recorded
+        ]
+        lines.append(f"**{step.question}**: {', '.join(display_values)}")
+    return "\n".join(lines)
+
+
+def format_answer_block(spec: WizardSpec, state: WizardState) -> str:
+    """Return the fenced answer block the resumed turn's user message carries."""
+    header = f"Wizard answers ({spec.prompt}):"
+    body_lines = [
+        f"{step.key}: {json.dumps(state.answers.get(step.key, []))}" for step in spec.steps
+    ]
+    body = "\n".join(body_lines)
+    return f"{header}\n```\n{body}\n```"

--- a/packages/core/daimon/core/wizard/apply.py
+++ b/packages/core/daimon/core/wizard/apply.py
@@ -85,6 +85,12 @@ def apply(state: WizardState, spec: WizardSpec, action: WizardAction) -> WizardS
                 raise ValueError("add_custom action carries empty or whitespace-only text")
             step = spec.steps[step_index]
             if step.kind is StepKind.MULTI:
+                if step.max is not None and len(state.answers.get(step.key, [])) >= step.max:
+                    # `max` gates the select's max_values, but nothing stops a
+                    # user reopening the custom-text modal; without this an
+                    # append loop violates the form's own declared ceiling and
+                    # grows the recorded answers without bound.
+                    return state
                 return _append_answer(state, step.key, text)
             new_state = _with_answer(state, step.key, [text])
             return dataclasses.replace(new_state, current_step=_clamp_step(step_index + 1, spec))

--- a/packages/core/daimon/core/wizard/apply.py
+++ b/packages/core/daimon/core/wizard/apply.py
@@ -1,0 +1,161 @@
+"""The one pure transition function every wizard tap runs through.
+
+`apply` is the single place that decides what a tap or a typed submission
+does to a `WizardState` — navigation, answer recording, and the review-to-
+submitted flip. No adapter branches on `ActionKind` itself; every process
+that dispatches a tap decodes it into a `WizardAction` (via `build_action`)
+and hands both action and state to `apply`, so the behaviour a user sees is
+identical no matter which platform rendered the screen that produced the
+tap.
+
+`build_action` is the companion translator: it turns an already-parsed
+custom_id action string (see `daimon.core.wizard.state`'s three grammars)
+into a `WizardAction`. It is deliberately narrow — `s{n}_enter` (the button
+that opens a modal) has no `WizardAction` because opening a modal is not a
+state transition; the adapter that receives that tap opens its platform's
+text-input UI directly and only calls back into `build_action` once the user
+has actually typed something, at which point the action string is
+`s{n}_custom`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from collections.abc import Sequence
+
+from daimon.core.wizard.spec import StepKind, WizardSpec
+from daimon.core.wizard.state import ActionKind, WizardAction, WizardState, WizardStatus
+
+_NAV_ACTION_RE = re.compile(r"^s(?P<step>\d{1,2})_(?P<suffix>c(?P<option>\d{1,2})|enter|custom)$")
+_SELECT_ACTION_RE = re.compile(r"^s(?P<step>\d{1,2})_sel$")
+
+
+def _clamp_step(step_index: int, spec: WizardSpec) -> int:
+    return max(0, min(step_index, len(spec.steps)))
+
+
+def _require_step_index(action: WizardAction, spec: WizardSpec) -> int:
+    step_index = action.step_index
+    if step_index is None or not (0 <= step_index < len(spec.steps)):
+        raise ValueError(
+            f"action {action.kind.value!r} carries step_index {step_index!r}, which is "
+            f"out of range for a {len(spec.steps)}-step spec"
+        )
+    return step_index
+
+
+def _with_answer(state: WizardState, key: str, values: list[str]) -> WizardState:
+    answers = dict(state.answers)
+    answers[key] = values
+    return dataclasses.replace(state, answers=answers)
+
+
+def _append_answer(state: WizardState, key: str, value: str) -> WizardState:
+    answers = dict(state.answers)
+    answers[key] = [*answers.get(key, []), value]
+    return dataclasses.replace(state, answers=answers)
+
+
+def apply(state: WizardState, spec: WizardSpec, action: WizardAction) -> WizardState:
+    """Return the new `WizardState` after `action` is applied to `state`.
+
+    Never mutates `state.answers` — every branch that records a value builds
+    a fresh dict via `_with_answer`/`_append_answer` and returns a new
+    `WizardState` via `dataclasses.replace`.
+    """
+    match action.kind:
+        case ActionKind.SELECT_CHOICE:
+            step_index = _require_step_index(action, spec)
+            if not action.values:
+                raise ValueError("select_choice action carries no values")
+            step = spec.steps[step_index]
+            new_state = _with_answer(state, step.key, [action.values[0]])
+            return dataclasses.replace(new_state, current_step=_clamp_step(step_index + 1, spec))
+
+        case ActionKind.SET_MULTI:
+            step_index = _require_step_index(action, spec)
+            step = spec.steps[step_index]
+            return _with_answer(state, step.key, list(action.values))
+
+        case ActionKind.ADD_CUSTOM:
+            step_index = _require_step_index(action, spec)
+            text = (action.text or "").strip()
+            if not text:
+                raise ValueError("add_custom action carries empty or whitespace-only text")
+            step = spec.steps[step_index]
+            if step.kind is StepKind.MULTI:
+                return _append_answer(state, step.key, text)
+            new_state = _with_answer(state, step.key, [text])
+            return dataclasses.replace(new_state, current_step=_clamp_step(step_index + 1, spec))
+
+        case ActionKind.NEXT:
+            if state.current_step < len(spec.steps):
+                step = spec.steps[state.current_step]
+                if step.kind is StepKind.MULTI and step.min is not None:
+                    recorded = len(state.answers.get(step.key, []))
+                    if recorded < step.min:
+                        return state
+            next_step = _clamp_step(state.current_step + 1, spec)
+            return dataclasses.replace(state, current_step=next_step)
+
+        case ActionKind.BACK:
+            prev_step = _clamp_step(state.current_step - 1, spec)
+            return dataclasses.replace(state, current_step=prev_step)
+
+        case ActionKind.SUBMIT:
+            if state.current_step != len(spec.steps):
+                return state
+            return dataclasses.replace(state, status=WizardStatus.SUBMITTED)
+
+
+def build_action(
+    action: str, *, spec: WizardSpec, values: Sequence[str], text: str | None
+) -> WizardAction:
+    """Translate one already-parsed custom_id action string into a `WizardAction`.
+
+    Raises `ValueError` for `s{n}_enter` (a modal opener, never a
+    transition), any string neither grammar recognizes, or a step/option
+    index out of range for `spec`.
+    """
+    if action == "next":
+        return WizardAction(kind=ActionKind.NEXT)
+    if action == "back":
+        return WizardAction(kind=ActionKind.BACK)
+    if action == "submit":
+        return WizardAction(kind=ActionKind.SUBMIT)
+
+    select_match = _SELECT_ACTION_RE.match(action)
+    if select_match is not None:
+        step_index = int(select_match.group("step"))
+        if not (0 <= step_index < len(spec.steps)):
+            raise ValueError(f"action {action!r} names step {step_index}, out of range for spec")
+        return WizardAction(kind=ActionKind.SET_MULTI, step_index=step_index, values=list(values))
+
+    nav_match = _NAV_ACTION_RE.match(action)
+    if nav_match is not None:
+        step_index = int(nav_match.group("step"))
+        if not (0 <= step_index < len(spec.steps)):
+            raise ValueError(f"action {action!r} names step {step_index}, out of range for spec")
+        suffix = nav_match.group("suffix")
+        if suffix == "enter":
+            raise ValueError(
+                f"action {action!r} opens a modal and is not a state transition; "
+                f"build_action must not be called for it"
+            )
+        if suffix == "custom":
+            return WizardAction(kind=ActionKind.ADD_CUSTOM, step_index=step_index, text=text)
+        option_index = int(nav_match.group("option"))
+        step = spec.steps[step_index]
+        if not (0 <= option_index < len(step.options)):
+            raise ValueError(
+                f"action {action!r} names option {option_index}, out of range for "
+                f"step {step_index}'s {len(step.options)} options"
+            )
+        return WizardAction(
+            kind=ActionKind.SELECT_CHOICE,
+            step_index=step_index,
+            values=[step.options[option_index].value],
+        )
+
+    raise ValueError(f"action {action!r} does not match any known wizard action grammar")

--- a/packages/core/daimon/core/wizard/apply.py
+++ b/packages/core/daimon/core/wizard/apply.py
@@ -136,6 +136,32 @@ def build_action(
         step_index = int(select_match.group("step"))
         if not (0 <= step_index < len(spec.steps)):
             raise ValueError(f"action {action!r} names step {step_index}, out of range for spec")
+        # The values arrive from the interaction payload, which this dispatch
+        # path treats as untrusted (the custom_id carries no state and the
+        # requester is re-checked on every tap). The button path already
+        # validates its option index against the spec; without the checks
+        # below the select path would be the one place that records whatever
+        # the client sent.
+        step = spec.steps[step_index]
+        if step.kind is not StepKind.MULTI:
+            raise ValueError(
+                f"action {action!r} is a multi-select on step {step_index}, which is a "
+                f"{step.kind.value} step"
+            )
+        allowed_values = {option.value for option in step.options}
+        unknown = [value for value in values if value not in allowed_values]
+        if unknown:
+            # Custom entries only ever arrive through ADD_CUSTOM; a select can
+            # only ever return values the spec itself declared.
+            raise ValueError(
+                f"action {action!r} carries values {unknown!r} that step {step_index} "
+                f"does not declare as options"
+            )
+        if step.max is not None and len(values) > step.max:
+            raise ValueError(
+                f"action {action!r} carries {len(values)} values, above step "
+                f"{step_index}'s `max` of {step.max}"
+            )
         return WizardAction(kind=ActionKind.SET_MULTI, step_index=step_index, values=list(values))
 
     nav_match = _NAV_ACTION_RE.match(action)

--- a/packages/core/daimon/core/wizard/expiry.py
+++ b/packages/core/daimon/core/wizard/expiry.py
@@ -1,0 +1,69 @@
+"""CDN signature parsing and form-expiry derivation.
+
+A wizard's images, when it has any, are attachments Discord serves from a
+signed CDN URL — the `ex` (expiry), `is` (issue time) and `hm` (signature)
+query parameters. Discord's documentation describes the parameters but
+commits to no fixed duration for them, so a form's own expiry cannot be a
+constant: the signed URLs a form's images are persisted as expire on their
+own schedule, and a form whose buttons stay tappable after its pictures have
+gone dark is exactly the state `derive_expires_at` exists to prevent. The
+form's TTL must instead be derived from the actual signature expiry the CDN
+returned when the images were posted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+from typing import Final
+from urllib.parse import parse_qs, urlparse
+
+DEFAULT_TTL: Final[timedelta] = timedelta(hours=12)
+SAFETY_MARGIN: Final[timedelta] = timedelta(minutes=5)
+UNKNOWN_SIGNATURE_TTL: Final[timedelta] = timedelta(hours=1)
+MIN_TTL: Final[timedelta] = timedelta(minutes=1)
+
+
+def parse_attachment_expiry(url: str) -> datetime | None:
+    """Return the UTC expiry the CDN signed into `url`'s `ex` parameter.
+
+    Returns `None` when the parameter is absent or not parseable as a
+    hexadecimal Unix timestamp. Never raises.
+    """
+    query = parse_qs(urlparse(url).query)
+    values = query.get("ex")
+    if not values:
+        return None
+    try:
+        epoch_seconds = int(values[0], 16)
+    except ValueError:
+        return None
+    return datetime.fromtimestamp(epoch_seconds, tz=UTC)
+
+
+def derive_expires_at(*, now: datetime, attachment_urls: Sequence[str]) -> datetime:
+    """Return the UTC instant a wizard form should expire at.
+
+    With no attachments, the form's ceiling is `now + DEFAULT_TTL`.
+    Otherwise the result is the minimum of `now + DEFAULT_TTL` and the
+    smallest parsed attachment expiry minus `SAFETY_MARGIN`. If any
+    attachment's expiry could not be parsed, the result is additionally
+    capped at `now + UNKNOWN_SIGNATURE_TTL` — an unreadable signature is
+    treated as expiring soon, not as expiring never. The result is always
+    floored at `now + MIN_TTL` so an already-past signature expiry never
+    produces a form that expires in the past.
+    """
+    if not attachment_urls:
+        return now + DEFAULT_TTL
+
+    parsed_expiries = [parse_attachment_expiry(url) for url in attachment_urls]
+    known_expiries = [expiry for expiry in parsed_expiries if expiry is not None]
+    has_unknown_signature = len(known_expiries) < len(parsed_expiries)
+
+    candidate = now + DEFAULT_TTL
+    if known_expiries:
+        candidate = min(candidate, min(known_expiries) - SAFETY_MARGIN)
+    if has_unknown_signature:
+        candidate = min(candidate, now + UNKNOWN_SIGNATURE_TTL)
+
+    return max(candidate, now + MIN_TTL)

--- a/packages/core/daimon/core/wizard/render.py
+++ b/packages/core/daimon/core/wizard/render.py
@@ -1,0 +1,207 @@
+"""The platform-neutral `Screen` description every wizard renderer consumes.
+
+`to_screen` is the one place that decides what a wizard run currently looks
+like — head text, an optional image, an optional select, and button rows —
+without ever mentioning a Discord type. Both the Discord and (should one
+land) a second platform's renderer read a `Screen` and translate it into
+their own component tree; neither re-derives navigation, review, or
+submitted-screen behaviour, because that behaviour lives here and in
+`daimon.core.wizard.apply`.
+
+Every action string this module emits is validated through
+`state.build_custom_id` at construction time — an unroutable or oversized
+action can never leave `to_screen`; the `ValueError` `build_custom_id`
+raises is allowed to propagate rather than being swallowed, because a
+renderer emitting a control nobody can dispatch is a bug in this module,
+not a runtime condition a caller should recover from.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from daimon.core.wizard.answers import summarize_answers
+from daimon.core.wizard.spec import MAX_BUTTONS_PER_ROW, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import WizardState, WizardStatus, build_custom_id
+
+ScreenStyle = Literal["primary", "secondary", "success"]
+
+
+@dataclass(frozen=True)
+class ScreenButton:
+    """One tappable button on a `Screen`."""
+
+    action: str
+    label: str
+    style: ScreenStyle
+    disabled: bool = False
+
+
+@dataclass(frozen=True)
+class ScreenSelectOption:
+    """One option of a `ScreenSelect`."""
+
+    label: str
+    value: str
+    description: str | None
+    default: bool
+
+
+@dataclass(frozen=True)
+class ScreenSelect:
+    """The multi-select control on a `multi` step's screen."""
+
+    action: str
+    placeholder: str
+    min_values: int
+    max_values: int
+    options: tuple[ScreenSelectOption, ...]
+
+
+@dataclass(frozen=True)
+class ScreenImage:
+    """The image a step's screen carries, by handle and/or persisted URL.
+
+    A renderer prefers a matching attachment (`handle`) when it has one and
+    falls back to `url`; when both are `None` the image is omitted.
+    """
+
+    handle: str | None
+    url: str | None
+
+
+@dataclass(frozen=True)
+class Screen:
+    """One platform-neutral description of what a wizard run currently shows."""
+
+    short_id: str
+    accent: Literal["blurple", "green"]
+    head_text: str
+    image: ScreenImage | None
+    body_text: str | None
+    select: ScreenSelect | None
+    button_rows: tuple[tuple[ScreenButton, ...], ...]
+
+
+def _nav_row(short_id: str, step: Step, step_index: int) -> tuple[ScreenButton, ...]:
+    buttons: list[ScreenButton] = []
+    show_custom_button = step.allow_custom and step.kind is not StepKind.TEXT
+    if show_custom_button:
+        custom_action = f"s{step_index}_custom"
+        build_custom_id(short_id, custom_action)
+        buttons.append(ScreenButton(action=custom_action, label="Add your own…", style="secondary"))
+    build_custom_id(short_id, "back")
+    buttons.append(ScreenButton(action="back", label="Back", style="secondary"))
+    build_custom_id(short_id, "next")
+    buttons.append(ScreenButton(action="next", label="Next", style="primary"))
+    return tuple(buttons)
+
+
+def _chunk_buttons(buttons: list[ScreenButton], size: int) -> list[tuple[ScreenButton, ...]]:
+    return [tuple(buttons[i : i + size]) for i in range(0, len(buttons), size)]
+
+
+def _step_screen(spec: WizardSpec, state: WizardState) -> Screen:
+    step_index = state.current_step
+    step = spec.steps[step_index]
+    step_count = len(spec.steps)
+    head_text = f"{spec.prompt}\nStep {step_index + 1} of {step_count}\n{step.question}"
+
+    image: ScreenImage | None = None
+    if step.image_handle is not None or step.image_url is not None:
+        image = ScreenImage(handle=step.image_handle, url=step.image_url)
+
+    select: ScreenSelect | None = None
+    button_rows: list[tuple[ScreenButton, ...]] = []
+
+    if step.kind is StepKind.CHOICE:
+        option_buttons: list[ScreenButton] = []
+        for option_index, option in enumerate(step.options):
+            action = f"s{step_index}_c{option_index}"
+            build_custom_id(state.short_id, action)
+            option_buttons.append(
+                ScreenButton(action=action, label=option.label, style="secondary")
+            )
+        button_rows.extend(_chunk_buttons(option_buttons, MAX_BUTTONS_PER_ROW))
+    elif step.kind is StepKind.MULTI:
+        select_action = f"s{step_index}_sel"
+        build_custom_id(state.short_id, select_action)
+        recorded = set(state.answers.get(step.key, []))
+        max_values = step.max if step.max is not None else len(step.options)
+        select = ScreenSelect(
+            action=select_action,
+            placeholder=step.question,
+            min_values=step.min if step.min is not None else 0,
+            max_values=max_values,
+            options=tuple(
+                ScreenSelectOption(
+                    label=option.label,
+                    value=option.value,
+                    description=option.description,
+                    default=option.value in recorded,
+                )
+                for option in step.options
+            ),
+        )
+    else:  # StepKind.TEXT
+        enter_action = f"s{step_index}_enter"
+        build_custom_id(state.short_id, enter_action)
+        button_rows.append((ScreenButton(action=enter_action, label="Enter…", style="primary"),))
+
+    button_rows.append(_nav_row(state.short_id, step, step_index))
+
+    return Screen(
+        short_id=state.short_id,
+        accent="blurple",
+        head_text=head_text,
+        image=image,
+        body_text=None,
+        select=select,
+        button_rows=tuple(button_rows),
+    )
+
+
+def _review_screen(spec: WizardSpec, state: WizardState) -> Screen:
+    build_custom_id(state.short_id, "back")
+    build_custom_id(state.short_id, "submit")
+    return Screen(
+        short_id=state.short_id,
+        accent="blurple",
+        head_text=f"{spec.prompt}\nReview your answers",
+        image=None,
+        body_text=summarize_answers(spec, state),
+        select=None,
+        button_rows=(
+            (
+                ScreenButton(action="back", label="Back", style="secondary"),
+                ScreenButton(action="submit", label="Submit", style="success"),
+            ),
+        ),
+    )
+
+
+def _collapsed_screen(spec: WizardSpec, state: WizardState) -> Screen:
+    return Screen(
+        short_id=state.short_id,
+        accent="green",
+        head_text=f"{spec.prompt}\nSubmitted",
+        image=None,
+        body_text=summarize_answers(spec, state),
+        select=None,
+        button_rows=(),
+    )
+
+
+def to_screen(spec: WizardSpec, state: WizardState) -> Screen:
+    """Return the `Screen` a wizard run currently shows.
+
+    One of three screens: collapsed (submitted, no controls), review (the
+    step after the last real step), or the step screen for
+    `spec.steps[state.current_step]`.
+    """
+    if state.status is WizardStatus.SUBMITTED:
+        return _collapsed_screen(spec, state)
+    if state.current_step >= len(spec.steps):
+        return _review_screen(spec, state)
+    return _step_screen(spec, state)

--- a/packages/core/daimon/core/wizard/spec.py
+++ b/packages/core/daimon/core/wizard/spec.py
@@ -270,8 +270,8 @@ class WizardSpec(BaseModel):
                 raise ValueError(
                     f"step {index} ({step.key!r}) shares image_handle "
                     f"{step.image_handle!r} with step {earlier_index}; each step's "
-                    f"image_handle must be unique because the post path maps returned "
-                    f"attachments back to steps by filename"
+                    f"image_handle must be unique because the post path uploads one "
+                    f"file per handle and maps the returned attachments back by position"
                 )
             seen_handles[step.image_handle] = index
 

--- a/packages/core/daimon/core/wizard/spec.py
+++ b/packages/core/daimon/core/wizard/spec.py
@@ -36,6 +36,16 @@ MAX_BUTTONS_PER_ROW: Final[int] = 5
 MAX_LABEL_CHARS: Final[int] = 80
 MAX_STEPS: Final[int] = 20
 MAX_IMAGES: Final[int] = 10
+# A step screen's head text is one TextDisplay carrying the prompt, a
+# "Step N of M" line, and the question.
+MAX_TEXT_DISPLAY_CHARS: Final[int] = 4000
+# Room for the "\nStep NN of NN\n" line the renderer inserts between the
+# prompt and the question.
+HEAD_TEXT_OVERHEAD_CHARS: Final[int] = 32
+# A multi step's question is rendered as the select's placeholder.
+MAX_SELECT_PLACEHOLDER_CHARS: Final[int] = 150
+MAX_SELECT_OPTION_DESCRIPTION_CHARS: Final[int] = 100
+MAX_SELECT_OPTION_VALUE_CHARS: Final[int] = 100
 
 
 class StepKind(StrEnum):
@@ -177,6 +187,41 @@ class WizardSpec(BaseModel):
                         f"{len(option.label)} characters long, exceeding Discord's "
                         f"{MAX_LABEL_CHARS}-character button label limit; shorten it"
                     )
+                if len(option.value) > MAX_SELECT_OPTION_VALUE_CHARS:
+                    raise ValueError(
+                        f"step {index} ({step.key!r}) has an option value "
+                        f"{len(option.value)} characters long, exceeding Discord's "
+                        f"{MAX_SELECT_OPTION_VALUE_CHARS}-character option value "
+                        f"limit; shorten it"
+                    )
+                if (
+                    option.description is not None
+                    and len(option.description) > MAX_SELECT_OPTION_DESCRIPTION_CHARS
+                ):
+                    raise ValueError(
+                        f"step {index} ({step.key!r}) has an option description "
+                        f"{len(option.description)} characters long, exceeding "
+                        f"Discord's {MAX_SELECT_OPTION_DESCRIPTION_CHARS}-character "
+                        f"option description limit; shorten it"
+                    )
+
+        head_budget = MAX_TEXT_DISPLAY_CHARS - HEAD_TEXT_OVERHEAD_CHARS
+        for index, step in enumerate(self.steps):
+            head_chars = len(self.prompt) + len(step.question)
+            if head_chars > head_budget:
+                raise ValueError(
+                    f"step {index} ({step.key!r}) renders a head text of {head_chars} "
+                    f"characters (prompt plus question), exceeding the {head_budget}-"
+                    f"character budget within Discord's {MAX_TEXT_DISPLAY_CHARS}-"
+                    f"character text limit; shorten the prompt or the question"
+                )
+            if step.kind is StepKind.MULTI and len(step.question) > MAX_SELECT_PLACEHOLDER_CHARS:
+                raise ValueError(
+                    f"step {index} ({step.key!r}) is a multi step whose question is "
+                    f"{len(step.question)} characters long; a multi step's question "
+                    f"is rendered as the select placeholder, which Discord caps at "
+                    f"{MAX_SELECT_PLACEHOLDER_CHARS} characters; shorten it"
+                )
 
         for index, step in enumerate(self.steps):
             if step.kind is not StepKind.MULTI:
@@ -190,6 +235,15 @@ class WizardSpec(BaseModel):
                 raise ValueError(
                     f"step {index} ({step.key!r}) has `max` {step.max} above its "
                     f"{len(step.options)} available options; lower `max` or add more options"
+                )
+            # Checked independently of `max`: when `max` is None the renderer
+            # derives max_values from the option count, so a `min` above that
+            # count is a select no user could ever satisfy -- and one Discord
+            # refuses to render at all.
+            if step.min is not None and step.min > len(step.options):
+                raise ValueError(
+                    f"step {index} ({step.key!r}) has `min` {step.min} above its "
+                    f"{len(step.options)} available options; lower `min` or add more options"
                 )
             if step.min is not None and step.max is not None and step.min > step.max:
                 raise ValueError(

--- a/packages/core/daimon/core/wizard/spec.py
+++ b/packages/core/daimon/core/wizard/spec.py
@@ -1,0 +1,238 @@
+"""Agent-authored form schema and its edge validation.
+
+`WizardSpec` is parsed from untrusted tool input: the whole form (prompt,
+questions, option labels, image handles) is model-authored text arriving at
+an MCP tool boundary. Pydantic validation happens here, at that boundary,
+rather than deep inside a renderer.
+
+Discord itself enforces hard ceilings — a message tops out at 40 nested
+components, a button label at 80 characters, a select at 25 options — and
+those are the ultimate source of truth. But letting an oversized form reach
+the renderer means it fails as a bare `ValueError` from inside discord.py,
+with no indication of which step or field caused it. `WizardSpec`'s model
+validator is the proactive inner ceiling: it walks every step before any
+component is built and raises an actionable `ValueError` that names the
+offending step's index and key, and tells the author to split the form into
+a shorter follow-up wizard.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from math import ceil
+from typing import Final
+
+from daimon.core.wizard.state import build_custom_id, new_short_id
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+MAX_SELECT_OPTIONS: Final[int] = 25
+MAX_TOTAL_COMPONENTS: Final[int] = 40
+# Discord's top-level (non-nested) component cap on a single message. Not
+# checked directly by this validator -- the per-step estimate below already
+# accounts for nested rows within MAX_TOTAL_COMPONENTS -- but reserved here
+# as the constant a Screen renderer built on top of this spec must respect.
+MAX_TOP_LEVEL_COMPONENTS: Final[int] = 10
+MAX_BUTTONS_PER_ROW: Final[int] = 5
+MAX_LABEL_CHARS: Final[int] = 80
+MAX_STEPS: Final[int] = 20
+MAX_IMAGES: Final[int] = 10
+
+
+class StepKind(StrEnum):
+    """The three step shapes a wizard form can author."""
+
+    CHOICE = "choice"
+    MULTI = "multi"
+    TEXT = "text"
+
+
+class Option(BaseModel):
+    """One selectable option on a `choice` or `multi` step."""
+
+    model_config = ConfigDict(frozen=True)
+
+    label: str = Field(description="Human-readable button/select-option text shown to the user.")
+    value: str = Field(
+        description="Stable machine value recorded in the answer when this option is chosen."
+    )
+    description: str | None = Field(
+        default=None, description="Optional secondary text shown alongside the option label."
+    )
+
+
+class Step(BaseModel):
+    """One screen of the wizard: a question plus how it is answered."""
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str = Field(
+        description="Stable identifier for this step's answer; must be unique across the form."
+    )
+    question: str = Field(description="The question text shown to the user on this step.")
+    kind: StepKind = Field(
+        description="Whether this step is a single choice, a multi-select, or free text."
+    )
+    options: list[Option] = Field(
+        default_factory=list[Option],
+        description="The selectable options for a `choice` or `multi` step. Unused for `text`.",
+    )
+    allow_custom: bool = Field(
+        default=True,
+        description="Whether the user may add a free-text option alongside the listed options.",
+    )
+    min: int | None = Field(
+        default=None, description="Minimum number of selections required on a `multi` step."
+    )
+    max: int | None = Field(
+        default=None, description="Maximum number of selections allowed on a `multi` step."
+    )
+    image_handle: str | None = Field(
+        default=None,
+        description=(
+            "File-store handle id previously returned by the image-generation tool -- "
+            "a finished PNG, never a URL and never a diagram source. Anything that "
+            "produces an image does so upstream, before the handle is attached here."
+        ),
+    )
+    image_url: str | None = Field(
+        default=None,
+        description="Server-populated; ignored when supplied by the caller.",
+    )
+
+
+def _estimate_step_components(step: Step) -> int:
+    """Conservative upper bound on the rendered component count for one step.
+
+    Base 4 (container, head text, separator, pre-nav gap), +1 when the step
+    carries an image, plus a per-kind body, plus the nav row and its buttons
+    (back, next, and the custom opener when `allow_custom`).
+    """
+    total = 4
+    if step.image_handle is not None:
+        total += 1
+    if step.kind is StepKind.CHOICE:
+        num_options = len(step.options)
+        total += ceil(num_options / MAX_BUTTONS_PER_ROW) + num_options
+    elif step.kind is StepKind.MULTI:
+        total += 2
+    else:  # StepKind.TEXT
+        total += 2
+    nav_buttons = 2 + (1 if step.allow_custom else 0)  # back, next, [custom opener]
+    total += 1 + nav_buttons  # nav row + its buttons
+    return total
+
+
+class WizardSpec(BaseModel):
+    """The full agent-authored form: a prompt plus an ordered list of steps."""
+
+    model_config = ConfigDict(frozen=True)
+
+    prompt: str
+    steps: list[Step]
+
+    @model_validator(mode="after")
+    def _validate_ceilings(self) -> WizardSpec:
+        if not self.steps:
+            raise ValueError("wizard spec declares zero steps; add at least one `steps` entry")
+        if len(self.steps) > MAX_STEPS:
+            raise ValueError(
+                f"wizard spec declares {len(self.steps)} steps, exceeding the "
+                f"{MAX_STEPS}-step ceiling; split the form into a shorter follow-up wizard"
+            )
+
+        seen_keys: set[str] = set()
+        for index, step in enumerate(self.steps):
+            if step.key in seen_keys:
+                raise ValueError(
+                    f"step {index} ({step.key!r}) reuses a key already used by an "
+                    f"earlier step; give every step a unique `key`"
+                )
+            seen_keys.add(step.key)
+
+        for index, step in enumerate(self.steps):
+            if step.kind in (StepKind.CHOICE, StepKind.MULTI):
+                if not step.options:
+                    raise ValueError(
+                        f"step {index} ({step.key!r}) is a {step.kind.value} step with "
+                        f"no options; add at least one `options` entry"
+                    )
+                if len(step.options) > MAX_SELECT_OPTIONS:
+                    raise ValueError(
+                        f"step {index} ({step.key!r}) declares {len(step.options)} "
+                        f"options, exceeding the {MAX_SELECT_OPTIONS}-option ceiling; "
+                        f"split the form into a shorter follow-up wizard"
+                    )
+            for option in step.options:
+                if len(option.label) > MAX_LABEL_CHARS:
+                    raise ValueError(
+                        f"step {index} ({step.key!r}) has an option label "
+                        f"{len(option.label)} characters long, exceeding Discord's "
+                        f"{MAX_LABEL_CHARS}-character button label limit; shorten it"
+                    )
+
+        for index, step in enumerate(self.steps):
+            if step.kind is not StepKind.MULTI:
+                continue
+            if step.min is not None and step.min < 0:
+                raise ValueError(
+                    f"step {index} ({step.key!r}) has `min` {step.min}, which is "
+                    f"negative; set `min` to 0 or higher"
+                )
+            if step.max is not None and step.max > len(step.options):
+                raise ValueError(
+                    f"step {index} ({step.key!r}) has `max` {step.max} above its "
+                    f"{len(step.options)} available options; lower `max` or add more options"
+                )
+            if step.min is not None and step.max is not None and step.min > step.max:
+                raise ValueError(
+                    f"step {index} ({step.key!r}) has `min` {step.min} greater than "
+                    f"`max` {step.max}; `min` must not exceed `max`"
+                )
+
+        image_step_indices = [
+            index for index, step in enumerate(self.steps) if step.image_handle is not None
+        ]
+        if len(image_step_indices) > MAX_IMAGES:
+            raise ValueError(
+                f"wizard spec attaches images to {len(image_step_indices)} steps, "
+                f"exceeding the {MAX_IMAGES}-image ceiling; split the form into a "
+                f"shorter follow-up wizard"
+            )
+
+        seen_handles: dict[str, int] = {}
+        for index, step in enumerate(self.steps):
+            if step.image_handle is None:
+                continue
+            earlier_index = seen_handles.get(step.image_handle)
+            if earlier_index is not None:
+                raise ValueError(
+                    f"step {index} ({step.key!r}) shares image_handle "
+                    f"{step.image_handle!r} with step {earlier_index}; each step's "
+                    f"image_handle must be unique because the post path maps returned "
+                    f"attachments back to steps by filename"
+                )
+            seen_handles[step.image_handle] = index
+
+        for index, step in enumerate(self.steps):
+            estimate = _estimate_step_components(step)
+            if estimate > MAX_TOTAL_COMPONENTS:
+                raise ValueError(
+                    f"step {index} ({step.key!r}) is estimated to render {estimate} "
+                    f"components, exceeding Discord's {MAX_TOTAL_COMPONENTS}-component "
+                    f"ceiling; split the form into a shorter follow-up wizard"
+                )
+
+        for index, step in enumerate(self.steps):
+            actions = [f"s{index}_c{n}" for n in range(len(step.options))]
+            actions += [f"s{index}_sel", f"s{index}_enter", f"s{index}_custom"]
+            actions += ["next", "back", "submit"]
+            for action in actions:
+                try:
+                    build_custom_id(new_short_id(), action)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"step {index} ({step.key!r}) would emit an unroutable or "
+                        f"oversized custom_id for action {action!r}: {exc}"
+                    ) from exc
+
+        return self

--- a/packages/core/daimon/core/wizard/spec.py
+++ b/packages/core/daimon/core/wizard/spec.py
@@ -106,13 +106,21 @@ def _estimate_step_components(step: Step) -> int:
     Base 4 (container, head text, separator, pre-nav gap), +1 when the step
     carries an image, plus a per-kind body, plus the nav row and its buttons
     (back, next, and the custom opener when `allow_custom`).
+
+    A `choice` option that carries a `description` renders heavier than a
+    bare button: it needs its own text element alongside the button (a
+    described option is a small section, not a single node), so it costs 2
+    components instead of 1. Ignoring this would silently undercount any
+    choice step that uses descriptions -- exactly the gap this ceiling
+    exists to catch before the renderer does.
     """
     total = 4
     if step.image_handle is not None:
         total += 1
     if step.kind is StepKind.CHOICE:
         num_options = len(step.options)
-        total += ceil(num_options / MAX_BUTTONS_PER_ROW) + num_options
+        option_weight = sum(2 if option.description is not None else 1 for option in step.options)
+        total += ceil(num_options / MAX_BUTTONS_PER_ROW) + option_weight
     elif step.kind is StepKind.MULTI:
         total += 2
     else:  # StepKind.TEXT

--- a/packages/core/daimon/core/wizard/state.py
+++ b/packages/core/daimon/core/wizard/state.py
@@ -1,0 +1,135 @@
+"""Domain state and wire grammar for the multi-step wizard.
+
+This module lives in `daimon.core`, not in either adapter, for the same
+reason `daimon.core.credential_requests` does: the MCP server (which posts
+a wizard's first screen) and the Discord bot (which dispatches every tap on
+it) cannot import each other, so the shared encode/decode logic has to sit
+one level up.
+
+Discord's `DynamicItem` dispatch matches an incoming `custom_id` with
+`pattern.fullmatch`, not a prefix search, and — critically — it fires
+*every* registered dynamic-item template whose pattern fullmatches, with no
+early break once one has matched. Two overlapping templates therefore
+double-dispatch a single tap. That is why `NAV_CUSTOM_ID_PATTERN`,
+`SELECT_CUSTOM_ID_PATTERN`, and `SUBMIT_CUSTOM_ID_PATTERN` must be provably
+pairwise disjoint, and why `build_custom_id` refuses to mint an id that
+neither pattern would route.
+
+There are THREE templates, not one, because three different widget classes
+dispatch them in the bot process: ordinary navigation and option buttons
+(`NAV_CUSTOM_ID_PATTERN`), the multi-select component (`SELECT_CUSTOM_ID_PATTERN`),
+and the submit button (`SUBMIT_CUSTOM_ID_PATTERN`), which is routed
+separately so the turn-spawning path has its own isolated dispatch entry
+point rather than sharing one with ordinary navigation. A button item and a
+select item are different discord.py `DynamicItem` subclasses, so the
+button and select grammars in particular must be provably disjoint from
+each other: the `_sel` action suffix appears only in
+`SELECT_CUSTOM_ID_TEMPLATE` and nowhere in `NAV_CUSTOM_ID_TEMPLATE`, so a
+select tap can never accidentally dispatch the button item class (or vice
+versa).
+
+The `wz:` prefix is deliberately disjoint from `daimon.core.credential_requests`'
+`ztc:` prefix and from the sibling message-feedback feature's `mfb:` prefix
+(when that module exists) — no wizard custom_id can ever fullmatch another
+feature's dispatch pattern, and no other feature's custom_id can fullmatch
+one of these.
+
+A `WizardState.current_step` equal to `len(spec.steps)` (one past the last
+real step index) means the review screen — the summary-and-submit screen
+shown after every question has an answer, not a step in `spec.steps` itself.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import string
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Final
+
+WIZARD_CUSTOM_ID_PREFIX: Final[str] = "wz:"
+SHORT_ID_LEN: Final[int] = 8
+MAX_CUSTOM_ID_CHARS: Final[int] = 100
+
+NAV_CUSTOM_ID_TEMPLATE: Final[str] = (
+    r"wz:(?P<short_id>[A-Za-z0-9]{8}):(?P<action>next|back|s\d{1,2}_c\d{1,2}|s\d{1,2}_enter|s\d{1,2}_custom)"
+)
+NAV_CUSTOM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(NAV_CUSTOM_ID_TEMPLATE)
+
+SELECT_CUSTOM_ID_TEMPLATE: Final[str] = r"wz:(?P<short_id>[A-Za-z0-9]{8}):(?P<action>s\d{1,2}_sel)"
+SELECT_CUSTOM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(SELECT_CUSTOM_ID_TEMPLATE)
+
+SUBMIT_CUSTOM_ID_TEMPLATE: Final[str] = r"wz:(?P<short_id>[A-Za-z0-9]{8}):submit"
+SUBMIT_CUSTOM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(SUBMIT_CUSTOM_ID_TEMPLATE)
+
+
+class WizardStatus(StrEnum):
+    """Lifecycle of a wizard run, keyed by its short id."""
+
+    OPEN = "open"
+    SUBMITTED = "submitted"
+    ABANDONED = "abandoned"
+
+
+class ActionKind(StrEnum):
+    """The taps a wizard interaction dispatcher can receive."""
+
+    SELECT_CHOICE = "select_choice"
+    SET_MULTI = "set_multi"
+    ADD_CUSTOM = "add_custom"
+    NEXT = "next"
+    BACK = "back"
+    SUBMIT = "submit"
+
+
+@dataclass(frozen=True)
+class WizardState:
+    """The persisted, platform-neutral state of one wizard run."""
+
+    short_id: str
+    current_step: int = 0
+    answers: dict[str, list[str]] = field(default_factory=dict[str, list[str]])
+    status: WizardStatus = WizardStatus.OPEN
+
+
+@dataclass(frozen=True)
+class WizardAction:
+    """A decoded tap or text submission applied against a `WizardState`."""
+
+    kind: ActionKind
+    step_index: int | None = None
+    values: list[str] = field(default_factory=list[str])
+    text: str | None = None
+
+
+def new_short_id() -> str:
+    """Return a fresh `SHORT_ID_LEN`-character base62 short id."""
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(SHORT_ID_LEN))
+
+
+def build_custom_id(short_id: str, action: str) -> str:
+    """Return the wire `custom_id` for `short_id`/`action`.
+
+    Raises `ValueError` when the result exceeds `MAX_CUSTOM_ID_CHARS` or when
+    neither `NAV_CUSTOM_ID_PATTERN`, `SELECT_CUSTOM_ID_PATTERN`, nor
+    `SUBMIT_CUSTOM_ID_PATTERN` would fullmatch it — a renderer must never
+    emit an id its own dispatcher cannot route.
+    """
+    custom_id = f"{WIZARD_CUSTOM_ID_PREFIX}{short_id}:{action}"
+    if len(custom_id) > MAX_CUSTOM_ID_CHARS:
+        raise ValueError(
+            f"custom_id {custom_id!r} is {len(custom_id)} characters, "
+            f"exceeding Discord's {MAX_CUSTOM_ID_CHARS}-character cap"
+        )
+    if not (
+        NAV_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+        or SELECT_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+        or SUBMIT_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+    ):
+        raise ValueError(
+            f"action {action!r} does not fullmatch any wizard custom_id grammar "
+            f"and would never be dispatched by the bot process"
+        )
+    return custom_id

--- a/packages/core/daimon/core/wizard_sweep.py
+++ b/packages/core/daimon/core/wizard_sweep.py
@@ -1,0 +1,50 @@
+"""Expire stale open wizard forms.
+
+An open `wizard_session` row keeps a Discord/Slack message's buttons
+dispatchable — a tap on it can still write answers or claim a submit. The
+row's `expires_at` is derived at post time from the CDN signature expiry of
+the images the form carries (`daimon.core.wizard.expiry.derive_expires_at`),
+so a form's buttons and its pictures are meant to die together. Once
+`expires_at` has passed, the form must stop being tappable even though
+nobody interacted with it.
+
+This sweeper flips those past-deadline open rows to `abandoned` rather than
+deleting them: the row stays around for the tap handler to give the "this
+form has expired" reply instead of silently doing nothing on an unknown
+short_id. Erasure — not this sweep — is what actually removes the row
+(`daimon.core.purge`); this sweep only bounds how long a stale, dispatchable
+form can remain.
+
+Shell-only: opens one session, delegates the state transition to the store's
+single predicated UPDATE, commits, and logs the count. No decisions live
+here and no try/except — the scheduler's call site owns the boundary catch,
+exactly as it does for the existing sweepers (`pending_file_sweeper.py`,
+`mcp_credential_sweep.py`). `now` is injected, never read from a clock inside
+this module.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import structlog
+from daimon.core.stores.wizard_session import abandon_expired_wizard_sessions
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_log = structlog.get_logger(__name__)
+
+
+async def sweep_expired_wizard_sessions(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    now: datetime,
+    limit: int = 500,
+) -> int:
+    """Flip up to `limit` open, past-expiry wizard_session rows to abandoned.
+
+    Returns the number of rows flipped.
+    """
+    async with session_factory() as session, session.begin():
+        count = await abandon_expired_wizard_sessions(session, now=now, limit=limit)
+    _log.info("wizard_sweep.expired", count=count)
+    return count

--- a/packages/core/tests/stores/test_wizard_session.py
+++ b/packages/core/tests/stores/test_wizard_session.py
@@ -1,0 +1,328 @@
+"""Integration tests for the wizard_session store — real Postgres.
+
+Covers the read/write lifecycle, the two single-statement gates
+(`update_wizard_state`, `try_claim_submit`), the bounded expiry sweep, and
+the platform-user-scoped erasure helpers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+from daimon.core.stores import wizard_session as store
+from daimon.core.stores.domain import WizardSessionRow
+from daimon.testing.factories import make_account, make_tenant, make_wizard_session
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+async def test_create_wizard_session_returns_pydantic_row_and_get_matches(
+    db_session: AsyncSession,
+) -> None:
+    created = await make_wizard_session(db_session)
+
+    assert isinstance(created, WizardSessionRow), "store must return Pydantic, not ORM"
+
+    fetched = await store.get_wizard_session(db_session, short_id=created.id)
+
+    assert fetched == created
+
+
+async def test_get_wizard_session_returns_none_for_unknown_id(
+    db_session: AsyncSession,
+) -> None:
+    fetched = await store.get_wizard_session(db_session, short_id="doesnotexist")
+
+    assert fetched is None
+
+
+async def test_update_wizard_state_on_open_unexpired_row_returns_one_and_persists(
+    db_session: AsyncSession,
+) -> None:
+    created = await make_wizard_session(db_session, answers={}, current_step=0)
+    now = created.updated_at + timedelta(seconds=5)
+
+    rowcount = await store.update_wizard_state(
+        db_session,
+        short_id=created.id,
+        answers={"choice": ["a"]},
+        current_step=1,
+        now=now,
+    )
+
+    assert rowcount == 1
+    refetched = await store.get_wizard_session(db_session, short_id=created.id)
+    assert refetched is not None
+    assert refetched.answers == {"choice": ["a"]}
+    assert refetched.current_step == 1
+    assert refetched.updated_at == now
+    assert refetched.updated_at > created.updated_at
+
+
+async def test_update_wizard_state_returns_zero_for_submitted_row(
+    db_session: AsyncSession,
+) -> None:
+    created = await make_wizard_session(db_session, status="submitted")
+
+    rowcount = await store.update_wizard_state(
+        db_session,
+        short_id=created.id,
+        answers={"choice": ["a"]},
+        current_step=1,
+        now=datetime.now(UTC),
+    )
+
+    assert rowcount == 0
+    refetched = await store.get_wizard_session(db_session, short_id=created.id)
+    assert refetched is not None
+    assert refetched.answers == created.answers, "a no-op update must leave answers untouched"
+    assert refetched.current_step == created.current_step
+
+
+async def test_update_wizard_state_returns_zero_for_expired_row(
+    db_session: AsyncSession,
+) -> None:
+    now = datetime.now(UTC)
+    created = await make_wizard_session(
+        db_session,
+        now=now - timedelta(hours=2),
+        expires_at=now - timedelta(hours=1),
+    )
+
+    rowcount = await store.update_wizard_state(
+        db_session,
+        short_id=created.id,
+        answers={"choice": ["a"]},
+        current_step=1,
+        now=now,
+    )
+
+    assert rowcount == 0
+    refetched = await store.get_wizard_session(db_session, short_id=created.id)
+    assert refetched is not None
+    assert refetched.answers == created.answers
+
+
+async def test_update_wizard_state_returns_zero_for_deleted_row(
+    db_session: AsyncSession,
+) -> None:
+    created = await make_wizard_session(db_session, requester_platform_user_id="del-me")
+    tenant_id = created.tenant_id
+    deleted = await store.delete_wizard_sessions_for_platform_user(
+        db_session, platform_user_id="del-me", tenant_id=tenant_id
+    )
+    assert deleted == 1
+
+    rowcount = await store.update_wizard_state(
+        db_session,
+        short_id=created.id,
+        answers={"choice": ["a"]},
+        current_step=1,
+        now=datetime.now(UTC),
+    )
+
+    assert rowcount == 0, "a tap on a purged row must write nothing"
+    assert (await store.get_wizard_session(db_session, short_id=created.id)) is None
+
+
+async def test_try_claim_submit_returns_row_on_first_call_and_none_on_second(
+    db_session: AsyncSession,
+) -> None:
+    created = await make_wizard_session(db_session)
+    now = datetime.now(UTC)
+
+    first = await store.try_claim_submit(
+        db_session, short_id=created.id, answers={"choice": ["a"]}, current_step=1, now=now
+    )
+    second = await store.try_claim_submit(
+        db_session,
+        short_id=created.id,
+        answers={"choice": ["a"]},
+        current_step=1,
+        now=now + timedelta(seconds=1),
+    )
+
+    assert first is not None
+    assert first.status == "submitted"
+    assert second is None, "a second claim of an already-submitted row must return None"
+
+
+async def test_concurrent_try_claim_submit_yields_exactly_one_winner(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Two Submit taps racing the same row: one wins, one gets None.
+
+    A second winner would mean a second billed turn spawned from the same
+    form. `try_claim_submit`'s single predicated UPDATE is the entire gate —
+    asserting the race empirically is the difference between trusting the
+    SQL shape and knowing it holds.
+    """
+    created = await make_wizard_session(db_session)
+    now = datetime.now(UTC)
+
+    async def claim() -> WizardSessionRow | None:
+        async with db_session_factory() as session:
+            row = await store.try_claim_submit(
+                session, short_id=created.id, answers={"choice": ["a"]}, current_step=1, now=now
+            )
+            await session.commit()
+            return row
+
+    first, second = await asyncio.gather(claim(), claim())
+
+    winners = [row for row in (first, second) if row is not None]
+    assert len(winners) == 1, (
+        "exactly one racing claim may submit a wizard session; a second claim "
+        f"winning would mean a second billed turn; got {len(winners)} winners"
+    )
+
+
+async def test_abandon_expired_wizard_sessions_flips_only_open_past_expiry_rows(
+    db_session: AsyncSession,
+) -> None:
+    now = datetime.now(UTC)
+    expired_open = await make_wizard_session(
+        db_session, now=now - timedelta(hours=2), expires_at=now - timedelta(hours=1)
+    )
+    still_open = await make_wizard_session(db_session, now=now, expires_at=now + timedelta(hours=1))
+    expired_submitted = await make_wizard_session(
+        db_session,
+        now=now - timedelta(hours=2),
+        expires_at=now - timedelta(hours=1),
+        status="submitted",
+    )
+
+    flipped = await store.abandon_expired_wizard_sessions(db_session, now=now)
+
+    assert flipped == 1
+    after_expired_open = await store.get_wizard_session(db_session, short_id=expired_open.id)
+    assert after_expired_open is not None
+    assert after_expired_open.status == "abandoned"
+    after_still_open = await store.get_wizard_session(db_session, short_id=still_open.id)
+    assert after_still_open is not None
+    assert after_still_open.status == "open", "an unexpired row must not be abandoned"
+    after_expired_submitted = await store.get_wizard_session(
+        db_session, short_id=expired_submitted.id
+    )
+    assert after_expired_submitted is not None
+    assert after_expired_submitted.status == "submitted", "a submitted row must not be touched"
+
+
+async def test_abandon_expired_wizard_sessions_honours_limit(
+    db_session: AsyncSession,
+) -> None:
+    now = datetime.now(UTC)
+    for _ in range(3):
+        await make_wizard_session(
+            db_session, now=now - timedelta(hours=2), expires_at=now - timedelta(hours=1)
+        )
+
+    flipped = await store.abandon_expired_wizard_sessions(db_session, now=now, limit=2)
+
+    assert flipped == 2
+
+
+async def test_delete_wizard_sessions_for_platform_user_deletes_regardless_of_status(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    open_row = await make_wizard_session(
+        db_session, tenant=tenant, account=account, requester_platform_user_id="erase-me"
+    )
+    submitted_row = await make_wizard_session(
+        db_session,
+        tenant=tenant,
+        account=account,
+        requester_platform_user_id="erase-me",
+        status="submitted",
+    )
+    abandoned_row = await make_wizard_session(
+        db_session,
+        tenant=tenant,
+        account=account,
+        requester_platform_user_id="erase-me",
+        status="abandoned",
+    )
+
+    deleted = await store.delete_wizard_sessions_for_platform_user(
+        db_session, platform_user_id="erase-me", tenant_id=tenant.id
+    )
+
+    assert deleted == 3, "delete must remove open, submitted, AND abandoned rows"
+    assert (await store.get_wizard_session(db_session, short_id=open_row.id)) is None
+    assert (await store.get_wizard_session(db_session, short_id=submitted_row.id)) is None
+    assert (await store.get_wizard_session(db_session, short_id=abandoned_row.id)) is None
+
+
+async def test_delete_wizard_sessions_for_platform_user_is_idempotent(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await make_wizard_session(
+        db_session, tenant=tenant, account=account, requester_platform_user_id="idem-me"
+    )
+
+    first = await store.delete_wizard_sessions_for_platform_user(
+        db_session, platform_user_id="idem-me", tenant_id=tenant.id
+    )
+    second = await store.delete_wizard_sessions_for_platform_user(
+        db_session, platform_user_id="idem-me", tenant_id=tenant.id
+    )
+
+    assert first == 1
+    assert second == 0, "a re-run delete of an already-erased user must be a no-op"
+
+
+async def test_delete_wizard_sessions_for_platform_user_does_not_touch_other_tenant(
+    db_session: AsyncSession,
+) -> None:
+    tenant_a = await make_tenant(db_session, workspace_id="guild-a")
+    tenant_b = await make_tenant(db_session, workspace_id="guild-b")
+    account_a = await make_account(db_session, tenant=tenant_a)
+    account_b = await make_account(db_session, tenant=tenant_b)
+    row_a = await make_wizard_session(
+        db_session,
+        tenant=tenant_a,
+        account=account_a,
+        requester_platform_user_id="shared-platform-id",
+    )
+    row_b = await make_wizard_session(
+        db_session,
+        tenant=tenant_b,
+        account=account_b,
+        requester_platform_user_id="shared-platform-id",
+    )
+
+    deleted = await store.delete_wizard_sessions_for_platform_user(
+        db_session, platform_user_id="shared-platform-id", tenant_id=tenant_a.id
+    )
+
+    assert deleted == 1
+    assert (await store.get_wizard_session(db_session, short_id=row_a.id)) is None
+    survivor = await store.get_wizard_session(db_session, short_id=row_b.id)
+    assert survivor is not None, (
+        "another tenant's row sharing the same platform user id must survive"
+    )
+
+
+async def test_count_wizard_sessions_for_platform_user_matches_delete_rowcount(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    for _ in range(3):
+        await make_wizard_session(
+            db_session, tenant=tenant, account=account, requester_platform_user_id="count-me"
+        )
+
+    count_before = await store.count_wizard_sessions_for_platform_user(
+        db_session, platform_user_id="count-me", tenant_id=tenant.id
+    )
+    deleted = await store.delete_wizard_sessions_for_platform_user(
+        db_session, platform_user_id="count-me", tenant_id=tenant.id
+    )
+
+    assert count_before == deleted == 3

--- a/packages/core/tests/stores/test_wizard_session.py
+++ b/packages/core/tests/stores/test_wizard_session.py
@@ -47,6 +47,7 @@ async def test_update_wizard_state_on_open_unexpired_row_returns_one_and_persist
         short_id=created.id,
         answers={"choice": ["a"]},
         current_step=1,
+        expected_updated_at=created.updated_at,
         now=now,
     )
 
@@ -69,6 +70,7 @@ async def test_update_wizard_state_returns_zero_for_submitted_row(
         short_id=created.id,
         answers={"choice": ["a"]},
         current_step=1,
+        expected_updated_at=created.updated_at,
         now=datetime.now(UTC),
     )
 
@@ -94,6 +96,7 @@ async def test_update_wizard_state_returns_zero_for_expired_row(
         short_id=created.id,
         answers={"choice": ["a"]},
         current_step=1,
+        expected_updated_at=created.updated_at,
         now=now,
     )
 
@@ -118,11 +121,48 @@ async def test_update_wizard_state_returns_zero_for_deleted_row(
         short_id=created.id,
         answers={"choice": ["a"]},
         current_step=1,
+        expected_updated_at=created.updated_at,
         now=datetime.now(UTC),
     )
 
     assert rowcount == 0, "a tap on a purged row must write nothing"
     assert (await store.get_wizard_session(db_session, short_id=created.id)) is None
+
+
+async def test_update_wizard_state_returns_zero_when_the_row_changed_since_it_was_read(
+    db_session: AsyncSession,
+) -> None:
+    """Two taps computed from the same base row: the second must lose rather
+    than overwrite the first's answer with state that predates it."""
+    created = await make_wizard_session(db_session, answers={}, current_step=0)
+    first_now = created.updated_at + timedelta(seconds=1)
+    second_now = created.updated_at + timedelta(seconds=2)
+
+    first = await store.update_wizard_state(
+        db_session,
+        short_id=created.id,
+        answers={"choice": ["a"]},
+        current_step=1,
+        expected_updated_at=created.updated_at,
+        now=first_now,
+    )
+    second = await store.update_wizard_state(
+        db_session,
+        short_id=created.id,
+        answers={},
+        current_step=1,
+        expected_updated_at=created.updated_at,
+        now=second_now,
+    )
+
+    assert first == 1, "the tap that read the current row must win"
+    assert second == 0, "a tap computed from a superseded row must write nothing"
+    refetched = await store.get_wizard_session(db_session, short_id=created.id)
+    assert refetched is not None
+    assert refetched.answers == {"choice": ["a"]}, (
+        "the losing tap must not erase the answer the winning tap recorded"
+    )
+    assert refetched.updated_at == first_now
 
 
 async def test_try_claim_submit_returns_row_on_first_call_and_none_on_second(

--- a/packages/core/tests/test_privacy.py
+++ b/packages/core/tests/test_privacy.py
@@ -43,6 +43,7 @@ from daimon.testing.factories import (
     make_cli_principal,
     make_platform_principal,
     make_tenant,
+    make_wizard_session,
 )
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -438,6 +439,73 @@ async def test_collect_purge_preview_credential_requests_matches_purge_account(
     )
 
 
+async def test_collect_purge_preview_wizard_sessions_matches_purge_account(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Preview counts wizard_sessions and agrees with purge_account's actual
+    deletion count — the right-to-erasure parity contract."""
+    tenant = await make_tenant(db_session, workspace_id="pv-wizard")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="PV_WIZARD_TARGET",
+        tenant=tenant,
+        account=account,
+    )
+    await make_wizard_session(
+        db_session,
+        tenant=tenant,
+        account=account,
+        requester_platform_user_id="PV_WIZARD_TARGET",
+    )
+    await db_session.commit()
+
+    preview = await collect_purge_preview(sm=db_session_factory, account_id=account.id)
+    report = await purge_account(sm=db_session_factory, account_id=account.id)
+
+    assert preview.wizard_sessions.count == 1, (
+        "must count the platform principal's wizard_session row"
+    )
+    assert preview.wizard_sessions.count == report.db.wizard_sessions, (
+        "preview and purge must agree on wizard_sessions"
+    )
+
+
+async def test_purge_erases_submitted_and_abandoned_wizard_sessions(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Erasure must not apply a lifecycle filter: open, submitted, and
+    abandoned wizard_session rows all carry the user's typed answers and must
+    all be gone after purge_account."""
+    tenant = await make_tenant(db_session, workspace_id="pv-wizard-lifecycle")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="PV_WIZARD_LIFECYCLE",
+        tenant=tenant,
+        account=account,
+    )
+    for status in ("open", "submitted", "abandoned"):
+        await make_wizard_session(
+            db_session,
+            tenant=tenant,
+            account=account,
+            requester_platform_user_id="PV_WIZARD_LIFECYCLE",
+            status=status,
+        )
+    await db_session.commit()
+
+    report = await purge_account(sm=db_session_factory, account_id=account.id)
+
+    assert report.db.wizard_sessions == 3, (
+        "purge must delete open, submitted, AND abandoned wizard_session rows"
+    )
+
+
 async def test_collect_purge_preview_matches_purge_account_coverage_field_for_field() -> None:
     """If `PurgeReport` grows a new int field, `PurgePreview` MUST mirror it.
 
@@ -466,6 +534,7 @@ async def test_collect_purge_preview_matches_purge_account_coverage_field_for_fi
         "slack_user_tokens": "slack_user_tokens",
         "slack_turn_contexts": "slack_turn_contexts",
         "credential_requests": "credential_requests",
+        "wizard_sessions": "wizard_sessions",
     }
 
     uncovered = report_fields - set(mapping.keys())
@@ -508,6 +577,7 @@ async def test_purge_covers_every_account_or_principal_scoped_table() -> None:
         "github_credentials": "principal_id",
         "agent_github_binding": "principal_id",
         "mcp_tokens": "account_id FK -> accounts.id",
+        "wizard_session": "account_id FK -> accounts.id",
     }
     # Intentional exclusions, each justified inline.
     allowlist: frozenset[str] = frozenset(
@@ -527,14 +597,6 @@ async def test_purge_covers_every_account_or_principal_scoped_table() -> None:
             # Billing carve-outs retained for integrity.
             "usage_events",
             "tenant_user_caps",
-            # account_id carries a real (nullable) FK purely so this drift
-            # guard can see the table (see WizardSession's docstring); the
-            # FK itself is not the deletion mechanism. Erasure runs via
-            # `delete_wizard_sessions_for_platform_user`, a
-            # platform-user-scoped delete mirroring `credential_requests`.
-            # Wiring that helper into `purge_account` (moving this entry to
-            # `purged`) is follow-up work, not yet landed.
-            "wizard_session",
         }
     )
 

--- a/packages/core/tests/test_privacy.py
+++ b/packages/core/tests/test_privacy.py
@@ -527,6 +527,14 @@ async def test_purge_covers_every_account_or_principal_scoped_table() -> None:
             # Billing carve-outs retained for integrity.
             "usage_events",
             "tenant_user_caps",
+            # account_id carries a real (nullable) FK purely so this drift
+            # guard can see the table (see WizardSession's docstring); the
+            # FK itself is not the deletion mechanism. Erasure runs via
+            # `delete_wizard_sessions_for_platform_user`, a
+            # platform-user-scoped delete mirroring `credential_requests`.
+            # Wiring that helper into `purge_account` (moving this entry to
+            # `purged`) is follow-up work, not yet landed.
+            "wizard_session",
         }
     )
 

--- a/packages/core/tests/test_wizard_sweep.py
+++ b/packages/core/tests/test_wizard_sweep.py
@@ -1,0 +1,95 @@
+"""Tests for daimon.core.wizard_sweep."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from daimon.core.stores import wizard_session as store
+from daimon.core.wizard_sweep import sweep_expired_wizard_sessions
+from daimon.testing.factories import make_wizard_session
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
+
+
+async def test_sweep_flips_open_row_past_deadline_to_abandoned(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    created = await make_wizard_session(
+        db_session, now=NOW - timedelta(hours=2), expires_at=NOW - timedelta(hours=1)
+    )
+    await db_session.commit()
+
+    count = await sweep_expired_wizard_sessions(db_session_factory, now=NOW)
+
+    assert count == 1
+    refetched = await store.get_wizard_session(db_session, short_id=created.id)
+    assert refetched is not None
+    assert refetched.status == "abandoned"
+
+
+async def test_sweep_leaves_open_row_before_deadline_untouched(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    created = await make_wizard_session(db_session, now=NOW, expires_at=NOW + timedelta(hours=1))
+    await db_session.commit()
+
+    count = await sweep_expired_wizard_sessions(db_session_factory, now=NOW)
+
+    assert count == 0
+    refetched = await store.get_wizard_session(db_session, short_id=created.id)
+    assert refetched is not None
+    assert refetched.status == "open"
+
+
+async def test_sweep_leaves_submitted_row_past_deadline_untouched(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    created = await make_wizard_session(
+        db_session,
+        now=NOW - timedelta(hours=2),
+        expires_at=NOW - timedelta(hours=1),
+        status="submitted",
+    )
+    await db_session.commit()
+
+    count = await sweep_expired_wizard_sessions(db_session_factory, now=NOW)
+
+    assert count == 0
+    refetched = await store.get_wizard_session(db_session, short_id=created.id)
+    assert refetched is not None
+    assert refetched.status == "submitted"
+
+
+async def test_sweep_return_value_equals_number_flipped(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    for _ in range(3):
+        await make_wizard_session(
+            db_session, now=NOW - timedelta(hours=2), expires_at=NOW - timedelta(hours=1)
+        )
+    await db_session.commit()
+
+    count = await sweep_expired_wizard_sessions(db_session_factory, now=NOW)
+
+    assert count == 3
+
+
+async def test_second_sweep_at_same_now_is_idempotent(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    await make_wizard_session(
+        db_session, now=NOW - timedelta(hours=2), expires_at=NOW - timedelta(hours=1)
+    )
+    await db_session.commit()
+
+    first = await sweep_expired_wizard_sessions(db_session_factory, now=NOW)
+    second = await sweep_expired_wizard_sessions(db_session_factory, now=NOW)
+
+    assert first == 1
+    assert second == 0, "a second sweep at the same instant must flip nothing"

--- a/packages/core/tests/wizard/test_answers.py
+++ b/packages/core/tests/wizard/test_answers.py
@@ -1,0 +1,140 @@
+"""Unit tests for wizard answer serialization (agent block vs display summary)."""
+
+from __future__ import annotations
+
+import json
+
+from daimon.core.wizard.answers import (
+    escape_discord_markup,
+    format_answer_block,
+    summarize_answers,
+)
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import WizardState
+
+_SPEC = WizardSpec(
+    prompt="Order form",
+    steps=[
+        Step(
+            key="color",
+            question="Pick a color",
+            kind=StepKind.CHOICE,
+            options=[Option(label="Red", value="red"), Option(label="Blue", value="blue")],
+        ),
+        Step(
+            key="toppings",
+            question="Pick toppings",
+            kind=StepKind.MULTI,
+            options=[
+                Option(label="Cheese", value="cheese"),
+                Option(label="Olives", value="olives"),
+            ],
+        ),
+        Step(key="notes", question="Any notes?", kind=StepKind.TEXT, options=[]),
+    ],
+)
+
+
+def _state(answers: dict[str, list[str]]) -> WizardState:
+    return WizardState(short_id="abcd1234", answers=answers)
+
+
+def test_format_answer_block_first_line_names_the_prompt() -> None:
+    block = format_answer_block(_SPEC, _state({}))
+
+    assert block.startswith("Wizard answers (Order form):"), (
+        "the block's header line must name the form's prompt"
+    )
+
+
+def test_format_answer_block_one_line_per_step_in_spec_order() -> None:
+    block = format_answer_block(
+        _SPEC, _state({"color": ["red"], "toppings": ["cheese", "olives"], "notes": ["hi"]})
+    )
+    lines = block.splitlines()
+
+    key_lines = [
+        line
+        for line in lines
+        if ":" in line and line.split(":")[0] in {"color", "toppings", "notes"}
+    ]
+    assert [line.split(":")[0] for line in key_lines] == ["color", "toppings", "notes"], (
+        "answer block must emit one line per step, in spec order"
+    )
+
+
+def test_format_answer_block_unanswered_step_emits_empty_array() -> None:
+    block = format_answer_block(_SPEC, _state({}))
+
+    assert "notes: []" in block, "an unanswered step must emit an empty JSON array"
+
+
+def test_format_answer_block_adversarial_value_survives_json_round_trip() -> None:
+    adversarial = 'colon: value, "quoted", newline\nhere, and a ` backtick'
+    block = format_answer_block(_SPEC, _state({"notes": [adversarial]}))
+
+    notes_line = next(line for line in block.splitlines() if line.startswith("notes:"))
+    recovered = json.loads(notes_line.removeprefix("notes: "))
+
+    assert recovered == [adversarial], (
+        "adversarial text with a colon, quotes, a newline and a backtick must round-trip via JSON"
+    )
+
+
+def test_format_answer_block_uses_raw_values_not_labels() -> None:
+    block = format_answer_block(_SPEC, _state({"color": ["red"]}))
+
+    assert "red" in block
+    assert "Red" not in block.split("Wizard answers")[1], (
+        "the answer block must carry raw option values, never labels"
+    )
+
+
+def test_summarize_answers_substitutes_labels_for_values() -> None:
+    summary = summarize_answers(_SPEC, _state({"color": ["red"]}))
+
+    assert "Red" in summary, "summarize_answers must substitute the option label for its value"
+    assert "red" not in summary.replace("Red", ""), (
+        "the raw value should not appear once substituted with its label"
+    )
+
+
+def test_summarize_answers_unanswered_step_renders_em_dash() -> None:
+    summary = summarize_answers(_SPEC, _state({}))
+
+    assert "—" in summary, "an unanswered step must render an em dash"
+
+
+def test_summarize_answers_escapes_markdown_and_mass_mention() -> None:
+    summary = summarize_answers(_SPEC, _state({"notes": ["*bold* @everyone"]}))
+
+    assert "\\*bold\\*" in summary, "markdown control characters must be escaped in the summary"
+    assert "@everyone" not in summary, "a raw @everyone must never survive into the summary"
+    assert "@​everyone" in summary, "mass mention must be neutralized with a zero-width space"
+
+
+def test_answer_block_and_summary_disagree_on_escaping_by_design() -> None:
+    text = "*bold* @everyone"
+    block = format_answer_block(_SPEC, _state({"notes": [text]}))
+    summary = summarize_answers(_SPEC, _state({"notes": [text]}))
+
+    assert text in block, "the agent-facing block must carry the raw, unescaped value"
+    assert text not in summary, "the display summary must escape the same value"
+
+
+def test_escape_discord_markup_escapes_control_characters() -> None:
+    escaped = escape_discord_markup("*_~`|>#-[]()")
+
+    for char in "*_~`|>#-[]()":
+        assert f"\\{char}" in escaped, f"{char!r} must be backslash-escaped"
+
+
+def test_escape_discord_markup_neutralizes_here_and_role_mention() -> None:
+    escaped = escape_discord_markup("@here <@&12345>")
+
+    assert "@here" not in escaped
+    assert "<@&12345>" not in escaped
+    assert "@​here" in escaped
+    assert "<@​&12345\\>" in escaped, (
+        "the mass-mention sequence is neutralized; > is still escaped like any other control char"
+    )

--- a/packages/core/tests/wizard/test_answers.py
+++ b/packages/core/tests/wizard/test_answers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from daimon.core.wizard.answers import (
+    MAX_SUMMARY_CHARS,
     escape_discord_markup,
     format_answer_block,
     summarize_answers,
@@ -137,4 +138,29 @@ def test_escape_discord_markup_neutralizes_here_and_role_mention() -> None:
     assert "@​here" in escaped
     assert "<@​&12345\\>" in escaped, (
         "the mass-mention sequence is neutralized; > is still escaped like any other control char"
+    )
+
+
+def test_summary_is_truncated_to_the_text_display_budget() -> None:
+    """An unbounded summary makes the review screen -- and the post-submit
+    collapse re-render, on an already-claimed submission -- fail to render."""
+    long_spec = WizardSpec(
+        prompt="Order form",
+        steps=[
+            Step(key=f"k{i}", question=f"Question {i}", kind=StepKind.TEXT, options=[])
+            for i in range(20)
+        ],
+    )
+    state = WizardState(short_id="abcd1234", answers={f"k{i}": ["x" * 200] for i in range(20)})
+
+    summary = summarize_answers(long_spec, state)
+
+    assert len(summary) <= MAX_SUMMARY_CHARS, (
+        "the summary must stay inside the budget a TextDisplay can carry"
+    )
+    assert summary.endswith("(answers truncated for display)"), (
+        "a truncated summary must say so rather than silently losing answers"
+    )
+    assert not summary.endswith("\\\n… (answers truncated for display)"), (
+        "the cut must not end on a lone backslash that would escape the marker's newline"
     )

--- a/packages/core/tests/wizard/test_apply.py
+++ b/packages/core/tests/wizard/test_apply.py
@@ -1,0 +1,230 @@
+"""Unit tests for the wizard's pure transition function and action translator."""
+
+from __future__ import annotations
+
+import pytest
+from daimon.core.wizard.apply import apply, build_action
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import ActionKind, WizardAction, WizardState, WizardStatus
+
+_CHOICE_STEP = Step(
+    key="color",
+    question="Pick a color",
+    kind=StepKind.CHOICE,
+    options=[Option(label="Red", value="red"), Option(label="Blue", value="blue")],
+)
+_MULTI_STEP = Step(
+    key="toppings",
+    question="Pick toppings",
+    kind=StepKind.MULTI,
+    options=[
+        Option(label="Cheese", value="cheese"),
+        Option(label="Olives", value="olives"),
+        Option(label="Pepperoni", value="pepperoni"),
+    ],
+    min=2,
+)
+_TEXT_STEP = Step(key="notes", question="Any notes?", kind=StepKind.TEXT, options=[])
+
+_SPEC = WizardSpec(prompt="Order form", steps=[_CHOICE_STEP, _MULTI_STEP, _TEXT_STEP])
+
+
+def _state(
+    *,
+    current_step: int = 0,
+    answers: dict[str, list[str]] | None = None,
+    status: WizardStatus = WizardStatus.OPEN,
+) -> WizardState:
+    return WizardState(
+        short_id="abcd1234",
+        current_step=current_step,
+        answers=answers if answers is not None else {},
+        status=status,
+    )
+
+
+def test_select_choice_records_option_value_and_advances() -> None:
+    state = _state(current_step=0)
+    action = WizardAction(kind=ActionKind.SELECT_CHOICE, step_index=0, values=["red"])
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.answers["color"] == ["red"], "choice value must be recorded under step key"
+    assert new_state.current_step == 1, "select_choice must auto-advance one step"
+
+
+def test_set_multi_records_values_and_does_not_advance() -> None:
+    state = _state(current_step=1)
+    action = WizardAction(kind=ActionKind.SET_MULTI, step_index=1, values=["cheese", "olives"])
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.answers["toppings"] == ["cheese", "olives"]
+    assert new_state.current_step == 1, "set_multi must not advance; Next advances"
+
+
+def test_next_on_unmet_required_multi_is_a_no_op() -> None:
+    state = _state(current_step=1, answers={"toppings": ["cheese"]})
+    action = WizardAction(kind=ActionKind.NEXT)
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.current_step == 1, "Next must refuse to advance below a multi step's min"
+    assert new_state == state, "no-op transition should return equivalent state"
+
+
+def test_next_on_met_multi_advances() -> None:
+    state = _state(current_step=1, answers={"toppings": ["cheese", "olives"]})
+    action = WizardAction(kind=ActionKind.NEXT)
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.current_step == 2, "Next must advance once the multi's min is met"
+
+
+def test_back_from_step_zero_stays_at_zero() -> None:
+    state = _state(current_step=0)
+    action = WizardAction(kind=ActionKind.BACK)
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.current_step == 0, "Back must clamp at the first step"
+
+
+def test_next_from_last_step_lands_on_review_index() -> None:
+    state = _state(current_step=2, answers={"toppings": ["cheese", "olives"]})
+    action = WizardAction(kind=ActionKind.NEXT)
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.current_step == len(_SPEC.steps), "review index is one past the last step"
+
+
+def test_custom_text_on_choice_step_replaces_and_advances() -> None:
+    state = _state(current_step=0)
+    action = WizardAction(kind=ActionKind.ADD_CUSTOM, step_index=0, text="Purple")
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.answers["color"] == ["Purple"]
+    assert new_state.current_step == 1, "custom text on a choice step must advance"
+
+
+def test_custom_text_on_multi_step_appends_and_stays() -> None:
+    state = _state(current_step=1, answers={"toppings": ["cheese"]})
+    action = WizardAction(kind=ActionKind.ADD_CUSTOM, step_index=1, text="Anchovies")
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.answers["toppings"] == ["cheese", "Anchovies"]
+    assert new_state.current_step == 1, "custom text on a multi step must not advance"
+
+
+@pytest.mark.parametrize("raw_text", ["", "   ", "\t\n"])
+def test_custom_text_empty_or_whitespace_raises(raw_text: str) -> None:
+    state = _state(current_step=0)
+    action = WizardAction(kind=ActionKind.ADD_CUSTOM, step_index=0, text=raw_text)
+
+    with pytest.raises(ValueError, match="empty"):
+        apply(state, _SPEC, action)
+
+
+def test_submit_at_review_index_flips_status_to_submitted() -> None:
+    state = _state(current_step=len(_SPEC.steps))
+    action = WizardAction(kind=ActionKind.SUBMIT)
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.status is WizardStatus.SUBMITTED
+
+
+@pytest.mark.parametrize("current_step", [0, 1, 2])
+def test_submit_anywhere_else_is_a_no_op(current_step: int) -> None:
+    state = _state(current_step=current_step)
+    action = WizardAction(kind=ActionKind.SUBMIT)
+
+    new_state = apply(state, _SPEC, action)
+
+    assert new_state.status is WizardStatus.OPEN
+    assert new_state == state
+
+
+def test_input_answers_dict_is_not_mutated() -> None:
+    original_answers = {"toppings": ["cheese"]}
+    state = _state(current_step=1, answers=original_answers)
+    action = WizardAction(kind=ActionKind.ADD_CUSTOM, step_index=1, text="Anchovies")
+
+    apply(state, _SPEC, action)
+
+    assert original_answers == {"toppings": ["cheese"]}, (
+        "apply must never mutate the caller's answers dict in place"
+    )
+    assert state.answers is original_answers, "the input state object itself must be untouched"
+
+
+def test_out_of_range_step_index_raises() -> None:
+    state = _state(current_step=0)
+    action = WizardAction(kind=ActionKind.SELECT_CHOICE, step_index=99, values=["red"])
+
+    with pytest.raises(ValueError, match="out of range"):
+        apply(state, _SPEC, action)
+
+
+def test_none_step_index_raises_for_value_recording_action() -> None:
+    state = _state(current_step=0)
+    action = WizardAction(kind=ActionKind.SET_MULTI, step_index=None, values=["cheese"])
+
+    with pytest.raises(ValueError, match="out of range"):
+        apply(state, _SPEC, action)
+
+
+def test_build_action_maps_next_back_submit() -> None:
+    assert build_action("next", spec=_SPEC, values=[], text=None) == WizardAction(
+        kind=ActionKind.NEXT
+    )
+    assert build_action("back", spec=_SPEC, values=[], text=None) == WizardAction(
+        kind=ActionKind.BACK
+    )
+    assert build_action("submit", spec=_SPEC, values=[], text=None) == WizardAction(
+        kind=ActionKind.SUBMIT
+    )
+
+
+def test_build_action_maps_select_to_set_multi() -> None:
+    action = build_action("s1_sel", spec=_SPEC, values=["cheese", "olives"], text=None)
+
+    assert action == WizardAction(
+        kind=ActionKind.SET_MULTI, step_index=1, values=["cheese", "olives"]
+    )
+
+
+def test_build_action_maps_choice_button_to_select_choice_with_looked_up_value() -> None:
+    action = build_action("s0_c1", spec=_SPEC, values=[], text=None)
+
+    assert action == WizardAction(kind=ActionKind.SELECT_CHOICE, step_index=0, values=["blue"])
+
+
+def test_build_action_maps_custom_to_add_custom() -> None:
+    action = build_action("s0_custom", spec=_SPEC, values=[], text="Purple")
+
+    assert action == WizardAction(kind=ActionKind.ADD_CUSTOM, step_index=0, text="Purple")
+
+
+def test_build_action_raises_for_enter() -> None:
+    with pytest.raises(ValueError, match="modal"):
+        build_action("s0_enter", spec=_SPEC, values=[], text=None)
+
+
+def test_build_action_raises_for_unknown_string() -> None:
+    with pytest.raises(ValueError, match="does not match"):
+        build_action("totally_unknown", spec=_SPEC, values=[], text=None)
+
+
+def test_build_action_raises_for_out_of_range_step() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        build_action("s9_sel", spec=_SPEC, values=["cheese"], text=None)
+
+
+def test_build_action_raises_for_out_of_range_option() -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        build_action("s0_c9", spec=_SPEC, values=[], text=None)

--- a/packages/core/tests/wizard/test_apply.py
+++ b/packages/core/tests/wizard/test_apply.py
@@ -120,6 +120,33 @@ def test_custom_text_on_multi_step_appends_and_stays() -> None:
     assert new_state.current_step == 1, "custom text on a multi step must not advance"
 
 
+def test_custom_text_on_a_multi_step_at_its_max_is_a_no_op() -> None:
+    """`max` gates the select's max_values, but nothing stops a user
+    reopening the custom-text modal -- the transition has to hold the line,
+    or the recorded answers grow without bound."""
+    capped_spec = WizardSpec(
+        prompt="Order form",
+        steps=[
+            Step(
+                key="toppings",
+                question="Pick toppings",
+                kind=StepKind.MULTI,
+                options=[
+                    Option(label="Cheese", value="cheese"),
+                    Option(label="Olives", value="olives"),
+                ],
+                max=2,
+            )
+        ],
+    )
+    state = WizardState(short_id="abcd1234", answers={"toppings": ["cheese", "Anchovies"]})
+    action = WizardAction(kind=ActionKind.ADD_CUSTOM, step_index=0, text="Pineapple")
+
+    new_state = apply(state, capped_spec, action)
+
+    assert new_state == state, "an append past the step's declared max must change nothing"
+
+
 @pytest.mark.parametrize("raw_text", ["", "   ", "\t\n"])
 def test_custom_text_empty_or_whitespace_raises(raw_text: str) -> None:
     state = _state(current_step=0)

--- a/packages/core/tests/wizard/test_apply.py
+++ b/packages/core/tests/wizard/test_apply.py
@@ -225,6 +225,40 @@ def test_build_action_maps_select_to_set_multi() -> None:
     )
 
 
+def test_build_action_rejects_a_select_value_the_step_does_not_declare() -> None:
+    """Interaction payloads are untrusted on this path: the button branch
+    validates its option index against the spec, so the select branch must
+    validate its values the same way."""
+    with pytest.raises(ValueError, match="does not declare"):
+        build_action("s1_sel", spec=_SPEC, values=["cheese", "anchovies"], text=None)
+
+
+def test_build_action_rejects_a_select_against_a_non_multi_step() -> None:
+    with pytest.raises(ValueError, match="choice step"):
+        build_action("s0_sel", spec=_SPEC, values=["red"], text=None)
+
+
+def test_build_action_rejects_more_select_values_than_the_step_allows() -> None:
+    capped_spec = WizardSpec(
+        prompt="Order form",
+        steps=[
+            Step(
+                key="toppings",
+                question="Pick toppings",
+                kind=StepKind.MULTI,
+                options=[
+                    Option(label="Cheese", value="cheese"),
+                    Option(label="Olives", value="olives"),
+                ],
+                max=1,
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="above step"):
+        build_action("s0_sel", spec=capped_spec, values=["cheese", "olives"], text=None)
+
+
 def test_build_action_maps_choice_button_to_select_choice_with_looked_up_value() -> None:
     action = build_action("s0_c1", spec=_SPEC, values=[], text=None)
 

--- a/packages/core/tests/wizard/test_expiry.py
+++ b/packages/core/tests/wizard/test_expiry.py
@@ -1,0 +1,92 @@
+"""Unit tests for CDN signature parsing and form-expiry derivation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from daimon.core.wizard.expiry import (
+    DEFAULT_TTL,
+    MIN_TTL,
+    SAFETY_MARGIN,
+    UNKNOWN_SIGNATURE_TTL,
+    derive_expires_at,
+    parse_attachment_expiry,
+)
+
+_NOW = datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC)
+
+
+def _url_with_expiry(expiry: datetime) -> str:
+    hex_epoch = format(int(expiry.timestamp()), "x")
+    return f"https://cdn.discordapp.com/attachments/1/2/a.png?ex={hex_epoch}&is=1&hm=deadbeef"
+
+
+def test_parse_attachment_expiry_reads_real_shaped_discord_cdn_url() -> None:
+    expected = datetime(2026, 8, 1, 0, 0, 0, tzinfo=UTC)
+    url = f"https://cdn.discordapp.com/attachments/123/456/img.png?ex={format(int(expected.timestamp()), 'x')}&is=6890a000&hm=abc123"
+
+    parsed = parse_attachment_expiry(url)
+
+    assert parsed == expected, "parse_attachment_expiry must decode the hex ex parameter as UTC"
+
+
+def test_parse_attachment_expiry_returns_none_without_ex_param() -> None:
+    assert (
+        parse_attachment_expiry("https://cdn.discordapp.com/attachments/1/2/a.png?is=1&hm=x")
+        is None
+    )
+
+
+def test_parse_attachment_expiry_returns_none_for_non_hex_ex() -> None:
+    assert (
+        parse_attachment_expiry("https://cdn.discordapp.com/attachments/1/2/a.png?ex=notahex")
+        is None
+    )
+
+
+def test_derive_expires_at_with_no_urls_returns_default_ttl() -> None:
+    result = derive_expires_at(now=_NOW, attachment_urls=[])
+
+    assert result == _NOW + DEFAULT_TTL
+
+
+def test_derive_expires_at_with_far_future_expiry_returns_default_ttl() -> None:
+    far_future = _NOW + timedelta(days=30)
+    result = derive_expires_at(now=_NOW, attachment_urls=[_url_with_expiry(far_future)])
+
+    assert result == _NOW + DEFAULT_TTL, (
+        "the default TTL is the binding cap when signatures outlive it"
+    )
+
+
+def test_derive_expires_at_with_near_expiry_returns_expiry_minus_margin() -> None:
+    near = _NOW + timedelta(hours=2)
+    result = derive_expires_at(now=_NOW, attachment_urls=[_url_with_expiry(near)])
+
+    assert result == near - SAFETY_MARGIN
+
+
+def test_derive_expires_at_with_mixture_returns_earliest_minus_margin() -> None:
+    near = _NOW + timedelta(hours=2)
+    far = _NOW + timedelta(hours=8)
+    result = derive_expires_at(
+        now=_NOW, attachment_urls=[_url_with_expiry(far), _url_with_expiry(near)]
+    )
+
+    assert result == near - SAFETY_MARGIN, "the earliest attachment expiry governs the form's TTL"
+
+
+def test_derive_expires_at_with_unparseable_url_caps_at_unknown_signature_ttl() -> None:
+    unparseable = "https://cdn.discordapp.com/attachments/1/2/a.png?is=1&hm=x"
+    result = derive_expires_at(now=_NOW, attachment_urls=[unparseable])
+
+    assert result == _NOW + UNKNOWN_SIGNATURE_TTL
+
+
+def test_derive_expires_at_with_past_expiry_floors_at_min_ttl() -> None:
+    past = _NOW - timedelta(hours=1)
+    result = derive_expires_at(now=_NOW, attachment_urls=[_url_with_expiry(past)])
+
+    assert result == _NOW + MIN_TTL, (
+        "an already-past signature expiry must never yield a past form expiry"
+    )

--- a/packages/core/tests/wizard/test_render.py
+++ b/packages/core/tests/wizard/test_render.py
@@ -1,0 +1,222 @@
+"""Unit tests for the platform-neutral Screen intermediate."""
+
+from __future__ import annotations
+
+from daimon.core.wizard.render import ScreenButton, to_screen
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import (
+    NAV_CUSTOM_ID_PATTERN,
+    SELECT_CUSTOM_ID_PATTERN,
+    SUBMIT_CUSTOM_ID_PATTERN,
+    WizardState,
+    WizardStatus,
+    build_custom_id,
+)
+
+_CHOICE_STEP = Step(
+    key="color",
+    question="Pick a color",
+    kind=StepKind.CHOICE,
+    options=[Option(label="Red", value="red"), Option(label="Blue", value="blue")],
+    allow_custom=True,
+)
+_MULTI_STEP = Step(
+    key="toppings",
+    question="Pick toppings",
+    kind=StepKind.MULTI,
+    options=[
+        Option(label="Cheese", value="cheese"),
+        Option(label="Olives", value="olives"),
+        Option(label="Pepperoni", value="pepperoni"),
+    ],
+    min=1,
+    max=2,
+    allow_custom=True,
+)
+_TEXT_STEP = Step(
+    key="notes", question="Any notes?", kind=StepKind.TEXT, options=[], allow_custom=True
+)
+_NO_CUSTOM_STEP = Step(
+    key="size",
+    question="Pick a size",
+    kind=StepKind.CHOICE,
+    options=[Option(label="Small", value="small")],
+    allow_custom=False,
+)
+_IMAGE_STEP = Step(
+    key="pet",
+    question="Pick a pet",
+    kind=StepKind.CHOICE,
+    options=[Option(label="Cat", value="cat")],
+    image_handle="handle-123",
+)
+
+_SPEC = WizardSpec(
+    prompt="Order form",
+    steps=[_CHOICE_STEP, _MULTI_STEP, _TEXT_STEP, _NO_CUSTOM_STEP, _IMAGE_STEP],
+)
+
+_SEVEN_OPTION_STEP = Step(
+    key="flavor",
+    question="Pick a flavor",
+    kind=StepKind.CHOICE,
+    options=[Option(label=f"Flavor {i}", value=f"f{i}") for i in range(7)],
+)
+_SEVEN_OPTION_SPEC = WizardSpec(prompt="Flavor form", steps=[_SEVEN_OPTION_STEP])
+
+
+def _state(
+    *,
+    current_step: int = 0,
+    answers: dict[str, list[str]] | None = None,
+    status: WizardStatus = WizardStatus.OPEN,
+) -> WizardState:
+    return WizardState(
+        short_id="abcd1234",
+        current_step=current_step,
+        answers=answers if answers is not None else {},
+        status=status,
+    )
+
+
+def _all_actions(screen_button_rows: tuple[tuple[ScreenButton, ...], ...]) -> list[str]:
+    return [button.action for row in screen_button_rows for button in row]
+
+
+def test_choice_step_screen_shape() -> None:
+    screen = to_screen(_SPEC, _state(current_step=0))
+
+    assert screen.accent == "blurple"
+    assert "Pick a color" in screen.head_text
+    assert "Step 1 of 5" in screen.head_text
+    assert screen.select is None
+    assert screen.button_rows[0] == (
+        ScreenButton(action="s0_c0", label="Red", style="secondary"),
+        ScreenButton(action="s0_c1", label="Blue", style="secondary"),
+    )
+    nav_row = screen.button_rows[-1]
+    assert [b.action for b in nav_row] == ["s0_custom", "back", "next"]
+
+
+def test_choice_step_seven_options_chunks_into_five_and_two_plus_nav() -> None:
+    screen = to_screen(_SEVEN_OPTION_SPEC, _state(current_step=0))
+
+    assert len(screen.button_rows[0]) == 5
+    assert len(screen.button_rows[1]) == 2
+    assert len(screen.button_rows) == 3, "one row of 5, one row of 2, plus the nav row"
+
+
+def test_step_counter_reflects_current_step() -> None:
+    screen = to_screen(_SPEC, _state(current_step=2))
+
+    assert "Step 3 of 5" in screen.head_text
+    assert "Any notes?" in screen.head_text
+
+
+def test_multi_step_select_action_matches_step_index() -> None:
+    screen = to_screen(_SPEC, _state(current_step=1))
+
+    assert screen.select is not None
+    assert screen.select.action == "s1_sel"
+    assert screen.select.placeholder == "Pick toppings"
+
+
+def test_multi_step_screen_marks_recorded_values_as_default() -> None:
+    screen = to_screen(_SPEC, _state(current_step=1, answers={"toppings": ["cheese"]}))
+
+    assert screen.select is not None
+    defaults = {option.value: option.default for option in screen.select.options}
+    assert defaults == {"cheese": True, "olives": False, "pepperoni": False}
+    assert screen.select.min_values == 1
+    assert screen.select.max_values == 2
+    nav_row = screen.button_rows[-1]
+    assert [b.action for b in nav_row] == ["s1_custom", "back", "next"]
+
+
+def test_text_step_never_has_custom_button_even_with_allow_custom_true() -> None:
+    screen = to_screen(_SPEC, _state(current_step=2))
+
+    assert screen.select is None
+    enter_row = screen.button_rows[0]
+    assert enter_row == (ScreenButton(action="s2_enter", label="Enter…", style="primary"),)
+    nav_row = screen.button_rows[-1]
+    assert [b.action for b in nav_row] == ["back", "next"], (
+        "a text step must never show the custom-entry button even when allow_custom is set"
+    )
+
+
+def test_step_with_allow_custom_false_has_no_custom_button() -> None:
+    screen = to_screen(_SPEC, _state(current_step=3))
+
+    nav_row = screen.button_rows[-1]
+    assert [b.action for b in nav_row] == ["back", "next"]
+
+
+def test_step_with_image_handle_produces_screen_image() -> None:
+    screen = to_screen(_SPEC, _state(current_step=4))
+
+    assert screen.image is not None
+    assert screen.image.handle == "handle-123"
+
+
+def test_review_screen_shape() -> None:
+    screen = to_screen(_SPEC, _state(current_step=len(_SPEC.steps), answers={"color": ["red"]}))
+
+    assert screen.accent == "blurple"
+    assert "Review your answers" in screen.head_text
+    assert screen.select is None
+    assert screen.image is None
+    assert screen.body_text is not None
+    assert screen.button_rows == (
+        (
+            ScreenButton(action="back", label="Back", style="secondary"),
+            ScreenButton(action="submit", label="Submit", style="success"),
+        ),
+    )
+
+
+def test_collapsed_screen_has_zero_button_rows() -> None:
+    screen = to_screen(_SPEC, _state(status=WizardStatus.SUBMITTED, answers={"color": ["red"]}))
+
+    assert screen.button_rows == (), "a submitted form must not be re-tappable"
+    assert screen.accent == "green"
+    assert screen.image is None
+
+
+def test_collapsed_and_review_screens_carry_no_image() -> None:
+    review = to_screen(_SPEC, _state(current_step=len(_SPEC.steps)))
+    collapsed = to_screen(_SPEC, _state(status=WizardStatus.SUBMITTED))
+
+    assert review.image is None
+    assert collapsed.image is None
+
+
+def test_every_emitted_action_round_trips_through_build_custom_id_and_matches_one_pattern() -> None:
+    states = [
+        _state(current_step=0),
+        _state(current_step=1, answers={"toppings": ["cheese"]}),
+        _state(current_step=2),
+        _state(current_step=3),
+        _state(current_step=4),
+        _state(current_step=len(_SPEC.steps)),
+        _state(status=WizardStatus.SUBMITTED),
+    ]
+    for state in states:
+        screen = to_screen(_SPEC, state)
+        actions = _all_actions(screen.button_rows)
+        if screen.select is not None:
+            actions.append(screen.select.action)
+        for action in actions:
+            custom_id = build_custom_id(screen.short_id, action)
+            patterns_matched = sum(
+                1
+                for pattern in (
+                    NAV_CUSTOM_ID_PATTERN,
+                    SELECT_CUSTOM_ID_PATTERN,
+                    SUBMIT_CUSTOM_ID_PATTERN,
+                )
+                if pattern.fullmatch(custom_id)
+            )
+            assert patterns_matched == 1, (
+                f"action {action!r} must fullmatch exactly one custom_id grammar"
+            )

--- a/packages/core/tests/wizard/test_spec.py
+++ b/packages/core/tests/wizard/test_spec.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import pytest
 from daimon.core.wizard.spec import (
+    HEAD_TEXT_OVERHEAD_CHARS,
+    MAX_SELECT_OPTION_DESCRIPTION_CHARS,
+    MAX_SELECT_OPTION_VALUE_CHARS,
     MAX_SELECT_OPTIONS,
+    MAX_SELECT_PLACEHOLDER_CHARS,
     MAX_STEPS,
+    MAX_TEXT_DISPLAY_CHARS,
     Option,
     Step,
     StepKind,
@@ -129,6 +134,79 @@ def test_multi_max_above_option_count_rejected() -> None:
             steps=[Step(key="k", question="q", kind=StepKind.MULTI, options=options, min=0, max=5)],
         )
     assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_multi_min_above_option_count_rejected_when_max_is_unset() -> None:
+    # With `max` unset the renderer derives max_values from the option count,
+    # so min=3 against 2 options would emit min_values > max_values.
+    options = [Option(label="a", value="a"), Option(label="b", value="b")]
+
+    with pytest.raises(ValidationError, match="available options") as exc_info:
+        WizardSpec(
+            prompt="p",
+            steps=[Step(key="k", question="q", kind=StepKind.MULTI, options=options, min=3)],
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_oversized_option_value_rejected() -> None:
+    option = Option(label="a", value="v" * (MAX_SELECT_OPTION_VALUE_CHARS + 1))
+
+    with pytest.raises(ValidationError, match="option value") as exc_info:
+        WizardSpec(
+            prompt="p", steps=[Step(key="k", question="q", kind=StepKind.CHOICE, options=[option])]
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_oversized_option_description_rejected() -> None:
+    option = Option(
+        label="a", value="a", description="d" * (MAX_SELECT_OPTION_DESCRIPTION_CHARS + 1)
+    )
+
+    with pytest.raises(ValidationError, match="option description") as exc_info:
+        WizardSpec(
+            prompt="p", steps=[Step(key="k", question="q", kind=StepKind.CHOICE, options=[option])]
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_oversized_head_text_rejected() -> None:
+    question = "q" * (MAX_TEXT_DISPLAY_CHARS - HEAD_TEXT_OVERHEAD_CHARS)
+
+    with pytest.raises(ValidationError, match="head text") as exc_info:
+        WizardSpec(prompt="p", steps=[Step(key="k", question=question, kind=StepKind.TEXT)])
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_multi_question_above_the_placeholder_limit_rejected() -> None:
+    options = [Option(label="a", value="a")]
+    question = "q" * (MAX_SELECT_PLACEHOLDER_CHARS + 1)
+
+    with pytest.raises(ValidationError, match="placeholder") as exc_info:
+        WizardSpec(
+            prompt="p",
+            steps=[Step(key="k", question=question, kind=StepKind.MULTI, options=options)],
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_a_long_question_is_accepted_on_a_non_multi_step() -> None:
+    """Only a multi step's question becomes a select placeholder; the same
+    length on a choice step renders as ordinary head text."""
+    spec = WizardSpec(
+        prompt="p",
+        steps=[
+            Step(
+                key="k",
+                question="q" * (MAX_SELECT_PLACEHOLDER_CHARS + 1),
+                kind=StepKind.CHOICE,
+                options=[Option(label="a", value="a")],
+            )
+        ],
+    )
+
+    assert len(spec.steps) == 1
 
 
 def test_too_many_image_bearing_steps_rejected() -> None:

--- a/packages/core/tests/wizard/test_spec.py
+++ b/packages/core/tests/wizard/test_spec.py
@@ -1,0 +1,167 @@
+"""Unit tests for the agent-authored wizard form schema (no I/O, no DB)."""
+
+from __future__ import annotations
+
+import pytest
+from daimon.core.wizard.spec import (
+    MAX_SELECT_OPTIONS,
+    MAX_STEPS,
+    Option,
+    Step,
+    StepKind,
+    WizardSpec,
+)
+from pydantic import ValidationError
+
+
+def test_minimal_choice_step_is_valid() -> None:
+    spec = WizardSpec(
+        prompt="pick one",
+        steps=[
+            Step(
+                key="k", question="q", kind=StepKind.CHOICE, options=[Option(label="a", value="a")]
+            )
+        ],
+    )
+
+    assert len(spec.steps) == 1, "a single valid choice step must be accepted"
+
+
+def test_minimal_multi_step_is_valid() -> None:
+    spec = WizardSpec(
+        prompt="pick some",
+        steps=[
+            Step(
+                key="k",
+                question="q",
+                kind=StepKind.MULTI,
+                options=[Option(label="a", value="a"), Option(label="b", value="b")],
+                min=0,
+                max=2,
+            )
+        ],
+    )
+
+    assert len(spec.steps) == 1, "a single valid multi step must be accepted"
+
+
+def test_minimal_text_step_is_valid() -> None:
+    spec = WizardSpec(prompt="tell me", steps=[Step(key="k", question="q", kind=StepKind.TEXT)])
+
+    assert len(spec.steps) == 1, "a single valid text step must be accepted"
+
+
+def test_zero_steps_rejected() -> None:
+    with pytest.raises(ValidationError, match="zero steps"):
+        WizardSpec(prompt="p", steps=[])
+
+
+def test_more_than_max_steps_rejected() -> None:
+    steps = [Step(key=f"k{i}", question="q", kind=StepKind.TEXT) for i in range(MAX_STEPS + 1)]
+
+    with pytest.raises(ValidationError, match="exceeding the"):
+        WizardSpec(prompt="p", steps=steps)
+
+
+def test_duplicate_keys_rejected() -> None:
+    steps = [
+        Step(key="dup", question="q1", kind=StepKind.TEXT),
+        Step(key="dup", question="q2", kind=StepKind.TEXT),
+    ]
+
+    with pytest.raises(ValidationError, match="dup") as exc_info:
+        WizardSpec(prompt="p", steps=steps)
+    assert "dup" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_choice_step_with_no_options_rejected() -> None:
+    with pytest.raises(ValidationError, match="no options") as exc_info:
+        WizardSpec(prompt="p", steps=[Step(key="k", question="q", kind=StepKind.CHOICE)])
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_too_many_options_rejected() -> None:
+    options = [Option(label=str(i), value=str(i)) for i in range(MAX_SELECT_OPTIONS + 1)]
+
+    with pytest.raises(ValidationError, match="exceeding the") as exc_info:
+        WizardSpec(
+            prompt="p", steps=[Step(key="k", question="q", kind=StepKind.CHOICE, options=options)]
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_oversized_option_label_rejected() -> None:
+    option = Option(label="x" * 81, value="v")
+
+    with pytest.raises(ValidationError, match="button label limit") as exc_info:
+        WizardSpec(
+            prompt="p", steps=[Step(key="k", question="q", kind=StepKind.CHOICE, options=[option])]
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_multi_min_greater_than_max_rejected() -> None:
+    options = [Option(label="a", value="a"), Option(label="b", value="b")]
+
+    with pytest.raises(ValidationError, match="must not exceed") as exc_info:
+        WizardSpec(
+            prompt="p",
+            steps=[
+                Step(
+                    key="k",
+                    question="q",
+                    kind=StepKind.MULTI,
+                    options=options,
+                    min=2,
+                    max=1,
+                )
+            ],
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_multi_max_above_option_count_rejected() -> None:
+    options = [Option(label="a", value="a")]
+
+    with pytest.raises(ValidationError, match="available options") as exc_info:
+        WizardSpec(
+            prompt="p",
+            steps=[Step(key="k", question="q", kind=StepKind.MULTI, options=options, min=0, max=5)],
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_too_many_image_bearing_steps_rejected() -> None:
+    steps = [
+        Step(key=f"k{i}", question="q", kind=StepKind.TEXT, image_handle=f"handle-{i}")
+        for i in range(11)
+    ]
+
+    with pytest.raises(ValidationError, match="image ceiling"):
+        WizardSpec(prompt="p", steps=steps)
+
+
+def test_duplicate_image_handle_rejected() -> None:
+    steps = [
+        Step(key="k0", question="q0", kind=StepKind.TEXT, image_handle="same-handle"),
+        Step(key="k1", question="q1", kind=StepKind.TEXT, image_handle="same-handle"),
+    ]
+
+    with pytest.raises(ValidationError, match="must be unique") as exc_info:
+        WizardSpec(prompt="p", steps=steps)
+    assert "same-handle" in str(exc_info.value), "the shared handle must appear in the message"
+
+
+def test_choice_step_exceeding_component_ceiling_rejected() -> None:
+    # 15 described options is well within MAX_SELECT_OPTIONS (25), but each
+    # described option renders as a heavier section (button + text), not a
+    # bare button -- pushing the estimated component count past the ceiling
+    # even though the option-count ceiling alone would allow it.
+    options = [Option(label=str(i), value=str(i), description="d") for i in range(15)]
+
+    with pytest.raises(ValidationError, match="component") as exc_info:
+        WizardSpec(
+            prompt="p",
+            steps=[Step(key="k", question="q", kind=StepKind.CHOICE, options=options)],
+        )
+    assert "k" in str(exc_info.value), "the offending step's key must appear in the message"

--- a/packages/core/tests/wizard/test_state.py
+++ b/packages/core/tests/wizard/test_state.py
@@ -1,0 +1,172 @@
+"""Unit tests for the wizard's domain state and custom_id grammar (no I/O, no DB)."""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+
+import pytest
+from daimon.core.credential_requests import CUSTOM_ID_PATTERN as CREDENTIAL_CUSTOM_ID_PATTERN
+from daimon.core.credential_requests import build_custom_id as build_credential_custom_id
+from daimon.core.credential_requests import mint_request_token
+from daimon.core.wizard.state import (
+    NAV_CUSTOM_ID_PATTERN,
+    SELECT_CUSTOM_ID_PATTERN,
+    SUBMIT_CUSTOM_ID_PATTERN,
+    ActionKind,
+    WizardAction,
+    WizardState,
+    build_custom_id,
+    new_short_id,
+)
+
+# Every action string the renderer can emit, spanning the low, middle and
+# high end of the two-digit step-index range MAX_STEPS (20) allows.
+_NAV_ACTIONS = [
+    "next",
+    "back",
+    "s0_c0",
+    "s0_c24",
+    "s5_enter",
+    "s12_custom",
+    "s19_c9",
+]
+_SELECT_ACTIONS = ["s0_sel", "s5_sel", "s19_sel"]
+_SUBMIT_ACTIONS = ["submit"]
+_ALL_ACTIONS = _NAV_ACTIONS + _SELECT_ACTIONS + _SUBMIT_ACTIONS
+
+_ALL_PATTERNS = (NAV_CUSTOM_ID_PATTERN, SELECT_CUSTOM_ID_PATTERN, SUBMIT_CUSTOM_ID_PATTERN)
+
+
+def test_new_short_id_returns_eight_base62_characters() -> None:
+    short_id = new_short_id()
+
+    assert len(short_id) == 8, "short id must be exactly SHORT_ID_LEN characters"
+    assert short_id.isalnum(), "short id must be drawn from the base62 alphabet"
+
+
+def test_new_short_id_two_calls_differ() -> None:
+    first = new_short_id()
+    second = new_short_id()
+
+    assert first != second, "two short-id mints must never collide in practice"
+
+
+@pytest.mark.parametrize("action", _NAV_ACTIONS)
+def test_nav_action_round_trips_through_build_custom_id(action: str) -> None:
+    short_id = new_short_id()
+
+    custom_id = build_custom_id(short_id, action)
+    match = NAV_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+
+    assert match is not None, "nav pattern must fullmatch a custom_id it minted for this action"
+    assert match["short_id"] == short_id, "the short_id group must round-trip the input short_id"
+    assert match["action"] == action, "the action group must round-trip the input action"
+
+
+@pytest.mark.parametrize("action", _SELECT_ACTIONS)
+def test_select_action_round_trips_through_build_custom_id(action: str) -> None:
+    short_id = new_short_id()
+
+    custom_id = build_custom_id(short_id, action)
+    match = SELECT_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+
+    assert match is not None, "select pattern must fullmatch a custom_id it minted for this action"
+    assert match["short_id"] == short_id, "the short_id group must round-trip the input short_id"
+    assert match["action"] == action, "the action group must round-trip the input action"
+
+
+def test_submit_action_round_trips_through_build_custom_id() -> None:
+    short_id = new_short_id()
+
+    custom_id = build_custom_id(short_id, "submit")
+    match = SUBMIT_CUSTOM_ID_PATTERN.fullmatch(custom_id)
+
+    assert match is not None, "submit pattern must fullmatch a custom_id it minted for submit"
+    assert match["short_id"] == short_id, "the short_id group must round-trip the input short_id"
+
+
+def test_build_custom_id_raises_for_unroutable_action() -> None:
+    with pytest.raises(ValueError, match="does not fullmatch"):
+        build_custom_id(new_short_id(), "totally_unroutable_action")
+
+
+def test_build_custom_id_raises_when_short_id_blows_the_char_budget() -> None:
+    oversized_short_id = "x" * 200
+
+    with pytest.raises(ValueError, match="exceeding"):
+        build_custom_id(oversized_short_id, "next")
+
+
+@pytest.mark.parametrize("action", _ALL_ACTIONS)
+def test_action_fullmatches_exactly_one_of_the_three_grammars(action: str) -> None:
+    short_id = new_short_id()
+    custom_id = build_custom_id(short_id, action)
+
+    match_count = sum(1 for pattern in _ALL_PATTERNS if pattern.fullmatch(custom_id))
+
+    assert match_count == 1, (
+        f"custom_id {custom_id!r} for action {action!r} must fullmatch exactly one "
+        f"grammar -- discord.py fires every registered dynamic-item template whose "
+        f"pattern fullmatches an incoming custom_id with no early break, so an "
+        f"overlap double-dispatches one tap"
+    )
+
+
+def test_wizard_grammars_disjoint_from_credential_request_grammar() -> None:
+    token = mint_request_token()
+    credential_custom_id = build_credential_custom_id(token)
+
+    for pattern in _ALL_PATTERNS:
+        assert pattern.fullmatch(credential_custom_id) is None, (
+            "a credential-request custom_id must never fullmatch a wizard grammar, "
+            "or discord.py would double-dispatch a credential-button tap into the "
+            "wizard's turn-spawning path"
+        )
+
+
+@pytest.mark.parametrize("action", _ALL_ACTIONS)
+def test_credential_request_grammar_disjoint_from_wizard_custom_id(action: str) -> None:
+    wizard_custom_id = build_custom_id(new_short_id(), action)
+
+    assert CREDENTIAL_CUSTOM_ID_PATTERN.fullmatch(wizard_custom_id) is None, (
+        "a wizard custom_id must never fullmatch the credential-request grammar, "
+        "or discord.py would double-dispatch a wizard tap into the credential path"
+    )
+
+
+def test_wizard_grammars_disjoint_from_message_feedback_grammar_when_present() -> None:
+    if importlib.util.find_spec("daimon.core.message_feedback") is None:
+        pytest.skip("message_feedback module has not landed in this tree yet")
+
+    from daimon.core.message_feedback import CUSTOM_ID_PATTERN as FEEDBACK_CUSTOM_ID_PATTERN
+
+    for action in _ALL_ACTIONS:
+        wizard_custom_id = build_custom_id(new_short_id(), action)
+
+        assert FEEDBACK_CUSTOM_ID_PATTERN.fullmatch(wizard_custom_id) is None, (
+            "a wizard custom_id must never fullmatch the message-feedback grammar, "
+            "or discord.py would double-dispatch a wizard tap into the feedback path"
+        )
+
+
+def test_wizard_state_is_frozen_and_replace_produces_a_new_instance() -> None:
+    state = WizardState(short_id="abcd1234")
+
+    updated = dataclasses.replace(state, current_step=1)
+
+    assert updated.current_step == 1, "dataclasses.replace must apply the field override"
+    assert state.current_step == 0, "the original instance must be untouched"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        state.current_step = 2  # type: ignore[misc]
+
+
+def test_wizard_action_is_frozen_and_replace_produces_a_new_instance() -> None:
+    action = WizardAction(kind=ActionKind.NEXT)
+
+    updated = dataclasses.replace(action, kind=ActionKind.BACK)
+
+    assert updated.kind == ActionKind.BACK, "dataclasses.replace must apply the field override"
+    assert action.kind == ActionKind.NEXT, "the original instance must be untouched"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        action.kind = ActionKind.SUBMIT  # type: ignore[misc]

--- a/packages/testing/daimon/testing/__init__.py
+++ b/packages/testing/daimon/testing/__init__.py
@@ -12,6 +12,7 @@ from daimon.testing.factories import (
     make_tenant_user_cap,
     make_thread_session,
     make_usage_event,
+    make_wizard_session,
 )
 from daimon.testing.ma import (
     EMPTY_CLOUD_CONFIG,
@@ -53,6 +54,7 @@ __all__ = [
     "make_tenant_user_cap",
     "make_thread_session",
     "make_usage_event",
+    "make_wizard_session",
     "send_events_response",
     "sse_response",
     "stub_anthropic",

--- a/packages/testing/daimon/testing/factories.py
+++ b/packages/testing/daimon/testing/factories.py
@@ -12,8 +12,9 @@ ORM access for test setup.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from typing import Any
 
 from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
     BetaManagedAgentsSpanModelUsage,
@@ -42,6 +43,9 @@ from daimon.core.stores import (
     thread_sessions,
     usage_events,
 )
+from daimon.core.stores import (
+    wizard_session as wizard_session_store,
+)
 from daimon.core.stores.agent_memory_stores import insert_memory_store
 from daimon.core.stores.domain import (
     AccountRow,
@@ -60,8 +64,11 @@ from daimon.core.stores.domain import (
     TenantUserCapRow,
     ThreadSessionRow,
     UsageEventRow,
+    WizardSessionRow,
 )
 from daimon.core.stores.tenant_ledger import insert_entry
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import new_short_id
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -470,3 +477,57 @@ async def make_mcp_token(
     row = await mcp_tokens.get_mcp_token(session, jti=jti)
     assert row is not None, "create_mcp_token_row must leave a resolvable row"
     return row
+
+
+async def make_wizard_session(
+    session: AsyncSession,
+    *,
+    tenant: TenantRow | None = None,
+    account: AccountRow | None = None,
+    short_id: str | None = None,
+    requester_platform_user_id: str = "U_WIZ",
+    channel_id: str | None = None,
+    message_id: str | None = None,
+    spec: dict[str, Any] | None = None,
+    answers: dict[str, list[str]] | None = None,
+    current_step: int = 0,
+    status: str = "open",
+    expires_at: datetime | None = None,
+    now: datetime | None = None,
+) -> WizardSessionRow:
+    """Insert a wizard_session row via `wizard_session.create_wizard_session`."""
+    tenant = tenant or await make_tenant(session)
+    account = account or await make_account(session, tenant=tenant)
+    short_id = short_id or new_short_id()
+    channel_id = channel_id if channel_id is not None else f"chan-{uuid.uuid4().hex[:8]}"
+    message_id = message_id if message_id is not None else f"msg-{uuid.uuid4().hex[:8]}"
+    now = now if now is not None else datetime.now(UTC)
+    expires_at = expires_at if expires_at is not None else now + timedelta(hours=1)
+    if spec is None:
+        default_spec = WizardSpec(
+            prompt="Pick one",
+            steps=[
+                Step(
+                    key="choice",
+                    question="Pick an option",
+                    kind=StepKind.CHOICE,
+                    options=[Option(label="A", value="a"), Option(label="B", value="b")],
+                )
+            ],
+        )
+        spec = default_spec.model_dump(mode="json")
+    return await wizard_session_store.create_wizard_session(
+        session,
+        short_id=short_id,
+        tenant_id=tenant.id,
+        account_id=account.id,
+        requester_platform_user_id=requester_platform_user_id,
+        channel_id=channel_id,
+        message_id=message_id,
+        spec=spec,
+        answers=answers if answers is not None else {},
+        current_step=current_step,
+        status=status,
+        expires_at=expires_at,
+        now=now,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ source_modules = [
     "daimon.core.skills",
     "daimon.core.specs",
     "daimon.core.turn",
+    "daimon.core.wizard",
 ]
 forbidden_modules = ["daimon.core._models"]
 # Stores are the sanctioned abstraction layer between adapters and the ORM.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ source_modules = [
     "daimon.core.specs",
     "daimon.core.turn",
     "daimon.core.wizard",
+    "daimon.core.wizard_sweep",
 ]
 forbidden_modules = ["daimon.core._models"]
 # Stores are the sanctioned abstraction layer between adapters and the ORM.

--- a/tests/integration/test_wizard_submit_turn.py
+++ b/tests/integration/test_wizard_submit_turn.py
@@ -82,6 +82,7 @@ _ENV_ID = "env_wizard_submit_test"
 _MODEL_ID = "claude-sonnet-4-6"
 _AGENT_TEXT = "Thanks -- here's your plan!"
 _REQUESTER_ID = "700000000000000001"
+_MESSAGE_ID = "900000000000000003"
 
 
 def _spec() -> WizardSpec:
@@ -248,6 +249,7 @@ def _interaction(
     )  # no spec=Member -> isinstance(..., Member) is False, is_admin=False
     interaction.user.id = int(user_id)
     interaction.client = client
+    interaction.message.id = int(_MESSAGE_ID)
     interaction.channel = channel
     interaction.guild_id = guild_id
     interaction.guild = MagicMock(spec=discord.Guild)
@@ -316,6 +318,7 @@ async def _seed_review_row(
             session,
             tenant=tenant,
             requester_platform_user_id=_REQUESTER_ID,
+            message_id=_MESSAGE_ID,
             spec=_spec().model_dump(mode="json"),
             answers={"colour": ["red"]},
             current_step=1,  # one past the last step index -> the review screen

--- a/tests/integration/test_wizard_submit_turn.py
+++ b/tests/integration/test_wizard_submit_turn.py
@@ -1,0 +1,577 @@
+"""End-to-end proof that a wizard Submit tap spawns exactly one billed,
+session-reusing turn through the shared admission/binding/run chokepoint.
+
+Drives `WizardSubmitButton` directly (the real dispatch entry point a Discord
+component interaction triggers) against a real `DaimonBot`/`DiscordRuntime`
+built the way `tests/parity/drivers/discord_driver.py` and
+`tests/integration/test_discord_turn_e2e.py` build one: real Postgres, a
+transport-level fake `AsyncAnthropic` (`MARouter` + SSE), and only
+`daimon.core.turn.prepare.create_session` boundary-stubbed (Discord-API-only
+session provisioning unrelated to what this suite tests). `admit`,
+`bind_session`, and `run_prepared_turn` are NEVER patched -- the real
+chokepoint runs on every test here, which is the whole point of this file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import httpx
+import pytest
+from anthropic.types.beta import BetaEnvironment, BetaManagedAgentsAgent, BetaManagedAgentsSession
+from anthropic.types.beta.beta_managed_agents_model_config import BetaManagedAgentsModelConfig
+from anthropic.types.beta.beta_managed_agents_session_agent import BetaManagedAgentsSessionAgent
+from anthropic.types.beta.beta_managed_agents_session_stats import BetaManagedAgentsSessionStats
+from anthropic.types.beta.beta_managed_agents_session_usage import BetaManagedAgentsSessionUsage
+from anthropic.types.beta.sessions.beta_managed_agents_agent_message_event import (
+    BetaManagedAgentsAgentMessageEvent,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_session_end_turn import (
+    BetaManagedAgentsSessionEndTurn,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_session_status_idle_event import (
+    BetaManagedAgentsSessionStatusIdleEvent,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_span_model_request_end_event import (
+    BetaManagedAgentsSpanModelRequestEndEvent,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
+    BetaManagedAgentsSpanModelUsage,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_text_block import (
+    BetaManagedAgentsTextBlock,
+)
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.runtime import DiscordRuntime, build_turn_deps
+from daimon.adapters.discord.wizard_submit import WizardSubmitButton
+from daimon.core.config import McpSettings
+from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores import tenant_ledger, usage_events
+from daimon.core.stores.accounts import get_account
+from daimon.core.stores.domain import TenantRow, WizardSessionRow
+from daimon.core.stores.identity import get_or_create_platform_principal
+from daimon.core.stores.thread_sessions import get_live_thread_session
+from daimon.core.stores.wizard_session import get_wizard_session
+from daimon.core.wizard.answers import format_answer_block
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import WizardState, WizardStatus, build_custom_id
+from daimon.testing.factories import make_tenant, make_thread_session, make_wizard_session
+from daimon.testing.ma import (
+    EMPTY_CLOUD_CONFIG,
+    MARouter,
+    build_fake_anthropic,
+    json_body,
+    list_response,
+    sse_response,
+)
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+_AGENT_ID = "ag_wizard_submit_test"
+_ENV_ID = "env_wizard_submit_test"
+_MODEL_ID = "claude-sonnet-4-6"
+_AGENT_TEXT = "Thanks -- here's your plan!"
+_REQUESTER_ID = "700000000000000001"
+
+
+def _spec() -> WizardSpec:
+    return WizardSpec(
+        prompt="Plan the picnic",
+        steps=[
+            Step(
+                key="colour",
+                question="Favourite colour?",
+                kind=StepKind.CHOICE,
+                options=[Option(label="Red", value="red"), Option(label="Blue", value="blue")],
+            ),
+        ],
+    )
+
+
+def _build_router(
+    tenant_id_str: str,
+    *,
+    sent_events: list[dict[str, Any]],
+    stream_hits: list[str],
+) -> MARouter:
+    """MARouter handling agent/environment resolution plus a turn SSE stream
+    that emits an `agent.message`, a `span.model_request_end` (the event the
+    billing chokepoint metering binds on), then `session.status_idle`.
+    `sent_events` records every `POST .../events` body (the resumed turn's
+    user message); `stream_hits` records every session id the SSE stream was
+    opened against (which session id the turn actually ran on)."""
+    agent_item = BetaManagedAgentsAgent(
+        id=_AGENT_ID,
+        type="agent",
+        name="test-agent",
+        model=BetaManagedAgentsModelConfig(id=_MODEL_ID),
+        metadata={MA_METADATA_KEY_TENANT: tenant_id_str, MA_METADATA_KEY_NAME: "test-agent"},
+        description=None,
+        created_at="2026-06-14T00:00:00Z",  # pyright: ignore[reportArgumentType]
+        updated_at="2026-06-14T00:00:00Z",  # pyright: ignore[reportArgumentType]
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    ).model_dump(mode="json")
+
+    env_item = BetaEnvironment(
+        id=_ENV_ID,
+        type="environment",
+        name="test-env",
+        config=EMPTY_CLOUD_CONFIG,
+        metadata={MA_METADATA_KEY_TENANT: tenant_id_str, MA_METADATA_KEY_NAME: "test-env"},
+        description="",
+        created_at="2026-06-14T00:00:00Z",
+        updated_at="2026-06-14T00:00:00Z",
+    ).model_dump(mode="json")
+
+    now = datetime.now(UTC)
+    agent_message_event = BetaManagedAgentsAgentMessageEvent(
+        id="evt_wizard_submit_msg",
+        type="agent.message",
+        processed_at=now,
+        content=[BetaManagedAgentsTextBlock(type="text", text=_AGENT_TEXT)],
+    ).model_dump(mode="json")
+    model_request_end_event = BetaManagedAgentsSpanModelRequestEndEvent(
+        id="evt_wizard_submit_usage",
+        is_error=False,
+        model_request_start_id="start_wizard_submit",
+        model_usage=BetaManagedAgentsSpanModelUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        ),
+        processed_at=now,
+        type="span.model_request_end",
+    ).model_dump(mode="json")
+    idle_event = BetaManagedAgentsSessionStatusIdleEvent(
+        id="evt_wizard_submit_idle",
+        type="session.status_idle",
+        processed_at=now,
+        stop_reason=BetaManagedAgentsSessionEndTurn(type="end_turn"),
+    ).model_dump(mode="json")
+
+    def _handle_send_events(request: httpx.Request, _match: re.Match[str]) -> httpx.Response:
+        sent_events.append(json_body(request))
+        return httpx.Response(200, json={"data": None})
+
+    def _handle_stream(request: httpx.Request, match: re.Match[str]) -> httpx.Response:
+        stream_hits.append(match["session_id"])
+        return sse_response([agent_message_event, model_request_end_event, idle_event])
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([agent_item]))
+    router.add("GET", r"/v1/agents/[^/]+", lambda req, _m: httpx.Response(200, json=agent_item))
+    router.add("GET", r"/v1/environments", lambda req, _m: list_response([env_item]))
+    router.add("GET", r"/v1/environments/[^/]+", lambda req, _m: httpx.Response(200, json=env_item))
+    router.add("POST", r"/v1/sessions/(?P<session_id>[^/]+)/events", _handle_send_events)
+    router.add("GET", r"/v1/sessions/(?P<session_id>[^/]+)/events/stream", _handle_stream)
+    return router
+
+
+def _make_runtime(
+    sessionmaker: async_sessionmaker[AsyncSession], router: MARouter
+) -> DiscordRuntime:
+    settings = MagicMock()
+    settings.mcp = McpSettings()
+    settings.billing.markup = Decimal("1.0")
+    settings.billing.signup_credit = Decimal("0")
+    settings.crypto.keys = []
+    settings.github.oauth_scopes = ()
+    discord_settings = MagicMock()
+    discord_settings.max_concurrent_turns_per_tenant = 100
+    discord_settings.bot_display_name = "daimon"
+    discord_settings.per_caller_thread_sessions = True
+    settings.discord = discord_settings
+
+    anthropic = build_fake_anthropic(router.dispatch)
+    resolver_cache = new_resolver_cache()
+    deployment_default = DeploymentDefault(agent_name="test-agent", environment_name="test-env")
+    return DiscordRuntime(
+        settings=settings,
+        anthropic=anthropic,
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,  # billing disabled -> is_over_cap always False
+        deployment_default=deployment_default,
+        resolver_cache=resolver_cache,
+        turn_deps=build_turn_deps(
+            settings,
+            anthropic,
+            sessionmaker,
+            deployment_default=deployment_default,
+            resolver_cache=resolver_cache,
+            billing_config=None,
+        ),
+    )
+
+
+def _make_bot(runtime: DiscordRuntime) -> DaimonBot:
+    intents = discord.Intents.default()
+    intents.message_content = True
+    bot = DaimonBot(runtime=runtime, intents=intents)
+    bot._connection.user = MagicMock(spec=discord.ClientUser)  # pyright: ignore[reportPrivateUsage]
+    bot._connection.user.id = 999  # pyright: ignore[reportPrivateUsage]
+    return bot
+
+
+def _make_channel(*, thread_id: int, parent_id: int) -> MagicMock:
+    channel = MagicMock(spec=discord.Thread)
+    channel.id = thread_id
+    channel.parent_id = parent_id
+    message_ref = MagicMock()
+    message_ref.id = 42
+    message_ref.edit = AsyncMock()
+    channel.send = AsyncMock(return_value=message_ref)
+    return channel
+
+
+def _interaction(
+    *, user_id: str, client: DaimonBot, channel: discord.Thread, guild_id: int
+) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = (
+        MagicMock()
+    )  # no spec=Member -> isinstance(..., Member) is False, is_admin=False
+    interaction.user.id = int(user_id)
+    interaction.client = client
+    interaction.channel = channel
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock(spec=discord.Guild)
+    interaction.guild.owner_id = 0
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.edit_original_response = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _submit_match(short_id: str) -> re.Match[str]:
+    custom_id = build_custom_id(short_id, "submit")
+    matched = WizardSubmitButton.__discord_ui_compiled_template__.fullmatch(custom_id)
+    assert matched is not None, "test action must satisfy WizardSubmitButton's own template"
+    return matched
+
+
+def _make_fake_session(*, session_id: str) -> BetaManagedAgentsSession:
+    now = datetime.now(UTC)
+    return BetaManagedAgentsSession(
+        id=session_id,
+        agent=BetaManagedAgentsSessionAgent(
+            id=_AGENT_ID,
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id=_MODEL_ID),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at=now,
+        environment_id=_ENV_ID,
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+        outcome_evaluations=[],
+    )
+
+
+async def _seed_funded_tenant(db_session: AsyncSession, *, workspace_id: str) -> TenantRow:
+    tenant = await make_tenant(db_session, platform="discord", workspace_id=workspace_id)
+    await tenant_ledger.insert_entry(
+        db_session,
+        tenant_id=tenant.id,
+        delta_usd=Decimal("100.00"),
+        reason="trial",
+        idempotency_key=f"trial:{tenant.id}",
+    )
+    await db_session.commit()
+    return tenant
+
+
+async def _seed_review_row(
+    db_session_factory: async_sessionmaker[AsyncSession], *, tenant: TenantRow
+) -> WizardSessionRow:
+    async with db_session_factory() as session, session.begin():
+        return await make_wizard_session(
+            session,
+            tenant=tenant,
+            requester_platform_user_id=_REQUESTER_ID,
+            spec=_spec().model_dump(mode="json"),
+            answers={"colour": ["red"]},
+            current_step=1,  # one past the last step index -> the review screen
+            status="open",
+        )
+
+
+# --- session reuse -----------------------------------------------------------
+
+
+async def test_submitting_a_form_resumes_the_threads_existing_session(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await _seed_funded_tenant(db_session, workspace_id="800001001")
+    row = await _seed_review_row(db_session_factory, tenant=tenant)
+
+    channel = _make_channel(thread_id=5001, parent_id=4001)
+    existing_session_id = "sess_already_live"
+    async with db_session_factory() as session, session.begin():
+        principal = await get_or_create_platform_principal(
+            session, tenant_id=tenant.id, platform="discord", external_id=_REQUESTER_ID
+        )
+        account = await get_account(session, principal.account_id)
+        assert account is not None
+        existing = await make_thread_session(
+            session,
+            tenant=tenant,
+            account=account,
+            platform="discord",
+            thread_id=str(channel.id),
+            ma_session_id=existing_session_id,
+        )
+
+    sent_events: list[dict[str, Any]] = []
+    stream_hits: list[str] = []
+    router = _build_router(str(tenant.id), sent_events=sent_events, stream_hits=stream_hits)
+    runtime = _make_runtime(db_session_factory, router)
+    bot = _make_bot(runtime)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, channel=channel, guild_id=123)
+
+    with patch("daimon.core.turn.prepare.create_session") as mock_create_session:
+        item = await WizardSubmitButton.from_custom_id(
+            interaction, MagicMock(), _submit_match(row.id)
+        )
+        assert await item.interaction_check(interaction) is True
+        await item.callback(interaction)
+
+        tasks = list(bot._bg_tasks)  # pyright: ignore[reportPrivateUsage]  # asserting the spawn contract
+        assert len(tasks) == 1, "a winning claim must spawn exactly one background task"
+        await asyncio.gather(*tasks)
+
+        mock_create_session.assert_not_called()
+
+    assert stream_hits == [existing_session_id], (
+        "the resumed turn must run against the ALREADY-LIVE session id, not a fresh one"
+    )
+    async with db_session_factory() as session:
+        after = await get_live_thread_session(
+            session,
+            tenant_id=tenant.id,
+            platform="discord",
+            thread_id=str(channel.id),
+            account_id=principal.account_id,
+        )
+    assert after is not None
+    assert after.id == existing.id, (
+        "no new thread_sessions row must be created for a reused session"
+    )
+    assert after.ma_session_id == existing_session_id
+
+
+# --- answer block as the user message ----------------------------------------
+
+
+async def test_submitting_a_form_sends_the_keyed_answer_block_as_the_user_message(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await _seed_funded_tenant(db_session, workspace_id="800002001")
+    row = await _seed_review_row(db_session_factory, tenant=tenant)
+
+    channel = _make_channel(thread_id=5002, parent_id=4002)
+    sent_events: list[dict[str, Any]] = []
+    stream_hits: list[str] = []
+    router = _build_router(str(tenant.id), sent_events=sent_events, stream_hits=stream_hits)
+    runtime = _make_runtime(db_session_factory, router)
+    bot = _make_bot(runtime)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, channel=channel, guild_id=123)
+
+    with patch("daimon.core.turn.prepare.create_session") as mock_create_session:
+        mock_create_session.return_value = _make_fake_session(session_id="sess_fresh_msg")
+        item = await WizardSubmitButton.from_custom_id(
+            interaction, MagicMock(), _submit_match(row.id)
+        )
+        assert await item.interaction_check(interaction) is True
+        await item.callback(interaction)
+        await asyncio.gather(*list(bot._bg_tasks))  # pyright: ignore[reportPrivateUsage]  # asserting the spawn contract
+
+    assert sent_events, "the resumed turn must post at least one user.message event"
+    expected = format_answer_block(
+        _spec(),
+        WizardState(
+            short_id=row.id,
+            current_step=row.current_step,
+            answers=row.answers,
+            status=WizardStatus.SUBMITTED,
+        ),
+    )
+    sent_texts = [
+        block["text"]
+        for event in sent_events
+        for block in event["events"][0]["content"]
+        if block.get("type") == "text"
+    ]
+    assert expected in sent_texts, (
+        f"expected the fenced, JSON-keyed answer block among the sent user.message texts, "
+        f"got: {sent_texts}"
+    )
+    for text in sent_texts:
+        assert "Favourite colour?" not in text, (
+            "the resumed turn's message must carry raw answer VALUES keyed by step, not "
+            "restated question prose -- the agent that authored the spec already knows the "
+            "question text"
+        )
+
+
+# --- billing chokepoint --------------------------------------------------------
+
+
+async def test_submitting_a_form_records_usage(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await _seed_funded_tenant(db_session, workspace_id="800003001")
+    row = await _seed_review_row(db_session_factory, tenant=tenant)
+
+    channel = _make_channel(thread_id=5003, parent_id=4003)
+    sent_events: list[dict[str, Any]] = []
+    stream_hits: list[str] = []
+    router = _build_router(str(tenant.id), sent_events=sent_events, stream_hits=stream_hits)
+    runtime = _make_runtime(db_session_factory, router)
+    bot = _make_bot(runtime)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, channel=channel, guild_id=123)
+
+    with patch("daimon.core.turn.prepare.create_session") as mock_create_session:
+        mock_create_session.return_value = _make_fake_session(session_id="sess_fresh_usage")
+        item = await WizardSubmitButton.from_custom_id(
+            interaction, MagicMock(), _submit_match(row.id)
+        )
+        assert await item.interaction_check(interaction) is True
+        await item.callback(interaction)
+        await asyncio.gather(*list(bot._bg_tasks))  # pyright: ignore[reportPrivateUsage]  # asserting the spawn contract
+
+    usage_rows = await usage_events.list_for_tenant(db_session, tenant_id=tenant.id)
+    assert len(usage_rows) == 1, (
+        "the resumed turn must write exactly one usage_events row -- proof it ran through "
+        "the shared billing chokepoint rather than a private turn path"
+    )
+    assert usage_rows[0].model == _MODEL_ID
+
+
+async def test_two_concurrent_submits_bill_exactly_one_turn(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await _seed_funded_tenant(db_session, workspace_id="800004001")
+    row = await _seed_review_row(db_session_factory, tenant=tenant)
+
+    channel = _make_channel(thread_id=5004, parent_id=4004)
+    sent_events: list[dict[str, Any]] = []
+    stream_hits: list[str] = []
+    router = _build_router(str(tenant.id), sent_events=sent_events, stream_hits=stream_hits)
+    runtime = _make_runtime(db_session_factory, router)
+    bot = _make_bot(runtime)
+    interaction_a = _interaction(user_id=_REQUESTER_ID, client=bot, channel=channel, guild_id=123)
+    interaction_b = _interaction(user_id=_REQUESTER_ID, client=bot, channel=channel, guild_id=123)
+
+    with patch("daimon.core.turn.prepare.create_session") as mock_create_session:
+        mock_create_session.return_value = _make_fake_session(session_id="sess_fresh_concurrent")
+        item_a = await WizardSubmitButton.from_custom_id(
+            interaction_a, MagicMock(), _submit_match(row.id)
+        )
+        item_b = await WizardSubmitButton.from_custom_id(
+            interaction_b, MagicMock(), _submit_match(row.id)
+        )
+        assert await item_a.interaction_check(interaction_a) is True
+        assert await item_b.interaction_check(interaction_b) is True
+
+        await asyncio.gather(item_a.callback(interaction_a), item_b.callback(interaction_b))
+
+        tasks = list(bot._bg_tasks)  # pyright: ignore[reportPrivateUsage]  # asserting the spawn contract
+        assert len(tasks) == 1, (
+            "only the winning claim may spawn a background turn -- a second spawned task "
+            "here would mean a second billed turn"
+        )
+        await asyncio.gather(*tasks)
+
+    usage_rows = await usage_events.list_for_tenant(db_session, tenant_id=tenant.id)
+    assert len(usage_rows) == 1, (
+        "two concurrent submits must bill exactly ONE turn -- a second usage_events row "
+        "here would be a real double charge against the tenant's balance"
+    )
+
+
+# --- post-hoc admission refusal -------------------------------------------------
+
+
+async def test_a_submitter_over_balance_is_told_and_no_turn_runs(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    # Deliberately NOT funded via _seed_funded_tenant -- an empty ledger sums
+    # to Decimal("0"), and is_over_balance treats balance <= 0 as depleted
+    # (mirrors tests/parity/test_turn_blocked_balance.py).
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="800005001")
+    await db_session.commit()
+    row = await _seed_review_row(db_session_factory, tenant=tenant)
+
+    channel = _make_channel(thread_id=5005, parent_id=4005)
+    sent_events: list[dict[str, Any]] = []
+    stream_hits: list[str] = []
+    router = _build_router(str(tenant.id), sent_events=sent_events, stream_hits=stream_hits)
+    runtime = _make_runtime(db_session_factory, router)
+    bot = _make_bot(runtime)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, channel=channel, guild_id=123)
+
+    with patch("daimon.core.turn.prepare.create_session") as mock_create_session:
+        item = await WizardSubmitButton.from_custom_id(
+            interaction, MagicMock(), _submit_match(row.id)
+        )
+        assert await item.interaction_check(interaction) is True
+        await item.callback(interaction)
+        tasks = list(bot._bg_tasks)  # pyright: ignore[reportPrivateUsage]  # asserting the spawn contract
+        assert len(tasks) == 1, (
+            "the claim must still win and spawn the turn -- admission runs AFTER the claim"
+        )
+        await asyncio.gather(*tasks)
+        mock_create_session.assert_not_called()
+
+    assert stream_hits == [], "an over-balance refusal must never reach the SSE turn stream"
+
+    posted_texts = [
+        call.args[0]
+        for call in channel.send.call_args_list
+        if call.args and isinstance(call.args[0], str)
+    ]
+    assert any("recorded" in text for text in posted_texts), (
+        f"the refusal must say the answers were recorded, got: {posted_texts}"
+    )
+    assert any("credit is depleted" in text for text in posted_texts), (
+        f"the refusal must reuse the existing credit-depleted copy, got: {posted_texts}"
+    )
+
+    usage_rows = await usage_events.list_for_tenant(db_session, tenant_id=tenant.id)
+    assert usage_rows == [], "an over-balance refusal must write zero usage_events rows"
+
+    async with db_session_factory() as session:
+        after = await get_wizard_session(session, short_id=row.id)
+    assert after is not None
+    assert after.status == "submitted", (
+        "the row must stay claimed -- the claim commits before admission runs, so a "
+        "post-hoc refusal must not lose the submitter's answers"
+    )

--- a/tests/integration/test_wizard_submit_turn.py
+++ b/tests/integration/test_wizard_submit_turn.py
@@ -517,6 +517,83 @@ async def test_two_concurrent_submits_bill_exactly_one_turn(
     )
 
 
+# --- per-tenant concurrency cap ---------------------------------------------------
+
+
+async def test_a_submit_turn_claims_and_releases_a_per_tenant_in_flight_slot(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    """A wizard turn costs the same upstream capacity as a mention turn, so it
+    counts against the same cap -- and must give the slot back."""
+    tenant = await _seed_funded_tenant(db_session, workspace_id="800006001")
+    row = await _seed_review_row(db_session_factory, tenant=tenant)
+
+    channel = _make_channel(thread_id=5006, parent_id=4006)
+    sent_events: list[dict[str, Any]] = []
+    stream_hits: list[str] = []
+    router = _build_router(str(tenant.id), sent_events=sent_events, stream_hits=stream_hits)
+    runtime = _make_runtime(db_session_factory, router)
+    bot = _make_bot(runtime)
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, channel=channel, guild_id=123)
+
+    with patch("daimon.core.turn.prepare.create_session") as mock_create_session:
+        mock_create_session.return_value = _make_fake_session(session_id="sess_fresh_slot")
+        item = await WizardSubmitButton.from_custom_id(
+            interaction, MagicMock(), _submit_match(row.id)
+        )
+        assert await item.interaction_check(interaction) is True
+        await item.callback(interaction)
+        await asyncio.gather(*list(bot._bg_tasks))  # pyright: ignore[reportPrivateUsage]  # asserting the spawn contract
+
+    assert stream_hits, "the turn must actually have run"
+    assert bot._inflight == {}, (  # pyright: ignore[reportPrivateUsage]  # asserting the cap bookkeeping contract
+        "the in-flight slot the turn claimed must be released once it finishes"
+    )
+
+
+async def test_a_submit_over_the_per_tenant_cap_runs_no_turn_and_says_so(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await _seed_funded_tenant(db_session, workspace_id="800007001")
+    row = await _seed_review_row(db_session_factory, tenant=tenant)
+
+    channel = _make_channel(thread_id=5007, parent_id=4007)
+    sent_events: list[dict[str, Any]] = []
+    stream_hits: list[str] = []
+    router = _build_router(str(tenant.id), sent_events=sent_events, stream_hits=stream_hits)
+    runtime = _make_runtime(db_session_factory, router)
+    runtime.settings.discord.max_concurrent_turns_per_tenant = 1
+    bot = _make_bot(runtime)
+    bot._inflight[tenant.id] = 1  # pyright: ignore[reportPrivateUsage]  # simulates a mention turn already holding this tenant's only slot
+    interaction = _interaction(user_id=_REQUESTER_ID, client=bot, channel=channel, guild_id=123)
+
+    with patch("daimon.core.turn.prepare.create_session"):
+        item = await WizardSubmitButton.from_custom_id(
+            interaction, MagicMock(), _submit_match(row.id)
+        )
+        assert await item.interaction_check(interaction) is True
+        await item.callback(interaction)
+        await asyncio.gather(*list(bot._bg_tasks))  # pyright: ignore[reportPrivateUsage]  # asserting the spawn contract
+
+    assert stream_hits == [], "an over-cap submit must never reach the SSE turn stream"
+    assert bot._inflight == {tenant.id: 1}, (  # pyright: ignore[reportPrivateUsage]  # asserting the cap bookkeeping contract
+        "a refused turn must not claim (or release) a slot it never took"
+    )
+
+    posted_texts = [
+        call.args[0]
+        for call in channel.send.call_args_list
+        if call.args and isinstance(call.args[0], str)
+    ]
+    assert any("recorded" in text and "in flight" in text for text in posted_texts), (
+        f"the refusal must say the answers were recorded and the server is busy, "
+        f"got: {posted_texts}"
+    )
+
+    usage_rows = await usage_events.list_for_tenant(db_session, tenant_id=tenant.id)
+    assert usage_rows == [], "an over-cap refusal must write zero usage_events rows"
+
+
 # --- post-hoc admission refusal -------------------------------------------------
 
 

--- a/tests/parity/test_wizard_discord_only.py
+++ b/tests/parity/test_wizard_discord_only.py
@@ -1,0 +1,41 @@
+"""Executable record of the wizard's deliberate Discord-only scope.
+
+An absent capability file in this suite is mechanically indistinguishable
+from an oversight: nothing else in the test suite would fail if a Slack
+wizard renderer were built without anyone updating the platform-neutral
+core's documented scope. Asserting the exemption here, rather than merely
+documenting it in a comment, makes that omission fail loudly instead of
+silently.
+
+No platform parametrization, no database -- this is a scope check, not a
+scenario test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import daimon.core.wizard
+
+
+def test_no_slack_wizard_module_exists() -> None:
+    assert importlib.util.find_spec("daimon.adapters.slack.wizard") is None, (
+        "a Slack wizard renderer has appeared -- if a Slack wizard is ever built, "
+        "this exemption record must be replaced rather than deleted. The "
+        "platform-neutral screen description daimon.core.wizard produces is the "
+        "seam a Slack renderer would attach to."
+    )
+
+
+def test_wizard_core_documents_the_discord_only_scope() -> None:
+    doc = daimon.core.wizard.__doc__
+
+    assert doc is not None, "daimon.core.wizard must carry a package docstring"
+    assert "Discord-only" in doc, (
+        "the package docstring must state the wizard's Discord-only scope in its "
+        "own terms, not just in a planning document"
+    )
+    assert "test_wizard_discord_only" in doc, (
+        "the package docstring must name this test file as the executable record "
+        "of the exemption, so prose and assertion don't drift apart"
+    )

--- a/tests/parity/test_wizard_renderer_parity.py
+++ b/tests/parity/test_wizard_renderer_parity.py
@@ -1,0 +1,183 @@
+"""Executable guard that the MCP-side and Discord-side wizard renderers agree.
+
+The two thin Screen-to-LayoutView translations
+(`daimon.adapters.mcp.tools.discord._wizard.build_wizard_view` and
+`daimon.adapters.discord.wizard_render.build_wizard_view`) are duplicated on
+purpose -- the MCP adapter and the Discord adapter cannot import each other
+(import-linter's independence contract) -- but duplication without a guard
+drifts silently: a button built in a different order, or a different accent
+colour, on either side would desync what a user sees after a tap from what
+they saw on the original post, with nothing else in the test suite catching
+it. This module imports both renderers directly (legitimate in a test,
+which is outside the packages the import-linter contracts govern) and
+asserts they produce byte-identical serialized components for the same
+`Screen`. This test is that guard.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from daimon.adapters.discord.wizard_render import (
+    build_wizard_view as discord_build_wizard_view,
+)
+from daimon.adapters.mcp.tools.discord._wizard import (
+    build_wizard_view as mcp_build_wizard_view,
+)
+from daimon.core.wizard.render import Screen, to_screen
+from daimon.core.wizard.spec import Option, Step, StepKind, WizardSpec
+from daimon.core.wizard.state import WizardState, WizardStatus
+
+_SHORT_ID = "abcd1234"
+
+
+def _choice_spec() -> WizardSpec:
+    return WizardSpec(
+        prompt="Configure the pipeline",
+        steps=[
+            Step(
+                key="stage",
+                question="Pick a stage",
+                kind=StepKind.CHOICE,
+                options=[Option(label="dev", value="dev"), Option(label="prod", value="prod")],
+            )
+        ],
+    )
+
+
+def _choice_screen() -> Screen:
+    return to_screen(_choice_spec(), WizardState(short_id=_SHORT_ID))
+
+
+def _multi_spec() -> WizardSpec:
+    return WizardSpec(
+        prompt="Configure the pipeline",
+        steps=[
+            Step(
+                key="regions",
+                question="Pick regions",
+                kind=StepKind.MULTI,
+                options=[
+                    Option(label="us", value="us"),
+                    Option(label="eu", value="eu"),
+                    Option(label="apac", value="apac"),
+                ],
+                min=1,
+                max=2,
+            )
+        ],
+    )
+
+
+def _multi_screen_with_selection() -> Screen:
+    return to_screen(
+        _multi_spec(), WizardState(short_id=_SHORT_ID, answers={"regions": ["us", "eu"]})
+    )
+
+
+def _multi_screen_no_selection() -> Screen:
+    return to_screen(_multi_spec(), WizardState(short_id=_SHORT_ID))
+
+
+def _text_spec() -> WizardSpec:
+    return WizardSpec(
+        prompt="Configure the pipeline",
+        steps=[Step(key="notes", question="Anything else?", kind=StepKind.TEXT)],
+    )
+
+
+def _text_screen() -> Screen:
+    return to_screen(_text_spec(), WizardState(short_id=_SHORT_ID))
+
+
+def _image_spec() -> WizardSpec:
+    return WizardSpec(
+        prompt="Configure the pipeline",
+        steps=[
+            Step(
+                key="stage",
+                question="Pick a stage",
+                kind=StepKind.CHOICE,
+                options=[Option(label="dev", value="dev")],
+                image_handle="img-1.png",
+                image_url="https://cdn.discordapp.com/attachments/1/2/img-1.png?ex=abc123",
+            )
+        ],
+    )
+
+
+def _image_screen() -> Screen:
+    return to_screen(_image_spec(), WizardState(short_id=_SHORT_ID))
+
+
+def _review_spec() -> WizardSpec:
+    return WizardSpec(
+        prompt="Configure the pipeline",
+        steps=[
+            Step(
+                key="stage",
+                question="Pick a stage",
+                kind=StepKind.CHOICE,
+                options=[Option(label="dev", value="dev")],
+            )
+        ],
+    )
+
+
+def _review_screen() -> Screen:
+    return to_screen(
+        _review_spec(),
+        WizardState(short_id=_SHORT_ID, current_step=1, answers={"stage": ["dev"]}),
+    )
+
+
+def _submitted_screen() -> Screen:
+    return to_screen(
+        _review_spec(),
+        WizardState(
+            short_id=_SHORT_ID,
+            current_step=1,
+            answers={"stage": ["dev"]},
+            status=WizardStatus.SUBMITTED,
+        ),
+    )
+
+
+_SCREEN_CASES: list[tuple[str, Callable[[], Screen]]] = [
+    ("choice step", _choice_screen),
+    ("multi step with an existing selection", _multi_screen_with_selection),
+    ("multi step with no selection", _multi_screen_no_selection),
+    ("text step", _text_screen),
+    ("step carrying an image with a persisted url", _image_screen),
+    ("review screen", _review_screen),
+    ("submitted screen", _submitted_screen),
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "build_screen"), _SCREEN_CASES, ids=[case[0] for case in _SCREEN_CASES]
+)
+def test_renderers_agree_component_for_component(
+    name: str, build_screen: Callable[[], Screen]
+) -> None:
+    screen = build_screen()
+    # No `files` on the posting side: both renderers must resolve the image
+    # (when present) by its persisted url, matching how a re-render works.
+    mcp_components = mcp_build_wizard_view(screen, files=None).to_components()
+    discord_components = discord_build_wizard_view(screen).to_components()
+    assert mcp_components == discord_components, (
+        f"the two renderers diverged on the {name!r} screen -- their serialized "
+        f"components must be identical:\nmcp={mcp_components!r}\n"
+        f"discord={discord_components!r}"
+    )
+
+
+def test_both_renderers_report_components_v2() -> None:
+    screen = _choice_screen()
+    assert mcp_build_wizard_view(screen, files=None).has_components_v2(), (
+        "the mcp-side view must report components-v2"
+    )
+    assert discord_build_wizard_view(screen).has_components_v2(), (
+        "the discord-side view must report components-v2"
+    )


### PR DESCRIPTION
## Summary

The agent can now ask a structured question mid-turn: it declares a form via a new `post_wizard` MCP tool, the Discord adapter renders it as real components-v2 (buttons, selects, modal text entry, per-step PNG images), and the user's selections come back to the agent as a typed, keyed answer block instead of prose to re-parse.

- **Pure core** (`daimon.core.wizard`): agent-authored form spec validated as untrusted input (Discord ceilings enforced), accumulated-answer state, a single pure transition for every tap, CDN-derived expiry, and a platform-neutral `Screen` intermediate.
- **Durable sessions**: `wizard_session` table (migration 0004) + async store — a half-finished form survives a bot restart; Submit is a single predicated `UPDATE … RETURNING` claim (two concurrent submits → exactly one winner). TTL sweeper runs on the scheduler tick; rows are wired into purge/preview and the privacy drift guards.
- **Two thin renderers** over the same `Screen` (MCP poster and bot re-renderer), kept identical by a parity test suite.
- **Stateless dispatch** via three disjoint `fullmatch`-anchored custom_id grammars; taps are authorized to the requester and bound to the originating message, and mentions are suppressed on every render path.
- **Submit path**: atomic claim → turn spawned immediately (cosmetic collapse-edit isolated afterwards) → resumed session turn routed through the existing admission chokepoint, drain gate, and per-tenant in-flight cap.

A post-review hardening pass is included (commits `46d5bc5…42da3b9`) covering the submit-claim ordering, lost-update races, spec ceilings, attachment mapping, mention suppression, and select-value validation.

## Test plan

- Full suite: **3769 passed, 5 skipped** against real Postgres (fresh-schema-per-test), including 5 end-to-end integration tests proving exactly one billed turn per submit
- Strict pyright 0 errors, ruff clean, all 6 import-linter contracts kept, repo lints (modals/anti-patterns/leakage) green
- Renderer parity + Discord-only scope guarded by dedicated parity tests
- Remaining manual step before deploy: live smoke test in a staging guild (post → walk → submit → one agent reply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)