### PR TITLE
Message feedback: reaction votes with a private free-text follow-up

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -230,6 +230,7 @@ class DaimonBot(commands.Bot):
         from daimon.adapters.discord.commands.memory import MemoryCog
         from daimon.adapters.discord.commands.privacy import PrivacyCog
         from daimon.adapters.discord.commands.routines import RoutinesCog
+        from daimon.adapters.discord.feedback_reactions import FeedbackReactionCog
 
         await self.add_cog(HelpCog(self))
         await self.add_cog(AgentSetupCog(self))
@@ -237,6 +238,7 @@ class DaimonBot(commands.Bot):
         await self.add_cog(BillingCog(self))
         await self.add_cog(PrivacyCog(self))
         await self.add_cog(MemoryCog(self))
+        await self.add_cog(FeedbackReactionCog(self))
 
         # One-time CLASS registration (not per-button) for the chat-initiated
         # credential-request button. Imported here, not at module level, since

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -265,6 +265,14 @@ class DaimonBot(commands.Bot):
 
         self.add_dynamic_items(WizardSubmitButton)
 
+        # A feedback button is delivered into a direct message and must
+        # still dispatch after this process restarts, so it needs the same
+        # class-level registration rather than a live view. Local import for
+        # the same cycle reason as above.
+        from daimon.adapters.discord.feedback_button import FeedbackButton
+
+        self.add_dynamic_items(FeedbackButton)
+
     async def _post_to_guild(self, guild: discord.Guild, embed: discord.Embed) -> None:
         """Post an embed via the fallback chain: text channel → DM owner → skip."""
         channel = _pick_post_channel(guild)

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -21,6 +21,7 @@ from daimon.adapters.discord.context import (
     build_delta_xml,
 )
 from daimon.adapters.discord.errors import generate_request_id, render_error
+from daimon.adapters.discord.feedback_seed import seed_feedback_reactions
 from daimon.adapters.discord.gating import should_process_message
 from daimon.adapters.discord.lifecycle import DiscordTurnLifecycle
 from daimon.adapters.discord.permissions import check_missing_permissions
@@ -1175,3 +1176,10 @@ class DaimonBot(commands.Bot):
                         watermark_message_id=final_lifecycle.final_message_id,
                     )
                     await _wm_session.commit()
+            # The lifecycle flag below excludes a cancelled turn, which also
+            # reaches this branch with a non-None final_message_id -- seeding
+            # the vote affordance under a cancellation notice is exactly what
+            # this guard prevents. Not gated on mapping_id, which is about
+            # session mapping, not whether the turn actually answered.
+            if final_lifecycle.was_answered and final_lifecycle.final_message_id is not None:
+                await seed_feedback_reactions(thread, message_id=final_lifecycle.final_message_id)

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_button.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_button.py
@@ -1,0 +1,117 @@
+"""FeedbackButton -- persistent button that opens the private feedback form.
+
+A reaction is not an interaction: Discord gives no way to open a modal
+directly from a reaction-add event. This button exists solely to obtain an
+interaction that legally can open one -- it is posted into a direct message
+after a down-vote, and its only job is to hand the click straight to
+`FeedbackModal`.
+
+Like `CredentialRequestButton`, a per-row button cannot be served by a
+single long-lived View instance registered with `bot.add_view()` -- this
+button's custom_id is minted fresh per feedback row.
+`discord.ui.DynamicItem` is the primitive that matches a *template* regex
+against an arbitrary future custom_id and reconstructs per-click state via
+`from_custom_id`, so this is the second (and, per `views.py`'s module
+docstring, still documented) place in this adapter that carries a
+persistent, dispatchable custom_id.
+
+Unlike `CredentialRequestButton`, `from_custom_id` here performs NO database
+read: the feedback row's own primary key is embedded in the custom_id and is
+entirely self-sufficient to reconstruct the button, so there is no lookup
+that could fail inside discord.py's exception-swallowing dispatcher.
+
+discord.py's own dispatcher swallows every exception raised inside
+`from_custom_id` and `callback` (logs internally and returns) -- the same
+behavior `credential_button.py`'s module docstring documents against the
+installed `discord/ui/view.py`. That makes those two methods a genuine
+adapter boundary here too: the ordinary let-failures-propagate rule does not
+apply, because propagating would mean the exception vanishes into a
+dispatcher we don't control and the user sees nothing but a stuck
+interaction. `callback` below catches broadly with a structlog record and an
+ephemeral reply for exactly that reason.
+
+Deliberately defines NO `interaction_check`: the button is delivered into a
+one-to-one direct message, so Discord's own channel membership is the outer
+access boundary, and the custom_id carries no user identity to compare a
+clicker against -- there is nothing here to check against. The authoritative
+gate lives in the write path: `FeedbackModal.on_submit` calls
+`attach_feedback_text`, which predicates its update on the clicking user's
+own `platform_user_id`, so a click carrying somebody else's row id writes
+nothing. Adding a check here that compared a user against a value the
+custom_id does not carry would be theatre; do not "restore" one without a
+deliberate decision to put a user id in the custom_id.
+
+Template-disjointness constraint: discord.py's dispatcher fires every
+registered dynamic item whose pattern fullmatches an incoming custom_id,
+with no early break, so this template's `mfb:` prefix must never overlap
+another registered template's prefix (`ztc:` for the credential button, the
+wizard's own prefixes).
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any, Self, cast
+
+import structlog
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.feedback_modal import FeedbackModal
+from daimon.core.message_feedback import CUSTOM_ID_TEMPLATE, build_custom_id
+
+import discord
+from discord.ext import commands
+
+_log = structlog.get_logger()
+
+_CALLBACK_FAILED = "Something went wrong opening the feedback form -- please try again."
+
+
+class FeedbackButton(
+    discord.ui.DynamicItem[discord.ui.Button[discord.ui.View]], template=CUSTOM_ID_TEMPLATE
+):
+    """Persistent, per-row feedback button reconstructed from its custom_id.
+
+    Registered ONCE as a class (not per-button) via `client.add_dynamic_items`
+    in `bot.py`'s `setup_hook`. See the module docstring for why there is no
+    `interaction_check` and why `from_custom_id`/`callback` catch broadly.
+    """
+
+    def __init__(self, *, feedback_id: str) -> None:
+        button: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            style=discord.ButtonStyle.secondary,
+            label="Tell us what went wrong",
+            custom_id=build_custom_id(feedback_id),
+        )
+        super().__init__(button)
+        self.feedback_id = feedback_id
+
+    @classmethod
+    async def from_custom_id(  # type: ignore[override]  # discord.py's ClientT is a free TypeVar; this adapter only ever runs DaimonBot
+        cls,
+        interaction: discord.Interaction[commands.Bot],
+        item: discord.ui.Item[Any],
+        match: re.Match[str],
+        /,
+    ) -> Self:
+        """Rebuild the item from its row id alone -- no database read.
+
+        Unlike `CredentialRequestButton.from_custom_id`, there is no lookup
+        here that could fail: the feedback row's primary key is the entire
+        state this button needs, so reconstruction can never raise from a DB
+        error inside discord.py's exception-swallowing dispatcher.
+        """
+        return cls(feedback_id=match["feedback_id"])
+
+    async def callback(  # type: ignore[override]  # see from_custom_id
+        self, interaction: discord.Interaction[commands.Bot]
+    ) -> None:
+        """Open the free-text form for this feedback row."""
+        try:
+            bot = cast(DaimonBot, interaction.client)
+            await interaction.response.send_modal(
+                FeedbackModal(runtime=bot.runtime, feedback_id=uuid.UUID(self.feedback_id))
+            )
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
+            _log.exception("feedback_button.callback_failed", err_type=type(err).__name__)
+            await interaction.response.send_message(_CALLBACK_FAILED, ephemeral=True)

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_button.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_button.py
@@ -114,4 +114,14 @@ class FeedbackButton(
             )
         except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
             _log.exception("feedback_button.callback_failed", err_type=type(err).__name__)
-            await interaction.response.send_message(_CALLBACK_FAILED, ephemeral=True)
+            # The caught error may have left the interaction already responded
+            # (`send_modal` raising `discord.InteractionResponded`, or failing
+            # after the response type was set). An unconditional
+            # `send_message` would then raise a SECOND time from inside this
+            # handler and vanish into the same dispatcher, leaving the user
+            # with neither the modal nor the apology. Same guard
+            # `FeedbackModal.on_error` uses.
+            if interaction.response.is_done():
+                await interaction.followup.send(_CALLBACK_FAILED, ephemeral=True)
+            else:
+                await interaction.response.send_message(_CALLBACK_FAILED, ephemeral=True)

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_modal.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_modal.py
@@ -1,0 +1,99 @@
+"""FeedbackModal -- the single-field free-text form the feedback button opens.
+
+Opened from `FeedbackButton.callback` after a click on a persistent button
+delivered into a direct message. The form collects exactly ONE field: the
+free-text criticism itself. There is no category picker and no second input
+-- the row being annotated is already fixed by the `feedback_id` carried in
+the button's `custom_id`, so the user never retypes anything else.
+
+Write path: `on_submit` defers ephemerally, rejects whitespace-only input
+server-side (the client already enforces `required=True`, but that is not
+trusted alone), then calls `daimon.core.stores.message_feedback.
+attach_feedback_text`, which gates the write on the clicking user's own
+`platform_user_id`. A `None` return covers both "the row was purged" and
+"this row belongs to someone else" -- the reply text deliberately does not
+distinguish the two, so a click carrying someone else's row id learns
+nothing about whether that row exists.
+
+Logging discipline: the submitted text is somebody's unsolicited criticism,
+not a secret, but it belongs in exactly one place -- the database row. It
+never enters a log record, a `custom_id`, an embed, or any non-ephemeral
+message. Every log line below carries the feedback row id only. This mirrors
+the hygiene guarantees `credential_modals.py` already documents for a
+different reason (there it is secrecy; here it is that this is unsolicited,
+personal criticism that should not multiply across the observability
+pipeline).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.stores.message_feedback import attach_feedback_text
+
+import discord
+
+_log = structlog.get_logger()
+
+_EMPTY_TEXT = "Feedback cannot be empty -- try again."
+_NO_LONGER_AVAILABLE = "This feedback request is no longer available."
+_SUBMIT_FAILED = "Something went wrong submitting your feedback -- please try again."
+_THANKS = "Thanks -- your feedback has been recorded."
+
+
+class FeedbackModal(discord.ui.Modal, title="What went wrong?"):
+    """Single-field free-text form, written through the ownership-predicated store call."""
+
+    def __init__(self, *, runtime: DiscordRuntime, feedback_id: uuid.UUID) -> None:
+        super().__init__()
+        self._runtime = runtime
+        self._feedback_id = feedback_id
+        self.text_input: discord.ui.TextInput[FeedbackModal] = discord.ui.TextInput(
+            label="What went wrong?",
+            style=discord.TextStyle.paragraph,
+            required=True,
+            max_length=4000,
+        )
+        self.add_item(self.text_input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        raw_text = str(self.text_input.value or "")
+
+        if not raw_text.strip():
+            await interaction.followup.send(_EMPTY_TEXT, ephemeral=True)
+            return
+
+        async with self._runtime.sessionmaker() as session, session.begin():
+            updated_row = await attach_feedback_text(
+                session,
+                feedback_id=self._feedback_id,
+                platform_user_id=str(interaction.user.id),
+                feedback_text=raw_text,
+            )
+
+        if updated_row is None:
+            _log.info("feedback_modal.no_longer_available", feedback_id=str(self._feedback_id))
+            await interaction.followup.send(_NO_LONGER_AVAILABLE, ephemeral=True)
+            return
+
+        _log.info("feedback_modal.submit", feedback_id=str(self._feedback_id))
+        await interaction.followup.send(_THANKS, ephemeral=True)
+
+    async def on_error(self, interaction: discord.Interaction, error: Exception) -> None:
+        """Adapter-boundary catch-all: a modal submission has no other error surface.
+
+        Unlike `from_custom_id`/`interaction_check`/`callback` on a
+        `DynamicItem` (see `feedback_button.py`), discord.py does NOT swallow
+        exceptions raised from `on_submit` -- it routes them here instead. But
+        leaving the default `on_error` behavior (log only) would still leave
+        the person staring at a form that silently failed, so this overrides
+        it to also send an apology.
+        """
+        _log.exception("feedback_modal.on_error", err_type=type(error).__name__)
+        if interaction.response.is_done():
+            await interaction.followup.send(_SUBMIT_FAILED, ephemeral=True)
+        else:
+            await interaction.response.send_message(_SUBMIT_FAILED, ephemeral=True)

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_reactions.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_reactions.py
@@ -22,9 +22,10 @@ reaction, direct-message, custom-emoji, and emoji-match gates with zero
 I/O; (3) `is_bot_authored`, tri-state -- `True`/`False` resolve
 immediately, `None` means the gateway omitted the undocumented, possibly-
 absent `message_author_id` field and this module falls back to one bounded
-message fetch, logging its use since that field could stop arriving
-without notice, where a failure means the author is unverifiable and
-records NOTHING -- never "assume ours"; (4) derive the tenant id (pure)
+message fetch, memoized per message id (see `_AUTHOR_CACHE_MAX_ENTRIES`),
+logging its use since that field could stop arriving without notice, where
+a failure means the author is unverifiable and records NOTHING -- never
+"assume ours"; (4) derive the tenant id (pure)
 and open one transaction to read the tenant, resolve a best-effort
 session/account attribution, and upsert the vote; (5) on a genuinely new
 down-vote, open the private follow-up (`_send_feedback_prompt`).
@@ -55,6 +56,16 @@ from discord.ext import commands
 
 log = structlog.get_logger()
 
+# Cap on the per-process memo of resolved author verdicts. The fallback is
+# rare today, but if `message_author_id` ever stops arriving then EVERY
+# thumbs reaction bot-wide -- overwhelmingly on human-authored messages --
+# costs a REST fetch competing with turn posting under discord.py's shared
+# rate limiter, and one person cycling add/remove on a single message
+# repeats it. Eviction is by insertion order, not recency: the access
+# pattern is a burst of reactions on a message that was just posted, so an
+# LRU's bookkeeping would buy nothing over a plain bounded dict.
+_AUTHOR_CACHE_MAX_ENTRIES = 1024
+
 
 class FeedbackReactionCog(commands.Cog):
     """Listens for a thumbs-up/down reaction on a bot message and records it.
@@ -66,6 +77,10 @@ class FeedbackReactionCog(commands.Cog):
 
     def __init__(self, bot: DaimonBot) -> None:
         self._bot = bot
+        # message id -> "the bot wrote it", populated only by a fetch that
+        # actually resolved an author. Per-process and deliberately not
+        # persisted: it is a REST-amplification bound, not a source of truth.
+        self._author_is_bot: dict[int, bool] = {}
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
@@ -158,18 +173,30 @@ class FeedbackReactionCog(commands.Cog):
     async def _is_bot_message_via_fetch(
         self, payload: discord.RawReactionActionEvent, *, bot_user_id: int
     ) -> bool:
-        """Resolve the undecidable case by fetching the message once.
+        """Resolve the undecidable case by fetching the message once per message.
 
         The gateway field this falls back from (`message_author_id`) is
         undocumented by Discord and may stop arriving without notice, so
         every use of this fallback is logged with its own distinct event so
-        a production rollout can tell whether this path is rare or common.
+        a production rollout can tell whether this path is rare or common --
+        the event fires on a memo hit too, so it keeps measuring how often
+        the field is missing rather than how often we fetch.
 
         Returns False (record nothing) whenever the author cannot be
         verified: a channel that cannot be resolved, or a fetch that raises.
-        An unverifiable author must never resolve to "assume ours".
+        An unverifiable author must never resolve to "assume ours". Those
+        outcomes are deliberately NOT memoized -- an unresolvable channel or
+        a transient fetch failure would otherwise permanently suppress every
+        later vote on that message.
         """
-        log.info("feedback.author_fallback_used", message_id=str(payload.message_id))
+        memoized = self._author_is_bot.get(payload.message_id)
+        log.info(
+            "feedback.author_fallback_used",
+            message_id=str(payload.message_id),
+            memoized=memoized is not None,
+        )
+        if memoized is not None:
+            return memoized
         try:
             channel = self._bot.get_channel(payload.channel_id)
             if channel is None:
@@ -180,7 +207,15 @@ class FeedbackReactionCog(commands.Cog):
         except discord.HTTPException:
             log.info("feedback.author_unverifiable", message_id=str(payload.message_id))
             return False
-        return message.author.id == bot_user_id
+        is_bot_message = message.author.id == bot_user_id
+        self._memoize_author(payload.message_id, is_bot_message)
+        return is_bot_message
+
+    def _memoize_author(self, message_id: int, is_bot_message: bool) -> None:
+        """Record one resolved verdict, dropping the oldest entry past the cap."""
+        if len(self._author_is_bot) >= _AUTHOR_CACHE_MAX_ENTRIES:
+            del self._author_is_bot[next(iter(self._author_is_bot))]
+        self._author_is_bot[message_id] = is_bot_message
 
     async def _send_feedback_prompt(
         self, payload: discord.RawReactionActionEvent, *, feedback_id: uuid.UUID

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_reactions.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_reactions.py
@@ -1,0 +1,219 @@
+"""FeedbackReactionCog -- listens for the two vote emoji and records votes.
+
+Discord routes `on_raw_reaction_add` through the gateway, not through the
+interaction/dispatcher machinery `credential_button.py` and
+`feedback_button.py` document -- but the same "adapter boundary" reasoning
+applies: discord.py's event dispatcher (`Client._run_event`) catches and
+logs anything a listener raises with `on_error`, which by default just
+prints the traceback and moves on. Anything unhandled here vanishes with
+nothing in OUR OWN structured logs, so `on_raw_reaction_add` wraps its whole
+body in one broad catch-all -- the single outermost boundary in this
+module. Nothing below it catches broadly.
+
+This is a listener-only Cog, not a slash-command family, so it lives at the
+adapter's top level rather than under `commands/`; `bot.py` is already well
+past the size where new concerns belong inline. Local import inside
+`setup_hook` avoids a cycle: this module imports `DaimonBot` at module
+level, the same shape `credential_button.py` and `feedback_button.py` use.
+
+Pipeline, cheapest and most certain gates first: (1) bot not connected yet
+-- bail; (2) `vote_for_reaction`, one pure call covering the bot-self-
+reaction, direct-message, custom-emoji, and emoji-match gates with zero
+I/O; (3) `is_bot_authored`, tri-state -- `True`/`False` resolve
+immediately, `None` means the gateway omitted the undocumented, possibly-
+absent `message_author_id` field and this module falls back to one bounded
+message fetch, logging its use since that field could stop arriving
+without notice, where a failure means the author is unverifiable and
+records NOTHING -- never "assume ours"; (4) derive the tenant id (pure)
+and open one transaction to read the tenant, resolve a best-effort
+session/account attribution, and upsert the vote; (5) on a genuinely new
+down-vote, open the private follow-up (`_send_feedback_prompt`).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import cast
+
+import structlog
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.feedback_button import FeedbackButton
+from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.message_feedback import (
+    Vote,
+    is_bot_authored,
+    should_trigger_feedback_dm,
+    vote_for_reaction,
+)
+from daimon.core.stores.identity import find_platform_principal
+from daimon.core.stores.message_feedback import record_vote
+from daimon.core.stores.tenants import get_tenant
+from daimon.core.stores.thread_sessions import get_latest_thread_session
+
+import discord
+from discord.ext import commands
+
+log = structlog.get_logger()
+
+
+class FeedbackReactionCog(commands.Cog):
+    """Listens for a thumbs-up/down reaction on a bot message and records it.
+
+    Registered ONCE via `bot.add_cog` in `setup_hook`. See the module
+    docstring for why `on_raw_reaction_add` is the one place in this module
+    that catches broadly.
+    """
+
+    def __init__(self, bot: DaimonBot) -> None:
+        self._bot = bot
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        try:
+            await self._record_vote_from_reaction(payload)
+        except Exception as err:  # noqa: BLE001 -- listener dispatch is an adapter boundary (see module docstring); discord.py's own event dispatcher swallows anything raised here
+            log.exception("feedback_reactions.handler_failed", err_type=type(err).__name__)
+
+    async def _record_vote_from_reaction(self, payload: discord.RawReactionActionEvent) -> None:
+        if self._bot.user is None:
+            return  # not connected yet
+        bot_user_id = self._bot.user.id
+
+        candidate_vote = vote_for_reaction(
+            emoji_name=payload.emoji.name,
+            emoji_is_custom=payload.emoji.id is not None,
+            reactor_id=payload.user_id,
+            bot_user_id=bot_user_id,
+            guild_id=payload.guild_id,
+        )
+        if candidate_vote is None:
+            return
+        verdict = is_bot_authored(
+            message_author_id=payload.message_author_id, bot_user_id=bot_user_id
+        )
+        if verdict is False:
+            return
+        if verdict is None and not await self._is_bot_message_via_fetch(
+            payload, bot_user_id=bot_user_id
+        ):
+            return
+
+        # guild_id is guaranteed non-None: vote_for_reaction already returned
+        # None above for any reaction with no guild (a DM reaction).
+        tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(payload.guild_id))
+
+        async with self._bot.runtime.sessionmaker() as session, session.begin():
+            tenant = await get_tenant(session, tenant_id)
+            if tenant is None:
+                log.info("feedback.tenant_missing", tenant_id=str(tenant_id))
+                return
+
+            # Best-effort attribution hint only (get_latest_thread_session's
+            # docstring) -- never used to bind or resume a session.
+            thread_row = await get_latest_thread_session(
+                session,
+                tenant_id=tenant_id,
+                platform="discord",
+                thread_id=str(payload.channel_id),
+            )
+            ma_session_id = thread_row.ma_session_id if thread_row is not None else None
+
+            # Read-only, deliberately NOT get_or_create: a bystander's
+            # reaction must not mint an identity record for a stranger.
+            principal = await find_platform_principal(
+                session,
+                tenant_id=tenant_id,
+                platform="discord",
+                external_id=str(payload.user_id),
+            )
+            account_id = principal.account_id if principal is not None else None
+
+            result = await record_vote(
+                session,
+                tenant_id=tenant_id,
+                platform="discord",
+                message_id=str(payload.message_id),
+                channel_id=str(payload.channel_id),
+                platform_user_id=str(payload.user_id),
+                account_id=account_id,
+                ma_session_id=ma_session_id,
+                vote=candidate_vote,
+            )
+
+        # `RecordVoteResult.previous_vote` is a bare `str | None` at the store
+        # boundary -- every row is written through this same record_vote call
+        # with a validated `Vote`, so this narrowing reflects a real invariant.
+        previous_vote = cast("Vote | None", result.previous_vote)
+
+        log.info(
+            "feedback.vote_recorded",
+            message_id=str(payload.message_id),
+            vote=candidate_vote,
+            is_new_vote=previous_vote != candidate_vote,
+        )
+
+        if should_trigger_feedback_dm(previous_vote=previous_vote, new_vote=candidate_vote):
+            await self._send_feedback_prompt(payload, feedback_id=result.row.id)
+
+    async def _is_bot_message_via_fetch(
+        self, payload: discord.RawReactionActionEvent, *, bot_user_id: int
+    ) -> bool:
+        """Resolve the undecidable case by fetching the message once.
+
+        The gateway field this falls back from (`message_author_id`) is
+        undocumented by Discord and may stop arriving without notice, so
+        every use of this fallback is logged with its own distinct event so
+        a production rollout can tell whether this path is rare or common.
+
+        Returns False (record nothing) whenever the author cannot be
+        verified: a channel that cannot be resolved, or a fetch that raises.
+        An unverifiable author must never resolve to "assume ours".
+        """
+        log.info("feedback.author_fallback_used", message_id=str(payload.message_id))
+        try:
+            channel = self._bot.get_channel(payload.channel_id)
+            if channel is None:
+                channel = await self._bot.fetch_channel(payload.channel_id)
+            if not isinstance(channel, discord.abc.Messageable):
+                return False
+            message = await channel.fetch_message(payload.message_id)
+        except discord.HTTPException:
+            log.info("feedback.author_unverifiable", message_id=str(payload.message_id))
+            return False
+        return message.author.id == bot_user_id
+
+    async def _send_feedback_prompt(
+        self, payload: discord.RawReactionActionEvent, *, feedback_id: uuid.UUID
+    ) -> None:
+        """Open the private free-text path for a genuinely new down-vote.
+
+        One message per new down-vote -- no batching, no re-pointing an
+        earlier message: each one names a different answer, so collapsing
+        them would lose which answer the text belongs to. The vote itself
+        is already committed by the time this runs, so a delivery failure
+        here (most commonly `discord.Forbidden` -- direct messages closed)
+        costs the reactor nothing but the follow-up prompt.
+        """
+        # guild_id is guaranteed non-None: the pure gate in vote_for_reaction
+        # already dropped any reaction lacking a guild.
+        link = (
+            f"https://discord.com/channels/{payload.guild_id}"
+            f"/{payload.channel_id}/{payload.message_id}"
+        )
+        # A live View exists only to carry the item onto the wire -- dispatch
+        # happens via class registration (FeedbackButton), never this instance.
+        view: discord.ui.View = discord.ui.View(timeout=None)
+        view.add_item(FeedbackButton(feedback_id=str(feedback_id)))
+        try:
+            user = self._bot.get_user(payload.user_id)
+            if user is None:
+                user = await self._bot.fetch_user(payload.user_id)
+            await user.send(
+                content=f"You flagged {link} -- want to tell us what went wrong?", view=view
+            )
+        except discord.HTTPException as exc:
+            # discord.Forbidden (closed DMs) is the common case -- there is no
+            # other channel to reach this person on, so this must never raise.
+            log.info(
+                "feedback.prompt_undeliverable", message_id=str(payload.message_id), error=str(exc)
+            )

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_seed.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_seed.py
@@ -1,0 +1,50 @@
+"""seed_feedback_reactions -- best-effort thumbs-up/down seeding.
+
+Adds the two vote emoji to a turn's final message so a reaction listener
+(`feedback_reactions.py`) has something to listen on. Deliberately its own
+module importing only `discord`, `structlog`, and the two emoji constants --
+no adapter imports -- so `bot.py` can import it at module level with no
+cycle, unlike the listener Cog and the button, which both import `DaimonBot`
+and therefore need a local import inside `setup_hook`.
+
+`add_reactions` is deliberately NOT added to `permissions.py`'s
+`REQUIRED_PERMISSIONS`: seeding is an affordance, never a gate, so a channel
+that forbids it must let the turn complete normally rather than change the
+bot's advertised required-permission set. `discord.Forbidden` (a subclass of
+`discord.HTTPException`) is exactly what a missing-permission channel raises,
+and it is caught here and only logged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import structlog
+from daimon.core.message_feedback import THUMBS_DOWN, THUMBS_UP
+
+import discord
+
+log = structlog.get_logger()
+
+
+async def seed_feedback_reactions(channel: discord.abc.Messageable, *, message_id: str) -> None:
+    """Add the positive emoji then the negative one to `message_id`'s message.
+
+    The positive emoji is added first so the two always render in the same
+    order. Best-effort: never raises. `discord.abc.Messageable` itself does
+    not declare `get_partial_message` -- only the concrete channel types
+    that actually support it do (`discord.Thread` among them, which is what
+    every caller in this adapter passes) -- so it is looked up dynamically
+    and this is a no-op for a channel type that lacks it.
+    """
+    get_partial_message: Callable[[int], discord.PartialMessage] | None = getattr(
+        channel, "get_partial_message", None
+    )
+    if get_partial_message is None:
+        return
+    try:
+        partial = get_partial_message(int(message_id))
+        await partial.add_reaction(THUMBS_UP)
+        await partial.add_reaction(THUMBS_DOWN)
+    except discord.HTTPException as exc:
+        log.warning("feedback.seed_failed", message_id=message_id, error=str(exc))

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_seed.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_seed.py
@@ -13,6 +13,16 @@ that forbids it must let the turn complete normally rather than change the
 bot's advertised required-permission set. `discord.Forbidden` (a subclass of
 `discord.HTTPException`) is exactly what a missing-permission channel raises,
 and it is caught here and only logged.
+
+This module is therefore a boundary in the sense `guideline:architecture`
+means it, despite being three lines of I/O: every caller runs it AFTER the
+answer has been delivered and the watermark written, so anything escaping it
+reaches the turn's error boundary and posts a "turn failed" message directly
+underneath a successfully delivered answer. `discord.HTTPException` is not
+the only way `add_reaction` fails -- an `OSError`/`aiohttp` connection error
+surviving discord.py's internal retry loop, or a `RuntimeError` from a
+closed client session during shutdown drain, both bypass it -- so the catch
+is deliberately as wide as the "never raises" contract it implements.
 """
 
 from __future__ import annotations
@@ -46,5 +56,10 @@ async def seed_feedback_reactions(channel: discord.abc.Messageable, *, message_i
         partial = get_partial_message(int(message_id))
         await partial.add_reaction(THUMBS_UP)
         await partial.add_reaction(THUMBS_DOWN)
-    except discord.HTTPException as exc:
-        log.warning("feedback.seed_failed", message_id=message_id, error=str(exc))
+    except Exception as exc:  # noqa: BLE001 -- best-effort affordance running after the answer was delivered; a seed failure must never surface as a turn failure (see module docstring)
+        log.warning(
+            "feedback.seed_failed",
+            message_id=message_id,
+            err_type=type(exc).__name__,
+            error=str(exc),
+        )

--- a/packages/adapters/discord/daimon/adapters/discord/lifecycle.py
+++ b/packages/adapters/discord/daimon/adapters/discord/lifecycle.py
@@ -124,6 +124,7 @@ class DiscordTurnLifecycle:
         self._terminal: bool = False
         self._cancel_view = cancel_view
         self._persisted_sealed_indices: set[int] = set()
+        self._was_answered: bool = False
 
     async def post_initial(self) -> None:
         """Post the initial thinking embed immediately, before the turn starts.
@@ -236,12 +237,14 @@ class DiscordTurnLifecycle:
             # If content is entirely empty (cancellation), show "Turn cancelled."
             has_tool_activity = any(isinstance(block, ToolUseBlock) for block in state.content)
             if has_tool_activity:
+                self._was_answered = True
                 log.info("turn.terminal_success", has_text=False, tool_only=True)
                 return
             await self._edit(self._message_ref, content="Turn cancelled.", embed=None, view=None)
             log.info("turn.terminal_success", has_text=False)
             return
 
+        self._was_answered = True
         chunks = split_for_discord_safe(response_text)
         # Clean replace: first chunk replaces the embed
         await self._edit(self._message_ref, content=chunks[0], embed=None, view=None)
@@ -280,3 +283,15 @@ class DiscordTurnLifecycle:
         if self._message_ref is None:
             return None
         return str(self._message_ref.id)
+
+    @property
+    def was_answered(self) -> bool:
+        """Whether the turn actually produced an answer.
+
+        False until a terminal success produced either a text answer or
+        visible tool activity. A cancelled turn and a failed turn both leave
+        this False. Callers need this to tell "the turn ended without error"
+        apart from "the turn actually answered" -- the two are NOT the same,
+        because a cancellation reaches this class through the success hook.
+        """
+        return self._was_answered

--- a/packages/adapters/discord/daimon/adapters/discord/views.py
+++ b/packages/adapters/discord/daimon/adapters/discord/views.py
@@ -7,16 +7,20 @@ All Views are non-persistent (VIEW-04): no custom_id, no bot.add_view(). CancelV
 timeout=None -- lifecycle manages removal.
 
 The documented exceptions: the chat-initiated credential-request button
-(`daimon.adapters.discord.credential_button.CredentialRequestButton`) and the
+(`daimon.adapters.discord.credential_button.CredentialRequestButton`), the
 wizard's navigation button and multi-select
 (`daimon.adapters.discord.wizard.WizardNavButton`,
-`daimon.adapters.discord.wizard.WizardSelect`) ARE persistent -- each carries
-a custom_id and is registered as a `discord.ui.DynamicItem` class in
-`setup_hook`. This is necessary because the process that posts the message
-(the MCP server, for both the credential button and the wizard's first
-screen) is not the process that dispatches its click (this bot) -- there is
-no live in-memory View instance to attach a non-persistent handler to. Every
-other interactive component in this adapter stays non-persistent.
+`daimon.adapters.discord.wizard.WizardSelect`), and the private-feedback
+button (`daimon.adapters.discord.feedback_button.FeedbackButton`) ARE
+persistent -- each carries a custom_id and is registered as a
+`discord.ui.DynamicItem` class in `setup_hook`. The credential button and the
+wizard's first screen are posted by the MCP server, a different process from
+the one that dispatches their click (this bot) -- there is no live in-memory
+View instance to attach a non-persistent handler to. `FeedbackButton` is
+persistent for a related but distinct reason: it is delivered into a direct
+message and must still dispatch after this bot process restarts, so there is
+again no live View instance to rely on. Every other interactive component in
+this adapter stays non-persistent.
 """
 
 from __future__ import annotations

--- a/packages/adapters/discord/tests/privacy_panel/conftest.py
+++ b/packages/adapters/discord/tests/privacy_panel/conftest.py
@@ -36,6 +36,7 @@ def _make_preview(**overrides: Any) -> PurgePreview:
         "slack_turn_contexts": PurgePreviewRow(count=0, example=None),
         "credential_requests": PurgePreviewRow(count=0, example=None),
         "wizard_sessions": PurgePreviewRow(count=0, example=None),
+        "message_feedback": PurgePreviewRow(count=0, example=None),
     }
     base.update(overrides)
     return PurgePreview(**base)

--- a/packages/adapters/discord/tests/test_branding.py
+++ b/packages/adapters/discord/tests/test_branding.py
@@ -89,6 +89,7 @@ def _make_preview() -> PurgePreview:
         slack_turn_contexts=zero,
         credential_requests=zero,
         wizard_sessions=zero,
+        message_feedback=zero,
     )
 
 

--- a/packages/adapters/discord/tests/test_feedback_button.py
+++ b/packages/adapters/discord/tests/test_feedback_button.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 from daimon.adapters.discord.credential_button import CredentialRequestButton
 from daimon.adapters.discord.feedback_button import FeedbackButton
 from daimon.adapters.discord.feedback_modal import FeedbackModal
@@ -33,6 +34,8 @@ def _interaction(*, client: Any) -> MagicMock:
     interaction.client = client
     interaction.response.send_message = AsyncMock()
     interaction.response.send_modal = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup.send = AsyncMock()
     return interaction
 
 
@@ -102,6 +105,29 @@ async def test_callback_when_send_modal_raises_replies_once_and_swallows_the_err
         "failure reply must tell the user opening the form failed"
     )
     kwargs = interaction.response.send_message.call_args.kwargs
+    assert kwargs.get("ephemeral") is True, "the failure reply must be ephemeral"
+
+
+async def test_callback_when_the_interaction_was_already_responded_replies_via_followup() -> None:
+    """The apology must not itself raise InteractionResponded inside the catch.
+
+    An unconditional `response.send_message` here raises a second time and
+    vanishes into discord.py's dispatcher, so the user gets neither the modal
+    nor the apology -- exactly what the catch exists to prevent.
+    """
+    item = FeedbackButton(feedback_id=str(uuid.uuid4()))
+    bot = _fake_bot(MagicMock())
+    interaction = _interaction(client=bot)
+    interaction.response.send_modal = AsyncMock(
+        side_effect=discord.InteractionResponded(MagicMock())
+    )
+    interaction.response.is_done = MagicMock(return_value=True)
+
+    await item.callback(interaction)  # must not raise
+
+    interaction.response.send_message.assert_not_awaited()
+    interaction.followup.send.assert_awaited_once()
+    kwargs = interaction.followup.send.call_args.kwargs
     assert kwargs.get("ephemeral") is True, "the failure reply must be ephemeral"
 
 

--- a/packages/adapters/discord/tests/test_feedback_button.py
+++ b/packages/adapters/discord/tests/test_feedback_button.py
@@ -1,0 +1,123 @@
+"""Tests for FeedbackButton -- from_custom_id / callback / template disjointness."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from daimon.adapters.discord.credential_button import CredentialRequestButton
+from daimon.adapters.discord.feedback_button import FeedbackButton
+from daimon.adapters.discord.feedback_modal import FeedbackModal
+from daimon.core.credential_requests import build_custom_id as build_credential_custom_id
+from daimon.core.credential_requests import mint_request_token
+from daimon.core.message_feedback import build_custom_id
+
+
+def _raising_sessionmaker() -> Any:
+    def _raise(*_args: Any, **_kwargs: Any) -> None:
+        msg = "from_custom_id must not touch the database"
+        raise AssertionError(msg)
+
+    return _raise
+
+
+def _fake_bot(sessionmaker: Any) -> Any:
+    """A minimal stand-in for DaimonBot -- only `.runtime.sessionmaker` is read."""
+    return SimpleNamespace(runtime=SimpleNamespace(sessionmaker=sessionmaker))
+
+
+def _interaction(*, client: Any) -> MagicMock:
+    interaction = MagicMock()
+    interaction.client = client
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    return interaction
+
+
+def _match(feedback_id: str) -> Any:
+    custom_id = build_custom_id(feedback_id)
+    matched = FeedbackButton.__discord_ui_compiled_template__.fullmatch(custom_id)
+    assert matched is not None, "test feedback_id must satisfy the button's own custom_id template"
+    return matched
+
+
+# --- from_custom_id -----------------------------------------------------------
+
+
+async def test_from_custom_id_returns_item_with_parsed_feedback_id() -> None:
+    feedback_id = str(uuid.uuid4())
+
+    item = await FeedbackButton.from_custom_id(
+        _interaction(client=None), MagicMock(), _match(feedback_id)
+    )
+
+    assert item.feedback_id == feedback_id, (
+        "the reconstructed item must carry the exact feedback_id encoded in the custom_id"
+    )
+
+
+async def test_from_custom_id_never_touches_the_database() -> None:
+    """Pins the property that makes the button restart-safe with no lookup."""
+    feedback_id = str(uuid.uuid4())
+    bot = _fake_bot(_raising_sessionmaker())
+    interaction = _interaction(client=bot)
+
+    item = await FeedbackButton.from_custom_id(interaction, MagicMock(), _match(feedback_id))
+
+    assert item.feedback_id == feedback_id, "reconstruction must succeed with no DB access"
+
+
+# --- callback ------------------------------------------------------------------
+
+
+async def test_callback_sends_modal_with_matching_feedback_id() -> None:
+    feedback_id = str(uuid.uuid4())
+    item = FeedbackButton(feedback_id=feedback_id)
+    bot = _fake_bot(MagicMock())
+    interaction = _interaction(client=bot)
+
+    await item.callback(interaction)
+
+    interaction.response.send_modal.assert_awaited_once()
+    sent_modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(sent_modal, FeedbackModal), "callback must open FeedbackModal"
+    assert sent_modal._feedback_id == uuid.UUID(feedback_id), (  # pyright: ignore[reportPrivateUsage]
+        "the modal must be constructed with the same feedback_id the button carries"
+    )
+
+
+async def test_callback_when_send_modal_raises_replies_once_and_swallows_the_error() -> None:
+    item = FeedbackButton(feedback_id=str(uuid.uuid4()))
+    bot = _fake_bot(MagicMock())
+    interaction = _interaction(client=bot)
+    interaction.response.send_modal = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await item.callback(interaction)  # must not raise -- dispatcher-swallowing boundary
+
+    interaction.response.send_message.assert_awaited_once()
+    message = interaction.response.send_message.call_args.args[0]
+    assert "went wrong" in message.lower(), (
+        "failure reply must tell the user opening the form failed"
+    )
+    kwargs = interaction.response.send_message.call_args.kwargs
+    assert kwargs.get("ephemeral") is True, "the failure reply must be ephemeral"
+
+
+# --- template disjointness ------------------------------------------------------
+
+
+def test_feedback_template_does_not_match_a_credential_custom_id() -> None:
+    credential_custom_id = build_credential_custom_id(mint_request_token())
+    assert (
+        FeedbackButton.__discord_ui_compiled_template__.fullmatch(credential_custom_id) is None
+    ), "overlapping templates double-dispatch a single click because discord.py fires every match"
+
+
+def test_credential_template_does_not_match_a_feedback_custom_id() -> None:
+    feedback_custom_id = build_custom_id(str(uuid.uuid4()))
+    assert (
+        CredentialRequestButton.__discord_ui_compiled_template__.fullmatch(feedback_custom_id)
+        is None
+    ), "overlapping templates double-dispatch a single click because discord.py fires every match"

--- a/packages/adapters/discord/tests/test_feedback_modal.py
+++ b/packages/adapters/discord/tests/test_feedback_modal.py
@@ -1,0 +1,235 @@
+"""Tests for FeedbackModal.on_submit -- the free-text write path.
+
+Rows are seeded and read back exclusively through `record_vote`
+(`daimon.core.stores.message_feedback`), never through raw ORM: a re-vote
+with the SAME vote value leaves `feedback_text` untouched (see that
+function's docstring) and returns the current row, which is exactly the
+"read it back" operation these tests need.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import structlog
+from daimon.adapters.discord.feedback_modal import FeedbackModal
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.message_feedback import record_vote
+from daimon.testing.factories import make_account, make_tenant
+from daimon.testing.ma import build_stub_anthropic
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_VOTER_ID = "100000000000000001"
+_OTHER_USER_ID = "200000000000000002"
+
+
+def _runtime(*, sessionmaker: async_sessionmaker[AsyncSession]) -> DiscordRuntime:
+    return DiscordRuntime(
+        settings=MagicMock(),
+        anthropic=build_stub_anthropic(),
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # feedback-modal tests never run a turn
+    )
+
+
+def _interaction(*, user_id: str) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user.id = int(user_id)
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _modal(*, runtime: DiscordRuntime, feedback_id: uuid.UUID, text: str) -> FeedbackModal:
+    modal = FeedbackModal(runtime=runtime, feedback_id=feedback_id)
+    modal.text_input._value = text  # pyright: ignore[reportPrivateUsage]
+    return modal
+
+
+async def _seed_vote(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID,
+    message_id: str,
+    platform_user_id: str = _VOTER_ID,
+) -> uuid.UUID:
+    async with db_session_factory() as session, session.begin():
+        result = await record_vote(
+            session,
+            tenant_id=tenant_id,
+            platform="discord",
+            message_id=message_id,
+            channel_id="chan-1",
+            platform_user_id=platform_user_id,
+            account_id=account_id,
+            ma_session_id="sess_a",
+            vote="down",
+        )
+    return result.row.id
+
+
+async def _read_back_feedback_text(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID,
+    message_id: str,
+    platform_user_id: str = _VOTER_ID,
+) -> str | None:
+    """Re-vote with the SAME value -- record_vote never touches feedback_text on update."""
+    async with db_session_factory() as session, session.begin():
+        result = await record_vote(
+            session,
+            tenant_id=tenant_id,
+            platform="discord",
+            message_id=message_id,
+            channel_id="chan-1",
+            platform_user_id=platform_user_id,
+            account_id=account_id,
+            ma_session_id="sess_a",
+            vote="down",
+        )
+    return result.row.feedback_text
+
+
+async def test_submitting_non_empty_text_attaches_it_to_the_voters_row(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, workspace_id="guild-submit")
+        account = await make_account(session, tenant=tenant)
+    feedback_id = await _seed_vote(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-submit"
+    )
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = _modal(runtime=runtime, feedback_id=feedback_id, text="the answer was wrong")
+
+    interaction = _interaction(user_id=_VOTER_ID)
+    await modal.on_submit(interaction)
+
+    stored_text = await _read_back_feedback_text(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-submit"
+    )
+    assert stored_text == "the answer was wrong", (
+        "the submitted text must attach to the voter's own row"
+    )
+    interaction.followup.send.assert_awaited_once()
+    kwargs = interaction.followup.send.call_args.kwargs
+    assert kwargs.get("ephemeral") is True, "the confirmation reply must be ephemeral"
+
+
+async def test_submitting_from_a_different_user_writes_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, workspace_id="guild-wronguser")
+        account = await make_account(session, tenant=tenant)
+    feedback_id = await _seed_vote(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-wronguser"
+    )
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = _modal(runtime=runtime, feedback_id=feedback_id, text="not my row")
+
+    interaction = _interaction(user_id=_OTHER_USER_ID)
+    await modal.on_submit(interaction)
+
+    stored_text = await _read_back_feedback_text(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-wronguser"
+    )
+    assert stored_text is None, "a click carrying someone else's row id must write nothing"
+    message = interaction.followup.send.call_args.args[0]
+    assert "no longer available" in message.lower(), (
+        "a foreign-row submission must report unavailability, not distinguish it from a missing row"
+    )
+
+
+async def test_submitting_for_a_missing_feedback_id_reports_unavailable_and_writes_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = _modal(runtime=runtime, feedback_id=uuid.uuid4(), text="ghost row")
+
+    interaction = _interaction(user_id=_VOTER_ID)
+    await modal.on_submit(interaction)
+
+    message = interaction.followup.send.call_args.args[0]
+    assert "no longer available" in message.lower(), (
+        "a missing row must report the same unavailability message as a foreign row"
+    )
+
+
+async def test_submitting_whitespace_only_text_writes_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, workspace_id="guild-whitespace")
+        account = await make_account(session, tenant=tenant)
+    feedback_id = await _seed_vote(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-whitespace"
+    )
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = _modal(runtime=runtime, feedback_id=feedback_id, text="   \n\t  ")
+
+    interaction = _interaction(user_id=_VOTER_ID)
+    await modal.on_submit(interaction)
+
+    stored_text = await _read_back_feedback_text(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-whitespace"
+    )
+    assert stored_text is None, "whitespace-only text must never be written"
+    message = interaction.followup.send.call_args.args[0]
+    assert "empty" in message.lower(), "the reply must say the feedback cannot be empty"
+
+
+async def test_second_submission_overwrites_the_first(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, workspace_id="guild-overwrite")
+        account = await make_account(session, tenant=tenant)
+    feedback_id = await _seed_vote(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-overwrite"
+    )
+    runtime = _runtime(sessionmaker=db_session_factory)
+
+    first_modal = _modal(runtime=runtime, feedback_id=feedback_id, text="first draft")
+    await first_modal.on_submit(_interaction(user_id=_VOTER_ID))
+
+    second_modal = _modal(runtime=runtime, feedback_id=feedback_id, text="second, better draft")
+    await second_modal.on_submit(_interaction(user_id=_VOTER_ID))
+
+    stored_text = await _read_back_feedback_text(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-overwrite"
+    )
+    assert stored_text == "second, better draft", "the last submission must win"
+
+
+async def test_submitted_text_never_appears_in_a_log_event(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, workspace_id="guild-loghygiene")
+        account = await make_account(session, tenant=tenant)
+    feedback_id = await _seed_vote(
+        db_session_factory, tenant_id=tenant.id, account_id=account.id, message_id="msg-loghygiene"
+    )
+    runtime = _runtime(sessionmaker=db_session_factory)
+    secret_text = "the model hallucinated a nonexistent API endpoint"
+    modal = _modal(runtime=runtime, feedback_id=feedback_id, text=secret_text)
+
+    with structlog.testing.capture_logs() as captured_logs:
+        await modal.on_submit(_interaction(user_id=_VOTER_ID))
+
+    for event in captured_logs:
+        assert secret_text not in repr(event), (
+            "the submitted free text must never reach a structlog event"
+        )

--- a/packages/adapters/discord/tests/test_feedback_reactions.py
+++ b/packages/adapters/discord/tests/test_feedback_reactions.py
@@ -262,6 +262,117 @@ async def test_fallback_fetch_message_raises_not_found_writes_nothing_and_does_n
     assert calls == [], "an unverifiable author must never resolve to 'assume ours'"
 
 
+async def test_fallback_fetches_once_for_repeated_reactions_on_the_same_message(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The memo is the bound on REST amplification if the gateway field goes away."""
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    _spy_on_record_vote(monkeypatch)
+    fetched_message = MagicMock()
+    fetched_message.author.id = 123456  # human-authored: the common case
+    fake_channel = MagicMock(spec=discord.abc.Messageable)
+    fake_channel.fetch_message = AsyncMock(return_value=fetched_message)
+    bot = _fake_bot(
+        sessionmaker=db_session_factory, get_channel=MagicMock(return_value=fake_channel)
+    )
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1016,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=None,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+    await cog.on_raw_reaction_add(payload)
+    await cog.on_raw_reaction_add(payload)
+
+    assert fake_channel.fetch_message.await_count == 1, (
+        "a resolved author verdict must be reused, not re-fetched on every reaction"
+    )
+
+
+async def test_fallback_refetches_after_a_failed_fetch_is_not_memoized(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient failure must not permanently suppress later votes on that message."""
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    fetched_message = MagicMock()
+    fetched_message.author.id = _BOT_USER_ID
+    fake_channel = MagicMock(spec=discord.abc.Messageable)
+    fake_channel.fetch_message = AsyncMock(
+        side_effect=[
+            discord.NotFound(MagicMock(status=404), "message not found"),
+            fetched_message,
+        ]
+    )
+    bot = _fake_bot(
+        sessionmaker=db_session_factory, get_channel=MagicMock(return_value=fake_channel)
+    )
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1017,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=None,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+    await cog.on_raw_reaction_add(payload)
+
+    assert fake_channel.fetch_message.await_count == 2, "a failed fetch must not be memoized"
+    assert len(calls) == 1, "the retry that resolved a bot author must record the vote"
+
+
+async def test_the_author_memo_is_bounded_and_evicts_the_oldest_message(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pins that the memo cannot grow without bound across a long-running process."""
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    _spy_on_record_vote(monkeypatch)
+    monkeypatch.setattr(feedback_reactions, "_AUTHOR_CACHE_MAX_ENTRIES", 2)
+    fetched_message = MagicMock()
+    fetched_message.author.id = 123456
+    fake_channel = MagicMock(spec=discord.abc.Messageable)
+    fake_channel.fetch_message = AsyncMock(return_value=fetched_message)
+    bot = _fake_bot(
+        sessionmaker=db_session_factory, get_channel=MagicMock(return_value=fake_channel)
+    )
+    cog = FeedbackReactionCog(bot)
+
+    def _payload_for(message_id: int) -> discord.RawReactionActionEvent:
+        return _build_payload(
+            message_id=message_id,
+            channel_id=2001,
+            user_id=_REACTOR_ID,
+            guild_id=_GUILD_ID,
+            emoji_name="\N{THUMBS DOWN SIGN}",
+            message_author_id=None,
+        )
+
+    for message_id in (1018, 1019, 1020):
+        await cog.on_raw_reaction_add(_payload_for(message_id))
+    await cog.on_raw_reaction_add(_payload_for(1018))
+
+    assert fake_channel.fetch_message.await_count == 4, (
+        "the oldest entry must be evicted at the cap, so the first message re-fetches"
+    )
+
+
 async def test_fast_path_does_not_call_fetch_message(
     db_session: AsyncSession,
     db_session_factory: async_sessionmaker[AsyncSession],

--- a/packages/adapters/discord/tests/test_feedback_reactions.py
+++ b/packages/adapters/discord/tests/test_feedback_reactions.py
@@ -1,0 +1,792 @@
+"""Tests for FeedbackReactionCog.on_raw_reaction_add -- gates, author
+verification, and vote persistence.
+
+Rows are verified through a spy wrapped around the real `record_vote` store
+call (see `_spy_on_record_vote`), never a raw ORM re-read: the private ORM
+module is banned in this test tree (T9, `scripts/lint_anti_patterns.sh`),
+and re-calling `record_vote` a second time to "read back" a row would
+itself overwrite fields (`account_id`, `ma_session_id`) the listener just
+set. The spy captures the exact `RecordVoteResult` the listener wrote (or
+an empty list, for every "writes nothing" assertion) with zero extra I/O.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from daimon.adapters.discord import feedback_reactions
+from daimon.adapters.discord.feedback_reactions import FeedbackReactionCog
+from daimon.core.message_feedback import CUSTOM_ID_PATTERN
+from daimon.core.stores.domain import RecordVoteResult
+from daimon.core.stores.identity import find_platform_principal
+from daimon.core.stores.thread_sessions import create_thread_session
+from daimon.testing.factories import make_platform_principal, make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_BOT_USER_ID = 999999999999999999
+_REACTOR_ID = 100000000000000001
+_OTHER_REACTOR_ID = 100000000000000002
+_GUILD_ID = 555555555555555555
+
+
+def _build_payload(
+    *,
+    message_id: int,
+    channel_id: int,
+    user_id: int,
+    guild_id: int | None,
+    emoji_name: str,
+    emoji_id: int | None = None,
+    message_author_id: int | None = None,
+) -> discord.RawReactionActionEvent:
+    """Construct a REAL RawReactionActionEvent from a bare gateway-shaped dict.
+
+    Omitting `message_author_id` here is exactly how the gateway omits it,
+    so tests exercising the fallback go through the real accessor rather
+    than a stubbed attribute.
+    """
+    data: dict[str, object] = {
+        "message_id": message_id,
+        "channel_id": channel_id,
+        "user_id": user_id,
+        "type": 0,
+    }
+    if guild_id is not None:
+        data["guild_id"] = guild_id
+    if message_author_id is not None:
+        data["message_author_id"] = message_author_id
+    emoji = discord.PartialEmoji(name=emoji_name, id=emoji_id)
+    return discord.RawReactionActionEvent(
+        data,  # type: ignore[arg-type]  # deliberately a bare gateway-shaped dict, not the full TypedDict -- see module docstring
+        emoji,
+        "REACTION_ADD",
+    )
+
+
+def _fake_bot(
+    *,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    get_channel: Any = None,
+    fetch_channel: Any = None,
+    get_user: Any = None,
+    fetch_user: Any = None,
+) -> Any:
+    """Minimal DaimonBot stand-in: only user/runtime/get_channel/fetch_channel/
+    get_user/fetch_user are read."""
+    return SimpleNamespace(
+        user=SimpleNamespace(id=_BOT_USER_ID),
+        runtime=SimpleNamespace(sessionmaker=sessionmaker),
+        get_channel=get_channel or MagicMock(return_value=None),
+        fetch_channel=fetch_channel or AsyncMock(),
+        get_user=get_user or MagicMock(return_value=None),
+        fetch_user=fetch_user or AsyncMock(),
+    )
+
+
+def _spy_on_record_vote(monkeypatch: pytest.MonkeyPatch) -> list[RecordVoteResult]:
+    """Wrap the real `record_vote` the Cog calls, capturing every result.
+
+    An empty list after the handler runs means `record_vote` was never
+    reached -- exactly the "writes nothing" assertion every negative test
+    needs, with no DB read at all.
+    """
+    calls: list[RecordVoteResult] = []
+    original = feedback_reactions.record_vote
+
+    async def _spy(*args: Any, **kwargs: Any) -> RecordVoteResult:
+        result = await original(*args, **kwargs)
+        calls.append(result)
+        return result
+
+    monkeypatch.setattr(feedback_reactions, "record_vote", _spy)
+    return calls
+
+
+# --- basic vote persistence -----------------------------------------------
+
+
+async def test_thumbs_down_by_guild_member_writes_one_row(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1001,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert len(calls) == 1, "exactly one vote must be recorded"
+    row = calls[0].row
+    assert row.tenant_id == tenant.id, "recorded row must carry the resolved tenant"
+    assert row.message_id == "1001", "recorded row must carry the reacted-to message id"
+    assert row.channel_id == "2001", "recorded row must carry the channel id"
+    assert row.platform_user_id == str(_REACTOR_ID), (
+        "recorded row must carry the reactor's platform id"
+    )
+    assert row.vote == "down", "a thumbs-down reaction must record a down vote"
+
+
+async def test_thumbs_up_writes_a_row_with_vote_up(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1002,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS UP SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert len(calls) == 1, "exactly one vote must be recorded"
+    assert calls[0].row.vote == "up", "a thumbs-up reaction must record an up vote"
+
+
+# --- the undocumented-field fallback ---------------------------------------
+
+
+async def test_fallback_fetch_message_authored_by_bot_writes_a_row(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    fetched_message = MagicMock()
+    fetched_message.author.id = _BOT_USER_ID
+    fake_channel = MagicMock(spec=discord.abc.Messageable)
+    fake_channel.fetch_message = AsyncMock(return_value=fetched_message)
+    bot = _fake_bot(
+        sessionmaker=db_session_factory, get_channel=MagicMock(return_value=fake_channel)
+    )
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1003,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=None,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert len(calls) == 1, (
+        "the fallback must record a vote when fetch_message confirms bot authorship"
+    )
+    fake_channel.fetch_message.assert_awaited_once_with(1003)
+
+
+async def test_fallback_fetch_message_authored_by_someone_else_writes_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    fetched_message = MagicMock()
+    fetched_message.author.id = 123456
+    fake_channel = MagicMock(spec=discord.abc.Messageable)
+    fake_channel.fetch_message = AsyncMock(return_value=fetched_message)
+    bot = _fake_bot(
+        sessionmaker=db_session_factory, get_channel=MagicMock(return_value=fake_channel)
+    )
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1004,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=None,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert calls == [], "a reaction to a human-authored message must never be recorded"
+
+
+async def test_fallback_fetch_message_raises_not_found_writes_nothing_and_does_not_raise(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    fake_channel = MagicMock(spec=discord.abc.Messageable)
+    fake_channel.fetch_message = AsyncMock(
+        side_effect=discord.NotFound(MagicMock(status=404), "message not found")
+    )
+    bot = _fake_bot(
+        sessionmaker=db_session_factory, get_channel=MagicMock(return_value=fake_channel)
+    )
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1005,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=None,
+    )
+
+    await cog.on_raw_reaction_add(payload)  # must not raise
+
+    assert calls == [], "an unverifiable author must never resolve to 'assume ours'"
+
+
+async def test_fast_path_does_not_call_fetch_message(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    fake_channel = MagicMock(spec=discord.abc.Messageable)
+    fake_channel.fetch_message = AsyncMock()
+    bot = _fake_bot(
+        sessionmaker=db_session_factory, get_channel=MagicMock(return_value=fake_channel)
+    )
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1006,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    fake_channel.fetch_message.assert_not_called()
+    assert len(calls) == 1, "the fast path must still record the vote"
+
+
+# --- pure gates --------------------------------------------------------------
+
+
+async def test_bots_own_reaction_writes_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1007,
+        channel_id=2001,
+        user_id=_BOT_USER_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert calls == [], "the bot's own seeded reactions must never count as votes"
+
+
+async def test_reaction_with_no_guild_id_writes_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1008,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=None,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)  # must not raise, no tenant to check against
+
+    assert calls == [], "a reaction with no guild resolves no tenant and must not be recorded"
+
+
+async def test_non_vote_emoji_writes_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1009,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{SMILING FACE WITH SMILING EYES}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert calls == [], "a non-vote emoji must never be recorded"
+
+
+async def test_custom_emoji_writes_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1010,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="x",
+        emoji_id=123,
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert calls == [], "a custom emoji must never be recorded, even if it happens to be a thumb"
+
+
+async def test_guild_with_no_tenant_row_writes_nothing_and_does_not_raise(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unprovisioned_guild_id = 777777777777777777
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1011,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=unprovisioned_guild_id,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)  # must not raise
+
+    assert calls == [], "a reaction in an unprovisioned guild must not be recorded"
+
+
+# --- attribution: session hint + account resolution --------------------------
+
+
+async def test_ma_session_id_populated_from_newest_live_session(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    principal = await make_platform_principal(
+        db_session, tenant=tenant, platform="discord", external_id=str(_REACTOR_ID)
+    )
+    await db_session.commit()
+    async with db_session_factory() as seed_session:
+        await create_thread_session(
+            seed_session,
+            tenant_id=tenant.id,
+            platform="discord",
+            thread_id="2001",
+            account_id=principal.account_id,
+            ma_session_id="sesn_live_001",
+        )
+        await seed_session.commit()
+
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1012,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert len(calls) == 1, "vote must be recorded"
+    assert calls[0].row.ma_session_id == "sesn_live_001", (
+        "ma_session_id must be populated from the newest live session in that channel"
+    )
+
+
+async def test_ma_session_id_is_none_when_no_thread_session_exists(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1013,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert len(calls) == 1, "vote must be recorded"
+    assert calls[0].row.ma_session_id is None, (
+        "ma_session_id must be None when no thread session exists"
+    )
+
+
+async def test_account_id_is_none_for_unknown_reactor_and_no_principal_is_created(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1014,
+        channel_id=2001,
+        user_id=_OTHER_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert len(calls) == 1, "vote must be recorded even for an unknown reactor"
+    assert calls[0].row.account_id is None, (
+        "account_id must be None for a reactor with no platform principal"
+    )
+    async with db_session_factory() as verify_session:
+        principal = await find_platform_principal(
+            verify_session,
+            tenant_id=tenant.id,
+            platform="discord",
+            external_id=str(_OTHER_REACTOR_ID),
+        )
+    assert principal is None, (
+        "a bystander's reaction must never mint a permanent platform principal record"
+    )
+
+
+async def test_account_id_populated_for_known_reactor(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    principal = await make_platform_principal(
+        db_session, tenant=tenant, platform="discord", external_id=str(_REACTOR_ID)
+    )
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    bot = _fake_bot(sessionmaker=db_session_factory)
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=1015,
+        channel_id=2001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    assert len(calls) == 1, "vote must be recorded"
+    assert calls[0].row.account_id == principal.account_id, (
+        "account_id must be populated for a reactor with an existing platform principal"
+    )
+
+
+# --- private follow-up on a genuinely new down-vote --------------------------
+
+
+async def test_first_thumbs_down_sends_exactly_one_private_message(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    _spy_on_record_vote(monkeypatch)
+    recipient = MagicMock()
+    recipient.send = AsyncMock()
+    bot = _fake_bot(sessionmaker=db_session_factory, get_user=MagicMock(return_value=recipient))
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=2001,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    recipient.send.assert_awaited_once()
+    kwargs = recipient.send.call_args.kwargs
+    content = kwargs["content"]
+    assert str(_GUILD_ID) in content, "the link must carry the guild id"
+    assert "3001" in content, "the link must carry the channel id"
+    assert "2001" in content, "the link must carry the message id"
+    view = kwargs["view"]
+    assert len(view.children) == 1, "the view must carry exactly one item"
+    button = view.children[0]
+    assert CUSTOM_ID_PATTERN.fullmatch(button.custom_id) is not None, (
+        "the button's custom_id must fullmatch the feedback grammar"
+    )
+
+
+async def test_repeat_thumbs_down_by_same_person_sends_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    recipient = MagicMock()
+    recipient.send = AsyncMock()
+    bot = _fake_bot(sessionmaker=db_session_factory, get_user=MagicMock(return_value=recipient))
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=2002,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+    await cog.on_raw_reaction_add(payload)
+
+    assert recipient.send.await_count == 1, (
+        "a repeat down-vote must not send a second private message"
+    )
+    assert len(calls) == 2, "record_vote is still called each time -- only the DM is suppressed"
+    assert calls[0].row.id == calls[1].row.id, (
+        "a repeat vote upserts the SAME row, never a second one"
+    )
+
+
+async def test_flip_from_up_to_down_sends_exactly_one_private_message(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    _spy_on_record_vote(monkeypatch)
+    recipient = MagicMock()
+    recipient.send = AsyncMock()
+    bot = _fake_bot(sessionmaker=db_session_factory, get_user=MagicMock(return_value=recipient))
+    cog = FeedbackReactionCog(bot)
+    up_payload = _build_payload(
+        message_id=2003,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS UP SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+    down_payload = _build_payload(
+        message_id=2003,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(up_payload)
+    await cog.on_raw_reaction_add(down_payload)
+
+    assert recipient.send.await_count == 1, "a flip from up to down must count as a new down-vote"
+
+
+async def test_flip_from_down_to_up_sends_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    _spy_on_record_vote(monkeypatch)
+    recipient = MagicMock()
+    recipient.send = AsyncMock()
+    bot = _fake_bot(sessionmaker=db_session_factory, get_user=MagicMock(return_value=recipient))
+    cog = FeedbackReactionCog(bot)
+    down_payload = _build_payload(
+        message_id=2004,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+    up_payload = _build_payload(
+        message_id=2004,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS UP SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(down_payload)
+    await cog.on_raw_reaction_add(up_payload)
+
+    assert recipient.send.await_count == 1, "only the down-vote should have triggered a prompt"
+
+
+async def test_thumbs_up_alone_sends_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    _spy_on_record_vote(monkeypatch)
+    recipient = MagicMock()
+    recipient.send = AsyncMock()
+    bot = _fake_bot(sessionmaker=db_session_factory, get_user=MagicMock(return_value=recipient))
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=2005,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS UP SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)
+
+    recipient.send.assert_not_awaited()
+
+
+async def test_closed_dms_still_leave_the_vote_recorded(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    calls = _spy_on_record_vote(monkeypatch)
+    recipient = MagicMock()
+    recipient.send = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(status=403), "Cannot send messages to this user")
+    )
+    bot = _fake_bot(sessionmaker=db_session_factory, get_user=MagicMock(return_value=recipient))
+    cog = FeedbackReactionCog(bot)
+    payload = _build_payload(
+        message_id=2006,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload)  # must not raise
+
+    assert len(calls) == 1, (
+        "a reactor with closed direct messages must still have their vote recorded"
+    )
+
+
+async def test_two_different_people_each_receive_one_private_message(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await make_tenant(db_session, workspace_id=str(_GUILD_ID))
+    await db_session.commit()
+    _spy_on_record_vote(monkeypatch)
+    recipients: dict[int, MagicMock] = {
+        _REACTOR_ID: MagicMock(send=AsyncMock()),
+        _OTHER_REACTOR_ID: MagicMock(send=AsyncMock()),
+    }
+
+    def _lookup_recipient(user_id: int) -> MagicMock:
+        return recipients[user_id]
+
+    bot = _fake_bot(
+        sessionmaker=db_session_factory,
+        get_user=MagicMock(side_effect=_lookup_recipient),
+    )
+    cog = FeedbackReactionCog(bot)
+    payload_a = _build_payload(
+        message_id=2007,
+        channel_id=3001,
+        user_id=_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+    payload_b = _build_payload(
+        message_id=2007,
+        channel_id=3001,
+        user_id=_OTHER_REACTOR_ID,
+        guild_id=_GUILD_ID,
+        emoji_name="\N{THUMBS DOWN SIGN}",
+        message_author_id=_BOT_USER_ID,
+    )
+
+    await cog.on_raw_reaction_add(payload_a)
+    await cog.on_raw_reaction_add(payload_b)
+
+    recipients[_REACTOR_ID].send.assert_awaited_once()
+    recipients[_OTHER_REACTOR_ID].send.assert_awaited_once()

--- a/packages/adapters/discord/tests/test_feedback_seed.py
+++ b/packages/adapters/discord/tests/test_feedback_seed.py
@@ -80,6 +80,30 @@ async def test_seed_when_first_add_reaction_raises_forbidden_returns_normally() 
     await seed_feedback_reactions(channel, message_id="123")  # must not raise
 
 
+async def test_seed_when_add_reaction_raises_a_connection_error_returns_normally() -> None:
+    """An aiohttp/OSError surviving discord.py's retry loop is not an HTTPException.
+
+    It runs after the answer was already delivered, so letting it escape would
+    post a "turn failed" message under a successful answer.
+    """
+    partial = MagicMock()
+    partial.add_reaction = AsyncMock(side_effect=OSError("connection reset by peer"))
+    channel = MagicMock()
+    channel.get_partial_message = MagicMock(return_value=partial)
+
+    await seed_feedback_reactions(channel, message_id="123")  # must not raise
+
+
+async def test_seed_when_add_reaction_raises_on_a_closed_session_returns_normally() -> None:
+    """Shutdown drain: aiohttp raises RuntimeError once the session is closed."""
+    partial = MagicMock()
+    partial.add_reaction = AsyncMock(side_effect=RuntimeError("Session is closed"))
+    channel = MagicMock()
+    channel.get_partial_message = MagicMock(return_value=partial)
+
+    await seed_feedback_reactions(channel, message_id="123")  # must not raise
+
+
 async def test_seed_is_a_no_op_for_a_channel_type_without_get_partial_message() -> None:
     channel = MagicMock(spec=[])  # no attributes at all, including get_partial_message
 

--- a/packages/adapters/discord/tests/test_feedback_seed.py
+++ b/packages/adapters/discord/tests/test_feedback_seed.py
@@ -1,0 +1,466 @@
+"""Tests for seed_feedback_reactions -- the best-effort seeding helper, and
+its wiring into _orchestrate's terminal-success branch.
+
+The unit tests below need no database. The integration tests drive
+`DaimonBot._orchestrate` end to end the way `test_orchestration.py` does,
+duplicating just enough of that file's setup helpers inline (per this
+codebase's testing guideline: don't share fixtures across test modules,
+inline what each file needs).
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import BetaEnvironment, BetaManagedAgentsAgent, BetaManagedAgentsSession
+from anthropic.types.beta.beta_cloud_config import BetaCloudConfig
+from anthropic.types.beta.beta_managed_agents_model_config import BetaManagedAgentsModelConfig
+from anthropic.types.beta.beta_managed_agents_session_agent import BetaManagedAgentsSessionAgent
+from anthropic.types.beta.beta_managed_agents_session_stats import BetaManagedAgentsSessionStats
+from anthropic.types.beta.beta_managed_agents_session_usage import BetaManagedAgentsSessionUsage
+from anthropic.types.beta.beta_packages import BetaPackages
+from anthropic.types.beta.beta_unrestricted_network import BetaUnrestrictedNetwork
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.feedback_seed import seed_feedback_reactions
+from daimon.adapters.discord.runtime import DiscordRuntime, build_turn_deps
+from daimon.core.config import McpSettings
+from daimon.core.errors import TurnError
+from daimon.core.ma_resolver import ResolverCache, new_resolver_cache
+from daimon.core.message_feedback import THUMBS_DOWN, THUMBS_UP
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault, ResolvedConfig
+from daimon.core.stores import tenant_ledger
+from daimon.core.turn.deps import TurnDeps
+from daimon.core.turn.state import TextBlock, TurnState
+from daimon.testing.factories import make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+# --- unit tests: the helper alone -------------------------------------------
+
+
+async def test_seed_adds_positive_then_negative_emoji() -> None:
+    partial = MagicMock()
+    partial.add_reaction = AsyncMock()
+    channel = MagicMock()
+    channel.get_partial_message = MagicMock(return_value=partial)
+
+    await seed_feedback_reactions(channel, message_id="123")
+
+    assert partial.add_reaction.await_count == 2, "both emoji must be added"
+    first_call, second_call = partial.add_reaction.await_args_list
+    assert first_call.args[0] == THUMBS_UP, "the positive emoji must be added first"
+    assert second_call.args[0] == THUMBS_DOWN, "the negative emoji must be added second"
+
+
+async def test_seed_when_add_reaction_raises_forbidden_returns_normally() -> None:
+    partial = MagicMock()
+    partial.add_reaction = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(status=403), "no perms")
+    )
+    channel = MagicMock()
+    channel.get_partial_message = MagicMock(return_value=partial)
+
+    await seed_feedback_reactions(channel, message_id="123")  # must not raise
+
+
+async def test_seed_when_first_add_reaction_raises_forbidden_returns_normally() -> None:
+    partial = MagicMock()
+    partial.add_reaction = AsyncMock(
+        side_effect=[discord.Forbidden(MagicMock(status=403), "no perms"), None]
+    )
+    channel = MagicMock()
+    channel.get_partial_message = MagicMock(return_value=partial)
+
+    await seed_feedback_reactions(channel, message_id="123")  # must not raise
+
+
+async def test_seed_is_a_no_op_for_a_channel_type_without_get_partial_message() -> None:
+    channel = MagicMock(spec=[])  # no attributes at all, including get_partial_message
+
+    await seed_feedback_reactions(channel, message_id="123")  # must not raise
+
+
+# --- integration: wired into _orchestrate's terminal-success branch --------
+
+
+def _make_fake_session(session_id: str = "sess_test") -> BetaManagedAgentsSession:
+    return BetaManagedAgentsSession(
+        id=session_id,
+        agent=BetaManagedAgentsSessionAgent(
+            id="agent_test",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-5"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at="2026-04-28T00:00:00Z",
+        environment_id="env_test",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at="2026-04-28T00:00:00Z",
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+        outcome_evaluations=[],
+    )
+
+
+def _make_fake_agent(name: str = "test-agent") -> BetaManagedAgentsAgent:
+    return BetaManagedAgentsAgent(
+        id="ag_test",
+        version=1,
+        name=name,
+        type="agent",
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-5"),
+        created_at=datetime(2026, 4, 28, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 28, tzinfo=UTC),
+        mcp_servers=[],
+        metadata={},
+        skills=[],
+        tools=[],
+    )
+
+
+def _make_fake_environment(name: str = "test-env") -> BetaEnvironment:
+    return BetaEnvironment(
+        id="env_test",
+        name=name,
+        type="environment",
+        config=BetaCloudConfig(
+            type="cloud",
+            networking=BetaUnrestrictedNetwork(type="unrestricted"),
+            packages=BetaPackages(apt=[], cargo=[], gem=[], go=[], npm=[], pip=[]),
+        ),
+        created_at="2026-04-28T00:00:00Z",
+        updated_at="2026-04-28T00:00:00Z",
+        description="",
+        metadata={},
+    )
+
+
+def _make_turn_deps(
+    settings: MagicMock,
+    anthropic: AsyncAnthropic,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    resolver_cache: ResolverCache,
+    deployment_default: DeploymentDefault,
+) -> TurnDeps:
+    return build_turn_deps(
+        settings,
+        anthropic,
+        sessionmaker,
+        deployment_default=deployment_default,
+        resolver_cache=resolver_cache,
+        billing_config=None,
+    )
+
+
+def _make_runtime(sessionmaker: async_sessionmaker[AsyncSession]) -> DiscordRuntime:
+    settings = MagicMock()
+    settings.mcp = McpSettings()
+    settings.billing.markup = Decimal("1.0")
+    settings.billing.signup_credit = Decimal("0")
+    discord_settings = MagicMock()
+    discord_settings.max_concurrent_turns_per_tenant = 100
+    settings.discord = discord_settings
+    anthropic = AsyncMock()
+    anthropic.beta.agents.retrieve = AsyncMock(return_value=_make_fake_agent())
+    anthropic.beta.environments.retrieve = AsyncMock(return_value=_make_fake_environment())
+    resolver_cache = new_resolver_cache()
+    deployment_default = DeploymentDefault()
+    return DiscordRuntime(
+        settings=settings,
+        anthropic=anthropic,
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=deployment_default,
+        resolver_cache=resolver_cache,
+        turn_deps=_make_turn_deps(
+            settings,
+            anthropic,
+            sessionmaker,
+            resolver_cache=resolver_cache,
+            deployment_default=deployment_default,
+        ),
+    )
+
+
+def _make_bot(runtime: DiscordRuntime) -> DaimonBot:
+    intents = discord.Intents.default()
+    intents.message_content = True
+    bot = DaimonBot(runtime=runtime, intents=intents)
+    bot._connection.user = MagicMock(spec=discord.ClientUser)  # pyright: ignore[reportPrivateUsage]
+    bot._connection.user.id = 999  # pyright: ignore[reportPrivateUsage]
+    bot._connection.user.mentioned_in = MagicMock(return_value=True)  # pyright: ignore[reportPrivateUsage]
+    return bot
+
+
+class _AsyncIter:
+    def __init__(self, items: list[discord.Message]) -> None:
+        self._items = iter(items)
+
+    def __aiter__(self) -> _AsyncIter:
+        return self
+
+    async def __anext__(self) -> discord.Message:
+        try:
+            return next(self._items)
+        except StopIteration as err:
+            raise StopAsyncIteration from err
+
+
+def _make_channel_message(
+    *,
+    content: str = "<@999> hello",
+    guild_id: int = 123456,
+    channel_id: int = 789,
+    author_id: int = 111,
+) -> discord.Message:
+    message = MagicMock(spec=discord.Message)
+    message.content = content
+    message.author = MagicMock()
+    message.author.bot = False
+    message.author.id = author_id
+    message.guild = MagicMock(spec=discord.Guild)
+    message.guild.id = guild_id
+    message.channel = MagicMock()
+    message.channel.__class__ = discord.TextChannel
+    message.channel.id = channel_id
+    message.channel.send = AsyncMock()
+    message.channel.history = MagicMock(return_value=_AsyncIter([]))
+    message.create_thread = AsyncMock()
+    message.add_reaction = AsyncMock()
+    message.attachments = []
+    message.mentions = [types.SimpleNamespace(id=999)]
+    return message
+
+
+def _stub_resolved_config() -> ResolvedConfig:
+    return ResolvedConfig(
+        agent_name="test-agent",
+        agent_name_tier="tenant",
+        environment_name="test-env",
+        environment_name_tier="tenant",
+    )
+
+
+async def _seed_balance(db_session: AsyncSession, tenant_id: uuid.UUID) -> None:
+    await tenant_ledger.insert_entry(
+        db_session,
+        tenant_id=tenant_id,
+        delta_usd=Decimal("100.00"),
+        reason="trial",
+        idempotency_key=f"trial:{tenant_id}",
+    )
+    await db_session.flush()
+
+
+def _make_seeding_thread() -> MagicMock:
+    """A mock_thread whose get_partial_message returns an AsyncMock-backed partial."""
+    bot_reply_msg = MagicMock(spec=discord.Message)
+    bot_reply_msg.id = 777888999
+    mock_thread = MagicMock(spec=discord.Thread)
+    mock_thread.id = 9999
+    mock_thread.send = AsyncMock(return_value=bot_reply_msg)
+    partial = MagicMock()
+    partial.add_reaction = AsyncMock()
+    mock_thread.get_partial_message = MagicMock(return_value=partial)
+    return mock_thread
+
+
+def _fake_run_turn(final_state: TurnState) -> object:
+    """Build a `run_turn` side_effect that actually drives the terminal
+    lifecycle hook, the way the real driver does -- a bare `.return_value`
+    on the mocked `run_turn` skips the hook entirely, so `was_answered`
+    would never flip regardless of what `TurnState` is returned.
+    """
+
+    async def _run(*, lifecycle: object, **_kwargs: object) -> TurnState:
+        if final_state.error is not None:
+            await lifecycle.on_terminal_failure(final_state, final_state.error)  # type: ignore[attr-defined]
+        else:
+            await lifecycle.on_terminal_success(final_state)  # type: ignore[attr-defined]
+        return final_state
+
+    return _run
+
+
+@patch("daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock)
+@patch("daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock)
+@patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock)
+@patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock)
+@patch("daimon.core.turn.admission.resolve_config", new_callable=AsyncMock)
+async def test_a_real_text_answer_seeds_both_emoji_on_the_final_message(
+    mock_resolve: AsyncMock,
+    mock_create_session: AsyncMock,
+    mock_run_turn: AsyncMock,
+    mock_find_env: AsyncMock,
+    mock_find_agent: AsyncMock,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="123456")
+    await _seed_balance(db_session, tenant.id)
+
+    mock_resolve.return_value = _stub_resolved_config()
+    mock_create_session.return_value = _make_fake_session("sess-seed-1")
+    mock_run_turn.side_effect = _fake_run_turn(
+        TurnState(content=[TextBlock(kind="text", text="the answer")])
+    )
+    mock_find_agent.return_value = "ag_test"
+    mock_find_env.return_value = "env_test"
+
+    runtime = _make_runtime(db_session_factory)
+    bot = _make_bot(runtime)
+    message = _make_channel_message()
+    mock_thread = _make_seeding_thread()
+    message.create_thread.return_value = mock_thread  # pyright: ignore[reportAttributeAccessIssue]
+
+    await bot.on_message(message)
+
+    mock_thread.get_partial_message.assert_called_once_with(777888999)
+    assert mock_thread.get_partial_message.return_value.add_reaction.await_count == 2, (
+        "an answered turn must seed both vote emoji on its final message"
+    )
+
+
+@patch("daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock)
+@patch("daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock)
+@patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock)
+@patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock)
+@patch("daimon.core.turn.admission.resolve_config", new_callable=AsyncMock)
+async def test_a_cancelled_turn_seeds_nothing(
+    mock_resolve: AsyncMock,
+    mock_create_session: AsyncMock,
+    mock_run_turn: AsyncMock,
+    mock_find_env: AsyncMock,
+    mock_find_agent: AsyncMock,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="123457")
+    await _seed_balance(db_session, tenant.id)
+
+    mock_resolve.return_value = _stub_resolved_config()
+    mock_create_session.return_value = _make_fake_session("sess-seed-2")
+    mock_run_turn.side_effect = _fake_run_turn(
+        TurnState()
+    )  # no content/error -- cancellation shape
+    mock_find_agent.return_value = "ag_test"
+    mock_find_env.return_value = "env_test"
+
+    runtime = _make_runtime(db_session_factory)
+    bot = _make_bot(runtime)
+    message = _make_channel_message(guild_id=123457)
+    mock_thread = _make_seeding_thread()
+    message.create_thread.return_value = mock_thread  # pyright: ignore[reportAttributeAccessIssue]
+
+    await bot.on_message(message)
+
+    mock_thread.get_partial_message.assert_not_called()
+
+
+@patch("daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock)
+@patch("daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock)
+@patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock)
+@patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock)
+@patch("daimon.core.turn.admission.resolve_config", new_callable=AsyncMock)
+async def test_a_turn_that_ends_in_error_seeds_nothing(
+    mock_resolve: AsyncMock,
+    mock_create_session: AsyncMock,
+    mock_run_turn: AsyncMock,
+    mock_find_env: AsyncMock,
+    mock_find_agent: AsyncMock,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="123458")
+    await _seed_balance(db_session, tenant.id)
+
+    mock_resolve.return_value = _stub_resolved_config()
+    mock_create_session.return_value = _make_fake_session("sess-seed-3")
+    mock_run_turn.side_effect = _fake_run_turn(
+        TurnState(error=TurnError(kind="reducer_bug", message="boom", cause=RuntimeError("boom")))
+    )
+    mock_find_agent.return_value = "ag_test"
+    mock_find_env.return_value = "env_test"
+
+    runtime = _make_runtime(db_session_factory)
+    bot = _make_bot(runtime)
+    message = _make_channel_message(guild_id=123458)
+    mock_thread = _make_seeding_thread()
+    message.create_thread.return_value = mock_thread  # pyright: ignore[reportAttributeAccessIssue]
+
+    await bot.on_message(message)
+
+    mock_thread.get_partial_message.assert_not_called()
+
+
+@patch("daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock)
+@patch("daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock)
+@patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock)
+@patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock)
+@patch("daimon.core.turn.admission.resolve_config", new_callable=AsyncMock)
+async def test_seeding_forbidden_still_completes_the_turn_and_writes_the_watermark(
+    mock_resolve: AsyncMock,
+    mock_create_session: AsyncMock,
+    mock_run_turn: AsyncMock,
+    mock_find_env: AsyncMock,
+    mock_find_agent: AsyncMock,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from daimon.core.stores.identity import get_or_create_platform_principal
+    from daimon.core.stores.thread_sessions import get_live_thread_session
+
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="123459")
+    await _seed_balance(db_session, tenant.id)
+    principal = await get_or_create_platform_principal(
+        db_session, tenant_id=tenant.id, platform="discord", external_id="111"
+    )
+    await db_session.commit()
+
+    mock_resolve.return_value = _stub_resolved_config()
+    mock_create_session.return_value = _make_fake_session("sess-seed-4")
+    mock_run_turn.side_effect = _fake_run_turn(
+        TurnState(content=[TextBlock(kind="text", text="the answer")])
+    )
+    mock_find_agent.return_value = "ag_test"
+    mock_find_env.return_value = "env_test"
+
+    runtime = _make_runtime(db_session_factory)
+    bot = _make_bot(runtime)
+    message = _make_channel_message(guild_id=123459)
+    mock_thread = _make_seeding_thread()
+    mock_thread.get_partial_message.return_value.add_reaction = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(status=403), "no perms")
+    )
+    message.create_thread.return_value = mock_thread  # pyright: ignore[reportAttributeAccessIssue]
+
+    await bot.on_message(message)  # must not raise
+
+    async with db_session_factory() as verify_session:
+        row = await get_live_thread_session(
+            verify_session,
+            tenant_id=tenant.id,
+            platform="discord",
+            thread_id="9999",
+            account_id=principal.account_id,
+        )
+    assert row is not None, "the turn must still complete and persist its session mapping"
+    assert row.watermark_message_id == "777888999", (
+        "seeding failure must not prevent the watermark write"
+    )

--- a/packages/adapters/discord/tests/test_feedback_seed.py
+++ b/packages/adapters/discord/tests/test_feedback_seed.py
@@ -10,6 +10,7 @@ inline what each file needs).
 
 from __future__ import annotations
 
+import re
 import types
 import uuid
 from datetime import UTC, datetime
@@ -17,6 +18,7 @@ from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
+import httpx
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import BetaEnvironment, BetaManagedAgentsAgent, BetaManagedAgentsSession
 from anthropic.types.beta.beta_cloud_config import BetaCloudConfig
@@ -39,6 +41,7 @@ from daimon.core.stores import tenant_ledger
 from daimon.core.turn.deps import TurnDeps
 from daimon.core.turn.state import TextBlock, TurnState
 from daimon.testing.factories import make_tenant
+from daimon.testing.ma import MARouter, build_stub_anthropic
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 # --- unit tests: the helper alone -------------------------------------------
@@ -140,37 +143,52 @@ def _make_fake_session(session_id: str = "sess_test") -> BetaManagedAgentsSessio
     )
 
 
-def _make_fake_agent(name: str = "test-agent") -> BetaManagedAgentsAgent:
-    return BetaManagedAgentsAgent(
-        id="ag_test",
-        version=1,
-        name=name,
-        type="agent",
-        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-5"),
-        created_at=datetime(2026, 4, 28, tzinfo=UTC),
-        updated_at=datetime(2026, 4, 28, tzinfo=UTC),
-        mcp_servers=[],
-        metadata={},
-        skills=[],
-        tools=[],
-    )
+def _build_ma_router() -> MARouter:
+    """Serve the agent/environment retrieves admission makes, transport-level.
 
+    A method-level `AsyncMock` on `client.beta.*` would accept any kwargs and
+    silently absorb SDK-signature drift, which is why the testing guideline
+    bans it; routing real Beta models through `httpx.MockTransport` runs the
+    SDK's own parameter validation and response parsing in every test.
+    """
 
-def _make_fake_environment(name: str = "test-env") -> BetaEnvironment:
-    return BetaEnvironment(
-        id="env_test",
-        name=name,
-        type="environment",
-        config=BetaCloudConfig(
-            type="cloud",
-            networking=BetaUnrestrictedNetwork(type="unrestricted"),
-            packages=BetaPackages(apt=[], cargo=[], gem=[], go=[], npm=[], pip=[]),
-        ),
-        created_at="2026-04-28T00:00:00Z",
-        updated_at="2026-04-28T00:00:00Z",
-        description="",
-        metadata={},
-    )
+    def _retrieve_agent(_request: httpx.Request, _match: re.Match[str]) -> httpx.Response:
+        agent = BetaManagedAgentsAgent(
+            id="ag_test",
+            version=1,
+            name="test-agent",
+            type="agent",
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-5"),
+            created_at=datetime(2026, 4, 28, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 28, tzinfo=UTC),
+            mcp_servers=[],
+            metadata={},
+            skills=[],
+            tools=[],
+        )
+        return httpx.Response(200, json=agent.model_dump(mode="json"))
+
+    def _retrieve_environment(_request: httpx.Request, _match: re.Match[str]) -> httpx.Response:
+        environment = BetaEnvironment(
+            id="env_test",
+            name="test-env",
+            type="environment",
+            config=BetaCloudConfig(
+                type="cloud",
+                networking=BetaUnrestrictedNetwork(type="unrestricted"),
+                packages=BetaPackages(apt=[], cargo=[], gem=[], go=[], npm=[], pip=[]),
+            ),
+            created_at="2026-04-28T00:00:00Z",
+            updated_at="2026-04-28T00:00:00Z",
+            description="",
+            metadata={},
+        )
+        return httpx.Response(200, json=environment.model_dump(mode="json"))
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents/[^/]+", _retrieve_agent)
+    router.add("GET", r"/v1/environments/[^/]+", _retrieve_environment)
+    return router
 
 
 def _make_turn_deps(
@@ -199,9 +217,7 @@ def _make_runtime(sessionmaker: async_sessionmaker[AsyncSession]) -> DiscordRunt
     discord_settings = MagicMock()
     discord_settings.max_concurrent_turns_per_tenant = 100
     settings.discord = discord_settings
-    anthropic = AsyncMock()
-    anthropic.beta.agents.retrieve = AsyncMock(return_value=_make_fake_agent())
-    anthropic.beta.environments.retrieve = AsyncMock(return_value=_make_fake_environment())
+    anthropic = build_stub_anthropic(_build_ma_router().dispatch)
     resolver_cache = new_resolver_cache()
     deployment_default = DeploymentDefault()
     return DiscordRuntime(

--- a/packages/adapters/discord/tests/test_lifecycle.py
+++ b/packages/adapters/discord/tests/test_lifecycle.py
@@ -645,6 +645,74 @@ def _terminal_embed(edits: list[tuple[Any, dict[str, Any]]]) -> discord.Embed:
     raise AssertionError("no terminal embed was flushed")
 
 
+class TestWasAnswered:
+    async def test_was_answered_is_false_when_no_terminal_hook_called(
+        self,
+    ) -> None:
+        """A lifecycle that never reached a terminal hook has not answered."""
+        lc, _sends, _edits = _make_lifecycle()
+
+        assert lc.was_answered is False, (
+            "a lifecycle with no terminal hook called must not report an answer"
+        )
+
+    async def test_was_answered_is_true_when_terminal_success_produces_final_text(self) -> None:
+        """A real text answer marks the turn as answered."""
+        lc, _sends, _edits = _make_lifecycle()
+        await lc.on_sse_event(_thinking_event())
+
+        state = TurnState(content=[TextBlock(kind="text", text="Hello response")])
+        await lc.on_terminal_success(state)
+
+        assert lc.was_answered is True, "a turn that produced final text must report an answer"
+
+    async def test_was_answered_is_true_when_terminal_success_has_tool_only_ending(self) -> None:
+        """Tool activity with no final text still counts as answered, and must
+        not be confused with a cancellation."""
+        lc, _sends, edits = _make_lifecycle()
+        await lc.on_sse_event(_thinking_event())
+
+        state = TurnState(
+            content=[
+                TextBlock(kind="text", text="I'll run that."),
+                ToolUseBlock(
+                    kind="tool_use", id="tu_1", type="agent.tool_use", name="bash", input={}
+                ),
+            ]
+        )
+        await lc.on_terminal_success(state)
+
+        assert lc.was_answered is True, "visible tool activity must report an answer"
+        assert all(e[1].get("content") != "Turn cancelled." for e in edits), (
+            "a turn with tool activity must not be rendered as a cancellation"
+        )
+
+    async def test_was_answered_is_false_when_terminal_success_has_empty_content(self) -> None:
+        """A cancelled turn -- no text, no tool activity -- must not report an
+        answer, and the rendered message must agree."""
+        lc, _sends, edits = _make_lifecycle()
+        await lc.on_sse_event(_thinking_event())
+
+        state = TurnState()  # completely empty content
+        await lc.on_terminal_success(state)
+
+        assert lc.was_answered is False, "a cancelled turn must not report an answer"
+        cancel_edit = edits[-1]
+        assert cancel_edit[1].get("content") == "Turn cancelled.", (
+            "a cancelled turn must render as 'Turn cancelled.'"
+        )
+
+    async def test_was_answered_is_false_when_terminal_failure(self) -> None:
+        """A failed turn must not report an answer."""
+        lc, _sends, _edits = _make_lifecycle()
+        await lc.on_sse_event(_thinking_event())
+
+        state = TurnState()
+        await lc.on_terminal_failure(state, Exception("boom"))
+
+        assert lc.was_answered is False, "a failed turn must not report an answer"
+
+
 class TestTurnSummaryFooter:
     async def test_priced_model_sets_cost_str(self) -> None:
         lc, _sends, edits = _make_lifecycle(model_id="claude-sonnet-4-6")

--- a/packages/adapters/discord/tests/test_orchestration.py
+++ b/packages/adapters/discord/tests/test_orchestration.py
@@ -897,6 +897,9 @@ class TestSetupHook:
         privacy_mod.PrivacyCog = mock_privacy_cog  # type: ignore[attr-defined]
         memory_mod = types.ModuleType("daimon.adapters.discord.commands.memory")
         memory_mod.MemoryCog = mock_memory_cog  # type: ignore[attr-defined]
+        mock_feedback_reaction_cog = MagicMock()
+        feedback_reactions_mod = types.ModuleType("daimon.adapters.discord.feedback_reactions")
+        feedback_reactions_mod.FeedbackReactionCog = mock_feedback_reaction_cog  # type: ignore[attr-defined]
 
         add_cog_calls: list[object] = []
 
@@ -914,17 +917,19 @@ class TestSetupHook:
                 "daimon.adapters.discord.commands.billing": billing_mod,
                 "daimon.adapters.discord.commands.privacy": privacy_mod,
                 "daimon.adapters.discord.commands.memory": memory_mod,
+                "daimon.adapters.discord.feedback_reactions": feedback_reactions_mod,
             },
         ):
             await bot.setup_hook()
 
-        assert len(add_cog_calls) == 6, "setup_hook should add exactly 6 Cogs"
+        assert len(add_cog_calls) == 7, "setup_hook should add exactly 7 Cogs"
         mock_help_cog.assert_called_once_with(bot)
         mock_agent_setup_cog.assert_called_once_with(bot)
         mock_routines_cog.assert_called_once_with(bot)
         mock_billing_cog.assert_called_once_with(bot)
         mock_privacy_cog.assert_called_once_with(bot)
         mock_memory_cog.assert_called_once_with(bot)
+        mock_feedback_reaction_cog.assert_called_once_with(bot)
 
 
 class TestBillingAdmissionGate:

--- a/packages/adapters/discord/tests/test_views.py
+++ b/packages/adapters/discord/tests/test_views.py
@@ -7,10 +7,23 @@ from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
+from daimon.adapters.discord import views
 from daimon.adapters.discord.views import (
     CancelView,
     GuardedView,
 )
+
+
+def test_module_docstring_names_both_persistent_button_exceptions() -> None:
+    docstring = views.__doc__ or ""
+    assert "CredentialRequestButton" in docstring, (
+        "this docstring is the only place the view-persistence rule is written down, "
+        "so a persistent component that does not appear here is an undocumented exception"
+    )
+    assert "FeedbackButton" in docstring, (
+        "this docstring is the only place the view-persistence rule is written down, "
+        "so a new persistent component that does not appear here is an undocumented exception"
+    )
 
 
 def _mock_interaction(*, user_id: int) -> MagicMock:

--- a/packages/adapters/slack/tests/test_privacy_panel.py
+++ b/packages/adapters/slack/tests/test_privacy_panel.py
@@ -309,6 +309,7 @@ def _make_preview(**overrides: Any) -> PurgePreview:
         "slack_turn_contexts": PurgePreviewRow(count=0, example=None),
         "credential_requests": PurgePreviewRow(count=0, example=None),
         "wizard_sessions": PurgePreviewRow(count=0, example=None),
+        "message_feedback": PurgePreviewRow(count=0, example=None),
     }
     base.update(overrides)
     return PurgePreview(**base)

--- a/packages/core/alembic/versions/0005_message_feedback.py
+++ b/packages/core/alembic/versions/0005_message_feedback.py
@@ -1,0 +1,84 @@
+"""message_feedback — one row per (tenant, message, voter) reaction vote.
+
+`platform_user_id` is the real identity key, not `account_id`: a person who
+reacts without ever having taken a turn has no `accounts` row, so
+`account_id` resolves to NULL, and NULL cannot serve as an upsert conflict
+target. `account_id` is kept as a nullable best-effort foreign key so later
+reads can join, and so an account-scoped erasure reaches these rows
+directly. `tenant_id` is NOT NULL and cascades on tenant teardown.
+
+downgrade: safe
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0005_message_feedback"
+down_revision: str | None = "0004_wizard_session"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "message_feedback",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("tenant_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("account_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("platform", sa.Text(), nullable=False),
+        sa.Column("message_id", sa.Text(), nullable=False),
+        sa.Column("channel_id", sa.Text(), nullable=False),
+        sa.Column("platform_user_id", sa.Text(), nullable=False),
+        sa.Column("ma_session_id", sa.Text(), nullable=True),
+        sa.Column("vote", sa.Text(), nullable=False),
+        sa.Column("feedback_text", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_message_feedback"),
+        sa.ForeignKeyConstraint(
+            ["tenant_id"],
+            ["tenants.id"],
+            ondelete="CASCADE",
+            name="fk_message_feedback_tenant_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["account_id"],
+            ["accounts.id"],
+            ondelete="CASCADE",
+            name="fk_message_feedback_account_id",
+        ),
+        sa.UniqueConstraint(
+            "tenant_id",
+            "message_id",
+            "platform_user_id",
+            name="uq_message_feedback_tenant_message_user",
+        ),
+    )
+    op.create_index(
+        "message_feedback_tenant_idx",
+        "message_feedback",
+        ["tenant_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("message_feedback_tenant_idx", table_name="message_feedback")
+    op.drop_table("message_feedback")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -855,6 +855,70 @@ class CredentialRequest(Base):
     used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
+class MessageFeedback(Base):
+    """One row per (tenant, message, voter) thumbs-up/down reaction vote.
+
+    `platform_user_id` is the real identity key, not `account_id`: a person
+    who reacts without ever having taken a turn has no `accounts` row, so
+    `account_id` resolves to NULL, and NULL cannot serve as an upsert conflict
+    target. `account_id` is kept as a nullable best-effort foreign key so
+    later reads can join, and so an account-scoped erasure reaches these rows
+    directly.
+
+    `ma_session_id` is a hint, not a join key. It is resolved at write time
+    from the most recent live session in the reacted-to channel. When one
+    caller owns the thread — the ordinary case, because threads are created
+    per mention — it is exact. When several callers hold live sessions in the
+    same thread it names the most recently created one, which may not be the
+    session that authored the specific message. Any future analysis must
+    treat it accordingly.
+
+    `tenant_id` is NOT NULL and cascades on tenant teardown; a reaction with
+    no resolvable tenant is dropped upstream rather than stored with a null
+    isolation key.
+    """
+
+    __tablename__ = "message_feedback"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "message_id",
+            "platform_user_id",
+            name="uq_message_feedback_tenant_message_user",
+        ),
+        Index("message_feedback_tenant_idx", "tenant_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    account_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("accounts.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    platform: Mapped[str] = mapped_column(Text, nullable=False)
+    message_id: Mapped[str] = mapped_column(Text, nullable=False)
+    channel_id: Mapped[str] = mapped_column(Text, nullable=False)
+    platform_user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    ma_session_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    vote: Mapped[str] = mapped_column(Text, nullable=False)
+    feedback_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
 class WizardSession(Base):
     """Durable state for one multi-step wizard form (`daimon.core.wizard`).
 

--- a/packages/core/daimon/core/message_feedback.py
+++ b/packages/core/daimon/core/message_feedback.py
@@ -1,0 +1,126 @@
+"""Pure vote-decision logic and the feedback-button `custom_id` grammar.
+
+This module lives in `daimon.core`, not the Discord adapter, for the same
+reason `daimon.core.credential_requests` does: the encode/decode contract for
+a persistent-button `custom_id` belongs one level above the adapter that
+renders the widget, so any future caller (a store, a reaction listener, a
+button handler) can share the same grammar without importing an adapter
+package.
+
+`CUSTOM_ID_PATTERN` MUST fullmatch every minted custom_id, and its prefix
+must stay disjoint from every other registered dynamic-item template's
+prefix. discord.py's `dispatch_dynamic_items` calls `pattern.fullmatch` on an
+incoming custom_id against EVERY registered template, with no early break --
+two overlapping templates would both fullmatch a single click and both
+handlers would fire. `CUSTOM_ID_PREFIX` here (`mfb:`) is therefore
+deliberately disjoint from the credential-request button's `ztc:` prefix.
+
+The custom_id carries the feedback row's own primary key (a UUID) rather
+than the Discord message id, because the button is delivered into a direct
+message, where no guild id is available to reconstruct the tenant-scoped
+`(tenant_id, message_id, platform_user_id)` uniqueness key the vote is
+actually keyed on -- the row id is the only handle that is self-sufficient
+there. It is a random UUID, so it is not enumerable, and the write path that
+consumes it additionally gates on the clicking user's own platform id.
+
+Message feedback is deliberately Discord-only. A reaction event on either
+platform carries no interaction handle of its own, so both platforms would
+need the same button-in-DM bridge to turn a down-vote into private feedback
+-- the actual blocker is that Slack's bot token lacks the two scopes that
+bridge would need: `reactions:read` (observe the reaction at all) and
+`im:write` (open the direct message to collect feedback). Adding either
+scope forces every installed workspace through a re-authorization flow, so
+the Discord-only scope is a deliberate, not accidental, exemption.
+`tests/parity/test_message_feedback_discord_only.py` is the executable
+record of that exemption -- it fails the day Slack's bot scopes grow either
+`reactions:read` or `im:write` without a Slack feedback path landing
+alongside them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final, Literal
+
+Vote = Literal["up", "down"]
+
+THUMBS_UP: Final[str] = "\N{THUMBS UP SIGN}"
+THUMBS_DOWN: Final[str] = "\N{THUMBS DOWN SIGN}"
+
+CUSTOM_ID_PREFIX: Final[str] = "mfb:"
+
+CUSTOM_ID_TEMPLATE: Final[str] = (
+    r"mfb:(?P<feedback_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"
+    r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
+CUSTOM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(CUSTOM_ID_TEMPLATE)
+
+
+def build_custom_id(feedback_id: str) -> str:
+    """Return the wire `custom_id` for a feedback row's primary key."""
+    return f"{CUSTOM_ID_PREFIX}{feedback_id}"
+
+
+def vote_for_reaction(
+    *,
+    emoji_name: str | None,
+    emoji_is_custom: bool,
+    reactor_id: int,
+    bot_user_id: int,
+    guild_id: int | None,
+) -> Vote | None:
+    """Classify a raw reaction-add gateway payload as a vote, or not.
+
+    Returns `None` (not a vote) when any of the following hold: the reaction
+    has no resolvable guild (a DM reaction resolves no tenant, so it is
+    ignored entirely, not attributed to any install); the reactor is the bot
+    itself (the bot's own seeded reactions must never count as votes); the
+    emoji is a custom (non-Unicode) emoji; or the emoji is not exactly
+    `THUMBS_UP` or `THUMBS_DOWN`. Skin-tone-modified thumbs emoji are
+    deliberately NOT matched -- they are distinct codepoint sequences from
+    the bare emoji this module seeds, and matching them would require
+    enumerating every Fitzpatrick modifier combination for no behavioral
+    benefit.
+
+    Deliberately does not take `message_author_id`: whether the reacted-to
+    message was bot-authored is a separate question, answered by
+    `is_bot_authored`, because that field is not reliably present on every
+    gateway payload that carries a reaction.
+    """
+    if guild_id is None:
+        return None
+    if reactor_id == bot_user_id:
+        return None
+    if emoji_is_custom:
+        return None
+    if emoji_name == THUMBS_UP:
+        return "up"
+    if emoji_name == THUMBS_DOWN:
+        return "down"
+    return None
+
+
+def is_bot_authored(*, message_author_id: int | None, bot_user_id: int) -> bool | None:
+    """Decide whether the reacted-to message was authored by the bot.
+
+    Tri-state: returns `True`/`False` when `message_author_id` is known, and
+    `None` when it is not -- meaning "undecidable from the gateway payload,
+    the caller must fetch the message". The `None` case exists because the
+    gateway field that carries a reaction event's message author is
+    undocumented by Discord and may be absent; this function only owns the
+    decision shape, the shell owns the REST fallback that resolves the `None`
+    case.
+    """
+    if message_author_id is None:
+        return None
+    return message_author_id == bot_user_id
+
+
+def should_trigger_feedback_dm(*, previous_vote: Vote | None, new_vote: Vote) -> bool:
+    """Decide whether a new vote should open the private feedback path.
+
+    A flip from `"up"` to `"down"` counts as a new down-vote and does
+    trigger the private path; a repeat `"down"` (the vote is unchanged) does
+    not.
+    """
+    return new_vote == "down" and previous_vote != "down"

--- a/packages/core/daimon/core/privacy.py
+++ b/packages/core/daimon/core/privacy.py
@@ -22,6 +22,7 @@ from daimon.core.stores import github_credentials as github_credentials_store
 from daimon.core.stores import github_oauth_states as github_oauth_states_store
 from daimon.core.stores import identity as identity_store
 from daimon.core.stores import mcp_tokens as mcp_tokens_store
+from daimon.core.stores import message_feedback as message_feedback_store
 from daimon.core.stores import routines as routines_store
 from daimon.core.stores import slack_turn_contexts as slack_turn_contexts_store
 from daimon.core.stores import slack_user_tokens as slack_user_tokens_store
@@ -68,6 +69,7 @@ class PurgePreview(BaseModel):
     slack_turn_contexts: PurgePreviewRow
     credential_requests: PurgePreviewRow
     wizard_sessions: PurgePreviewRow
+    message_feedback: PurgePreviewRow
 
 
 def _format_platform_principal(p: PlatformPrincipalRow) -> str:
@@ -308,6 +310,20 @@ async def collect_purge_preview(
             )
         wizard_sessions = PurgePreviewRow(count=wizard_sessions_total, example=None)
 
+        # 14. message_feedback — account-scoped (keyed by account_id, not
+        # principal), OR'd with the account's (tenant, platform-user) keys
+        # exactly as purge_account's delete does, since a vote cast before the
+        # person had an accounts row carries a null account_id. The argument
+        # shapes here are identical to purge_account's call by contract — any
+        # divergence makes this preview lie about what erasure will remove.
+        message_feedback_platform_user_keys = [(pp.tenant_id, pp.external_id) for pp in pp_list]
+        message_feedback_count = await message_feedback_store.count_message_feedback_for_account(
+            session,
+            account_id=account_id,
+            platform_user_keys=message_feedback_platform_user_keys,
+        )
+        message_feedback = PurgePreviewRow(count=message_feedback_count, example=None)
+
     return PurgePreview(
         linked_principals=linked_principals,
         principal_links=principal_links,
@@ -323,4 +339,5 @@ async def collect_purge_preview(
         slack_turn_contexts=slack_turn_contexts,
         credential_requests=credential_requests,
         wizard_sessions=wizard_sessions,
+        message_feedback=message_feedback,
     )

--- a/packages/core/daimon/core/privacy.py
+++ b/packages/core/daimon/core/privacy.py
@@ -9,6 +9,16 @@ the Anthropic workspace and are not enumerated here.
 Adding a new account- or principal-scoped table that `purge_account` learns to
 delete MUST update this module too, or the preview undercounts. The schema-
 reflecting drift-guard test in `tests/test_privacy.py` enforces this at CI time.
+
+Scope of "every row": both this preview and the purge it mirrors are scoped to
+the account's OWN principals. One residue class follows from that and is
+documented in full under `daimon.core.purge`'s carve-outs — message_feedback
+rows cast in a tenant where the person has no principal (a vote by a bystander
+carries account_id = NULL and no principal is minted for it) are neither
+previewed nor deleted by a run invoked from another tenant. The remediation is
+guild-local and self-service: running this same privacy purge inside that guild
+mints a principal there, which brings its (tenant, platform-user) key into
+scope and erases those rows.
 """
 
 from __future__ import annotations

--- a/packages/core/daimon/core/purge.py
+++ b/packages/core/daimon/core/purge.py
@@ -10,14 +10,22 @@ appending one helper call here plus one int field on `PurgeReport`. Current
 sequence: user_skills -> github_credentials -> agent_github_binding ->
 github_oauth_states (both kinds where the table permits) -> credential_requests
 (both kinds, platform-user-scoped like github_oauth_states) -> wizard_session
-(both kinds, platform-user-scoped like credential_requests) -> routines
-(platform only) -> principal_links -> principal row. Account-level deletes
-(mcp_tokens, message_feedback, user_configs, accounts) run in `purge_account`
-after all principal rows are gone; mcp_tokens and message_feedback are keyed
-by account_id and are deleted before delete_account so their CASCADE FKs to
+(both kinds, platform-user-scoped like credential_requests) -> message_feedback
+(platform only, platform-user-scoped) -> routines (platform only) ->
+principal_links -> principal row. Account-level deletes (mcp_tokens,
+message_feedback, user_configs, accounts) run in `purge_account` after all
+principal rows are gone; mcp_tokens and message_feedback are keyed by
+account_id and are deleted before delete_account so their CASCADE FKs to
 accounts.id are satisfied. message_feedback is deleted by an account-id
 predicate OR'd with the account's (tenant, platform-user) keys, because a
 vote cast before the person had an account row carries a null account id.
+
+message_feedback is the one table deleted on BOTH paths, because it is the
+one table whose rows can carry either identity key. The principal path
+deletes only the principal's own (tenant, platform-user) rows; the account
+path then sweeps whatever the account-id predicate still reaches. The two
+passes cannot double-count — the second only sees what the first left — so
+the summed report still equals `collect_purge_preview`'s single count.
 
 wizard_session rides the platform-user-scoped delete path rather than an
 accounts.id cascade: the row's identity key is the requester's platform user
@@ -184,6 +192,21 @@ async def _purge_principal_in_session(
             platform_user_id=principal.external_id,
             tenant_id=principal.tenant_id,
         )
+        # message_feedback carries the SAME (tenant, platform-user) identity key
+        # as the three tables above, so it must be purged on this path too:
+        # a vote row can carry account_id = NULL (the reaction path never mints
+        # a principal), leaving votes AND their attached free text behind if
+        # only the account-level pass in purge_account deleted them.
+        # Deliberately the narrow platform-user-keyed helper, not the
+        # account-keyed one: purging ONE principal must not erase the same
+        # account's votes under another tenant.
+        message_feedback_count = (
+            await message_feedback_store.delete_message_feedback_for_platform_user(
+                session,
+                tenant_id=principal.tenant_id,
+                platform_user_id=principal.external_id,
+            )
+        )
     else:
         routines_count = 0
         kind = "cli"
@@ -221,6 +244,12 @@ async def _purge_principal_in_session(
             platform_user_id=principal.os_user,
             tenant_id=principal.tenant_id,
         )
+        # A vote is always cast by a platform user reacting in a guild, so a
+        # CLI principal owns no message_feedback rows — nothing to delete, and
+        # no symmetric call here: os_user is not a reaction identity, and
+        # running one would risk deleting an unrelated platform user's rows
+        # that happen to share the string.
+        message_feedback_count = 0
 
     # user_skills and github_credentials are keyed by principal_id alone — both
     # principal kinds own rows in these tables.
@@ -265,6 +294,7 @@ async def _purge_principal_in_session(
         slack_user_tokens=slack_user_tokens_count,
         credential_requests=credential_requests_count,
         wizard_sessions=wizard_sessions_count,
+        message_feedback=message_feedback_count,
     )
 
 

--- a/packages/core/daimon/core/purge.py
+++ b/packages/core/daimon/core/purge.py
@@ -12,9 +12,12 @@ github_oauth_states (both kinds where the table permits) -> credential_requests
 (both kinds, platform-user-scoped like github_oauth_states) -> wizard_session
 (both kinds, platform-user-scoped like credential_requests) -> routines
 (platform only) -> principal_links -> principal row. Account-level deletes
-(mcp_tokens, user_configs, accounts) run in `purge_account` after all principal
-rows are gone; mcp_tokens is keyed by account_id and is deleted before
-delete_account so its NO-ACTION/CASCADE FK to accounts.id is satisfied.
+(mcp_tokens, message_feedback, user_configs, accounts) run in `purge_account`
+after all principal rows are gone; mcp_tokens and message_feedback are keyed
+by account_id and are deleted before delete_account so their CASCADE FKs to
+accounts.id are satisfied. message_feedback is deleted by an account-id
+predicate OR'd with the account's (tenant, platform-user) keys, because a
+vote cast before the person had an account row carries a null account id.
 
 wizard_session rides the platform-user-scoped delete path rather than an
 accounts.id cascade: the row's identity key is the requester's platform user
@@ -66,6 +69,7 @@ from daimon.core.stores import github_credentials as github_credentials_store
 from daimon.core.stores import github_oauth_states as github_oauth_states_store
 from daimon.core.stores import identity as identity_store
 from daimon.core.stores import mcp_tokens as mcp_tokens_store
+from daimon.core.stores import message_feedback as message_feedback_store
 from daimon.core.stores import routines as routines_store
 from daimon.core.stores import slack_turn_contexts as slack_turn_contexts_store
 from daimon.core.stores import slack_user_tokens as slack_user_tokens_store
@@ -101,6 +105,7 @@ class PurgeReport(BaseModel):
     slack_turn_contexts: int = 0
     credential_requests: int = 0
     wizard_sessions: int = 0
+    message_feedback: int = 0
 
     def merge(self, other: PurgeReport) -> PurgeReport:
         return PurgeReport(
@@ -119,6 +124,7 @@ class PurgeReport(BaseModel):
             slack_turn_contexts=self.slack_turn_contexts + other.slack_turn_contexts,
             credential_requests=self.credential_requests + other.credential_requests,
             wizard_sessions=self.wizard_sessions + other.wizard_sessions,
+            message_feedback=self.message_feedback + other.message_feedback,
         )
 
 
@@ -362,6 +368,15 @@ async def purge_account(
         mcp_tokens_count = await mcp_tokens_store.delete_tokens_for_account(
             session, account_id=account_id
         )
+        # message_feedback: account-id-keyed OR'd with the account's
+        # (tenant, platform-user) keys — a vote cast before the person had an
+        # accounts row carries a null account_id and is only reachable via the
+        # platform-user key. CLI principals contribute no keys: reactions only
+        # ever come from a platform user, so cli_list is not walked here.
+        platform_user_keys = [(pp.tenant_id, pp.external_id) for pp in pp_list]
+        message_feedback_count = await message_feedback_store.delete_message_feedback_for_account(
+            session, account_id=account_id, platform_user_keys=platform_user_keys
+        )
         # slack_turn_contexts (D-07): keyed by (tenant_id, account_id), not
         # principal_id. Loop every tenant the account's principals belong to —
         # mirrors the upstream session-deletion loop below.
@@ -379,6 +394,7 @@ async def purge_account(
         db_report = report.merge(
             PurgeReport(
                 mcp_tokens=mcp_tokens_count,
+                message_feedback=message_feedback_count,
                 user_configs=user_cfg_count,
                 accounts=account_count,
                 slack_turn_contexts=slack_turn_contexts_count,

--- a/packages/core/daimon/core/purge.py
+++ b/packages/core/daimon/core/purge.py
@@ -60,6 +60,23 @@ Deliberate carve-outs:
   so account purge does NOT touch them — archiving one because a single member
   invoked erasure would destroy the guild's shared agent memory. They may
   retain information about the purged user.
+- message_feedback rows cast in a tenant where the person has NO principal are
+  out of reach of an erasure run from another tenant. This is the one table
+  that records rows for someone with no principal anywhere: the reaction path
+  deliberately never mints one for a bystander, so a vote (and any free text
+  they then submit) lands with account_id = NULL, attributable only by
+  (tenant_id, platform_user_id). An erasure invoked in guild A derives its
+  platform-user keys from the account's own principals, which do not include
+  (tenant_B, user), so guild B's row survives. Unlike the tenant-scoped
+  oauth-state ghost rows above, these are durable and hold free text.
+  Remediation is guild-local and self-service: running the privacy purge
+  inside guild B mints a tenant-B principal, which brings (tenant_B, user)
+  into the key set and erases those rows. Deliberately not closed by a
+  platform-scoped, tenant-agnostic predicate: it would be correct only for
+  platforms whose external ids are globally unique (Discord snowflakes, not
+  Slack workspace-scoped user ids), so it would make erasure's blast radius
+  depend on the platform — a worse contract than one documented, reachable
+  remediation path.
 """
 
 from __future__ import annotations

--- a/packages/core/daimon/core/stores/domain.py
+++ b/packages/core/daimon/core/stores/domain.py
@@ -413,6 +413,43 @@ class CredentialRequestRow(BaseModel):
     used_at: datetime | None
 
 
+class MessageFeedbackRow(BaseModel):
+    """Pydantic row for MessageFeedback — one thumbs-up/down reaction vote.
+
+    `vote` is a bare `str` at the store boundary, the same narrowing
+    precedent `CredentialRequestRow.kind` already sets — the `Vote` literal
+    lives in `daimon.core.message_feedback`, not here.
+    """
+
+    model_config = ConfigDict(from_attributes=True, frozen=True)
+
+    id: uuid.UUID
+    tenant_id: uuid.UUID
+    account_id: uuid.UUID | None
+    platform: str
+    message_id: str
+    channel_id: str
+    platform_user_id: str
+    ma_session_id: str | None
+    vote: str
+    feedback_text: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class RecordVoteResult(BaseModel):
+    """Return of `record_vote`: the upserted row plus the voter's prior vote.
+
+    `previous_vote` is the value the voter had recorded for this message
+    before this call, and is `None` when this is their first vote on it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    row: MessageFeedbackRow
+    previous_vote: str | None
+
+
 class WizardSessionRow(BaseModel):
     """Pydantic row for WizardSession — one multi-step wizard form's durable state."""
 

--- a/packages/core/daimon/core/stores/message_feedback.py
+++ b/packages/core/daimon/core/stores/message_feedback.py
@@ -125,6 +125,36 @@ async def attach_feedback_text(
     return MessageFeedbackRow.model_validate(orm)
 
 
+async def delete_message_feedback_for_platform_user(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    platform_user_id: str,
+) -> int:
+    """Delete one platform user's vote rows in one tenant. Idempotent.
+
+    The principal-scoped counterpart to
+    `delete_message_feedback_for_account`: keyed by the identity a vote
+    actually carries, so it reaches rows written before the voter had an
+    `accounts` row. Deliberately does NOT OR in an account-id predicate —
+    purging ONE principal must not erase the same account's votes cast under
+    a different tenant or a different platform identity.
+
+    Tenant-scoped for the same reason `credential_requests` and
+    `wizard_session` are: `platform_user_id` is not globally unique across
+    platforms (Slack user ids are workspace-scoped).
+    """
+    result = await session.execute(
+        delete(MessageFeedback).where(
+            MessageFeedback.tenant_id == tenant_id,
+            MessageFeedback.platform_user_id == platform_user_id,
+        )
+    )
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
 def _account_or_platform_user_predicate(
     *, account_id: uuid.UUID, platform_user_keys: Sequence[tuple[uuid.UUID, str]]
 ) -> ColumnElement[bool]:

--- a/packages/core/daimon/core/stores/message_feedback.py
+++ b/packages/core/daimon/core/stores/message_feedback.py
@@ -1,0 +1,184 @@
+"""Async store for message_feedback — thumbs-up/down reaction votes.
+
+No try/except anywhere in this module — exceptions propagate to the adapter
+boundary. Callers own the transaction; every write ends with `await
+session.flush()`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Any, cast
+
+from daimon.core._models import MessageFeedback
+from daimon.core.message_feedback import Vote
+from daimon.core.stores.domain import MessageFeedbackRow, RecordVoteResult
+from sqlalchemy import ColumnElement, CursorResult, delete, func, or_, select, tuple_, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def record_vote(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    platform: str,
+    message_id: str,
+    channel_id: str,
+    platform_user_id: str,
+    account_id: uuid.UUID | None,
+    ma_session_id: str | None,
+    vote: Vote,
+) -> RecordVoteResult:
+    """Upsert the voter's vote for `message_id`, reporting their prior vote.
+
+    Two statements. First, read (and row-lock) the current vote for the
+    conflict target — this is `previous_vote`. Second, upsert on the
+    tenant/message/voter uniqueness key, updating `vote`, `channel_id`,
+    `account_id`, and `ma_session_id`.
+
+    `feedback_text` is deliberately absent from the update: a later re-vote
+    must not erase text the person already wrote for a prior vote on the same
+    message.
+
+    One race the row lock does not cover: two concurrent FIRST votes by the
+    same person on the same message both read no prior row, so both report
+    `previous_vote=None` and a caller-side private follow-up could fire
+    twice. This is bounded, self-inflicted (one person, one message), and
+    cheaper than a table-level lock.
+    """
+    previous_vote = (
+        await session.execute(
+            select(MessageFeedback.vote)
+            .where(
+                MessageFeedback.tenant_id == tenant_id,
+                MessageFeedback.message_id == message_id,
+                MessageFeedback.platform_user_id == platform_user_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+
+    stmt = (
+        pg_insert(MessageFeedback)
+        .values(
+            tenant_id=tenant_id,
+            account_id=account_id,
+            platform=platform,
+            message_id=message_id,
+            channel_id=channel_id,
+            platform_user_id=platform_user_id,
+            ma_session_id=ma_session_id,
+            vote=vote,
+        )
+        .on_conflict_do_update(
+            constraint="uq_message_feedback_tenant_message_user",
+            set_={
+                "vote": vote,
+                "channel_id": channel_id,
+                "account_id": account_id,
+                "ma_session_id": ma_session_id,
+                "updated_at": func.now(),
+            },
+        )
+        .returning(MessageFeedback)
+    )
+    orm = (await session.execute(stmt)).scalar_one()
+    await session.flush()
+    return RecordVoteResult(
+        row=MessageFeedbackRow.model_validate(orm),
+        previous_vote=previous_vote,
+    )
+
+
+async def attach_feedback_text(
+    session: AsyncSession,
+    *,
+    feedback_id: uuid.UUID,
+    platform_user_id: str,
+    feedback_text: str,
+) -> MessageFeedbackRow | None:
+    """Attach free text to an existing vote row, gated on the voter's own id.
+
+    The `platform_user_id` predicate is a real authorization gate, not a
+    convenience filter: it means a click carrying someone else's row id
+    writes nothing. `None` means "no such row for this person" and
+    deliberately does not distinguish a purged row from a mismatched one —
+    the caller must not try to. Deliberately does NOT filter on the row's
+    current vote value, so text written after a later flip back to a
+    positive vote still lands.
+    """
+    stmt = (
+        update(MessageFeedback)
+        .where(
+            MessageFeedback.id == feedback_id,
+            MessageFeedback.platform_user_id == platform_user_id,
+        )
+        .values(feedback_text=feedback_text, updated_at=func.now())
+        .returning(MessageFeedback)
+    )
+    orm = (await session.execute(stmt)).scalar_one_or_none()
+    await session.flush()
+    if orm is None:
+        return None
+    return MessageFeedbackRow.model_validate(orm)
+
+
+def _account_or_platform_user_predicate(
+    *, account_id: uuid.UUID, platform_user_keys: Sequence[tuple[uuid.UUID, str]]
+) -> ColumnElement[bool]:
+    """Shared predicate for the delete/count pair — they MUST stay identical.
+
+    Starts from `account_id == account_id`; when `platform_user_keys` is
+    non-empty, ORs in a `(tenant_id, platform_user_id)` membership check. A
+    row written before the voter had an `accounts` row carries `account_id
+    = NULL` and is unreachable by an account-keyed delete alone, which
+    would be a silent erasure gap — the second predicate closes it.
+    """
+    predicates: list[ColumnElement[bool]] = [MessageFeedback.account_id == account_id]
+    if platform_user_keys:
+        predicates.append(
+            tuple_(MessageFeedback.tenant_id, MessageFeedback.platform_user_id).in_(
+                list(platform_user_keys)
+            )
+        )
+    return or_(*predicates)
+
+
+async def delete_message_feedback_for_account(
+    session: AsyncSession,
+    *,
+    account_id: uuid.UUID,
+    platform_user_keys: Sequence[tuple[uuid.UUID, str]],
+) -> int:
+    """Delete every vote row attributable to `account_id`. Idempotent.
+
+    Must build the SAME predicate as `count_message_feedback_for_account`, or
+    the /privacy cascade preview diverges from what this actually deletes.
+    """
+    predicate = _account_or_platform_user_predicate(
+        account_id=account_id, platform_user_keys=platform_user_keys
+    )
+    result = await session.execute(delete(MessageFeedback).where(predicate))
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
+async def count_message_feedback_for_account(
+    session: AsyncSession,
+    *,
+    account_id: uuid.UUID,
+    platform_user_keys: Sequence[tuple[uuid.UUID, str]],
+) -> int:
+    """Count vote rows that `delete_message_feedback_for_account` would delete.
+
+    Read-only. Must build the SAME predicate as the delete, or the /privacy
+    cascade preview diverges from what the delete actually removes.
+    """
+    predicate = _account_or_platform_user_predicate(
+        account_id=account_id, platform_user_keys=platform_user_keys
+    )
+    stmt = select(func.count()).select_from(MessageFeedback).where(predicate)
+    return int((await session.execute(stmt)).scalar_one())

--- a/packages/core/daimon/core/stores/thread_sessions.py
+++ b/packages/core/daimon/core/stores/thread_sessions.py
@@ -13,6 +13,11 @@ existing thread cold-creates a fresh per-caller session on the next turn.
 
 No unique constraint on thread identity — recreate intentionally inserts a
 second row while marking the old row 'dead'.
+
+Two read helpers exist for deliberately different purposes:
+`get_live_thread_session` is the turn pipeline's caller-scoped lookup (see the
+security invariant above); `get_latest_thread_session` drops the account_id
+predicate and exists only to give message feedback an attribution hint.
 """
 
 from __future__ import annotations
@@ -49,6 +54,40 @@ async def get_live_thread_session(
                 ThreadSession.platform == platform,
                 ThreadSession.thread_id == thread_id,
                 ThreadSession.account_id == account_id,
+                ThreadSession.status == "live",
+            )
+            .order_by(ThreadSession.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if orm is None:
+        return None
+    return ThreadSessionRow.model_validate(orm)
+
+
+async def get_latest_thread_session(
+    session: AsyncSession,
+    *,
+    tenant_id: _uuid.UUID,
+    platform: str,
+    thread_id: str,
+) -> ThreadSessionRow | None:
+    """Return the newest live row for (tenant_id, platform, thread_id), or None.
+
+    Deliberately NOT the session-lookup used by the turn pipeline — dropping
+    the `account_id` predicate that `get_live_thread_session` applies also
+    drops the caller-isolation guarantee that predicate exists to provide.
+    This helper exists for attribution hints only (message feedback resolving
+    which session likely authored a reacted-to message) and must never be
+    used to bind or resume a session.
+    """
+    orm = (
+        await session.execute(
+            select(ThreadSession)
+            .where(
+                ThreadSession.tenant_id == tenant_id,
+                ThreadSession.platform == platform,
+                ThreadSession.thread_id == thread_id,
                 ThreadSession.status == "live",
             )
             .order_by(ThreadSession.created_at.desc())

--- a/packages/core/tests/stores/test_message_feedback.py
+++ b/packages/core/tests/stores/test_message_feedback.py
@@ -365,6 +365,52 @@ async def test_delete_for_account_with_matching_platform_user_key_also_deletes_n
     )
 
 
+async def test_delete_for_platform_user_ignores_account_id_and_stays_tenant_scoped(
+    db_session: AsyncSession,
+) -> None:
+    """The principal-scoped delete must not reach the account's rows elsewhere.
+
+    Purging ONE principal erases that person's votes in that tenant only —
+    including the null-account ones — while the same account's rows under
+    another tenant survive for that tenant's own principal to carry.
+    """
+    tenant_a = await make_tenant(db_session, workspace_id="mf-store-guild-a")
+    tenant_b = await make_tenant(db_session, workspace_id="mf-store-guild-b")
+    account = await make_account(db_session, tenant=tenant_a)
+    for tenant_id, message_id, account_id in (
+        (tenant_a.id, "msg-13", account.id),
+        (tenant_a.id, "msg-14", None),
+        (tenant_b.id, "msg-15", account.id),
+    ):
+        await store.record_vote(
+            db_session,
+            tenant_id=tenant_id,
+            platform="discord",
+            message_id=message_id,
+            channel_id="chan-1",
+            platform_user_id="voter-shared",
+            account_id=account_id,
+            ma_session_id=None,
+            vote="down",
+        )
+
+    deleted = await store.delete_message_feedback_for_platform_user(
+        db_session, tenant_id=tenant_a.id, platform_user_id="voter-shared"
+    )
+
+    assert deleted == 2, "both of tenant A's rows must go, account-keyed and null-account alike"
+    surviving = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.tenant_id == tenant_b.id)
+        )
+    ).scalar_one()
+    assert surviving == 1, (
+        "the same account's row under another tenant must survive a per-principal delete"
+    )
+
+
 async def test_count_for_account_matches_subsequent_delete(
     db_session: AsyncSession,
 ) -> None:

--- a/packages/core/tests/stores/test_message_feedback.py
+++ b/packages/core/tests/stores/test_message_feedback.py
@@ -1,0 +1,404 @@
+"""Integration tests for the message_feedback store — real Postgres.
+
+Covers the upsert-with-previous-vote-report, the free-text ownership gate,
+and the erasure-scoped delete/count pair (including the account_id=NULL
+regression this pair exists to close).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from daimon.core._models import MessageFeedback
+from daimon.core.stores import message_feedback as store
+from daimon.testing.factories import make_account, make_tenant
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def test_first_record_vote_inserts_one_row_and_reports_no_previous_vote(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+
+    result = await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-1",
+        channel_id="chan-1",
+        platform_user_id="voter-1",
+        account_id=account.id,
+        ma_session_id="sess_a",
+        vote="up",
+    )
+
+    assert result.previous_vote is None, "a first-ever vote must report no previous vote"
+    assert result.row.vote == "up"
+
+    count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.tenant_id == tenant.id, MessageFeedback.message_id == "msg-1")
+        )
+    ).scalar_one()
+    assert count == 1
+
+
+async def test_re_vote_with_opposite_value_leaves_one_row_and_reports_old_value(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-2",
+        channel_id="chan-1",
+        platform_user_id="voter-1",
+        account_id=account.id,
+        ma_session_id="sess_a",
+        vote="up",
+    )
+
+    result = await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-2",
+        channel_id="chan-1",
+        platform_user_id="voter-1",
+        account_id=account.id,
+        ma_session_id="sess_a",
+        vote="down",
+    )
+
+    assert result.previous_vote == "up", "must report the voter's prior vote"
+    assert result.row.vote == "down", "the row must now hold the new vote"
+
+    count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.tenant_id == tenant.id, MessageFeedback.message_id == "msg-2")
+        )
+    ).scalar_one()
+    assert count == 1, "a re-vote must leave exactly one row"
+
+
+async def test_re_vote_does_not_clear_previously_attached_feedback_text(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    first = await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-3",
+        channel_id="chan-1",
+        platform_user_id="voter-1",
+        account_id=account.id,
+        ma_session_id="sess_a",
+        vote="down",
+    )
+    await store.attach_feedback_text(
+        db_session,
+        feedback_id=first.row.id,
+        platform_user_id="voter-1",
+        feedback_text="the chart axes were mislabeled",
+    )
+
+    result = await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-3",
+        channel_id="chan-1",
+        platform_user_id="voter-1",
+        account_id=account.id,
+        ma_session_id="sess_a",
+        vote="up",
+    )
+
+    assert result.row.feedback_text == "the chart axes were mislabeled", (
+        "a re-vote must not erase text the voter already wrote"
+    )
+
+
+async def test_two_different_platform_user_ids_on_same_message_produce_two_rows(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-4",
+        channel_id="chan-1",
+        platform_user_id="voter-a",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="up",
+    )
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-4",
+        channel_id="chan-1",
+        platform_user_id="voter-b",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="down",
+    )
+
+    count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.tenant_id == tenant.id, MessageFeedback.message_id == "msg-4")
+        )
+    ).scalar_one()
+    assert count == 2, "two different voters on one message must produce two rows"
+
+
+async def test_same_message_and_voter_under_two_tenants_produce_two_rows(
+    db_session: AsyncSession,
+) -> None:
+    tenant_a = await make_tenant(db_session, workspace_id="tenant-a")
+    tenant_b = await make_tenant(db_session, workspace_id="tenant-b")
+    account_a = await make_account(db_session, tenant=tenant_a)
+    account_b = await make_account(db_session, tenant=tenant_b)
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant_a.id,
+        platform="discord",
+        message_id="msg-shared",
+        channel_id="chan-1",
+        platform_user_id="voter-cross-tenant",
+        account_id=account_a.id,
+        ma_session_id=None,
+        vote="up",
+    )
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant_b.id,
+        platform="discord",
+        message_id="msg-shared",
+        channel_id="chan-1",
+        platform_user_id="voter-cross-tenant",
+        account_id=account_b.id,
+        ma_session_id=None,
+        vote="up",
+    )
+
+    count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.message_id == "msg-shared")
+        )
+    ).scalar_one()
+    assert count == 2, "the same (message_id, platform_user_id) under two tenants must not collide"
+
+
+async def test_record_vote_with_no_account_and_no_session_succeeds(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+
+    result = await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-5",
+        channel_id="chan-1",
+        platform_user_id="voter-no-account",
+        account_id=None,
+        ma_session_id=None,
+        vote="up",
+    )
+
+    assert result.row.account_id is None
+    assert result.row.ma_session_id is None
+
+
+async def test_attach_feedback_text_with_right_id_and_right_user_updates_row(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    voted = await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-6",
+        channel_id="chan-1",
+        platform_user_id="voter-1",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="down",
+    )
+
+    updated = await store.attach_feedback_text(
+        db_session,
+        feedback_id=voted.row.id,
+        platform_user_id="voter-1",
+        feedback_text="the numbers looked off",
+    )
+
+    assert updated is not None
+    assert updated.feedback_text == "the numbers looked off"
+
+
+async def test_attach_feedback_text_with_different_platform_user_returns_none_and_leaves_row(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    voted = await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-7",
+        channel_id="chan-1",
+        platform_user_id="voter-1",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="down",
+    )
+
+    result = await store.attach_feedback_text(
+        db_session,
+        feedback_id=voted.row.id,
+        platform_user_id="someone-else",
+        feedback_text="attempted hijack",
+    )
+
+    assert result is None, "a mismatched platform_user_id must write nothing"
+
+    orm = (
+        await db_session.execute(select(MessageFeedback).where(MessageFeedback.id == voted.row.id))
+    ).scalar_one()
+    assert orm.feedback_text is None, "the row's feedback_text must be unchanged"
+
+
+async def test_attach_feedback_text_for_deleted_row_returns_none(
+    db_session: AsyncSession,
+) -> None:
+    result = await store.attach_feedback_text(
+        db_session,
+        feedback_id=uuid.uuid4(),
+        platform_user_id="voter-1",
+        feedback_text="ghost row",
+    )
+
+    assert result is None
+
+
+async def test_delete_for_account_with_empty_keys_deletes_only_account_keyed_rows(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-8",
+        channel_id="chan-1",
+        platform_user_id="voter-account-keyed",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="up",
+    )
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-9",
+        channel_id="chan-1",
+        platform_user_id="voter-null-account",
+        account_id=None,
+        ma_session_id=None,
+        vote="up",
+    )
+
+    deleted = await store.delete_message_feedback_for_account(
+        db_session, account_id=account.id, platform_user_keys=[]
+    )
+
+    assert deleted == 1, "an empty key list must delete only the account-keyed row"
+
+
+async def test_delete_for_account_with_matching_platform_user_key_also_deletes_null_account_row(
+    db_session: AsyncSession,
+) -> None:
+    """The erasure-gap regression test."""
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-10",
+        channel_id="chan-1",
+        platform_user_id="voter-pre-account",
+        account_id=None,
+        ma_session_id=None,
+        vote="up",
+    )
+
+    deleted = await store.delete_message_feedback_for_account(
+        db_session,
+        account_id=account.id,
+        platform_user_keys=[(tenant.id, "voter-pre-account")],
+    )
+
+    assert deleted == 1, (
+        "a matching (tenant_id, platform_user_id) key must reach a row whose account_id is NULL"
+    )
+
+
+async def test_count_for_account_matches_subsequent_delete(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-11",
+        channel_id="chan-1",
+        platform_user_id="voter-count-a",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="up",
+    )
+    await store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="msg-12",
+        channel_id="chan-1",
+        platform_user_id="voter-count-b",
+        account_id=None,
+        ma_session_id=None,
+        vote="down",
+    )
+    keys = [(tenant.id, "voter-count-b")]
+
+    count_before = await store.count_message_feedback_for_account(
+        db_session, account_id=account.id, platform_user_keys=keys
+    )
+    deleted = await store.delete_message_feedback_for_account(
+        db_session, account_id=account.id, platform_user_keys=keys
+    )
+
+    assert count_before == deleted == 2

--- a/packages/core/tests/stores/test_message_feedback_schema.py
+++ b/packages/core/tests/stores/test_message_feedback_schema.py
@@ -1,0 +1,81 @@
+"""Schema-drift guard for message_feedback.
+
+The single-column PK on `id`, the tenant-scoped uniqueness key, and both FK
+cascades are load-bearing invariants: a re-vote upserts on the uniqueness
+key, and either a tenant or an account teardown must not strand rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import Connection, Inspector, inspect
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+
+def _pk_columns(sync_conn: Connection, table: str) -> list[str]:
+    inspector: Inspector = inspect(sync_conn)
+    pk = inspector.get_pk_constraint(table)
+    return list(pk["constrained_columns"])
+
+
+def _fk_ondelete(sync_conn: Connection, table: str, column: str, referred_table: str) -> str | None:
+    inspector: Inspector = inspect(sync_conn)
+    for fk in inspector.get_foreign_keys(table):
+        if fk["referred_table"] == referred_table and column in fk["constrained_columns"]:
+            options = fk.get("options") or {}
+            ondelete = options.get("ondelete")
+            return str(ondelete) if ondelete is not None else None
+    return None
+
+
+def _unique_constraint_columns(sync_conn: Connection, table: str, name: str) -> list[str] | None:
+    inspector: Inspector = inspect(sync_conn)
+    for uc in inspector.get_unique_constraints(table):
+        if uc["name"] == name:
+            return list(uc["column_names"])
+    return None
+
+
+async def test_message_feedback_has_single_column_id_pk(db_session: AsyncSession) -> None:
+    pk_cols = await db_session.run_sync(lambda s: _pk_columns(s.connection(), "message_feedback"))
+    assert pk_cols == ["id"], f"message_feedback PK drift: expected ['id'], got {pk_cols}"
+
+
+async def test_message_feedback_tenant_id_fk_cascades_on_delete(
+    db_session: AsyncSession,
+) -> None:
+    ondelete = await db_session.run_sync(
+        lambda s: _fk_ondelete(s.connection(), "message_feedback", "tenant_id", "tenants")
+    )
+    assert ondelete == "CASCADE", (
+        f"message_feedback.tenant_id FK must be ON DELETE CASCADE, got {ondelete}"
+    )
+
+
+async def test_message_feedback_account_id_fk_exists_and_cascades_on_delete(
+    db_session: AsyncSession,
+) -> None:
+    ondelete = await db_session.run_sync(
+        lambda s: _fk_ondelete(s.connection(), "message_feedback", "account_id", "accounts")
+    )
+    assert ondelete == "CASCADE", (
+        f"message_feedback.account_id FK must be ON DELETE CASCADE, got {ondelete}"
+    )
+
+
+async def test_message_feedback_uniqueness_key_covers_tenant_message_voter(
+    db_session: AsyncSession,
+) -> None:
+    columns = await db_session.run_sync(
+        lambda s: _unique_constraint_columns(
+            s.connection(),
+            "message_feedback",
+            "uq_message_feedback_tenant_message_user",
+        )
+    )
+    assert columns == ["tenant_id", "message_id", "platform_user_id"], (
+        "uq_message_feedback_tenant_message_user drift: expected "
+        f"['tenant_id', 'message_id', 'platform_user_id'], got {columns}"
+    )

--- a/packages/core/tests/stores/test_thread_sessions.py
+++ b/packages/core/tests/stores/test_thread_sessions.py
@@ -17,6 +17,7 @@ from daimon.core._models import ThreadSession
 from daimon.core.stores.domain import ThreadSessionRow
 from daimon.core.stores.thread_sessions import (
     create_thread_session,
+    get_latest_thread_session,
     get_live_thread_session,
     mark_dead,
     update_watermark,
@@ -341,3 +342,81 @@ async def test_create_thread_session_persists_account_id(
     assert fetched.account_id == account_id, (
         "account_id must survive the DB round-trip via get_live_thread_session"
     )
+
+
+async def test_get_latest_thread_session_returns_newest_row_across_accounts(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    """Unlike get_live_thread_session, this ignores account_id entirely."""
+    account_a = uuid.uuid4()
+    account_b = uuid.uuid4()
+    await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="latest-test",
+        account_id=account_a,
+        ma_session_id="sess_old",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="latest-test",
+        account_id=account_b,
+        ma_session_id="sess_new",
+        created_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+
+    fetched = await get_latest_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="latest-test",
+    )
+
+    assert fetched is not None
+    assert fetched.ma_session_id == "sess_new", (
+        "get_latest_thread_session must return the newest row regardless of account"
+    )
+
+
+async def test_get_latest_thread_session_ignores_dead_rows(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    account_id = uuid.uuid4()
+    row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="latest-dead-test",
+        account_id=account_id,
+        ma_session_id="sess_dead",
+    )
+    await mark_dead(db_session, id=row.id)
+
+    fetched = await get_latest_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="latest-dead-test",
+    )
+
+    assert fetched is None, "get_latest_thread_session must exclude dead rows"
+
+
+async def test_get_latest_thread_session_returns_none_for_unknown_thread(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    fetched = await get_latest_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="unknown-thread",
+    )
+
+    assert fetched is None

--- a/packages/core/tests/test_message_feedback.py
+++ b/packages/core/tests/test_message_feedback.py
@@ -1,0 +1,234 @@
+"""Unit tests for the message-feedback vote logic and custom_id grammar (no I/O, no DB)."""
+
+from __future__ import annotations
+
+import uuid
+
+from daimon.core.credential_requests import CUSTOM_ID_PATTERN as CREDENTIAL_CUSTOM_ID_PATTERN
+from daimon.core.credential_requests import build_custom_id as build_credential_custom_id
+from daimon.core.credential_requests import mint_request_token
+from daimon.core.message_feedback import (
+    CUSTOM_ID_PATTERN,
+    THUMBS_DOWN,
+    THUMBS_UP,
+    build_custom_id,
+    is_bot_authored,
+    should_trigger_feedback_dm,
+    vote_for_reaction,
+)
+
+BOT_USER_ID = 1
+REACTOR_ID = 2
+GUILD_ID = 9
+
+
+# --- vote_for_reaction ---
+
+
+def test_vote_for_reaction_thumbs_up_by_non_bot_user_in_guild_returns_up() -> None:
+    assert (
+        vote_for_reaction(
+            emoji_name=THUMBS_UP,
+            emoji_is_custom=False,
+            reactor_id=REACTOR_ID,
+            bot_user_id=BOT_USER_ID,
+            guild_id=GUILD_ID,
+        )
+        == "up"
+    ), "a plain thumbs-up by a non-bot user in a guild must count as an up-vote"
+
+
+def test_vote_for_reaction_thumbs_down_by_non_bot_user_in_guild_returns_down() -> None:
+    assert (
+        vote_for_reaction(
+            emoji_name=THUMBS_DOWN,
+            emoji_is_custom=False,
+            reactor_id=REACTOR_ID,
+            bot_user_id=BOT_USER_ID,
+            guild_id=GUILD_ID,
+        )
+        == "down"
+    ), "a plain thumbs-down by a non-bot user in a guild must count as a down-vote"
+
+
+def test_vote_for_reaction_reactor_is_bot_returns_none() -> None:
+    assert (
+        vote_for_reaction(
+            emoji_name=THUMBS_DOWN,
+            emoji_is_custom=False,
+            reactor_id=BOT_USER_ID,
+            bot_user_id=BOT_USER_ID,
+            guild_id=GUILD_ID,
+        )
+        is None
+    ), "the bot's own seeded reactions must never count as votes for themselves"
+
+
+def test_vote_for_reaction_no_guild_returns_none_even_for_valid_thumbs_emoji() -> None:
+    assert (
+        vote_for_reaction(
+            emoji_name=THUMBS_UP,
+            emoji_is_custom=False,
+            reactor_id=REACTOR_ID,
+            bot_user_id=BOT_USER_ID,
+            guild_id=None,
+        )
+        is None
+    ), "a DM reaction resolves no tenant and must be ignored entirely"
+
+
+def test_vote_for_reaction_custom_emoji_returns_none() -> None:
+    assert (
+        vote_for_reaction(
+            emoji_name=THUMBS_UP,
+            emoji_is_custom=True,
+            reactor_id=REACTOR_ID,
+            bot_user_id=BOT_USER_ID,
+            guild_id=GUILD_ID,
+        )
+        is None
+    ), "a custom (non-Unicode) emoji must never count as a vote"
+
+
+def test_vote_for_reaction_emoji_name_none_returns_none() -> None:
+    assert (
+        vote_for_reaction(
+            emoji_name=None,
+            emoji_is_custom=False,
+            reactor_id=REACTOR_ID,
+            bot_user_id=BOT_USER_ID,
+            guild_id=GUILD_ID,
+        )
+        is None
+    ), "a missing emoji name must never count as a vote"
+
+
+def test_vote_for_reaction_unrelated_emoji_returns_none() -> None:
+    assert (
+        vote_for_reaction(
+            emoji_name="\N{PARTY POPPER}",
+            emoji_is_custom=False,
+            reactor_id=REACTOR_ID,
+            bot_user_id=BOT_USER_ID,
+            guild_id=GUILD_ID,
+        )
+        is None
+    ), "an emoji that is neither thumbs-up nor thumbs-down must not count as a vote"
+
+
+def test_vote_for_reaction_skin_tone_thumbs_up_returns_none() -> None:
+    skin_toned = THUMBS_UP + "\N{EMOJI MODIFIER FITZPATRICK TYPE-3}"
+    assert (
+        vote_for_reaction(
+            emoji_name=skin_toned,
+            emoji_is_custom=False,
+            reactor_id=REACTOR_ID,
+            bot_user_id=BOT_USER_ID,
+            guild_id=GUILD_ID,
+        )
+        is None
+    ), "skin-tone variants are distinct codepoint sequences and are deliberately not matched"
+
+
+# --- is_bot_authored ---
+
+
+def test_is_bot_authored_true_when_author_matches_bot() -> None:
+    assert is_bot_authored(message_author_id=BOT_USER_ID, bot_user_id=BOT_USER_ID) is True, (
+        "a message authored by the bot's own id must be classified as bot-authored"
+    )
+
+
+def test_is_bot_authored_false_when_author_differs() -> None:
+    assert is_bot_authored(message_author_id=REACTOR_ID, bot_user_id=BOT_USER_ID) is False, (
+        "a message authored by a different id must be classified as not bot-authored"
+    )
+
+
+def test_is_bot_authored_none_when_author_id_is_none() -> None:
+    result = is_bot_authored(message_author_id=None, bot_user_id=BOT_USER_ID)
+    assert result is None, (
+        "an absent author id must return None (undecidable), not False -- False means "
+        "'not ours' while None means 'must fetch to find out', and the two are not the same"
+    )
+
+
+# --- should_trigger_feedback_dm ---
+
+
+def test_should_trigger_feedback_dm_first_downvote_returns_true() -> None:
+    assert should_trigger_feedback_dm(previous_vote=None, new_vote="down") is True, (
+        "a first-ever down-vote must trigger the private feedback path"
+    )
+
+
+def test_should_trigger_feedback_dm_flip_from_up_to_down_returns_true() -> None:
+    assert should_trigger_feedback_dm(previous_vote="up", new_vote="down") is True, (
+        "a flip from up to down must count as a new down-vote and trigger the private path"
+    )
+
+
+def test_should_trigger_feedback_dm_repeat_downvote_returns_false() -> None:
+    assert should_trigger_feedback_dm(previous_vote="down", new_vote="down") is False, (
+        "a repeat down-vote (no state change) must not re-trigger the private path"
+    )
+
+
+def test_should_trigger_feedback_dm_upvote_never_triggers() -> None:
+    for previous_vote in (None, "up", "down"):
+        assert should_trigger_feedback_dm(previous_vote=previous_vote, new_vote="up") is False, (
+            f"an up-vote must never trigger the private path regardless of previous_vote="
+            f"{previous_vote!r}"
+        )
+
+
+# --- custom_id grammar ---
+
+
+def test_custom_id_pattern_fullmatches_and_round_trips_feedback_id() -> None:
+    feedback_id = str(uuid.uuid4())
+    custom_id = build_custom_id(feedback_id)
+
+    match = CUSTOM_ID_PATTERN.fullmatch(custom_id)
+
+    assert match is not None, "the template must fullmatch a real minted feedback custom_id"
+    assert match["feedback_id"] == feedback_id, (
+        "the feedback_id group must round-trip the input uuid string"
+    )
+
+
+def test_custom_id_pattern_matches_lowercase_and_uppercase_hex_uuid() -> None:
+    lowercase = str(uuid.uuid4())
+    uppercase = lowercase.upper()
+
+    assert CUSTOM_ID_PATTERN.fullmatch(build_custom_id(lowercase)) is not None, (
+        "a lowercase-hex uuid must fullmatch"
+    )
+    assert CUSTOM_ID_PATTERN.fullmatch(build_custom_id(uppercase)) is not None, (
+        "an uppercase-hex uuid must fullmatch"
+    )
+
+
+def test_custom_id_pattern_rejects_bare_uuid_with_no_prefix() -> None:
+    bare = str(uuid.uuid4())
+    assert CUSTOM_ID_PATTERN.fullmatch(bare) is None, (
+        "a custom_id missing the mfb: prefix must not match"
+    )
+
+
+def test_feedback_custom_id_does_not_fullmatch_credential_template() -> None:
+    feedback_custom_id = build_custom_id(str(uuid.uuid4()))
+    assert CREDENTIAL_CUSTOM_ID_PATTERN.fullmatch(feedback_custom_id) is None, (
+        "discord.py fires every registered dynamic-item template whose pattern fullmatches "
+        "an incoming custom_id, with no early break, so a feedback custom_id must never also "
+        "fullmatch the credential-request template -- overlap would double-dispatch one click"
+    )
+
+
+def test_credential_custom_id_does_not_fullmatch_feedback_template() -> None:
+    credential_custom_id = build_credential_custom_id(mint_request_token())
+    assert CUSTOM_ID_PATTERN.fullmatch(credential_custom_id) is None, (
+        "discord.py fires every registered dynamic-item template whose pattern fullmatches "
+        "an incoming custom_id, with no early break, so a credential-request custom_id must "
+        "never also fullmatch the feedback template -- overlap would double-dispatch one click"
+    )

--- a/packages/core/tests/test_privacy.py
+++ b/packages/core/tests/test_privacy.py
@@ -572,6 +572,77 @@ async def test_collect_purge_preview_message_feedback_matches_purge_account_incl
     )
 
 
+async def test_a_vote_in_a_tenant_without_a_principal_is_erased_by_a_purge_run_there(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Pins the documented remediation for the one erasure residue class.
+
+    A bystander's vote never mints a principal, so a person with an account in
+    guild A who reacts in guild B leaves a row attributable only by
+    (tenant_B, user) — out of reach of an erasure invoked from guild A. The
+    carve-out in `daimon.core.purge`'s docstring says the remedy is to run the
+    purge inside guild B, which mints a principal there. This test is what
+    keeps that promise honest.
+    """
+    tenant_a = await make_tenant(db_session, workspace_id="pv-residue-guild-a")
+    tenant_b = await make_tenant(db_session, workspace_id="pv-residue-guild-b")
+    account = await make_account(db_session, tenant=tenant_a)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="PV_RESIDUE_USER",
+        tenant=tenant_a,
+        account=account,
+    )
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant_b.id,
+        platform="discord",
+        message_id="pv-residue-1",
+        channel_id="C1",
+        platform_user_id="PV_RESIDUE_USER",
+        account_id=None,
+        ma_session_id=None,
+        vote="down",
+    )
+    await db_session.commit()
+
+    from_guild_a = await purge_account(sm=db_session_factory, account_id=account.id)
+
+    assert from_guild_a.db.message_feedback == 0, (
+        "a purge invoked from guild A cannot reach a guild-B vote with no principal there"
+    )
+
+    # The documented remediation: taking any action in guild B that mints a
+    # principal brings (tenant_B, user) into the key set.
+    remediation_account = await make_account(db_session, tenant=tenant_b)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="PV_RESIDUE_USER",
+        tenant=tenant_b,
+        account=remediation_account,
+    )
+    await db_session.commit()
+
+    preview = await collect_purge_preview(sm=db_session_factory, account_id=remediation_account.id)
+    from_guild_b = await purge_account(sm=db_session_factory, account_id=remediation_account.id)
+
+    assert preview.message_feedback.count == 1, (
+        "the guild-local preview must show the residual vote the person can now erase"
+    )
+    assert from_guild_b.db.message_feedback == 1, "the guild-local purge must erase it"
+    remaining = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.tenant_id == tenant_b.id)
+        )
+    ).scalar_one()
+    assert remaining == 0, "no residue may survive the documented remediation path"
+
+
 async def test_collect_purge_preview_matches_purge_account_coverage_field_for_field() -> None:
     """If `PurgeReport` grows a new int field, `PurgePreview` MUST mirror it.
 

--- a/packages/core/tests/test_privacy.py
+++ b/packages/core/tests/test_privacy.py
@@ -18,6 +18,7 @@ from daimon.core._models import (
     Base,
     CliPrincipal,
     McpToken,
+    MessageFeedback,
     PlatformPrincipal,
     Routine,
     UserConfig,
@@ -33,6 +34,7 @@ from daimon.core.stores import agent_github_binding as agent_github_binding_stor
 from daimon.core.stores import credential_requests as credential_requests_store
 from daimon.core.stores import github_credentials as github_credentials_store
 from daimon.core.stores import mcp_tokens as mcp_tokens_store
+from daimon.core.stores import message_feedback as message_feedback_store
 from daimon.core.stores import routines as routines_store
 from daimon.core.stores import slack_turn_contexts as slack_turn_contexts_store
 from daimon.core.stores import slack_user_tokens as slack_user_tokens_store
@@ -506,6 +508,70 @@ async def test_purge_erases_submitted_and_abandoned_wizard_sessions(
     )
 
 
+async def test_collect_purge_preview_message_feedback_matches_purge_account_including_null_account(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Preview counts message_feedback and agrees with purge_account's actual
+    deletion count — including the null-account-id vote, the whole point of
+    this test."""
+    tenant = await make_tenant(db_session, workspace_id="pv-msg-feedback")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="PV_FEEDBACK_TARGET",
+        tenant=tenant,
+        account=account,
+    )
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="pv-msg-1",
+        channel_id="C1",
+        platform_user_id="PV_FEEDBACK_TARGET",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="up",
+    )
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="pv-msg-2",
+        channel_id="C1",
+        platform_user_id="PV_FEEDBACK_TARGET",
+        account_id=None,
+        ma_session_id=None,
+        vote="down",
+    )
+    await db_session.commit()
+
+    preview = await collect_purge_preview(sm=db_session_factory, account_id=account.id)
+    report = await purge_account(sm=db_session_factory, account_id=account.id)
+
+    assert preview.message_feedback.count == 2, (
+        "preview must count both the account-keyed vote and the null-account "
+        "vote reachable via the platform-user key"
+    )
+    assert preview.message_feedback.count == report.db.message_feedback, (
+        "preview and purge must agree on message_feedback"
+    )
+
+    remaining = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.tenant_id == tenant.id)
+        )
+    ).scalar_one()
+    assert remaining == 0, (
+        "purge must erase every message_feedback row for this account, including "
+        "the one whose account_id was NULL at vote time"
+    )
+
+
 async def test_collect_purge_preview_matches_purge_account_coverage_field_for_field() -> None:
     """If `PurgeReport` grows a new int field, `PurgePreview` MUST mirror it.
 
@@ -535,6 +601,7 @@ async def test_collect_purge_preview_matches_purge_account_coverage_field_for_fi
         "slack_turn_contexts": "slack_turn_contexts",
         "credential_requests": "credential_requests",
         "wizard_sessions": "wizard_sessions",
+        "message_feedback": "message_feedback",
     }
 
     uncovered = report_fields - set(mapping.keys())
@@ -578,6 +645,7 @@ async def test_purge_covers_every_account_or_principal_scoped_table() -> None:
         "agent_github_binding": "principal_id",
         "mcp_tokens": "account_id FK -> accounts.id",
         "wizard_session": "account_id FK -> accounts.id",
+        "message_feedback": "account_id FK -> accounts.id",
     }
     # Intentional exclusions, each justified inline.
     allowlist: frozenset[str] = frozenset(

--- a/packages/core/tests/test_purge.py
+++ b/packages/core/tests/test_purge.py
@@ -22,6 +22,7 @@ from daimon.core._models import (
     Account,
     ChannelConfig,
     CliPrincipal,
+    MessageFeedback,
     PlatformPrincipal,
     PrincipalLink,
     Routine,
@@ -39,6 +40,7 @@ from daimon.core.purge import (
 from daimon.core.stores import credential_requests as credential_requests_store
 from daimon.core.stores import github_credentials as github_credentials_store
 from daimon.core.stores import github_oauth_states as github_oauth_states_store
+from daimon.core.stores import message_feedback as message_feedback_store
 from daimon.core.stores import routines as routines_store
 from daimon.core.stores import slack_turn_contexts as slack_turn_contexts_store
 from daimon.core.stores import slack_user_tokens as slack_user_tokens_store
@@ -51,7 +53,7 @@ from daimon.testing.factories import (
     make_tenant,
 )
 from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .factories.github import make_oauth_state
@@ -1497,3 +1499,166 @@ async def test_purge_principal_credential_requests_does_not_delete_same_user_in_
         db_session, platform_user_id="shared-user-id", tenant_id=tenant_b.id
     )
     assert surviving == 1, "the other tenant's same-user-id row must survive"
+
+
+async def test_purge_principal_platform_deletes_message_feedback_including_null_account_rows(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A platform purge must not strand the votes (and free text) it can attribute.
+
+    The null-account row is the whole point: the reaction path deliberately
+    never mints a principal, so a vote cast before the person took a turn is
+    reachable only through the (tenant, platform-user) key this purge owns.
+    """
+    tenant = await make_tenant(db_session, workspace_id="mf-purge-principal")
+    account = await make_account(db_session, tenant=tenant)
+    pp = await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="user-voter",
+        tenant=tenant,
+        account=account,
+    )
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="mf-purge-1",
+        channel_id="C1",
+        platform_user_id="user-voter",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="up",
+    )
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="mf-purge-2",
+        channel_id="C1",
+        platform_user_id="user-voter",
+        account_id=None,
+        ma_session_id=None,
+        vote="down",
+    )
+    # A bystander's vote in the same tenant must survive.
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="mf-purge-1",
+        channel_id="C1",
+        platform_user_id="user-bystander",
+        account_id=None,
+        ma_session_id=None,
+        vote="down",
+    )
+    await db_session.commit()
+
+    report = await purge_principal(sm=db_session_factory, principal_id=pp.id, kind="platform")
+
+    assert report.db.message_feedback == 2, (
+        "both the account-keyed and the null-account vote must be deleted and reported"
+    )
+    remaining = (
+        (
+            await db_session.execute(
+                select(MessageFeedback.platform_user_id).where(
+                    MessageFeedback.tenant_id == tenant.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert list(remaining) == ["user-bystander"], "only the purged voter's rows may be deleted"
+
+
+async def test_purge_principal_message_feedback_does_not_delete_same_user_in_other_tenant(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Tenant-scoped like every other platform-user-keyed delete on this path."""
+    tenant_a = await make_tenant(db_session, workspace_id="mf-purge-guild-a")
+    tenant_b = await make_tenant(db_session, workspace_id="mf-purge-guild-b")
+    account_a = await make_account(db_session, tenant=tenant_a)
+    pp_a = await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="shared-voter-id",
+        tenant=tenant_a,
+        account=account_a,
+    )
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant_a.id,
+        platform="discord",
+        message_id="mf-cross-1",
+        channel_id="C1",
+        platform_user_id="shared-voter-id",
+        account_id=account_a.id,
+        ma_session_id=None,
+        vote="down",
+    )
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant_b.id,
+        platform="discord",
+        message_id="mf-cross-2",
+        channel_id="C1",
+        platform_user_id="shared-voter-id",
+        account_id=None,
+        ma_session_id=None,
+        vote="down",
+    )
+    await db_session.commit()
+
+    report = await purge_principal(sm=db_session_factory, principal_id=pp_a.id, kind="platform")
+
+    assert report.db.message_feedback == 1, "only tenant A's vote row must be deleted"
+    surviving = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.tenant_id == tenant_b.id)
+        )
+    ).scalar_one()
+    assert surviving == 1, "the other tenant's same-user-id vote must survive"
+
+
+async def test_purge_principal_cli_message_feedback_reports_zero(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Votes only ever come from a platform user, so a CLI purge reports zero."""
+    tenant = await make_tenant(db_session, workspace_id="mf-purge-cli")
+    account = await make_account(db_session, tenant=tenant)
+    cli = await make_cli_principal(db_session, os_user="mf-cli", tenant=tenant, account=account)
+    await message_feedback_store.record_vote(
+        db_session,
+        tenant_id=tenant.id,
+        platform="discord",
+        message_id="mf-cli-1",
+        channel_id="C1",
+        platform_user_id="mf-cli",
+        account_id=account.id,
+        ma_session_id=None,
+        vote="down",
+    )
+    await db_session.commit()
+
+    report = await purge_principal(sm=db_session_factory, principal_id=cli.id, kind="cli")
+
+    assert report.db.message_feedback == 0, "a CLI principal owns no vote rows"
+    surviving = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(MessageFeedback)
+            .where(MessageFeedback.tenant_id == tenant.id)
+        )
+    ).scalar_one()
+    assert surviving == 1, (
+        "an os_user string must never be treated as a reaction identity and delete a "
+        "platform user's votes"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ source_modules = [
     "daimon.core.health",
     "daimon.core.ids",
     "daimon.core.ma",
+    "daimon.core.message_feedback",
     "daimon.core.observability",
     "daimon.core.privacy",
     "daimon.core.purge",

--- a/tests/parity/test_message_feedback_discord_only.py
+++ b/tests/parity/test_message_feedback_discord_only.py
@@ -1,0 +1,37 @@
+"""Executable record of message feedback's deliberate Discord-only scope.
+
+An absent capability file in this suite is mechanically indistinguishable
+from an oversight: nothing else in the test suite would fail if Slack's bot
+scopes silently grew the two permissions a Slack feedback path would need,
+without anyone building that path or updating the platform-neutral core's
+documented scope. Asserting the exemption here, rather than merely
+documenting it in a comment, makes that drift fail loudly instead of
+silently.
+
+No platform parametrization, no database -- this is a scope check, not a
+scenario test.
+"""
+
+from __future__ import annotations
+
+import daimon.core.message_feedback
+from daimon.core.slack_oauth import SLACK_BOT_SCOPES
+
+
+def test_slack_bot_scopes_still_lack_the_reaction_feedback_scopes() -> None:
+    assert "reactions:read" not in SLACK_BOT_SCOPES and "im:write" not in SLACK_BOT_SCOPES, (
+        "message feedback is Discord-only because Slack cannot observe reactions or open a "
+        "direct message without the reactions:read and im:write bot scopes; if this test "
+        "fails, either build the Slack feedback path or update this exemption record -- do "
+        "not simply delete the assertion"
+    )
+
+
+def test_message_feedback_core_documents_the_discord_only_scope() -> None:
+    doc = daimon.core.message_feedback.__doc__
+
+    assert doc is not None, "daimon.core.message_feedback must carry a module docstring"
+    assert "reactions:read" in doc, (
+        "the module docstring must name the reactions:read scope Slack lacks"
+    )
+    assert "im:write" in doc, "the module docstring must name the im:write scope Slack lacks"


### PR DESCRIPTION
## Summary

Every bot answer now carries a cheap feedback channel. Answered turns get seeded 👍/👎 reactions; a raw-reaction listener records each vote as a tenant-scoped `message_feedback` row (keyed by message and platform user, with a best-effort session hint), and a *new* 👎 opens a private DM with a button whose modal collects free text that updates the same row in place — reactions aren't interactions, so the DM button exists to legally open the modal.

- **Pure core** (`daimon.core.message_feedback`): vote predicates + the `mfb:` custom_id grammar, provably disjoint from the existing wizard/credential grammars.
- **Durable rows**: migration 0005 + async store (`record_vote` upsert with `SELECT FOR UPDATE`, `attach_feedback_text` predicated on row id + platform user id), wired into purge/preview erasure with the drift guard passing for real.
- **Discord adapter**: `was_answered` on the turn lifecycle (feedback only seeds on real answers, never cancellations/failures), persistent `FeedbackButton`/`FeedbackModal`, raw-reaction cog with a bounded author-verification memo, and best-effort seeding that can never fail a delivered answer.
- **Discord-only by design**, recorded as an explicit parity exemption test.

A post-review hardening pass is included (commits `749c0fa…d6a17c9`): seeding failure isolation, `is_done()`-guarded error replies, fallback-fetch memoization, principal-purge coverage for vote rows, documented cross-tenant erasure carve-out, and transport-level MA fakes replacing a method-level mock.

## Test plan

- Full suite: **4038 passed, 4 skipped** against real Postgres (fresh-schema-per-test)
- Strict pyright 0 errors, ruff clean, all 6 import-linter contracts kept, all repo lints green (modals, anti-patterns, migrations, leakage)
- Mutation checks performed live for the ownership gate, DM-trigger predicate, and `was_answered` guard
- Goal-backward verification: 31/31 observable truths confirmed against the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)