### PR TITLE
Per-notebook filesystem isolation for the notebook host

### DIFF
--- a/apps/notebook-host/src/notebook_host/admin.py
+++ b/apps/notebook-host/src/notebook_host/admin.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import hmac
 import os
-import shutil
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -24,6 +23,7 @@ from notebook_host.blogs_store import (
 )
 from notebook_host.capability import CapabilityClaims, verify_token
 from notebook_host.config import Settings
+from notebook_host.jail import SlugPaths, ensure_slug_jail, get_slug_paths, remove_slug_tree
 from notebook_host.lifecycle import (
     NotebookProcess,
     ValidationResult,
@@ -39,12 +39,12 @@ from notebook_host.pids_store import record_from_process, save_pids
 
 class Spawner(Protocol):
     def __call__(
-        self, slug: str, file_path: Path, port: int, *, mode: Literal["edit", "run"] = "edit"
+        self, slug: str, paths: SlugPaths, port: int, *, mode: Literal["edit", "run"] = "edit"
     ) -> subprocess.Popen[bytes]: ...
 
 
 class Validator(Protocol):
-    def __call__(self, slug: str, file_path: Path) -> ValidationResult: ...
+    def __call__(self, slug: str, paths: SlugPaths) -> ValidationResult: ...
 
 
 @dataclass
@@ -115,12 +115,19 @@ def _bearer_dep(settings: Settings) -> Callable[[str | None], None]:
     return require
 
 
-def _atomic_write_bytes(path: Path, content: bytes) -> None:
-    """Write via tmp + ``os.replace`` so a concurrent reader never sees a torn file."""
+def _atomic_write_bytes(path: Path, content: bytes, *, owner_uid: int | None = None) -> None:
+    """Write via tmp + ``os.replace`` so a concurrent reader never sees a torn file.
+
+    When ``owner_uid`` is given, the tmp file is chowned to ``(owner_uid,
+    owner_uid)`` before the replace, so the file is never visible at its final
+    path with the wrong owner.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f".{path.name}.tmp")
     try:
         tmp.write_bytes(content)
+        if owner_uid is not None:
+            os.chown(tmp, owner_uid, owner_uid)
         os.replace(tmp, path)
     except OSError:
         tmp.unlink(missing_ok=True)
@@ -137,16 +144,15 @@ async def _spawn_tracked(
     pool exhausted), or 504 (spawn timeout). Shared by the notebook and blog
     PUT handlers so the two never drift.
     """
-    state.settings.data_dir.mkdir(parents=True, exist_ok=True)
-    path = state.settings.data_dir / f"{slug}.py"
-    path.write_bytes(source_bytes)
+    paths = ensure_slug_jail(state.settings.data_dir, slug)
+    _atomic_write_bytes(paths.notebook, source_bytes)
 
     # Confirm the cells actually execute before we tear down any
     # existing notebook for this slug. Runs off the event loop (the
     # marimo export is blocking). A failure here leaves a previously
     # published notebook for this slug untouched and serving.
     if state.validator is not None:
-        result = await asyncio.to_thread(state.validator, slug, path)
+        result = await asyncio.to_thread(state.validator, slug, paths)
         if not result.ok:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -163,7 +169,7 @@ async def _spawn_tracked(
     port = allocate_port(
         state.processes, state.settings.marimo_port_start, state.settings.marimo_port_end
     )
-    proc = state.spawner(slug, path, port, mode=mode)
+    proc = state.spawner(slug, paths, port, mode=mode)
     np = state.make_process(slug, port, proc, mode=mode)
     state.processes[slug] = np
 
@@ -227,7 +233,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
                 "url": np.url,
                 "port": np.port,
                 "pid": np.process.pid,
-                "size_bytes": (state.settings.data_dir / f"{slug}.py").stat().st_size,
+                "size_bytes": get_slug_paths(state.settings.data_dir, slug).notebook.stat().st_size,
                 "subprocess_ttl_seconds": ttl,
                 "expires_at": expires_at.isoformat() if expires_at is not None else None,
             }
@@ -249,8 +255,10 @@ def create_admin_router(state: AdminState) -> APIRouter:
                 f"({len(body)} > {state.settings.max_attachment_bytes_ceiling})",
             )
         async with state.lock_for(slug):
-            data_dir = state.settings.data_dir / f"{slug}.data"
-            final_path = data_dir / name
+            # ensure the tree exists even when an attachment arrives before
+            # the first publish, with the same 0700 mode a publish would set.
+            paths = ensure_slug_jail(state.settings.data_dir, slug)
+            final_path = paths.data / name
             _atomic_write_bytes(final_path, body)
             return {
                 "slug": slug,
@@ -269,11 +277,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
         np = state.processes.pop(slug, None)
         if np is not None:
             kill(np)
-        (state.settings.data_dir / f"{slug}.py").unlink(missing_ok=True)
-        # A crash between the .py unlink and these rmtrees leaks the dirs;
-        # the slug is gone from state.processes so sweep won't re-discover them.
-        shutil.rmtree(state.settings.data_dir / f"{slug}.data", ignore_errors=True)
-        shutil.rmtree(state.settings.data_dir / f"{slug}_workspace", ignore_errors=True)
+        remove_slug_tree(state.settings.data_dir, slug)
         state.snapshot_pids()
 
     @router.get("/admin/notebooks", dependencies=[Depends(require_admin)])
@@ -313,7 +317,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
                 "url": np.url,
                 "port": np.port,
                 "pid": np.process.pid,
-                "size_bytes": (state.settings.data_dir / f"{slug}.py").stat().st_size,
+                "size_bytes": get_slug_paths(state.settings.data_dir, slug).notebook.stat().st_size,
             }
 
     @router.get("/admin/blogs", dependencies=[Depends(require_admin)])
@@ -346,9 +350,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
         if np is not None:
             kill(np)
         unregister_blog(state.settings.resolved_blogs_file, slug)
-        (state.settings.data_dir / f"{slug}.py").unlink(missing_ok=True)
-        shutil.rmtree(state.settings.data_dir / f"{slug}.data", ignore_errors=True)
-        shutil.rmtree(state.settings.data_dir / f"{slug}_workspace", ignore_errors=True)
+        remove_slug_tree(state.settings.data_dir, slug)
         state.snapshot_pids()
 
     @router.post("/admin/sweep", dependencies=[Depends(require_admin)])
@@ -364,9 +366,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
                 continue
             kill(np)
             state.processes.pop(slug, None)
-            (state.settings.data_dir / f"{slug}.py").unlink(missing_ok=True)
-            shutil.rmtree(state.settings.data_dir / f"{slug}.data", ignore_errors=True)
-            shutil.rmtree(state.settings.data_dir / f"{slug}_workspace", ignore_errors=True)
+            remove_slug_tree(state.settings.data_dir, slug)
             reaped.append({"slug": slug, "reason": reason, "age_s": round(np.age_s, 2)})
         if reaped:
             state.snapshot_pids()
@@ -405,7 +405,10 @@ def create_admin_router(state: AdminState) -> APIRouter:
                 )
             name = safe_attachment_name(claims.name)
             async with state.lock_for(slug):
-                final_path = state.settings.data_dir / f"{slug}.data" / name
+                # ensure the tree exists even when an attachment arrives before
+                # the first publish, with the same 0700 mode a publish would set.
+                paths = ensure_slug_jail(state.settings.data_dir, slug)
+                final_path = paths.data / name
                 _atomic_write_bytes(final_path, body)
                 return {
                     "slug": slug,
@@ -417,7 +420,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
         mode: Literal["edit", "run"] = "run" if claims.op == "blog" else "edit"
         async with state.lock_for(slug):
             np = await _spawn_tracked(state, slug, body, mode=mode)
-            size_bytes = (state.settings.data_dir / f"{slug}.py").stat().st_size
+            size_bytes = get_slug_paths(state.settings.data_dir, slug).notebook.stat().st_size
             if claims.op == "blog":
                 register_blog(
                     state.settings.resolved_blogs_file,

--- a/apps/notebook-host/src/notebook_host/admin.py
+++ b/apps/notebook-host/src/notebook_host/admin.py
@@ -325,13 +325,18 @@ def create_admin_router(state: AdminState) -> APIRouter:
         dependencies=[Depends(require_admin)],
         status_code=status.HTTP_204_NO_CONTENT,
     )
-    def delete_notebook(slug: str) -> None:  # pyright: ignore[reportUnusedFunction]
+    async def delete_notebook(slug: str) -> None:  # pyright: ignore[reportUnusedFunction]
         slug = safe_slug(slug)
-        np = state.processes.pop(slug, None)
-        if np is not None:
-            kill(np)
-        remove_slug_tree(state.settings.data_dir, slug, uids_file=state.settings.resolved_uids_file)
-        state.snapshot_pids()
+        async with state.lock_for(slug):
+            np = state.processes.pop(slug, None)
+            if np is not None:
+                # kill blocks up to 5s (SIGTERM wait); must not block the
+                # event loop now that the handler is async.
+                await asyncio.to_thread(kill, np)
+            remove_slug_tree(
+                state.settings.data_dir, slug, uids_file=state.settings.resolved_uids_file
+            )
+            state.snapshot_pids()
 
     @router.get("/admin/notebooks", dependencies=[Depends(require_admin)])
     def list_notebooks() -> dict[str, object]:  # pyright: ignore[reportUnusedFunction]
@@ -397,14 +402,22 @@ def create_admin_router(state: AdminState) -> APIRouter:
         dependencies=[Depends(require_admin)],
         status_code=status.HTTP_204_NO_CONTENT,
     )
-    def delete_blog(slug: str) -> None:  # pyright: ignore[reportUnusedFunction]
+    async def delete_blog(slug: str) -> None:  # pyright: ignore[reportUnusedFunction]
         slug = safe_slug(slug)
-        np = state.processes.pop(slug, None)
-        if np is not None:
-            kill(np)
-        unregister_blog(state.settings.resolved_blogs_file, slug)
-        remove_slug_tree(state.settings.data_dir, slug, uids_file=state.settings.resolved_uids_file)
-        state.snapshot_pids()
+        async with state.lock_for(slug):
+            # Unregister first, while the lock is held, so the registry stops
+            # naming this slug before anything blocking (kill) starts. This is
+            # what lets the sweep's self-heal, re-reading the registry under
+            # the same lock, see the slug is already gone rather than racing
+            # to respawn it.
+            unregister_blog(state.settings.resolved_blogs_file, slug)
+            np = state.processes.pop(slug, None)
+            if np is not None:
+                await asyncio.to_thread(kill, np)
+            remove_slug_tree(
+                state.settings.data_dir, slug, uids_file=state.settings.resolved_uids_file
+            )
+            state.snapshot_pids()
 
     @router.post("/admin/sweep", dependencies=[Depends(require_admin)])
     def sweep() -> dict[str, object]:  # pyright: ignore[reportUnusedFunction]

--- a/apps/notebook-host/src/notebook_host/admin.py
+++ b/apps/notebook-host/src/notebook_host/admin.py
@@ -23,6 +23,7 @@ from notebook_host.blogs_store import (
 )
 from notebook_host.capability import CapabilityClaims, verify_token
 from notebook_host.config import Settings
+from notebook_host.consumed_store import burn_jti
 from notebook_host.jail import (
     JailUnavailableError,
     SlugPaths,
@@ -75,9 +76,6 @@ class AdminState:
     # Serialises concurrent PUTs to the same slug. Without it, two PUTs can
     # interleave kill/allocate/spawn and orphan the loser's subprocess.
     slug_locks: dict[str, asyncio.Lock] = field(default_factory=dict[str, asyncio.Lock])
-    # Single-use capability-token jtis already burned. Process-local; bounded by
-    # the token TTL (~300s) across restarts. Replay of a consumed token → 409.
-    consumed: set[str] = field(default_factory=set[str])
 
     def make_process(
         self,
@@ -445,7 +443,19 @@ def create_admin_router(state: AdminState) -> APIRouter:
         # Public route — authed by the capability token, NOT the admin bearer.
         secrets_list = [s.get_secret_value() for s in state.settings.admin_secrets]
         claims: CapabilityClaims = verify_token(secrets_list, token, now=datetime.now(UTC))
-        if claims.jti in state.consumed:
+        # Burn before reading the body: burn_jti's check-and-write is one call
+        # with no await in between, so two concurrent replays of one token
+        # cannot both observe it as unused. Burning here (rather than after a
+        # successful write) means a token whose upload later fails a size
+        # check is not reusable — that is what single-use means; the
+        # alternative reopens the replay window this closes.
+        burned = burn_jti(
+            state.settings.resolved_consumed_file,
+            claims.jti,
+            exp=claims.exp,
+            now=int(datetime.now(UTC).timestamp()),
+        )
+        if not burned:
             raise HTTPException(status.HTTP_409_CONFLICT, "capability token already used")
         body = await request.body()
         ceiling = (
@@ -459,11 +469,6 @@ def create_admin_router(state: AdminState) -> APIRouter:
                 f"upload body exceeds cap (size={len(body)}, token_max={claims.max_bytes}, "
                 f"host_ceiling={ceiling})",
             )
-        # Single-use is best-effort: the in-set check and this add straddle the
-        # body read, so two concurrent replays of one token could both pass. Low
-        # risk — both carry identical authorized bytes and the slug lock serialises
-        # the writes. Process-local, TTL-bounded; a persistent store is day-2.
-        state.consumed.add(claims.jti)
         slug = safe_slug(claims.slug)
 
         if claims.op == "data":

--- a/apps/notebook-host/src/notebook_host/admin.py
+++ b/apps/notebook-host/src/notebook_host/admin.py
@@ -23,7 +23,15 @@ from notebook_host.blogs_store import (
 )
 from notebook_host.capability import CapabilityClaims, verify_token
 from notebook_host.config import Settings
-from notebook_host.jail import SlugPaths, ensure_slug_jail, get_slug_paths, remove_slug_tree
+from notebook_host.jail import (
+    JailUnavailableError,
+    SlugPaths,
+    UidPoolExhaustedError,
+    ensure_slug_jail,
+    get_slug_paths,
+    remove_slug_tree,
+    resolve_jail_uid,
+)
 from notebook_host.lifecycle import (
     NotebookProcess,
     ValidationResult,
@@ -39,12 +47,20 @@ from notebook_host.pids_store import record_from_process, save_pids
 
 class Spawner(Protocol):
     def __call__(
-        self, slug: str, paths: SlugPaths, port: int, *, mode: Literal["edit", "run"] = "edit"
+        self,
+        slug: str,
+        paths: SlugPaths,
+        port: int,
+        *,
+        mode: Literal["edit", "run"] = "edit",
+        jail_uid: int | None = None,
     ) -> subprocess.Popen[bytes]: ...
 
 
 class Validator(Protocol):
-    def __call__(self, slug: str, paths: SlugPaths) -> ValidationResult: ...
+    def __call__(
+        self, slug: str, paths: SlugPaths, *, jail_uid: int | None = None
+    ) -> ValidationResult: ...
 
 
 @dataclass
@@ -141,18 +157,39 @@ async def _spawn_tracked(
 
     The caller must hold ``state.lock_for(slug)``. Returns the live
     ``NotebookProcess``. Raises ``HTTPException`` 422 (validation), 503 (port
-    pool exhausted), or 504 (spawn timeout). Shared by the notebook and blog
-    PUT handlers so the two never drift.
+    pool exhausted, or notebook isolation unavailable), or 504 (spawn
+    timeout). Shared by the notebook and blog PUT handlers so the two never
+    drift.
     """
-    paths = ensure_slug_jail(state.settings.data_dir, slug)
-    _atomic_write_bytes(paths.notebook, source_bytes)
+    # This is the request boundary — the one place admin.py is allowed to
+    # catch JailUnavailableError/UidPoolExhaustedError. Both mean the host is
+    # refusing to serve rather than failing transiently, mirroring
+    # allocate_port's existing 503 for pool exhaustion.
+    try:
+        uid = resolve_jail_uid(
+            state.settings.resolved_uids_file,
+            slug,
+            start=state.settings.jail_uid_start,
+            end=state.settings.jail_uid_end,
+            allow_unjailed=state.settings.allow_unjailed_spawn,
+        )
+    except JailUnavailableError as err:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, f"notebook isolation unavailable: {err}"
+        ) from err
+    except UidPoolExhaustedError as err:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, f"uid pool exhausted: {err}"
+        ) from err
+    paths = ensure_slug_jail(state.settings.data_dir, slug, uid=uid)
+    _atomic_write_bytes(paths.notebook, source_bytes, owner_uid=uid)
 
     # Confirm the cells actually execute before we tear down any
     # existing notebook for this slug. Runs off the event loop (the
     # marimo export is blocking). A failure here leaves a previously
     # published notebook for this slug untouched and serving.
     if state.validator is not None:
-        result = await asyncio.to_thread(state.validator, slug, paths)
+        result = await asyncio.to_thread(state.validator, slug, paths, jail_uid=uid)
         if not result.ok:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -169,7 +206,7 @@ async def _spawn_tracked(
     port = allocate_port(
         state.processes, state.settings.marimo_port_start, state.settings.marimo_port_end
     )
-    proc = state.spawner(slug, paths, port, mode=mode)
+    proc = state.spawner(slug, paths, port, mode=mode, jail_uid=uid)
     np = state.make_process(slug, port, proc, mode=mode)
     state.processes[slug] = np
 
@@ -257,9 +294,25 @@ def create_admin_router(state: AdminState) -> APIRouter:
         async with state.lock_for(slug):
             # ensure the tree exists even when an attachment arrives before
             # the first publish, with the same 0700 mode a publish would set.
-            paths = ensure_slug_jail(state.settings.data_dir, slug)
+            try:
+                uid = resolve_jail_uid(
+                    state.settings.resolved_uids_file,
+                    slug,
+                    start=state.settings.jail_uid_start,
+                    end=state.settings.jail_uid_end,
+                    allow_unjailed=state.settings.allow_unjailed_spawn,
+                )
+            except JailUnavailableError as err:
+                raise HTTPException(
+                    status.HTTP_503_SERVICE_UNAVAILABLE, f"notebook isolation unavailable: {err}"
+                ) from err
+            except UidPoolExhaustedError as err:
+                raise HTTPException(
+                    status.HTTP_503_SERVICE_UNAVAILABLE, f"uid pool exhausted: {err}"
+                ) from err
+            paths = ensure_slug_jail(state.settings.data_dir, slug, uid=uid)
             final_path = paths.data / name
-            _atomic_write_bytes(final_path, body)
+            _atomic_write_bytes(final_path, body, owner_uid=uid)
             return {
                 "slug": slug,
                 "name": name,
@@ -277,7 +330,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
         np = state.processes.pop(slug, None)
         if np is not None:
             kill(np)
-        remove_slug_tree(state.settings.data_dir, slug)
+        remove_slug_tree(state.settings.data_dir, slug, uids_file=state.settings.resolved_uids_file)
         state.snapshot_pids()
 
     @router.get("/admin/notebooks", dependencies=[Depends(require_admin)])
@@ -350,7 +403,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
         if np is not None:
             kill(np)
         unregister_blog(state.settings.resolved_blogs_file, slug)
-        remove_slug_tree(state.settings.data_dir, slug)
+        remove_slug_tree(state.settings.data_dir, slug, uids_file=state.settings.resolved_uids_file)
         state.snapshot_pids()
 
     @router.post("/admin/sweep", dependencies=[Depends(require_admin)])
@@ -366,7 +419,9 @@ def create_admin_router(state: AdminState) -> APIRouter:
                 continue
             kill(np)
             state.processes.pop(slug, None)
-            remove_slug_tree(state.settings.data_dir, slug)
+            remove_slug_tree(
+                state.settings.data_dir, slug, uids_file=state.settings.resolved_uids_file
+            )
             reaped.append({"slug": slug, "reason": reason, "age_s": round(np.age_s, 2)})
         if reaped:
             state.snapshot_pids()
@@ -407,9 +462,26 @@ def create_admin_router(state: AdminState) -> APIRouter:
             async with state.lock_for(slug):
                 # ensure the tree exists even when an attachment arrives before
                 # the first publish, with the same 0700 mode a publish would set.
-                paths = ensure_slug_jail(state.settings.data_dir, slug)
+                try:
+                    uid = resolve_jail_uid(
+                        state.settings.resolved_uids_file,
+                        slug,
+                        start=state.settings.jail_uid_start,
+                        end=state.settings.jail_uid_end,
+                        allow_unjailed=state.settings.allow_unjailed_spawn,
+                    )
+                except JailUnavailableError as err:
+                    raise HTTPException(
+                        status.HTTP_503_SERVICE_UNAVAILABLE,
+                        f"notebook isolation unavailable: {err}",
+                    ) from err
+                except UidPoolExhaustedError as err:
+                    raise HTTPException(
+                        status.HTTP_503_SERVICE_UNAVAILABLE, f"uid pool exhausted: {err}"
+                    ) from err
+                paths = ensure_slug_jail(state.settings.data_dir, slug, uid=uid)
                 final_path = paths.data / name
-                _atomic_write_bytes(final_path, body)
+                _atomic_write_bytes(final_path, body, owner_uid=uid)
                 return {
                     "slug": slug,
                     "name": name,

--- a/apps/notebook-host/src/notebook_host/blogs_store.py
+++ b/apps/notebook-host/src/notebook_host/blogs_store.py
@@ -18,6 +18,12 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
+_REGISTRY_MODE = 0o600
+"""Explicit mode for blogs.json. It lists every slug, and per D-04 the slug
+is the only access control on the unauthenticated ``/n/{slug}/*`` proxy — a
+default-umask 0644 would let any jailed process read it and obtain every
+other notebook's URL, now that ``data_dir`` is traversable (0711)."""
+
 
 class BlogRecord(BaseModel):
     slug: str
@@ -52,11 +58,16 @@ def load_blogs(path: Path) -> dict[str, BlogRecord]:
 
 
 def save_blogs(path: Path, records: dict[str, BlogRecord]) -> None:
-    """Atomically rewrite the registry (tmp + rename on the same filesystem)."""
+    """Atomically rewrite the registry (tmp + rename on the same filesystem).
+
+    The tmp file is locked to ``_REGISTRY_MODE`` (0600) before the rename,
+    not after — no window where a freshly written registry is world-readable.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     payload = {slug: rec.model_dump() for slug, rec in records.items()}
     tmp.write_text(json.dumps(payload, indent=2))
+    os.chmod(tmp, _REGISTRY_MODE)
     os.replace(tmp, path)
 
 

--- a/apps/notebook-host/src/notebook_host/config.py
+++ b/apps/notebook-host/src/notebook_host/config.py
@@ -107,6 +107,29 @@ class Settings(BaseSettings):
     # 1 hour before SIGXCPU. Notebooks doing legitimate long-running compute
     # may need this raised. 0 disables the cap.
     marimo_rlimit_cpu_seconds: int = 3600
+    # Start of the per-slug uid pool range (inclusive). 1000 slots starting
+    # at 100000, verified free of any /etc/passwd entry in the
+    # python:3.12-slim base image. The concurrent ceiling is the 61-slot
+    # port pool; the range only has to cover concurrent notebooks plus
+    # permanent blogs, because a uid is released when its slug's tree is
+    # deleted.
+    jail_uid_start: int = 100000
+    # End of the per-slug uid pool range (inclusive).
+    jail_uid_end: int = 100999
+    # This is a break-glass setting for hosts that cannot apply the uid jail (non-root
+    # container, non-POSIX dev machine). Default False means such a host
+    # refuses to serve notebooks rather than serving them unisolated —
+    # deliberately NOT modelled on the RLIMIT gate above, which warns and
+    # degrades: that's acceptable for a resource cap and is not acceptable
+    # for an isolation boundary.
+    allow_unjailed_spawn: bool = False
+    # Path to the persisted uid registry. Host writes {slug: uid} whenever a
+    # new slug is jailed; ``None`` (default) means "use
+    # ``data_dir / 'uids.json'``" — keeps it on the same persistent volume
+    # as pids.json/blogs.json, same framing as pids_file/blogs_file below.
+    # It must live outside every slug root so no jailed process can read or
+    # rewrite it.
+    uids_file: Path | None = None
     # Path to the orphan-recovery pids file. Host writes {slug: PidRecord}
     # on every register/unregister; at startup, reads + reaps any live
     # PIDs that survived the previous host crash. ``None`` (default) means
@@ -127,6 +150,11 @@ class Settings(BaseSettings):
     def resolved_blogs_file(self) -> Path:
         """The actual blogs.json path: explicit setting, else data_dir / blogs.json."""
         return self.blogs_file if self.blogs_file is not None else self.data_dir / "blogs.json"
+
+    @property
+    def resolved_uids_file(self) -> Path:
+        """The actual uids.json path: explicit setting, else data_dir / uids.json."""
+        return self.uids_file if self.uids_file is not None else self.data_dir / "uids.json"
 
     # WebSocket Origin allowlist. Empty list = check disabled (suitable for
     # trusted-network deployments where the host isn't browser-reachable

--- a/apps/notebook-host/src/notebook_host/config.py
+++ b/apps/notebook-host/src/notebook_host/config.py
@@ -140,6 +140,13 @@ class Settings(BaseSettings):
     # mode. ``None`` (default) means "use ``data_dir / 'blogs.json'``" — kept on
     # the same persistent volume as the source files.
     blogs_file: Path | None = None
+    # Path to the burned single-use capability-token jti registry. The
+    # /upload/{token} handler writes {jti: exp} here on every successful burn;
+    # this set survives a host restart, unlike the process-local set it
+    # replaced — a token burned before a restart is still refused after one.
+    # ``None`` (default) means "use ``data_dir / 'consumed.json'``" — kept on
+    # the same persistent volume as the other registries.
+    consumed_file: Path | None = None
 
     @property
     def resolved_pids_file(self) -> Path:
@@ -150,6 +157,15 @@ class Settings(BaseSettings):
     def resolved_blogs_file(self) -> Path:
         """The actual blogs.json path: explicit setting, else data_dir / blogs.json."""
         return self.blogs_file if self.blogs_file is not None else self.data_dir / "blogs.json"
+
+    @property
+    def resolved_consumed_file(self) -> Path:
+        """The actual consumed.json path: explicit setting, else data_dir / consumed.json."""
+        return (
+            self.consumed_file
+            if self.consumed_file is not None
+            else self.data_dir / "consumed.json"
+        )
 
     @property
     def resolved_uids_file(self) -> Path:

--- a/apps/notebook-host/src/notebook_host/consumed_store.py
+++ b/apps/notebook-host/src/notebook_host/consumed_store.py
@@ -1,0 +1,93 @@
+"""Durable registry of burned single-use capability-token jtis.
+
+The public ``/upload/{token}`` route is authenticated by a capability token
+whose ``jti`` must be usable exactly once. Recording that in memory (a
+process-local set) means a token captured inside its TTL survives a host
+restart and can be replayed — the burned set vanished with the process that
+burned it. This file is the fix: burned jtis persist to disk, keyed to the
+token's own ``exp`` so the set can be pruned instead of growing for the life
+of a host designed to run indefinitely.
+
+Pure functions only — the single I/O is the file read/write (no clock, no
+process control, no network); ``burn_jti`` and ``prune_consumed`` take `now`
+as an explicit parameter rather than reading the clock. Mirrors
+blogs_store.py's posture: a malformed file is treated as empty rather than
+fatal, and writes are atomic (tmp + rename).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+_REGISTRY_MODE = 0o600
+"""Explicit mode for consumed.json — host-owned process state, not meant to
+be readable by any jailed slug now that ``data_dir`` is traversable (0711)."""
+
+
+def load_consumed(path: Path) -> dict[str, int]:
+    """Read the registry as {jti: exp}. Returns an empty dict if missing or malformed.
+
+    A malformed file means a previous instance died mid-write. We can't trust
+    partial state, so we forget it and let the next burn rebuild — same
+    posture as load_pids / load_blogs.
+    """
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, int] = {}
+    for jti_obj, exp_obj in raw.items():  # pyright: ignore[reportUnknownVariableType]
+        if not isinstance(jti_obj, str) or not isinstance(exp_obj, int):
+            continue
+        out[jti_obj] = exp_obj
+    return out
+
+
+def save_consumed(path: Path, records: dict[str, int]) -> None:
+    """Atomically rewrite the registry (tmp + rename on the same filesystem).
+
+    The tmp file is locked to ``_REGISTRY_MODE`` (0600) before the rename,
+    not after — no window where a freshly written registry is world-readable.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(records, indent=2))
+    os.chmod(tmp, _REGISTRY_MODE)
+    os.replace(tmp, path)
+
+
+def prune_consumed(records: dict[str, int], *, now: int) -> dict[str, int]:
+    """Return a new dict without entries whose ``exp`` has passed.
+
+    Pure — takes ``now`` explicitly rather than reading the clock. Does not
+    mutate ``records``.
+    """
+    return {jti: exp for jti, exp in records.items() if exp > now}
+
+
+def is_consumed(path: Path, jti: str) -> bool:
+    """Whether ``jti`` has already been burned."""
+    return jti in load_consumed(path)
+
+
+def burn_jti(path: Path, jti: str, *, exp: int, now: int) -> bool:
+    """Atomically check-and-burn ``jti``. Returns True if this call burned it.
+
+    Loads, prunes expired entries (bounding the file's steady-state size),
+    then inserts ``jti`` with ``exp`` if it wasn't already present. One call
+    does the check and the write, so there is no window between them — the
+    caller must place this before reading the request body so two concurrent
+    replays of the same token cannot both observe it as unused.
+    """
+    records = prune_consumed(load_consumed(path), now=now)
+    already_burned = jti in records
+    if not already_burned:
+        records[jti] = exp
+    save_consumed(path, records)
+    return not already_burned

--- a/apps/notebook-host/src/notebook_host/jail.py
+++ b/apps/notebook-host/src/notebook_host/jail.py
@@ -87,6 +87,21 @@ def lock_data_dir_root(data_dir: Path) -> None:
     os.chmod(data_dir, DATA_DIR_MODE)
 
 
+def lock_registry_file(path: Path) -> None:
+    """Chmod an existing host-owned registry file to ``_REGISTRY_MODE``. No-op if absent.
+
+    The stores lock their tmp file before the atomic rename, so a file this
+    host has written is already correct. This exists for the files a host
+    *inherits* — a registry created by a release that predates the jail keeps
+    its old default-umask mode (0644) until something happens to rewrite it,
+    which on a quiet host may be never. Since the same boot that inherits them
+    also makes ``data_dir`` traversable, leaving them is what turns an
+    unlistable-parent assumption into a readable file.
+    """
+    if path.exists():
+        os.chmod(path, _REGISTRY_MODE)
+
+
 @dataclass(frozen=True)
 class SlugPaths:
     """Every on-disk path a slug owns. The single source of truth for the layout.

--- a/apps/notebook-host/src/notebook_host/jail.py
+++ b/apps/notebook-host/src/notebook_host/jail.py
@@ -17,6 +17,7 @@ no network).
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 from dataclasses import dataclass
@@ -96,3 +97,107 @@ def remove_slug_tree(data_dir: Path, slug: str) -> None:
     ``slug`` must already have passed ``lifecycle.safe_slug``.
     """
     shutil.rmtree(get_slug_paths(data_dir, slug).root, ignore_errors=True)
+
+
+# ─── uid pool ────────────────────────────────────────────────────────────────
+#
+# A persisted slug -> uid registry, not a deterministic hash of the slug.
+# Blogs are permanent and accumulate for the life of the deployment, so a
+# hash into any convenient-sized range carries real birthday-collision risk
+# — and a collision silently defeats isolation for both colliding slugs. The
+# registry lives at ``data_dir / "uids.json"``, alongside ``blogs.json`` and
+# ``pids.json``, outside every slug root. A plain ``dict[str, int]`` is
+# enough here — unlike ``PidRecord``/``BlogRecord``, a uid row carries no
+# other fields, so a Pydantic model would buy nothing.
+
+
+class UidPoolExhaustedError(RuntimeError):
+    """Raised when every uid in the configured range is already allocated."""
+
+
+def load_uid_registry(path: Path) -> dict[str, int]:
+    """Read the uid registry. Returns an empty dict if missing or malformed.
+
+    Same posture as ``pids_store.load_pids``: a malformed file means a
+    previous instance died mid-write, so we forget it rather than trust
+    partial state. Entries whose key is not a ``str`` or whose value is not
+    a genuine ``int`` (``bool`` is an ``int`` subclass and is rejected too)
+    are skipped rather than raising.
+    """
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, int] = {}
+    for key, value in raw.items():  # pyright: ignore[reportUnknownVariableType]
+        if not isinstance(key, str):
+            continue
+        if not isinstance(value, int) or isinstance(value, bool):
+            continue
+        out[key] = value
+    return out
+
+
+def save_uid_registry(path: Path, records: dict[str, int]) -> None:
+    """Atomically rewrite the uid registry (tmp + rename), same idiom as save_pids."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(records, indent=2))
+    os.replace(tmp, path)
+
+
+def allocate_uid(registry: dict[str, int], slug: str, *, start: int, end: int) -> int:
+    """Return the uid for ``slug``, allocating a new one if needed. Pure.
+
+    If ``slug`` is already in ``registry``, its existing uid is returned
+    unchanged — idempotency the boot migration depends on. Otherwise the
+    lowest value in ``range(start, end + 1)`` not present in
+    ``registry.values()`` is returned. Does not touch disk and does not
+    mutate ``registry``. Raises ``UidPoolExhaustedError`` if every value in
+    the range is already taken.
+    """
+    if slug in registry:
+        return registry[slug]
+    used = set(registry.values())
+    for uid in range(start, end + 1):
+        if uid not in used:
+            return uid
+    raise UidPoolExhaustedError(f"uid pool exhausted ({start}-{end}, {len(registry)} allocated)")
+
+
+def get_or_create_slug_uid(path: Path, slug: str, *, start: int, end: int) -> int:
+    """Load the registry, allocate (or reuse) a uid for ``slug``, save if changed.
+
+    No write on the hit path — an already-registered slug returns without
+    rewriting the file.
+    """
+    registry = load_uid_registry(path)
+    if slug in registry:
+        return registry[slug]
+    uid = allocate_uid(registry, slug, start=start, end=end)
+    registry[slug] = uid
+    save_uid_registry(path, registry)
+    return uid
+
+
+def release_slug_uid(path: Path, slug: str) -> None:
+    """Drop a slug's uid from the registry, making it immediately reusable.
+
+    A no-op for a slug that isn't registered — does not raise and does not
+    create the file if it didn't already exist.
+
+    The caller MUST have already killed the slug's process before calling
+    this: the uid becomes reusable the instant this returns, and a
+    surviving process still holding the old uid would otherwise be able to
+    reach whichever slug gets allocated it next. Releasing is required
+    rather than optional — edit-mode notebooks are TTL-reaped every
+    ``subprocess_ttl_seconds`` (default 24h), so a never-releasing pool
+    would burn through its whole range on ordinary churn.
+    """
+    registry = load_uid_registry(path)
+    if registry.pop(slug, None) is not None:
+        save_uid_registry(path, registry)

--- a/apps/notebook-host/src/notebook_host/jail.py
+++ b/apps/notebook-host/src/notebook_host/jail.py
@@ -15,6 +15,15 @@ uid-resolution/privilege-drop functions are the only filesystem/process I/O
 (mkdir, chmod, chown, rmtree, and dropping into another uid — no clock, no
 network).
 
+``data_dir`` itself must be traversable (mode 0711, ``DATA_DIR_MODE`` below) so
+a dropped uid can resolve an absolute path down into its own subtree — Linux
+requires the ``x`` bit on every path component, including ones the caller
+doesn't otherwise need to read. It must not be listable, so a jailed process
+can reach a path it already knows but cannot enumerate sibling slugs. This is
+strictly weaker than the per-slug boundary (``SLUG_TREE_MODE``, still 0700)
+and does not change it: the parent grants traversal only, ownership of every
+subtree stays exclusive to that slug's uid.
+
 Two documented limitations of the uid split, deliberately not worked around:
 
 1. Allocated uids have no ``/etc/passwd`` entry. ``uv``/``marimo`` do not need
@@ -38,7 +47,44 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-_TREE_MODE = 0o700
+SLUG_TREE_MODE = 0o700
+"""Mode for each slug's four owned directories (root, data, workspace, home).
+
+This is the real isolation boundary: only the slug's own uid (chowned by
+``ensure_slug_jail``) can read, write, or traverse it.
+"""
+
+DATA_DIR_MODE = 0o711
+"""Mode for ``data_dir`` itself — traversable by any uid, listable by none.
+
+Corrected 2026-07-31: a live container rehearsal (plan 05) proved ``0700``
+denies a dropped uid traversal into its OWN subtree, since resolving an
+absolute path requires the ``x`` bit on every path component. ``0711`` fixes
+that while keeping ``data_dir`` unlistable (no ``r`` bit), so a jailed
+process can reach a path it already knows but cannot enumerate other slugs.
+``migration.py`` must use this exact value — call ``lock_data_dir_root``
+rather than chmod'ing ``data_dir`` with a locally-defined mode, so the two
+can never drift apart.
+"""
+
+_REGISTRY_MODE = 0o600
+"""Mode for host-owned registry files (uids.json here; blogs.json/pids.json
+in their own modules). Explicit because under ``DATA_DIR_MODE`` the parent no
+longer hides them via its own unlistability, and the file's default-umask
+mode (0644) would otherwise leave it world-readable. ``blogs.json`` in
+particular lists every slug, and per D-04 the slug is the only access control
+on the unauthenticated ``/n/{slug}/*`` proxy — reading it hands out every
+other notebook's URL."""
+
+
+def lock_data_dir_root(data_dir: Path) -> None:
+    """Chmod ``data_dir`` itself to ``DATA_DIR_MODE``. Idempotent; call on every boot.
+
+    The single place this mode is ever applied — callers (``migration.py``)
+    must go through this function instead of chmod'ing ``data_dir`` directly,
+    so the parent's mode can't silently drift from the slug tree's.
+    """
+    os.chmod(data_dir, DATA_DIR_MODE)
 
 
 @dataclass(frozen=True)
@@ -95,7 +141,7 @@ def ensure_slug_jail(data_dir: Path, slug: str, *, uid: int | None = None) -> Sl
     dirs = (paths.root, paths.data, paths.workspace, paths.home)
     for d in dirs:
         d.mkdir(parents=True, exist_ok=True)
-        os.chmod(d, _TREE_MODE)
+        os.chmod(d, SLUG_TREE_MODE)
         if uid is not None:
             os.chown(d, uid, uid)
     return paths
@@ -166,10 +212,16 @@ def load_uid_registry(path: Path) -> dict[str, int]:
 
 
 def save_uid_registry(path: Path, records: dict[str, int]) -> None:
-    """Atomically rewrite the uid registry (tmp + rename), same idiom as save_pids."""
+    """Atomically rewrite the uid registry (tmp + rename), same idiom as save_pids.
+
+    The tmp file is locked to ``_REGISTRY_MODE`` (0600) before the rename, not
+    after — so there is never a window where a freshly written or rewritten
+    registry is briefly world-readable under the default umask.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(records, indent=2))
+    os.chmod(tmp, _REGISTRY_MODE)
     os.replace(tmp, path)
 
 

--- a/apps/notebook-host/src/notebook_host/jail.py
+++ b/apps/notebook-host/src/notebook_host/jail.py
@@ -1,18 +1,32 @@
 """Per-slug on-disk layout and directory-tree lifecycle.
 
-This module owns two things: the shape of a slug's directory tree
-(``SlugPaths``) and creating/removing that tree on disk. ``data_dir/<slug>/``
-is the isolation boundary a jailed marimo process is confined to; every
-host-owned registry file (``blogs.json``, ``pids.json``, ``uids.json``)
-deliberately sits outside it, as a sibling of every slug root rather than
-inside any of them.
+This module owns three things: the shape of a slug's directory tree
+(``SlugPaths``), creating/removing that tree on disk, and the privilege-drop
+mechanism a spawned/validated notebook runs under. ``data_dir/<slug>/`` is the
+isolation boundary a jailed marimo process is confined to; every host-owned
+registry file (``blogs.json``, ``pids.json``, ``uids.json``) deliberately sits
+outside it, as a sibling of every slug root rather than inside any of them.
 
 Nothing here imports ``Settings`` — callers read config and pass paths / ints
 in explicitly, so this module has no dependency on ``notebook_host.config``.
 
-Pure functions only for path computation; the tree create/remove pair is the
-only filesystem I/O (mkdir/chmod/chown/rmtree — no clock, no process control,
-no network).
+Pure functions only for path computation; the tree create/remove pair and the
+uid-resolution/privilege-drop functions are the only filesystem/process I/O
+(mkdir, chmod, chown, rmtree, and dropping into another uid — no clock, no
+network).
+
+Two documented limitations of the uid split, deliberately not worked around:
+
+1. Allocated uids have no ``/etc/passwd`` entry. ``uv``/``marimo`` do not need
+   one (verified — neither does an NSS lookup once ``HOME`` is set explicitly),
+   but notebook code that itself calls ``Path.home()``,
+   ``os.path.expanduser("~")`` or ``getpass.getuser()`` will raise
+   ``KeyError: getpwuid()``. This is a correctness footnote for tenant
+   notebook authors, not an isolation gap.
+2. Because ``HOME`` is per-slug, each slug's ``uv`` cache is private. Repeated
+   ``--sandbox`` publishes across *different* slugs each pay their own PEP 723
+   dependency download instead of sharing one warm cache — a direct,
+   unavoidable consequence of per-uid isolation, not a bug.
 """
 
 from __future__ import annotations
@@ -20,6 +34,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -86,7 +101,7 @@ def ensure_slug_jail(data_dir: Path, slug: str, *, uid: int | None = None) -> Sl
     return paths
 
 
-def remove_slug_tree(data_dir: Path, slug: str) -> None:
+def remove_slug_tree(data_dir: Path, slug: str, *, uids_file: Path | None = None) -> None:
     """Remove a slug's whole directory tree in one call.
 
     Replaces the unlink-plus-two-rmtrees pattern the flat layout required
@@ -94,9 +109,17 @@ def remove_slug_tree(data_dir: Path, slug: str) -> None:
     background sweep delete only one of the three on-disk pieces. A no-op
     (does not raise) if the tree doesn't exist.
 
+    When ``uids_file`` is given, the slug's uid is also released from the
+    registry (via ``release_slug_uid``) after the tree is gone — keeping uid
+    release on the same single code path every delete site already calls,
+    rather than adding a fourth thing each caller must remember. Omitted by
+    default so this plan changes no caller's behaviour.
+
     ``slug`` must already have passed ``lifecycle.safe_slug``.
     """
     shutil.rmtree(get_slug_paths(data_dir, slug).root, ignore_errors=True)
+    if uids_file is not None:
+        release_slug_uid(uids_file, slug)
 
 
 # ─── uid pool ────────────────────────────────────────────────────────────────
@@ -201,3 +224,94 @@ def release_slug_uid(path: Path, slug: str) -> None:
     registry = load_uid_registry(path)
     if registry.pop(slug, None) is not None:
         save_uid_registry(path, registry)
+
+
+# ─── privilege drop ──────────────────────────────────────────────────────────
+#
+# The jail's failure policy is the opposite of the rlimit-only preexec in
+# lifecycle.py: rlimits warn and degrade (fine for a resource cap), the jail
+# fails closed (required for a security control, D-05). Keeping the drop here
+# rather than folding it into lifecycle._make_preexec is deliberate — merging
+# the two failure policies into one function is exactly how the isolation
+# would get silently lost.
+
+
+class JailUnavailableError(RuntimeError):
+    """Raised when the jail cannot be applied and no explicit opt-out is set."""
+
+
+def can_apply_jail() -> bool:
+    """Whether this process can actually drop privilege into another uid.
+
+    The ``os.geteuid() == 0`` check is the operative one, not merely whether
+    the platform exposes the privilege-changing syscalls used below: a
+    non-root process cannot change its uid to another value regardless of
+    platform, so this gate is POSIX-and-root, not Linux-only like the rlimit
+    gate in ``lifecycle._make_preexec`` (which only cares about ``RLIMIT_AS``
+    reliability, not privilege). The ``hasattr`` checks are evaluated first so
+    a non-POSIX platform short-circuits before reaching ``os.geteuid()``,
+    which doesn't exist there.
+    """
+    return hasattr(os, "setuid") and hasattr(os, "setgroups") and os.geteuid() == 0
+
+
+def resolve_jail_uid(
+    uids_file: Path, slug: str, *, start: int, end: int, allow_unjailed: bool
+) -> int | None:
+    """Resolve the uid a spawn/validate call for ``slug`` should drop into.
+
+    Fail-closed per D-05: when the jail cannot be applied (not root, or this
+    platform cannot change process identity), this raises
+    ``JailUnavailableError`` unless the caller has explicitly set
+    ``allow_unjailed=True`` (the deliberate dev-host opt-out, wired to the
+    ``allow_unjailed_spawn`` setting) — in which case it returns ``None`` and
+    the caller spawns unjailed rather than refusing.
+
+    ``UidPoolExhaustedError`` from the underlying allocation is allowed to
+    propagate unchanged, even when ``allow_unjailed=True``: a full pool must be
+    loud, never a silent fall-through to an unjailed spawn.
+    """
+    if can_apply_jail():
+        return get_or_create_slug_uid(uids_file, slug, start=start, end=end)
+    if allow_unjailed:
+        return None
+    raise JailUnavailableError(
+        "cannot apply the notebook jail on this host (not root, or this "
+        "platform cannot change process identity); refusing to spawn "
+        "unjailed. Set allow_unjailed_spawn=True to explicitly opt out on a "
+        "dev host."
+    )
+
+
+def build_jailed_preexec(
+    uid: int, *, rlimit_as_bytes: int | None, rlimit_cpu_seconds: int | None
+) -> Callable[[], None]:
+    """Build the preexec_fn that drops the forked child into ``uid``.
+
+    Always returns a callable — never ``None``. This is a deliberate
+    divergence from ``lifecycle._make_preexec``, which returns ``None`` on
+    non-Linux or when no rlimits are configured: a jail that silently does not
+    apply is exactly the failure mode this plan exists to remove, so there is
+    no code path here that can produce a no-op preexec.
+
+    The gid always equals the uid — each slug gets its own primary group of
+    the same number, so no separate gid allocation is needed.
+
+    Import ``resource`` here (POSIX-only stdlib), matching ``_make_preexec``'s
+    existing guarded-import style.
+    """
+    import resource  # POSIX-only stdlib; this whole mechanism requires POSIX.
+
+    def _apply() -> None:  # runs in the forked child, before launching marimo
+        os.setgroups([])  # MUST precede setgid/setuid — omitting this leaves
+        # the child in every supplementary group the host process (root)
+        # belongs to, even after setuid/setgid drop the primary identity.
+        os.setgid(uid)  # MUST precede setuid — a process cannot change gid
+        # once its uid is no longer 0.
+        os.setuid(uid)
+        if rlimit_as_bytes:
+            resource.setrlimit(resource.RLIMIT_AS, (rlimit_as_bytes, rlimit_as_bytes))
+        if rlimit_cpu_seconds:
+            resource.setrlimit(resource.RLIMIT_CPU, (rlimit_cpu_seconds, rlimit_cpu_seconds))
+
+    return _apply

--- a/apps/notebook-host/src/notebook_host/jail.py
+++ b/apps/notebook-host/src/notebook_host/jail.py
@@ -1,0 +1,98 @@
+"""Per-slug on-disk layout and directory-tree lifecycle.
+
+This module owns two things: the shape of a slug's directory tree
+(``SlugPaths``) and creating/removing that tree on disk. ``data_dir/<slug>/``
+is the isolation boundary a jailed marimo process is confined to; every
+host-owned registry file (``blogs.json``, ``pids.json``, ``uids.json``)
+deliberately sits outside it, as a sibling of every slug root rather than
+inside any of them.
+
+Nothing here imports ``Settings`` — callers read config and pass paths / ints
+in explicitly, so this module has no dependency on ``notebook_host.config``.
+
+Pure functions only for path computation; the tree create/remove pair is the
+only filesystem I/O (mkdir/chmod/chown/rmtree — no clock, no process control,
+no network).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+_TREE_MODE = 0o700
+
+
+@dataclass(frozen=True)
+class SlugPaths:
+    """Every on-disk path a slug owns. The single source of truth for the layout.
+
+    ``notebook``'s basename is always ``notebook.py`` regardless of slug —
+    deliberate, because ``spawn_marimo`` passes ``file_path.name`` as marimo's
+    positional argument, so a fixed basename keeps that argv slug-independent.
+    """
+
+    root: Path
+    notebook: Path
+    data: Path
+    workspace: Path
+    home: Path
+    log: Path
+
+
+def get_slug_paths(data_dir: Path, slug: str) -> SlugPaths:
+    """Compute every path a slug owns. Pure — no filesystem access.
+
+    ``slug`` must already have passed ``lifecycle.safe_slug``; this function
+    does not re-validate it (importing ``lifecycle`` from here would create a
+    cycle, since plan-wiring makes ``lifecycle`` import ``jail``).
+    """
+    root = data_dir / slug
+    return SlugPaths(
+        root=root,
+        notebook=root / "notebook.py",
+        data=root / "data",
+        workspace=root / "workspace",
+        home=root / "home",
+        log=root / "marimo.log",
+    )
+
+
+def ensure_slug_jail(data_dir: Path, slug: str, *, uid: int | None = None) -> SlugPaths:
+    """Create (or repair) a slug's whole directory tree at mode 0700.
+
+    Creates ``root``, ``data``, ``workspace``, ``home`` and chmods each to
+    0700 unconditionally — ``mkdir``'s ``mode`` argument is masked by umask,
+    so an explicit ``chmod`` is required. When ``uid`` is given, each of those
+    four directories is also chowned to ``(uid, uid)``.
+
+    Idempotent: safe to call repeatedly on an existing, already-owned tree.
+    Does NOT touch ``notebook.py``, ``marimo.log``, or anything already inside
+    ``data/`` — file ownership is the write site's job, and files created by
+    the jailed marimo process are already owned correctly by construction.
+
+    ``slug`` must already have passed ``lifecycle.safe_slug``.
+    """
+    paths = get_slug_paths(data_dir, slug)
+    dirs = (paths.root, paths.data, paths.workspace, paths.home)
+    for d in dirs:
+        d.mkdir(parents=True, exist_ok=True)
+        os.chmod(d, _TREE_MODE)
+        if uid is not None:
+            os.chown(d, uid, uid)
+    return paths
+
+
+def remove_slug_tree(data_dir: Path, slug: str) -> None:
+    """Remove a slug's whole directory tree in one call.
+
+    Replaces the unlink-plus-two-rmtrees pattern the flat layout required
+    across three call sites — exactly the duplication that let the
+    background sweep delete only one of the three on-disk pieces. A no-op
+    (does not raise) if the tree doesn't exist.
+
+    ``slug`` must already have passed ``lifecycle.safe_slug``.
+    """
+    shutil.rmtree(get_slug_paths(data_dir, slug).root, ignore_errors=True)

--- a/apps/notebook-host/src/notebook_host/lifecycle.py
+++ b/apps/notebook-host/src/notebook_host/lifecycle.py
@@ -21,7 +21,7 @@ from typing import Literal
 import httpx
 from fastapi import HTTPException, status
 
-from notebook_host.jail import SlugPaths
+from notebook_host.jail import SlugPaths, build_jailed_preexec
 
 _log = logging.getLogger(__name__)
 
@@ -196,6 +196,7 @@ def spawn_marimo(
     sandbox: bool = False,
     rlimit_as_bytes: int | None = None,
     rlimit_cpu_seconds: int | None = None,
+    jail_uid: int | None = None,
 ) -> subprocess.Popen[bytes]:
     """Spawn ``marimo <mode> <basename>`` on ``port`` from a per-slug workspace.
 
@@ -204,13 +205,21 @@ def spawn_marimo(
     passthrough. ``start_new_session`` isolates the child's process group;
     env is scrubbed so notebook code can't read the admin bearer; RLIMIT_AS/CPU
     (Linux) cap runaway notebooks (inherited by the sandbox's re-exec'd
-    descendants).
+    descendants). ``HOME`` always points into ``paths.home`` — inside the
+    slug's own tree — regardless of whether ``jail_uid`` is set, so the
+    dev/CI unjailed path exercises the same environment shape production runs
+    under.
 
     ``sandbox`` adds ``--sandbox``, which makes marimo install the notebook's
     PEP 723 ``dependencies`` into an isolated uv venv — the only way a notebook
     can use a library outside the host's baked set. Pass it only for notebooks
     that declare inline metadata (``has_inline_script_metadata``); a headerless
     notebook under ``--sandbox`` loses the baked pandas/numpy/pymc stack.
+
+    When ``jail_uid`` is set, the child runs as that per-notebook uid
+    (``build_jailed_preexec``) instead of the host's own uid; when it is
+    ``None`` (the default), behaviour is unchanged from before this uid split
+    existed — the existing rlimit-only preexec, with its non-Linux warning.
     """
     uv = shutil.which("uv")
     if uv is None:
@@ -231,14 +240,28 @@ def spawn_marimo(
         f"/n/{slug}",
     ]
     log_path = paths.log
+    # Opened here, in the host process, before the fork — so the file is
+    # created root-owned even though it lives inside the uid-owned 0700 slug
+    # root. That's correct and needs no chown: the child inherits this
+    # already-open file descriptor, and POSIX does not re-check permissions on
+    # an inherited fd. Do not chown this file, and do not move the open()
+    # after the privilege drop — the dropped-uid child would then be opening a
+    # path it has no rights to, breaking log writes outright.
     log_fh = open(log_path, "ab")  # noqa: SIM115 — owned by subprocess
-    preexec = _make_preexec(rlimit_as_bytes, rlimit_cpu_seconds)
-    if preexec is None and sys.platform != "linux" and (rlimit_as_bytes or rlimit_cpu_seconds):
-        _log.warning(
-            "rlimit configured but platform=%s is not Linux; "
-            "subprocess will run without resource caps",
-            sys.platform,
+    env = scrub_env(dict(os.environ))
+    env["HOME"] = str(paths.home)
+    if jail_uid is not None:
+        preexec = build_jailed_preexec(
+            jail_uid, rlimit_as_bytes=rlimit_as_bytes, rlimit_cpu_seconds=rlimit_cpu_seconds
         )
+    else:
+        preexec = _make_preexec(rlimit_as_bytes, rlimit_cpu_seconds)
+        if preexec is None and sys.platform != "linux" and (rlimit_as_bytes or rlimit_cpu_seconds):
+            _log.warning(
+                "rlimit configured but platform=%s is not Linux; "
+                "subprocess will run without resource caps",
+                sys.platform,
+            )
     try:
         return subprocess.Popen(
             cmd,
@@ -246,7 +269,7 @@ def spawn_marimo(
             stdout=log_fh,
             stderr=subprocess.STDOUT,
             start_new_session=True,
-            env=scrub_env(dict(os.environ)),
+            env=env,
             preexec_fn=preexec,
         )
     finally:
@@ -308,6 +331,7 @@ def validate_notebook(
     sandbox: bool = False,
     rlimit_as_bytes: int | None = None,
     rlimit_cpu_seconds: int | None = None,
+    jail_uid: int | None = None,
 ) -> ValidationResult:
     """Run ``marimo export html`` to confirm the notebook's cells actually run.
 
@@ -324,6 +348,11 @@ def validate_notebook(
     cold sandbox install here also warms uv's shared cache, so the subsequent
     spawn starts fast.
 
+    The validator deliberately runs under the same jail as the spawned
+    process: it executes the same untrusted notebook code, so ``jail_uid``
+    (when set) drops privilege here too, and ``HOME`` points into the same
+    per-slug tree.
+
     Blocking (uses ``subprocess.run``) — call via ``asyncio.to_thread`` from the
     async request handler. On timeout, returns ``ok=True`` with
     ``timed_out=True``: a slow-but-possibly-valid notebook is published rather
@@ -334,8 +363,22 @@ def validate_notebook(
     if uv is None:
         raise RuntimeError("uv not on PATH")
     workspace = _prepare_workspace(paths)
-    preexec = _make_preexec(rlimit_as_bytes, rlimit_cpu_seconds)
+    if jail_uid is not None:
+        preexec = build_jailed_preexec(
+            jail_uid, rlimit_as_bytes=rlimit_as_bytes, rlimit_cpu_seconds=rlimit_cpu_seconds
+        )
+    else:
+        preexec = _make_preexec(rlimit_as_bytes, rlimit_cpu_seconds)
+    env = scrub_env(dict(os.environ))
+    env["HOME"] = str(paths.home)
     with tempfile.TemporaryDirectory() as tmp:
+        if jail_uid is not None:
+            # Unlike the log file above, this directory is opened *by the
+            # child* (marimo's own `-o` write), after the privilege drop, not
+            # inherited as an already-open fd — so it needs a real chown, or
+            # the export fails for every notebook the moment the jail is on,
+            # looking like a marimo export error rather than a permissions bug.
+            os.chown(tmp, jail_uid, jail_uid)
         cmd = [uv, "run", "--with", "marimo", "marimo", "export", "html"]
         if sandbox:
             cmd.append("--sandbox")
@@ -344,7 +387,7 @@ def validate_notebook(
             proc = subprocess.run(  # noqa: S603
                 cmd,
                 cwd=str(workspace),
-                env=scrub_env(dict(os.environ)),
+                env=env,
                 preexec_fn=preexec,
                 capture_output=True,
                 text=True,

--- a/apps/notebook-host/src/notebook_host/lifecycle.py
+++ b/apps/notebook-host/src/notebook_host/lifecycle.py
@@ -21,6 +21,8 @@ from typing import Literal
 import httpx
 from fastapi import HTTPException, status
 
+from notebook_host.jail import SlugPaths
+
 _log = logging.getLogger(__name__)
 
 _SLUG_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -150,43 +152,44 @@ def _make_preexec(
     return _apply
 
 
-def _prepare_workspace(file_path: Path, slug: str) -> Path:
-    """Create ``<slug>_workspace/`` next to ``file_path`` and wire its symlinks.
+def _prepare_workspace(paths: SlugPaths) -> Path:
+    """Create ``paths.workspace`` and wire its symlinks, entirely inside ``paths.root``.
 
-    Layout (under ``file_path.parent``):
-        <slug>.py                    — source file (caller-owned)
-        <slug>.data/                 — data dir for attachments
-        <slug>_workspace/            — marimo cwd
-            data        -> ../<slug>.data
-            <slug>.py   -> ../<slug>.py
+    Layout (under ``paths.root``):
+        notebook.py   — source file (caller-owned)
+        data/         — data dir for attachments
+        workspace/    — marimo cwd
+            data        -> ../data
+            notebook.py -> ../notebook.py
+
+    Both symlink targets stay inside ``paths.root`` — nothing in a live
+    workspace resolves above the slug's own directory, unlike the old flat
+    layout's ``../<slug>.data`` / ``../<slug>.py`` targets, which pointed into
+    the shared ``data_dir`` and reached every other slug's files.
 
     Idempotent: stale links/files are replaced so a mid-spawn crash doesn't
     wedge the next attempt.
     """
-    data_dir_parent = file_path.parent
-    slug_data_dir = data_dir_parent / f"{slug}.data"
-    slug_data_dir.mkdir(parents=True, exist_ok=True)
-
-    workspace = data_dir_parent / f"{slug}_workspace"
-    workspace.mkdir(parents=True, exist_ok=True)
+    paths.data.mkdir(parents=True, exist_ok=True)
+    paths.workspace.mkdir(parents=True, exist_ok=True)
 
     # Relative symlinks so the workspace dir is location-independent.
-    data_link = workspace / "data"
-    source_link = workspace / file_path.name  # e.g. "<slug>.py"
+    data_link = paths.workspace / "data"
+    source_link = paths.workspace / paths.notebook.name  # "notebook.py"
     targets: tuple[tuple[Path, Path], ...] = (
-        (data_link, Path("..") / f"{slug}.data"),
-        (source_link, Path("..") / file_path.name),
+        (data_link, Path("..") / "data"),
+        (source_link, Path("..") / paths.notebook.name),
     )
     for link, target in targets:
         if link.is_symlink() or link.exists():
             link.unlink()
         link.symlink_to(target)
-    return workspace
+    return paths.workspace
 
 
 def spawn_marimo(
     slug: str,
-    file_path: Path,
+    paths: SlugPaths,
     port: int,
     *,
     mode: Literal["edit", "run"] = "edit",
@@ -196,11 +199,12 @@ def spawn_marimo(
 ) -> subprocess.Popen[bytes]:
     """Spawn ``marimo <mode> <basename>`` on ``port`` from a per-slug workspace.
 
-    cwd is the workspace dir, so the basename arg resolves through the source
-    symlink. ``--base-url /n/<slug>`` keeps the proxy a straight passthrough.
-    ``start_new_session`` isolates the child's process group; env is scrubbed
-    so notebook code can't read the admin bearer; RLIMIT_AS/CPU (Linux) cap
-    runaway notebooks (inherited by the sandbox's re-exec'd descendants).
+    cwd is ``paths.workspace``, so the basename arg resolves through the
+    source symlink. ``--base-url /n/<slug>`` keeps the proxy a straight
+    passthrough. ``start_new_session`` isolates the child's process group;
+    env is scrubbed so notebook code can't read the admin bearer; RLIMIT_AS/CPU
+    (Linux) cap runaway notebooks (inherited by the sandbox's re-exec'd
+    descendants).
 
     ``sandbox`` adds ``--sandbox``, which makes marimo install the notebook's
     PEP 723 ``dependencies`` into an isolated uv venv — the only way a notebook
@@ -211,12 +215,12 @@ def spawn_marimo(
     uv = shutil.which("uv")
     if uv is None:
         raise RuntimeError("uv not on PATH")
-    workspace = _prepare_workspace(file_path, slug)
+    workspace = _prepare_workspace(paths)
     cmd = [uv, "run", "--with", "marimo", "marimo", mode]
     if sandbox:
         cmd.append("--sandbox")
     cmd += [
-        file_path.name,
+        paths.notebook.name,
         "--no-token",
         "--headless",
         "--host",
@@ -226,7 +230,7 @@ def spawn_marimo(
         "--base-url",
         f"/n/{slug}",
     ]
-    log_path = file_path.parent / f"{slug}.marimo.log"
+    log_path = paths.log
     log_fh = open(log_path, "ab")  # noqa: SIM115 — owned by subprocess
     preexec = _make_preexec(rlimit_as_bytes, rlimit_cpu_seconds)
     if preexec is None and sys.platform != "linux" and (rlimit_as_bytes or rlimit_cpu_seconds):
@@ -298,7 +302,7 @@ def _extract_cell_errors(output: str) -> list[str]:
 
 def validate_notebook(
     slug: str,
-    file_path: Path,
+    paths: SlugPaths,
     *,
     timeout_s: float,
     sandbox: bool = False,
@@ -329,13 +333,13 @@ def validate_notebook(
     uv = shutil.which("uv")
     if uv is None:
         raise RuntimeError("uv not on PATH")
-    workspace = _prepare_workspace(file_path, slug)
+    workspace = _prepare_workspace(paths)
     preexec = _make_preexec(rlimit_as_bytes, rlimit_cpu_seconds)
     with tempfile.TemporaryDirectory() as tmp:
         cmd = [uv, "run", "--with", "marimo", "marimo", "export", "html"]
         if sandbox:
             cmd.append("--sandbox")
-        cmd += [file_path.name, "-o", str(Path(tmp) / "check.html")]
+        cmd += [paths.notebook.name, "-o", str(Path(tmp) / "check.html")]
         try:
             proc = subprocess.run(  # noqa: S603
                 cmd,

--- a/apps/notebook-host/src/notebook_host/main.py
+++ b/apps/notebook-host/src/notebook_host/main.py
@@ -22,7 +22,15 @@ from fastapi import FastAPI, HTTPException
 from notebook_host.admin import AdminState, create_admin_router
 from notebook_host.blogs_store import load_blogs
 from notebook_host.config import Settings
-from notebook_host.jail import SlugPaths, ensure_slug_jail, remove_slug_tree
+from notebook_host.jail import (
+    JailUnavailableError,
+    SlugPaths,
+    UidPoolExhaustedError,
+    can_apply_jail,
+    ensure_slug_jail,
+    remove_slug_tree,
+    resolve_jail_uid,
+)
 from notebook_host.lifecycle import (
     NotebookProcess,
     ValidationResult,
@@ -48,7 +56,12 @@ def create_app(settings: Settings) -> FastAPI:
     # the same mode as the spawn, so both read the on-disk source (already
     # written by the PUT handler) through the same detector.
     def _spawner(
-        slug: str, paths: SlugPaths, port: int, *, mode: Literal["edit", "run"] = "edit"
+        slug: str,
+        paths: SlugPaths,
+        port: int,
+        *,
+        mode: Literal["edit", "run"] = "edit",
+        jail_uid: int | None = None,
     ) -> subprocess.Popen[bytes]:
         return spawn_marimo(
             slug,
@@ -58,9 +71,10 @@ def create_app(settings: Settings) -> FastAPI:
             sandbox=has_inline_script_metadata(paths.notebook.read_text(encoding="utf-8")),
             rlimit_as_bytes=settings.marimo_rlimit_as_bytes or None,
             rlimit_cpu_seconds=settings.marimo_rlimit_cpu_seconds or None,
+            jail_uid=jail_uid,
         )
 
-    def _validator(slug: str, paths: SlugPaths) -> ValidationResult:
+    def _validator(slug: str, paths: SlugPaths, *, jail_uid: int | None = None) -> ValidationResult:
         return validate_notebook(
             slug,
             paths,
@@ -68,6 +82,7 @@ def create_app(settings: Settings) -> FastAPI:
             sandbox=has_inline_script_metadata(paths.notebook.read_text(encoding="utf-8")),
             rlimit_as_bytes=settings.marimo_rlimit_as_bytes or None,
             rlimit_cpu_seconds=settings.marimo_rlimit_cpu_seconds or None,
+            jail_uid=jail_uid,
         )
 
     state = AdminState(
@@ -79,6 +94,17 @@ def create_app(settings: Settings) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:  # pyright: ignore[reportUnusedFunction]
+        # Fail-closed boot gate (D-05): a host that cannot apply the jail must
+        # not come up at all. Refusing per-request instead would leave an
+        # apparently healthy host answering nothing but 503s — a configuration
+        # refusal that reads as an outage of unknown cause.
+        if not can_apply_jail() and not settings.allow_unjailed_spawn:
+            raise JailUnavailableError(
+                "cannot apply the notebook jail on this host (not root, or this "
+                "platform cannot change process identity); refusing to boot. Set "
+                "DAIMON_NOTEBOOK__ALLOW_UNJAILED_SPAWN=true to explicitly opt out "
+                "on a dev host."
+            )
         settings.data_dir.mkdir(parents=True, exist_ok=True)
         # Reap any marimo subprocesses left behind by a previous host crash
         # before we accept any PUTs. The previous host's pids.json is the
@@ -117,12 +143,24 @@ async def _spawn_blog_process(state: AdminState, slug: str) -> bool:
 
     Source must already exist on the persistent volume at
     ``data_dir/<slug>/notebook.py``. Used by boot respawn and the sweep's
-    self-heal. A failure (missing source, pool exhausted, spawn timeout) logs
-    and returns False — callers must not let one bad blog abort their loop.
-    The caller is responsible for popping any stale entry for ``slug`` before
-    calling (so its port frees up for reuse).
+    self-heal. A failure (missing source, pool exhausted, spawn timeout, or the
+    jail being unavailable) logs and returns False — callers must not let one
+    bad blog abort their loop. A blog that cannot be jailed stays down; it must
+    not respawn unisolated. The caller is responsible for popping any stale
+    entry for ``slug`` before calling (so its port frees up for reuse).
     """
-    paths = ensure_slug_jail(state.settings.data_dir, slug)
+    try:
+        uid = resolve_jail_uid(
+            state.settings.resolved_uids_file,
+            slug,
+            start=state.settings.jail_uid_start,
+            end=state.settings.jail_uid_end,
+            allow_unjailed=state.settings.allow_unjailed_spawn,
+        )
+    except (JailUnavailableError, UidPoolExhaustedError) as err:
+        _log.error("blog %r respawn could not be jailed: %s", slug, err)
+        return False
+    paths = ensure_slug_jail(state.settings.data_dir, slug, uid=uid)
     if not paths.notebook.exists():
         _log.warning("blog %r has no source at %s; skipping respawn", slug, paths.notebook)
         return False
@@ -130,7 +168,7 @@ async def _spawn_blog_process(state: AdminState, slug: str) -> bool:
         port = allocate_port(
             state.processes, state.settings.marimo_port_start, state.settings.marimo_port_end
         )
-        proc = state.spawner(slug, paths, port, mode="run")
+        proc = state.spawner(slug, paths, port, mode="run", jail_uid=uid)
     except HTTPException as err:
         _log.warning("blog %r respawn could not start: %s", slug, err.detail)
         return False
@@ -183,7 +221,7 @@ async def _sweep_once(state: AdminState) -> bool:
             continue
         kill(np)
         state.processes.pop(slug, None)
-        remove_slug_tree(state.settings.data_dir, slug)
+        remove_slug_tree(state.settings.data_dir, slug, uids_file=state.settings.resolved_uids_file)
         mutated = True
     # Self-heal any registered blog that isn't currently running. This covers a
     # respawn that failed earlier (popped from state.processes but still in the

--- a/apps/notebook-host/src/notebook_host/main.py
+++ b/apps/notebook-host/src/notebook_host/main.py
@@ -118,6 +118,12 @@ def create_app(settings: Settings) -> FastAPI:
             uid_start=settings.jail_uid_start,
             uid_end=settings.jail_uid_end,
             allow_unjailed=settings.allow_unjailed_spawn,
+            registry_files=(
+                settings.resolved_blogs_file,
+                settings.resolved_pids_file,
+                settings.resolved_consumed_file,
+                settings.resolved_uids_file,
+            ),
         )
         if migrated:
             _log.info(

--- a/apps/notebook-host/src/notebook_host/main.py
+++ b/apps/notebook-host/src/notebook_host/main.py
@@ -245,9 +245,21 @@ async def _sweep_once(state: AdminState) -> bool:
     # registry) — without this, such a blog would stay down until the next host
     # boot. Boot does the same via _respawn_registered_blogs; doing it every
     # sweep makes "retry next sweep" actually true.
+    #
+    # The outer load_blogs is a cheap candidate scan taken outside any lock, so
+    # it can race delete_blog: a slug it names may already be mid-delete (or
+    # finish deleting) before we get here. Re-reading load_blogs a second time
+    # *inside* the same per-slug lock delete_blog holds is what closes that
+    # window — a candidate that was unregistered under the lock is dropped
+    # instead of respawned. The double read looks redundant; it is not.
     for slug in load_blogs(state.settings.resolved_blogs_file):
-        if slug not in state.processes and await _spawn_blog_process(state, slug):
-            mutated = True
+        async with state.lock_for(slug):
+            if slug not in load_blogs(state.settings.resolved_blogs_file):
+                continue
+            if slug in state.processes:
+                continue
+            if await _spawn_blog_process(state, slug):
+                mutated = True
     return mutated
 
 

--- a/apps/notebook-host/src/notebook_host/main.py
+++ b/apps/notebook-host/src/notebook_host/main.py
@@ -15,7 +15,6 @@ import logging
 import subprocess
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import Literal
 
 from fastapi import FastAPI, HTTPException
@@ -23,6 +22,7 @@ from fastapi import FastAPI, HTTPException
 from notebook_host.admin import AdminState, create_admin_router
 from notebook_host.blogs_store import load_blogs
 from notebook_host.config import Settings
+from notebook_host.jail import SlugPaths, ensure_slug_jail, remove_slug_tree
 from notebook_host.lifecycle import (
     NotebookProcess,
     ValidationResult,
@@ -48,24 +48,24 @@ def create_app(settings: Settings) -> FastAPI:
     # the same mode as the spawn, so both read the on-disk source (already
     # written by the PUT handler) through the same detector.
     def _spawner(
-        slug: str, file_path: Path, port: int, *, mode: Literal["edit", "run"] = "edit"
+        slug: str, paths: SlugPaths, port: int, *, mode: Literal["edit", "run"] = "edit"
     ) -> subprocess.Popen[bytes]:
         return spawn_marimo(
             slug,
-            file_path,
+            paths,
             port,
             mode=mode,
-            sandbox=has_inline_script_metadata(file_path.read_text(encoding="utf-8")),
+            sandbox=has_inline_script_metadata(paths.notebook.read_text(encoding="utf-8")),
             rlimit_as_bytes=settings.marimo_rlimit_as_bytes or None,
             rlimit_cpu_seconds=settings.marimo_rlimit_cpu_seconds or None,
         )
 
-    def _validator(slug: str, file_path: Path) -> ValidationResult:
+    def _validator(slug: str, paths: SlugPaths) -> ValidationResult:
         return validate_notebook(
             slug,
-            file_path,
+            paths,
             timeout_s=settings.validation_timeout_seconds,
-            sandbox=has_inline_script_metadata(file_path.read_text(encoding="utf-8")),
+            sandbox=has_inline_script_metadata(paths.notebook.read_text(encoding="utf-8")),
             rlimit_as_bytes=settings.marimo_rlimit_as_bytes or None,
             rlimit_cpu_seconds=settings.marimo_rlimit_cpu_seconds or None,
         )
@@ -115,21 +115,22 @@ def create_app(settings: Settings) -> FastAPI:
 async def _spawn_blog_process(state: AdminState, slug: str) -> bool:
     """Spawn a registered blog in run mode and track it. Returns True on success.
 
-    Source must already exist on the persistent volume at ``data_dir/<slug>.py``.
-    Used by boot respawn and the sweep's self-heal. A failure (missing source,
-    pool exhausted, spawn timeout) logs and returns False — callers must not let
-    one bad blog abort their loop. The caller is responsible for popping any
-    stale entry for ``slug`` before calling (so its port frees up for reuse).
+    Source must already exist on the persistent volume at
+    ``data_dir/<slug>/notebook.py``. Used by boot respawn and the sweep's
+    self-heal. A failure (missing source, pool exhausted, spawn timeout) logs
+    and returns False — callers must not let one bad blog abort their loop.
+    The caller is responsible for popping any stale entry for ``slug`` before
+    calling (so its port frees up for reuse).
     """
-    path = state.settings.data_dir / f"{slug}.py"
-    if not path.exists():
-        _log.warning("blog %r has no source at %s; skipping respawn", slug, path)
+    paths = ensure_slug_jail(state.settings.data_dir, slug)
+    if not paths.notebook.exists():
+        _log.warning("blog %r has no source at %s; skipping respawn", slug, paths.notebook)
         return False
     try:
         port = allocate_port(
             state.processes, state.settings.marimo_port_start, state.settings.marimo_port_end
         )
-        proc = state.spawner(slug, path, port, mode="run")
+        proc = state.spawner(slug, paths, port, mode="run")
     except HTTPException as err:
         _log.warning("blog %r respawn could not start: %s", slug, err.detail)
         return False
@@ -163,8 +164,10 @@ async def _sweep_once(state: AdminState) -> bool:
     """One sweep pass. Returns True if it mutated state.processes.
 
     Blogs (run mode): never age-reaped; a dead one is respawned from disk
-    (self-heal). Ephemeral notebooks (edit mode): reaped + source-deleted when
-    should_reap is true.
+    (self-heal). Ephemeral notebooks (edit mode): reaped + their whole slug
+    tree (source, attachments, workspace, log) removed when should_reap is
+    true — the background sweep and the two delete endpoints share identical
+    cleanup semantics by construction.
     """
     mutated = False
     for slug in list(state.processes.keys()):
@@ -180,7 +183,7 @@ async def _sweep_once(state: AdminState) -> bool:
             continue
         kill(np)
         state.processes.pop(slug, None)
-        (state.settings.data_dir / f"{slug}.py").unlink(missing_ok=True)
+        remove_slug_tree(state.settings.data_dir, slug)
         mutated = True
     # Self-heal any registered blog that isn't currently running. This covers a
     # respawn that failed earlier (popped from state.processes but still in the

--- a/apps/notebook-host/src/notebook_host/main.py
+++ b/apps/notebook-host/src/notebook_host/main.py
@@ -42,6 +42,7 @@ from notebook_host.lifecycle import (
     validate_notebook,
     wait_for_port,
 )
+from notebook_host.migration import migrate_flat_layout
 from notebook_host.pids_store import reap_orphans
 from notebook_host.proxy import create_proxy_router
 
@@ -106,6 +107,22 @@ def create_app(settings: Settings) -> FastAPI:
                 "on a dev host."
             )
         settings.data_dir.mkdir(parents=True, exist_ok=True)
+        # Move any pre-jail flat layout onto the nested one before anything
+        # else touches data_dir — reap_orphans and the blog respawn below
+        # both assume data_dir/<slug>/notebook.py already exists. Not
+        # wrapped in try/except: a migration failure must abort the boot
+        # rather than come up serving a half-isolated data_dir.
+        migrated = migrate_flat_layout(
+            settings.data_dir,
+            uids_file=settings.resolved_uids_file,
+            uid_start=settings.jail_uid_start,
+            uid_end=settings.jail_uid_end,
+            allow_unjailed=settings.allow_unjailed_spawn,
+        )
+        if migrated:
+            _log.info(
+                "migrated %d legacy blog(s) to the nested layout: %s", len(migrated), migrated
+            )
         # Reap any marimo subprocesses left behind by a previous host crash
         # before we accept any PUTs. The previous host's pids.json is the
         # only record of what's still running with start_new_session=True.

--- a/apps/notebook-host/src/notebook_host/migration.py
+++ b/apps/notebook-host/src/notebook_host/migration.py
@@ -27,11 +27,17 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+from collections.abc import Sequence
 from pathlib import Path
 
 from fastapi import HTTPException
 
-from notebook_host.jail import SLUG_TREE_MODE, lock_data_dir_root, resolve_jail_uid
+from notebook_host.jail import (
+    SLUG_TREE_MODE,
+    lock_data_dir_root,
+    lock_registry_file,
+    resolve_jail_uid,
+)
 from notebook_host.lifecycle import safe_slug
 
 _log = logging.getLogger(__name__)
@@ -46,6 +52,7 @@ def migrate_flat_layout(
     uid_start: int,
     uid_end: int,
     allow_unjailed: bool,
+    registry_files: Sequence[Path] = (),
 ) -> list[str]:
     """Move every flat legacy slug under ``data_dir`` onto the nested layout.
 
@@ -59,12 +66,21 @@ def migrate_flat_layout(
     slug sits inside a still-unlocked parent alongside not-yet-migrated flat
     siblings.
 
+    ``registry_files`` are host-owned registry paths (``blogs.json``,
+    ``pids.json``, ...) that this host may have INHERITED from a release
+    predating the jail. They are locked in the same first step as ``data_dir``,
+    because the boot that makes ``data_dir`` traversable is exactly the boot
+    that must stop relying on an unlistable parent to hide them. Files this
+    host writes itself are already locked by their store before the rename.
+
     ``UidPoolExhaustedError`` and ``JailUnavailableError`` (from
     ``resolve_jail_uid``) are allowed to propagate uncaught: a migration that
     cannot isolate every legacy slug must abort the boot rather than leave
     some of them unjailed.
     """
     lock_data_dir_root(data_dir)
+    for registry in registry_files:
+        lock_registry_file(registry)
 
     migrated: list[str] = []
 

--- a/apps/notebook-host/src/notebook_host/migration.py
+++ b/apps/notebook-host/src/notebook_host/migration.py
@@ -31,12 +31,11 @@ from pathlib import Path
 
 from fastapi import HTTPException
 
-from notebook_host.jail import resolve_jail_uid
+from notebook_host.jail import SLUG_TREE_MODE, lock_data_dir_root, resolve_jail_uid
 from notebook_host.lifecycle import safe_slug
 
 _log = logging.getLogger(__name__)
 
-_TREE_MODE = 0o700
 _STAGING_PREFIX = ".migrating-"
 
 
@@ -54,17 +53,18 @@ def migrate_flat_layout(
     fully migrated). Must be called before anything else touches ``data_dir``
     — nothing here is safe to run concurrently with a spawn or a request.
 
-    ``data_dir`` itself is locked to ``0700`` as the very first step, before
-    any per-slug directory is created or chowned, so there is never a window
-    where a freshly jailed slug sits inside a still-traversable parent
-    alongside not-yet-migrated flat siblings.
+    ``data_dir`` itself is locked to ``jail.DATA_DIR_MODE`` (0711 — traversable,
+    not listable) as the very first step, before any per-slug directory is
+    created or chowned, so there is never a window where a freshly jailed
+    slug sits inside a still-unlocked parent alongside not-yet-migrated flat
+    siblings.
 
     ``UidPoolExhaustedError`` and ``JailUnavailableError`` (from
     ``resolve_jail_uid``) are allowed to propagate uncaught: a migration that
     cannot isolate every legacy slug must abort the boot rather than leave
     some of them unjailed.
     """
-    os.chmod(data_dir, _TREE_MODE)
+    lock_data_dir_root(data_dir)
 
     migrated: list[str] = []
 
@@ -112,12 +112,12 @@ def migrate_flat_layout(
 
         staging = data_dir / f"{_STAGING_PREFIX}{slug}"
         staging.mkdir(exist_ok=True)
-        os.chmod(staging, _TREE_MODE)
+        os.chmod(staging, SLUG_TREE_MODE)
 
         for name in ("workspace", "home"):
             d = staging / name
             d.mkdir(exist_ok=True)
-            os.chmod(d, _TREE_MODE)
+            os.chmod(d, SLUG_TREE_MODE)
 
         data = staging / "data"
         legacy_data = data_dir / f"{slug}.data"
@@ -125,7 +125,7 @@ def migrate_flat_layout(
             os.rename(legacy_data, data)
         elif not data.exists():
             data.mkdir()
-        os.chmod(data, _TREE_MODE)
+        os.chmod(data, SLUG_TREE_MODE)
 
         # Last: the source move is what marks staging as "complete" for pass
         # 1's resume predicate above, so it must happen only after every

--- a/apps/notebook-host/src/notebook_host/migration.py
+++ b/apps/notebook-host/src/notebook_host/migration.py
@@ -1,0 +1,181 @@
+"""Crash-safe, idempotent migration from the flat on-disk layout to the nested one.
+
+Every release before the per-slug jail wrote a flat layout directly under
+``data_dir``: ``<slug>.py``, ``<slug>.data/`` (attachments), ``<slug>_workspace/``
+(disposable), and ``<slug>.marimo.log``, siblings of ``blogs.json``/``pids.json``.
+The jail needs each slug isolated in its own ``0700``-owned subtree
+(``data_dir/<slug>/{notebook.py, data/, workspace/, home/, marimo.log}``), so an
+existing deployment's ``data_dir`` has to be moved onto that shape before
+anything reads or spawns from it.
+
+The host can be SIGKILLed at any point — a deploy replaces the container out
+from under it — so this has to converge to the fully-migrated state no matter
+which step a previous run died at, and running it again once already migrated
+must be a no-op. The mechanism: build each slug's new tree in a staging
+directory (``data_dir/.migrating-<slug>``), moving the notebook source in
+*last* so its presence in staging is a single reliable marker meaning
+"everything else already moved in", then ``os.rename`` (atomic on the same
+filesystem, same guarantee ``pids_store.save_pids`` already relies on) the
+staging directory onto its final name.
+
+Nothing here imports ``Settings``; the caller reads config and passes values,
+matching ``jail.py``'s posture.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from notebook_host.jail import resolve_jail_uid
+from notebook_host.lifecycle import safe_slug
+
+_log = logging.getLogger(__name__)
+
+_TREE_MODE = 0o700
+_STAGING_PREFIX = ".migrating-"
+
+
+def migrate_flat_layout(
+    data_dir: Path,
+    *,
+    uids_file: Path,
+    uid_start: int,
+    uid_end: int,
+    allow_unjailed: bool,
+) -> list[str]:
+    """Move every flat legacy slug under ``data_dir`` onto the nested layout.
+
+    Returns the slugs migrated by this call (empty once the tree is already
+    fully migrated). Must be called before anything else touches ``data_dir``
+    — nothing here is safe to run concurrently with a spawn or a request.
+
+    ``data_dir`` itself is locked to ``0700`` as the very first step, before
+    any per-slug directory is created or chowned, so there is never a window
+    where a freshly jailed slug sits inside a still-traversable parent
+    alongside not-yet-migrated flat siblings.
+
+    ``UidPoolExhaustedError`` and ``JailUnavailableError`` (from
+    ``resolve_jail_uid``) are allowed to propagate uncaught: a migration that
+    cannot isolate every legacy slug must abort the boot rather than leave
+    some of them unjailed.
+    """
+    os.chmod(data_dir, _TREE_MODE)
+
+    migrated: list[str] = []
+
+    # Pass 1 — resume any staging directory left by an interrupted run.
+    for staging in sorted(data_dir.glob(f"{_STAGING_PREFIX}*")):
+        slug = staging.name.removeprefix(_STAGING_PREFIX)
+        final = data_dir / slug
+        if final.exists():
+            # The final tree already won the race; the staging copy is a
+            # leftover from a run that got all the way to promote and then
+            # died before it could clean up, or from external tampering.
+            shutil.rmtree(staging)
+            continue
+        if (staging / "notebook.py").exists():
+            # Killed after the source moved in but before the promote. The
+            # tree is otherwise complete (attachments, workspace, home all
+            # moved in before the source, by construction of pass 2 below),
+            # so finish exactly like pass 2 would: resolve the uid, chown,
+            # promote.
+            _finish_staging(staging, final, slug, uids_file, uid_start, uid_end, allow_unjailed)
+            migrated.append(slug)
+        # else: leave the staging directory exactly where it is. It may
+        # already hold attachments moved in from the flat layout while the
+        # flat `<slug>.py` still exists — pass 2 will complete this same
+        # staging directory rather than starting over.
+
+    # Pass 2 — migrate remaining flat sources.
+    for source in sorted(data_dir.glob("*.py")):
+        slug = source.stem
+        try:
+            safe_slug(slug)
+        except HTTPException:
+            _log.warning("skipping %s: %r is not a valid slug, leaving it in place", source, slug)
+            continue
+
+        final = data_dir / slug
+        if final.exists():
+            _log.warning(
+                "both a flat source %s and a nested directory %s exist; "
+                "leaving the flat file for an operator to inspect",
+                source,
+                final,
+            )
+            continue
+
+        staging = data_dir / f"{_STAGING_PREFIX}{slug}"
+        staging.mkdir(exist_ok=True)
+        os.chmod(staging, _TREE_MODE)
+
+        for name in ("workspace", "home"):
+            d = staging / name
+            d.mkdir(exist_ok=True)
+            os.chmod(d, _TREE_MODE)
+
+        data = staging / "data"
+        legacy_data = data_dir / f"{slug}.data"
+        if not data.exists() and legacy_data.exists():
+            os.rename(legacy_data, data)
+        elif not data.exists():
+            data.mkdir()
+        os.chmod(data, _TREE_MODE)
+
+        # Last: the source move is what marks staging as "complete" for pass
+        # 1's resume predicate above, so it must happen only after every
+        # other piece of the tree is already in place.
+        os.rename(source, staging / "notebook.py")
+
+        _finish_staging(staging, final, slug, uids_file, uid_start, uid_end, allow_unjailed)
+        migrated.append(slug)
+
+    # Pass 3 — drop the disposable flat leftovers. Both are regenerated on
+    # the next spawn, and neither glob can match the nested equivalents
+    # (`data_dir/<slug>/workspace`, `data_dir/<slug>/marimo.log`), so this is
+    # idempotent by construction.
+    for workspace_dir in data_dir.glob("*_workspace"):
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+    for log_file in data_dir.glob("*.marimo.log"):
+        log_file.unlink(missing_ok=True)
+
+    if migrated:
+        _log.info("migrated %d legacy slug(s) to the nested layout: %s", len(migrated), migrated)
+    return migrated
+
+
+def _finish_staging(
+    staging: Path,
+    final: Path,
+    slug: str,
+    uids_file: Path,
+    uid_start: int,
+    uid_end: int,
+    allow_unjailed: bool,
+) -> None:
+    """Resolve the slug's uid, chown the staged tree, and promote it into place.
+
+    The legacy `.data/` contents are host-owned files the jailed process must
+    be able to read, so a recursive chown is required here — the one place it
+    is: `ensure_slug_jail` deliberately only owns the four directories, since
+    everywhere else a slug's files are created by the already-uid-owned
+    process itself.
+    """
+    uid = resolve_jail_uid(
+        uids_file, slug, start=uid_start, end=uid_end, allow_unjailed=allow_unjailed
+    )
+    if uid is not None:
+        _chown_recursive(staging, uid)
+    os.rename(staging, final)
+    _log.info("migrated legacy slug %r to the nested layout", slug)
+
+
+def _chown_recursive(root: Path, uid: int) -> None:
+    for path in root.rglob("*"):
+        os.chown(path, uid, uid, follow_symlinks=False)
+    os.chown(root, uid, uid)

--- a/apps/notebook-host/src/notebook_host/pids_store.py
+++ b/apps/notebook-host/src/notebook_host/pids_store.py
@@ -17,13 +17,17 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import signal
+import sys
 import time
 from datetime import datetime
 from pathlib import Path
 
 from pydantic import BaseModel
+
+_log = logging.getLogger(__name__)
 
 _REGISTRY_MODE = 0o600
 """Explicit mode for pids.json — host-owned process state, not meant to be
@@ -94,13 +98,47 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
-def reap_orphans(path: Path, *, term_wait_seconds: float = 5.0) -> list[PidRecord]:
-    """Read pids file, SIGTERM each live entry (escalating to SIGKILL), clear file.
+def _pid_matches_record(rec: PidRecord) -> bool:
+    """True when ``/proc/<pid>/cmdline`` still identifies the process as ``rec``'s marimo.
 
-    Returns the list of records that were live at sweep time (caller may
-    log them). Records whose PID is already dead are skipped silently.
-    Called exactly once at host startup before any new spawn — leaves the
-    pids file empty on exit so the next register starts from a clean slate.
+    Liveness alone is not identity — PIDs are recycled by the OS, so a
+    persisted record can point at a number the kernel has since handed to an
+    unrelated process. This reads the live process's argv and requires both
+    the ``marimo`` token and the exact ``/n/<slug>`` value passed to
+    ``--base-url`` (``spawn_marimo``), so the check is specific to *that*
+    slug's subprocess, not merely "some marimo". A PID we cannot identify —
+    ``/proc`` entry gone, or unreadable — must not be signalled.
+
+    Linux only (``/proc``). On any other platform this always returns False;
+    ``reap_orphans`` logs once that orphan reaping is unavailable there,
+    preferring a leaked orphan on a dev host over a wrong-process kill.
+    """
+    if sys.platform != "linux":
+        return False
+    try:
+        raw = Path(f"/proc/{rec.pid}/cmdline").read_bytes()
+    except (FileNotFoundError, ProcessLookupError, PermissionError):
+        return False
+    argv = [part.decode("utf-8", errors="replace") for part in raw.split(b"\x00") if part]
+    return "marimo" in argv and f"/n/{rec.slug}" in argv
+
+
+def reap_orphans(path: Path, *, term_wait_seconds: float = 5.0) -> list[PidRecord]:
+    """Read pids file, SIGTERM each live *matching* entry (escalating to SIGKILL), clear file.
+
+    A record is only signalled when its PID is both alive and still
+    identifiable, via ``/proc/<pid>/cmdline``, as that slug's marimo process
+    (see ``_pid_matches_record``) — liveness alone used to be treated as proof
+    of identity, which meant a PID recycled onto an unrelated process would be
+    SIGTERM'd then SIGKILL'd with only a log line claiming N orphans reaped.
+
+    Returns the list of records that were both live and identity-matched at
+    sweep time (caller may log them). Records whose PID is already dead, or
+    whose cmdline no longer matches, are skipped silently (well, at debug
+    level) — not signalled, not returned. Called exactly once at host startup
+    before any new spawn — leaves the pids file empty on exit so the next
+    register starts from a clean slate, regardless of what was or wasn't
+    signalled.
     """
     records = load_pids(path)
     if not records:
@@ -108,9 +146,25 @@ def reap_orphans(path: Path, *, term_wait_seconds: float = 5.0) -> list[PidRecor
         # with no prior state. No-op if missing.
         return []
 
+    if sys.platform != "linux":
+        _log.warning(
+            "orphan reaping requires /proc to verify process identity before "
+            "signalling; platform=%s cannot provide that, so %d persisted "
+            "record(s) will not be signalled",
+            sys.platform,
+            len(records),
+        )
+
     reaped: list[PidRecord] = []
     for rec in records.values():
         if not _pid_alive(rec.pid):
+            continue
+        if not _pid_matches_record(rec):
+            _log.debug(
+                "pid %d for slug %r no longer identifies as that slug's marimo; not signalling",
+                rec.pid,
+                rec.slug,
+            )
             continue
         reaped.append(rec)
         try:

--- a/apps/notebook-host/src/notebook_host/pids_store.py
+++ b/apps/notebook-host/src/notebook_host/pids_store.py
@@ -25,6 +25,10 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
+_REGISTRY_MODE = 0o600
+"""Explicit mode for pids.json — host-owned process state, not meant to be
+readable by any jailed slug now that ``data_dir`` is traversable (0711)."""
+
 
 class PidRecord(BaseModel):
     slug: str
@@ -64,12 +68,15 @@ def save_pids(path: Path, records: dict[str, PidRecord]) -> None:
     """Atomically rewrite the pids file (tmp + rename).
 
     The rename is atomic on the same filesystem, so a host crash mid-write
-    leaves either the old file or the new — never a truncated file.
+    leaves either the old file or the new — never a truncated file. The tmp
+    file is locked to ``_REGISTRY_MODE`` (0600) before that rename, not
+    after — no window where a freshly written pids file is world-readable.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     payload = {slug: rec.model_dump() for slug, rec in records.items()}
     tmp.write_text(json.dumps(payload, indent=2))
+    os.chmod(tmp, _REGISTRY_MODE)
     os.replace(tmp, path)
 
 

--- a/apps/notebook-host/tests/conftest.py
+++ b/apps/notebook-host/tests/conftest.py
@@ -19,3 +19,21 @@ def monkeypatch_admin_secret(monkeypatch: pytest.MonkeyPatch) -> None:
             monkeypatch.delenv(key, raising=False)
     # Set the required secret
     monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "test-secret")
+
+
+def set_unjailed_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Opt a test into the unjailed-spawn break-glass.
+
+    CI runs as an unprivileged user, so ``can_apply_jail()`` is False there
+    and the production default (fail-closed, D-05) refuses to spawn — every
+    publish would 503 until a test opts out. Call this from any test that is
+    exercising something other than the jail itself.
+
+    Deliberately NOT folded into the autouse fixture above: the production
+    default must stay observable so `test_settings_defaults_match_documented_values`
+    keeps asserting ``allow_unjailed_spawn is False`` against a clean
+    environment, and a future test that ought to exercise fail-closed must
+    not silently inherit the break-glass. One named call site per test is
+    greppable; an invisible global is not.
+    """
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ALLOW_UNJAILED_SPAWN", "true")

--- a/apps/notebook-host/tests/test_admin.py
+++ b/apps/notebook-host/tests/test_admin.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from notebook_host.jail import SlugPaths, get_slug_paths
 
 AUTH = "Bearer test-secret"
 NO_AUTH = "Bearer wrong-secret"
@@ -24,17 +25,17 @@ NO_AUTH = "Bearer wrong-secret"
 
 def _make_stub_spawner(
     pid: int = 12345,
-) -> tuple[unittest.mock.MagicMock, list[tuple[str, Path, int]]]:
+) -> tuple[unittest.mock.MagicMock, list[tuple[str, SlugPaths, int]]]:
     """Return (stub_spawner, calls_log).
 
-    The stub records every (slug, file_path, port) call and returns a Popen mock.
+    The stub records every (slug, paths, port) call and returns a Popen mock.
     """
-    calls: list[tuple[str, Path, int]] = []
+    calls: list[tuple[str, SlugPaths, int]] = []
 
     def spawner(
-        slug: str, file_path: Path, port: int, *, mode: str = "edit"
+        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
     ) -> subprocess.Popen[bytes]:
-        calls.append((slug, file_path, port))
+        calls.append((slug, paths, port))
         mock_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
         mock_proc.poll.return_value = None  # alive
         mock_proc.pid = pid
@@ -52,7 +53,7 @@ def _make_test_app(
 ) -> tuple[TestClient, Any, unittest.mock.MagicMock]:
     """Build a FastAPI app with stub spawner and monkeypatched wait_for_port.
 
-    Pass ``validator`` (a callable ``(slug, file_path) -> ValidationResult``) to
+    Pass ``validator`` (a callable ``(slug, paths) -> ValidationResult``) to
     exercise the pre-publish validation path; the default of None disables it.
 
     Returns (client, admin_state, stub_spawner).
@@ -159,7 +160,7 @@ def test_put_notebook_with_valid_bearer_returns_200(
 def test_put_notebook_writes_file_to_data_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """PUT /admin/notebooks/{slug} writes <data_dir>/<slug>.py with posted source."""
+    """PUT /admin/notebooks/{slug} writes data_dir/<slug>/notebook.py with posted source."""
     client, _, _ = _make_test_app(tmp_path, monkeypatch)
     source = "import marimo\napp = marimo.App()\n"
     client.put(
@@ -167,7 +168,7 @@ def test_put_notebook_writes_file_to_data_dir(
         json={"source": source},
         headers={"Authorization": AUTH},
     )
-    written = (tmp_path / "nb1.py").read_text()
+    written = (tmp_path / "nb1" / "notebook.py").read_text()
     assert written == source, "file should contain the posted source verbatim"
 
 
@@ -250,7 +251,9 @@ def test_put_notebook_oversize_source_returns_413(
     )
     assert resp.status_code == 413, f"oversize source should return 413, got {resp.status_code}"
     assert "max_source_bytes" in resp.text, "detail should reference the cap"
-    assert not (tmp_path / "big-nb.py").exists(), "no file should be written on size-cap reject"
+    assert not (tmp_path / "big-nb" / "notebook.py").exists(), (
+        "no file should be written on size-cap reject"
+    )
 
 
 def test_put_notebook_under_size_cap_succeeds(
@@ -291,36 +294,39 @@ def test_delete_notebook_returns_204(tmp_path: Path, monkeypatch: pytest.MonkeyP
     # First PUT to create
     client.put("/admin/notebooks/del-me", json={"source": "y = 2"}, headers={"Authorization": AUTH})
     assert "del-me" in state.processes, "state should contain del-me after PUT"
-    assert (tmp_path / "del-me.py").exists(), "file should exist after PUT"
+    assert (tmp_path / "del-me" / "notebook.py").exists(), "file should exist after PUT"
 
     # Now DELETE
     resp = client.delete("/admin/notebooks/del-me", headers={"Authorization": AUTH})
     assert resp.status_code == 204, "DELETE should return 204"
     assert "del-me" not in state.processes, "registry should not contain del-me after DELETE"
-    assert not (tmp_path / "del-me.py").exists(), "file should be removed after DELETE"
+    assert not (tmp_path / "del-me" / "notebook.py").exists(), "file should be removed after DELETE"
 
 
-def test_delete_notebook_rmtrees_data_and_workspace_dirs(
+def test_delete_notebook_removes_source_attachment_and_workspace_in_one_call(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """DELETE also removes <slug>.data/ and <slug>_workspace/ (with their contents)."""
+    """DELETE removes the whole slug tree — source, attachment, and workspace — in one call.
+
+    Proves the delete unification behaviourally: publish, attach, delete, and
+    assert the entire slug root is gone rather than inspecting three separate
+    cleanup calls.
+    """
     client, state, _ = _make_test_app(tmp_path, monkeypatch)
 
     client.put("/admin/notebooks/del-me", json={"source": "y=2"}, headers={"Authorization": AUTH})
-    # The stub spawner doesn't run _prepare_workspace, so simulate the dirs.
-    data_dir = tmp_path / "del-me.data"
-    data_dir.mkdir(exist_ok=True)
-    (data_dir / "sales.csv").write_bytes(b"a,b\n1,2\n")
-    workspace = tmp_path / "del-me_workspace"
-    workspace.mkdir(exist_ok=True)
-    (workspace / "data").symlink_to(Path("..") / "del-me.data")
-    (workspace / "del-me.py").symlink_to(Path("..") / "del-me.py")
+    client.put(
+        "/admin/notebooks/del-me/data/sales.csv",
+        content=b"a,b\n1,2\n",
+        headers={"Authorization": AUTH},
+    )
+    assert (tmp_path / "del-me").exists(), "slug root should exist after publish + attach"
 
     resp = client.delete("/admin/notebooks/del-me", headers={"Authorization": AUTH})
     assert resp.status_code == 204, "DELETE should return 204"
-    assert not (tmp_path / "del-me.py").exists(), "source file should be removed"
-    assert not data_dir.exists(), "<slug>.data/ should be rmtreed (with attachments)"
-    assert not workspace.exists(), "<slug>_workspace/ should be rmtreed (with symlinks)"
+    assert (tmp_path / "del-me").exists() is False, (
+        "source, attachment, workspace and log must all be gone after one DELETE"
+    )
     assert "del-me" not in state.processes
 
 
@@ -402,7 +408,9 @@ def test_sweep_reaps_dead_and_ttl_past_entries(
     dead_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
     dead_proc.poll.return_value = 1  # dead
     dead_proc.pid = 11111
-    (tmp_path / "dead-nb.py").write_text("x", encoding="utf-8")
+    dead_paths = get_slug_paths(tmp_path, "dead-nb")
+    dead_paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    dead_paths.notebook.write_text("x", encoding="utf-8")
     processes["dead-nb"] = NotebookProcess(
         slug="dead-nb",
         port=8500,
@@ -415,7 +423,9 @@ def test_sweep_reaps_dead_and_ttl_past_entries(
     alive_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
     alive_proc.poll.return_value = None  # alive
     alive_proc.pid = 22222
-    (tmp_path / "old-nb.py").write_text("y", encoding="utf-8")
+    old_paths = get_slug_paths(tmp_path, "old-nb")
+    old_paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    old_paths.notebook.write_text("y", encoding="utf-8")
     processes["old-nb"] = NotebookProcess(
         slug="old-nb",
         port=8501,
@@ -429,7 +439,9 @@ def test_sweep_reaps_dead_and_ttl_past_entries(
     good_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
     good_proc.poll.return_value = None
     good_proc.pid = 33333
-    (tmp_path / "good-nb.py").write_text("z", encoding="utf-8")
+    good_paths = get_slug_paths(tmp_path, "good-nb")
+    good_paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    good_paths.notebook.write_text("z", encoding="utf-8")
     processes["good-nb"] = NotebookProcess(
         slug="good-nb",
         port=8502,
@@ -450,10 +462,10 @@ def test_sweep_reaps_dead_and_ttl_past_entries(
     assert "good-nb" in state.processes, "good-nb should remain in registry"
 
 
-def test_sweep_rmtrees_data_and_workspace_dirs(
+def test_sweep_removes_whole_slug_tree_for_reaped_slugs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """POST /admin/sweep also rmtrees <slug>.data/ and <slug>_workspace/ for reaped slugs."""
+    """POST /admin/sweep removes the whole slug tree (source, data, workspace) for reaped slugs."""
     import notebook_host.admin as admin_mod
     from notebook_host.admin import AdminState, create_admin_router
     from notebook_host.config import load_settings
@@ -476,14 +488,14 @@ def test_sweep_rmtrees_data_and_workspace_dirs(
     dead_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
     dead_proc.poll.return_value = 1
     dead_proc.pid = 11111
-    (tmp_path / "dead-nb.py").write_text("x", encoding="utf-8")
-    data_dir = tmp_path / "dead-nb.data"
-    data_dir.mkdir()
-    (data_dir / "x.csv").write_bytes(b"a")
-    workspace = tmp_path / "dead-nb_workspace"
-    workspace.mkdir()
-    (workspace / "data").symlink_to(Path("..") / "dead-nb.data")
-    (workspace / "dead-nb.py").symlink_to(Path("..") / "dead-nb.py")
+    dead_paths = get_slug_paths(tmp_path, "dead-nb")
+    dead_paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    dead_paths.notebook.write_text("x", encoding="utf-8")
+    dead_paths.data.mkdir()
+    (dead_paths.data / "x.csv").write_bytes(b"a")
+    dead_paths.workspace.mkdir()
+    (dead_paths.workspace / "data").symlink_to(Path("..") / "data")
+    (dead_paths.workspace / "notebook.py").symlink_to(Path("..") / "notebook.py")
 
     processes["dead-nb"] = NotebookProcess(
         slug="dead-nb",
@@ -496,9 +508,9 @@ def test_sweep_rmtrees_data_and_workspace_dirs(
     resp = client.post("/admin/sweep", headers={"Authorization": AUTH})
     assert resp.status_code == 200, "sweep should return 200"
     assert "dead-nb" not in state.processes, "registry should not contain reaped slug"
-    assert not (tmp_path / "dead-nb.py").exists(), "source file should be removed"
-    assert not data_dir.exists(), "<slug>.data/ should be rmtreed by sweep"
-    assert not workspace.exists(), "<slug>_workspace/ should be rmtreed by sweep"
+    assert dead_paths.root.exists() is False, (
+        "the whole slug tree (source, data, workspace) should be removed by sweep"
+    )
 
 
 def test_put_notebook_returns_null_expires_at_when_ttl_indefinite(
@@ -547,7 +559,9 @@ def test_sweep_keeps_old_alive_process_when_ttl_indefinite(
     dead_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
     dead_proc.poll.return_value = 1
     dead_proc.pid = 11111
-    (tmp_path / "dead-nb.py").write_text("x", encoding="utf-8")
+    dead_paths = get_slug_paths(tmp_path, "dead-nb")
+    dead_paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    dead_paths.notebook.write_text("x", encoding="utf-8")
     processes["dead-nb"] = NotebookProcess(
         slug="dead-nb",
         port=8500,
@@ -561,7 +575,9 @@ def test_sweep_keeps_old_alive_process_when_ttl_indefinite(
     old_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
     old_proc.poll.return_value = None
     old_proc.pid = 22222
-    (tmp_path / "old-nb.py").write_text("y", encoding="utf-8")
+    old_paths = get_slug_paths(tmp_path, "old-nb")
+    old_paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    old_paths.notebook.write_text("y", encoding="utf-8")
     processes["old-nb"] = NotebookProcess(
         slug="old-nb",
         port=8501,
@@ -722,7 +738,7 @@ def test_put_notebook_rejected_when_validation_fails(
     """A validator that reports failure → 422 with cell_errors, and no spawn."""
     from notebook_host.lifecycle import ValidationResult
 
-    def failing_validator(slug: str, file_path: Path) -> ValidationResult:
+    def failing_validator(slug: str, paths: SlugPaths) -> ValidationResult:
         return ValidationResult(
             ok=False,
             errors=["MultipleDefinitionError: The variable 'ax' was defined by another cell"],
@@ -751,7 +767,7 @@ def test_put_notebook_failed_validation_leaves_existing_notebook_running(
 
     results = [ValidationResult(ok=True), ValidationResult(ok=False, errors=["boom"])]
 
-    def validator(slug: str, file_path: Path) -> ValidationResult:
+    def validator(slug: str, paths: SlugPaths) -> ValidationResult:
         return results.pop(0)
 
     client, state, stub_spawner = _make_test_app(tmp_path, monkeypatch, validator=validator)
@@ -776,13 +792,13 @@ def test_put_notebook_failed_validation_leaves_existing_notebook_running(
 def test_put_notebook_published_when_validation_passes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A passing validator → normal 200 publish, validator called with (slug, path)."""
+    """A passing validator → normal 200 publish, validator called with (slug, paths)."""
     from notebook_host.lifecycle import ValidationResult
 
     seen: list[tuple[str, str]] = []
 
-    def ok_validator(slug: str, file_path: Path) -> ValidationResult:
-        seen.append((slug, file_path.name))
+    def ok_validator(slug: str, paths: SlugPaths) -> ValidationResult:
+        seen.append((slug, paths.notebook.name))
         return ValidationResult(ok=True)
 
     client, state, stub_spawner = _make_test_app(tmp_path, monkeypatch, validator=ok_validator)
@@ -792,5 +808,5 @@ def test_put_notebook_published_when_validation_passes(
         headers={"Authorization": AUTH},
     )
     assert resp.status_code == 200, "a notebook that passes validation should publish normally"
-    assert seen == [("good", "good.py")], "validator should be called with (slug, source path)"
+    assert seen == [("good", "notebook.py")], "validator should be called with (slug, SlugPaths)"
     assert stub_spawner.call_count == 1, "a validated notebook should be spawned exactly once"

--- a/apps/notebook-host/tests/test_admin.py
+++ b/apps/notebook-host/tests/test_admin.py
@@ -7,9 +7,11 @@ are spawned. `wait_for_port` is monkeypatched at the module level to return True
 
 from __future__ import annotations
 
+import runpy
 import subprocess
 import time
 import unittest.mock
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -19,23 +21,40 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from notebook_host.jail import SlugPaths, get_slug_paths
 
+# `--import-mode=importlib` (root pyproject.toml) doesn't add this directory
+# to sys.path, and there's no `__init__.py` here (one would collide with the
+# top-level `tests` package name already claimed by `packages/core/tests`).
+# `runpy` loads `conftest.py` by file path without touching sys.path or
+# sys.modules, so a full monorepo `pytest` collection can't collide with
+# similar sys.path tricks in other adapters' tests (see
+# `packages/adapters/mcp/tests/tools/conftest.py`).
+set_unjailed_test_env: Callable[[pytest.MonkeyPatch], None] = runpy.run_path(
+    str(Path(__file__).parent / "conftest.py")
+)["set_unjailed_test_env"]
+
 AUTH = "Bearer test-secret"
 NO_AUTH = "Bearer wrong-secret"
 
 
 def _make_stub_spawner(
     pid: int = 12345,
-) -> tuple[unittest.mock.MagicMock, list[tuple[str, SlugPaths, int]]]:
+) -> tuple[unittest.mock.MagicMock, list[tuple[str, SlugPaths, int, int | None]]]:
     """Return (stub_spawner, calls_log).
 
-    The stub records every (slug, paths, port) call and returns a Popen mock.
+    The stub records every (slug, paths, port, jail_uid) call and returns a
+    Popen mock.
     """
-    calls: list[tuple[str, SlugPaths, int]] = []
+    calls: list[tuple[str, SlugPaths, int, int | None]] = []
 
     def spawner(
-        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
+        slug: str,
+        paths: SlugPaths,
+        port: int,
+        *,
+        mode: str = "edit",
+        jail_uid: int | None = None,
     ) -> subprocess.Popen[bytes]:
-        calls.append((slug, paths, port))
+        calls.append((slug, paths, port, jail_uid))
         mock_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
         mock_proc.poll.return_value = None  # alive
         mock_proc.pid = pid
@@ -67,6 +86,7 @@ def _make_test_app(
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8501")
     monkeypatch.setenv("DAIMON_NOTEBOOK__SPAWN_TIMEOUT_SECONDS", "2.0")
+    set_unjailed_test_env(monkeypatch)
 
     settings = load_settings(_env_file=None)
     stub_spawner, _ = _make_stub_spawner()
@@ -185,6 +205,7 @@ def test_put_existing_slug_kills_old_and_respawns(
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8501")
     monkeypatch.setenv("DAIMON_NOTEBOOK__SPAWN_TIMEOUT_SECONDS", "2.0")
+    set_unjailed_test_env(monkeypatch)
 
     settings = load_settings(_env_file=None)
     stub_spawner, calls = _make_stub_spawner()
@@ -284,6 +305,82 @@ def test_put_notebook_timeout_returns_504(tmp_path: Path, monkeypatch: pytest.Mo
     assert "slow-nb" not in state.processes, "registry should not contain the slug after timeout"
 
 
+# ─── fail-closed jail gate (D-05) ────────────────────────────────────────────
+# These deliberately do NOT call set_unjailed_test_env — they pin the
+# production default (fail-closed) rather than opting out of it.
+
+
+def test_put_notebook_returns_503_when_jail_unavailable_and_no_break_glass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A host that cannot jail refuses to publish (503) rather than serving unisolated."""
+    import notebook_host.admin as admin_mod
+    import notebook_host.jail as jail_mod
+    from notebook_host.admin import AdminState, create_admin_router
+    from notebook_host.config import load_settings
+
+    monkeypatch.setenv("DAIMON_NOTEBOOK__DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "test-secret")
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8501")
+    # allow_unjailed_spawn is deliberately left unset — production default (False).
+    settings = load_settings(_env_file=None)
+    monkeypatch.setattr(jail_mod, "can_apply_jail", lambda: False)
+
+    stub_spawner, _ = _make_stub_spawner()
+
+    async def _fake_wait(port: int, slug: str, timeout_s: float) -> bool:
+        return True
+
+    monkeypatch.setattr(admin_mod, "wait_for_port", _fake_wait)
+    state = AdminState(settings=settings, processes={}, spawner=stub_spawner)
+    app = FastAPI()
+    app.include_router(create_admin_router(state))
+    client = TestClient(app)
+
+    resp = client.put(
+        "/admin/notebooks/x", json={"source": "x = 1"}, headers={"Authorization": AUTH}
+    )
+    assert resp.status_code == 503, (
+        "an unjailable host must refuse to publish rather than serve unisolated"
+    )
+    assert "isolation" in resp.text.lower(), "the 503 detail should name the condition"
+
+
+def test_put_notebook_returns_200_when_break_glass_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same unjailable host publishes once the break-glass setting is on."""
+    import notebook_host.admin as admin_mod
+    import notebook_host.jail as jail_mod
+    from notebook_host.admin import AdminState, create_admin_router
+    from notebook_host.config import load_settings
+
+    monkeypatch.setenv("DAIMON_NOTEBOOK__DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "test-secret")
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8501")
+    set_unjailed_test_env(monkeypatch)
+    settings = load_settings(_env_file=None)
+    monkeypatch.setattr(jail_mod, "can_apply_jail", lambda: False)
+
+    stub_spawner, _ = _make_stub_spawner()
+
+    async def _fake_wait(port: int, slug: str, timeout_s: float) -> bool:
+        return True
+
+    monkeypatch.setattr(admin_mod, "wait_for_port", _fake_wait)
+    state = AdminState(settings=settings, processes={}, spawner=stub_spawner)
+    app = FastAPI()
+    app.include_router(create_admin_router(state))
+    client = TestClient(app)
+
+    resp = client.put(
+        "/admin/notebooks/x", json={"source": "x = 1"}, headers={"Authorization": AUTH}
+    )
+    assert resp.status_code == 200, "the break-glass opt-out should let an unjailable host publish"
+
+
 # ─── /admin/notebooks DELETE ─────────────────────────────────────────────────
 
 
@@ -301,6 +398,26 @@ def test_delete_notebook_returns_204(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert resp.status_code == 204, "DELETE should return 204"
     assert "del-me" not in state.processes, "registry should not contain del-me after DELETE"
     assert not (tmp_path / "del-me" / "notebook.py").exists(), "file should be removed after DELETE"
+
+
+def test_delete_notebook_releases_uid_from_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DELETE releases the slug's uid back to the pool, not just kills the process."""
+    from notebook_host.jail import load_uid_registry, save_uid_registry
+
+    client, state, _ = _make_test_app(tmp_path, monkeypatch)
+    client.put("/admin/notebooks/del-uid", json={"source": "x=1"}, headers={"Authorization": AUTH})
+    # can_apply_jail() is False on this (unprivileged) test host, so the publish
+    # above ran unjailed and left no registry entry of its own — seed one
+    # directly to simulate a slug that a jailed host had previously allocated.
+    save_uid_registry(state.settings.resolved_uids_file, {"del-uid": 100042})
+
+    resp = client.delete("/admin/notebooks/del-uid", headers={"Authorization": AUTH})
+    assert resp.status_code == 204, "DELETE should return 204"
+
+    registry = load_uid_registry(state.settings.resolved_uids_file)
+    assert "del-uid" not in registry, "DELETE should release the slug's uid back to the pool"
 
 
 def test_delete_notebook_removes_source_attachment_and_workspace_in_one_call(
@@ -630,6 +747,7 @@ def test_admin_accepts_any_configured_bearer(
     monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRETS", "primary-token,backup-token")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8501")
+    set_unjailed_test_env(monkeypatch)
 
     settings = load_settings(_env_file=None)
     stub_spawner, _ = _make_stub_spawner()
@@ -678,6 +796,7 @@ def test_singular_admin_secret_still_works(tmp_path: Path, monkeypatch: pytest.M
     monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "legacy-token")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8501")
+    set_unjailed_test_env(monkeypatch)
 
     settings = load_settings(_env_file=None)
     assert len(settings.admin_secrets) == 1, (
@@ -738,7 +857,9 @@ def test_put_notebook_rejected_when_validation_fails(
     """A validator that reports failure → 422 with cell_errors, and no spawn."""
     from notebook_host.lifecycle import ValidationResult
 
-    def failing_validator(slug: str, paths: SlugPaths) -> ValidationResult:
+    def failing_validator(
+        slug: str, paths: SlugPaths, *, jail_uid: int | None = None
+    ) -> ValidationResult:
         return ValidationResult(
             ok=False,
             errors=["MultipleDefinitionError: The variable 'ax' was defined by another cell"],
@@ -767,7 +888,7 @@ def test_put_notebook_failed_validation_leaves_existing_notebook_running(
 
     results = [ValidationResult(ok=True), ValidationResult(ok=False, errors=["boom"])]
 
-    def validator(slug: str, paths: SlugPaths) -> ValidationResult:
+    def validator(slug: str, paths: SlugPaths, *, jail_uid: int | None = None) -> ValidationResult:
         return results.pop(0)
 
     client, state, stub_spawner = _make_test_app(tmp_path, monkeypatch, validator=validator)
@@ -797,7 +918,9 @@ def test_put_notebook_published_when_validation_passes(
 
     seen: list[tuple[str, str]] = []
 
-    def ok_validator(slug: str, paths: SlugPaths) -> ValidationResult:
+    def ok_validator(
+        slug: str, paths: SlugPaths, *, jail_uid: int | None = None
+    ) -> ValidationResult:
         seen.append((slug, paths.notebook.name))
         return ValidationResult(ok=True)
 

--- a/apps/notebook-host/tests/test_admin_upload.py
+++ b/apps/notebook-host/tests/test_admin_upload.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from notebook_host.jail import SlugPaths, get_slug_paths
 
 _SECRET = "test-secret"
 
@@ -64,7 +65,7 @@ def _make_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClie
     settings = load_settings(_env_file=None)
 
     def spawner(
-        slug: str, file_path: Path, port: int, *, mode: str = "edit"
+        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
     ) -> subprocess.Popen[bytes]:
         m: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
         m.poll.return_value = None
@@ -90,7 +91,7 @@ def test_upload_blog_writes_source_byte_exact_and_registers(
     source = b"# notebook\n" + b"x = 1\n" * 9000  # ~55 KB — the case inline source truncated on
     r = client.put(f"/upload/{_mint('blog', 'my-blog')}", content=source)
     assert r.status_code == 200, f"blog upload should succeed, got {r.status_code}: {r.text}"
-    on_disk = (tmp_path / "my-blog.py").read_bytes()
+    on_disk = get_slug_paths(tmp_path, "my-blog").notebook.read_bytes()
     assert hashlib.sha256(on_disk).hexdigest() == hashlib.sha256(source).hexdigest(), (
         "source written byte-exact"
     )
@@ -105,7 +106,7 @@ def test_upload_data_writes_raw_bytes_byte_exact(
     tok = _mint("data", "my-blog", name="posterior.nc", max_bytes=1_500_000)
     r = client.put(f"/upload/{tok}", content=blob)
     assert r.status_code == 200, f"data upload should succeed, got {r.status_code}: {r.text}"
-    assert (tmp_path / "my-blog.data" / "posterior.nc").read_bytes() == blob, (
+    assert (get_slug_paths(tmp_path, "my-blog").data / "posterior.nc").read_bytes() == blob, (
         "1 MB written byte-exact"
     )
     assert r.json()["path"] == "data/posterior.nc", "agent-visible read path returned"
@@ -124,7 +125,7 @@ def test_upload_rejects_forged_token(tmp_path: Path, monkeypatch: pytest.MonkeyP
     client, _ = _make_app(tmp_path, monkeypatch)
     r = client.put(f"/upload/{_mint('blog', 'x', secret='attacker')}", content=b"evil")
     assert r.status_code == 403, "a token signed by an unknown key is rejected"
-    assert not (tmp_path / "x.py").exists(), "no file written on a forged token"
+    assert not get_slug_paths(tmp_path, "x").notebook.exists(), "no file written on a forged token"
 
 
 def test_upload_single_use_replay_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -135,7 +136,9 @@ def test_upload_single_use_replay_rejected(tmp_path: Path, monkeypatch: pytest.M
     assert r1.status_code == 200 and r2.status_code == 409, (
         "first use ok, replay of the same jti → 409"
     )
-    assert (tmp_path / "once.py").read_bytes() == b"# first\n", "replay does not overwrite"
+    assert get_slug_paths(tmp_path, "once").notebook.read_bytes() == b"# first\n", (
+        "replay does not overwrite"
+    )
 
 
 def test_upload_oversize_body_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -143,7 +146,7 @@ def test_upload_oversize_body_rejected(tmp_path: Path, monkeypatch: pytest.Monke
     tok = _mint("blog", "big", max_bytes=1000)
     r = client.put(f"/upload/{tok}", content=b"z" * 5000)
     assert r.status_code == 413, "body over the token's max_bytes → 413"
-    assert not (tmp_path / "big.py").exists(), "no file written when oversize"
+    assert not get_slug_paths(tmp_path, "big").notebook.exists(), "no file written when oversize"
 
 
 def test_upload_data_with_no_name_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -162,4 +165,6 @@ def test_upload_rejects_body_over_host_ceiling_under_token_max(
     tok = _mint("blog", "ceil", max_bytes=2_000_000)
     r = client.put(f"/upload/{tok}", content=b"z" * 1_100_000)
     assert r.status_code == 413, f"body over the host ceiling → 413, got {r.status_code}"
-    assert not (tmp_path / "ceil.py").exists(), "no file written when over the host ceiling"
+    assert not get_slug_paths(tmp_path, "ceil").notebook.exists(), (
+        "no file written when over the host ceiling"
+    )

--- a/apps/notebook-host/tests/test_admin_upload.py
+++ b/apps/notebook-host/tests/test_admin_upload.py
@@ -22,6 +22,7 @@ from typing import Any
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from notebook_host.admin import AdminState, create_admin_router
 from notebook_host.jail import SlugPaths, get_slug_paths
 
 # `--import-mode=importlib` (root pyproject.toml) doesn't add this directory
@@ -166,6 +167,38 @@ def test_upload_oversize_body_rejected(tmp_path: Path, monkeypatch: pytest.Monke
     r = client.put(f"/upload/{tok}", content=b"z" * 5000)
     assert r.status_code == 413, "body over the token's max_bytes → 413"
     assert not get_slug_paths(tmp_path, "big").notebook.exists(), "no file written when oversize"
+
+    retry = client.put(f"/upload/{tok}", content=b"z" * 500)
+    assert retry.status_code == 409, (
+        "the token was burned before the size check ran, so a retry after a rejected "
+        "oversize upload is not reusable — that is the documented consequence of closing "
+        "the concurrent-replay window before the body read"
+    )
+
+
+def test_upload_replay_rejected_across_a_fresh_admin_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A capability token burned before a host restart must still be refused after one.
+
+    Regression test for the defect: the old `AdminState.consumed` in-memory
+    set only ever passed the single-use check because the process stayed
+    alive across the two requests in a test. Building a *fresh* AdminState
+    and app over the same data_dir — the shape of a real host restart —
+    proves the burn now survives on disk rather than in that set.
+    """
+    client, state = _make_app(tmp_path, monkeypatch)
+    tok = _mint("blog", "restart-test", jti="reused-across-restart")
+    r1 = client.put(f"/upload/{tok}", content=b"# first\n")
+    assert r1.status_code == 200, r1.text
+
+    fresh_state = AdminState(settings=state.settings, processes={}, spawner=state.spawner)
+    fresh_app = FastAPI()
+    fresh_app.include_router(create_admin_router(fresh_state))
+    fresh_client = TestClient(fresh_app, raise_server_exceptions=True)
+
+    r2 = fresh_client.put(f"/upload/{tok}", content=b"# replay\n")
+    assert r2.status_code == 409, "a token burned before a restart must still be refused after one"
 
 
 def test_upload_data_with_no_name_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/notebook-host/tests/test_admin_upload.py
+++ b/apps/notebook-host/tests/test_admin_upload.py
@@ -11,8 +11,10 @@ import base64
 import hashlib
 import hmac
 import json
+import runpy
 import subprocess
 import unittest.mock
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -21,6 +23,17 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from notebook_host.jail import SlugPaths, get_slug_paths
+
+# `--import-mode=importlib` (root pyproject.toml) doesn't add this directory
+# to sys.path, and there's no `__init__.py` here (one would collide with the
+# top-level `tests` package name already claimed by `packages/core/tests`).
+# `runpy` loads `conftest.py` by file path without touching sys.path or
+# sys.modules, so a full monorepo `pytest` collection can't collide with
+# similar sys.path tricks in other adapters' tests (see
+# `packages/adapters/mcp/tests/tools/conftest.py`).
+set_unjailed_test_env: Callable[[pytest.MonkeyPatch], None] = runpy.run_path(
+    str(Path(__file__).parent / "conftest.py")
+)["set_unjailed_test_env"]
 
 _SECRET = "test-secret"
 
@@ -62,10 +75,16 @@ def _make_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClie
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8501")
     monkeypatch.setenv("DAIMON_NOTEBOOK__SPAWN_TIMEOUT_SECONDS", "2.0")
+    set_unjailed_test_env(monkeypatch)
     settings = load_settings(_env_file=None)
 
     def spawner(
-        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
+        slug: str,
+        paths: SlugPaths,
+        port: int,
+        *,
+        mode: str = "edit",
+        jail_uid: int | None = None,
     ) -> subprocess.Popen[bytes]:
         m: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
         m.poll.return_value = None

--- a/apps/notebook-host/tests/test_attach_data.py
+++ b/apps/notebook-host/tests/test_attach_data.py
@@ -1,6 +1,6 @@
 """Tests for the host-side PUT /admin/notebooks/{slug}/data/{name} endpoint.
 
-The data-PUT endpoint writes a raw blob to ``<data_dir>/<slug>.data/<name>``
+The data-PUT endpoint writes a raw blob to ``data_dir/<slug>/data/<name>``
 atomically (tmp + os.replace) and does NOT spawn marimo. It is the host
 half of the agent-side ``attach_notebook_data`` MCP tool.
 """
@@ -18,6 +18,7 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from notebook_host.jail import SlugPaths, get_slug_paths
 
 AUTH = "Bearer test-secret"
 NO_AUTH = "Bearer wrong-secret"
@@ -27,7 +28,7 @@ def _make_stub_spawner() -> unittest.mock.MagicMock:
     """Return a stub spawner that records calls and returns a fake Popen."""
 
     def spawner(
-        slug: str, file_path: Path, port: int, *, mode: str = "edit"
+        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
     ) -> subprocess.Popen[bytes]:
         mock_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
         mock_proc.poll.return_value = None
@@ -82,7 +83,7 @@ def test_put_data_without_bearer_returns_401(
 
 
 def test_put_data_writes_blob_atomically(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """PUT data writes raw body to <data_dir>/<slug>.data/<name> byte-for-byte."""
+    """PUT data writes raw body to data_dir/<slug>/data/<name> byte-for-byte."""
     client, _, _, _ = _make_test_app(tmp_path, monkeypatch)
     payload = b"\x00\x01\x02binary\xff\xfeblob"
     resp = client.put(
@@ -98,12 +99,13 @@ def test_put_data_writes_blob_atomically(tmp_path: Path, monkeypatch: pytest.Mon
     assert body["path"] == "data/blob.bin", (
         "response path should be the notebook-visible 'data/<name>' form"
     )
-    final_path = tmp_path / "myslug.data" / "blob.bin"
+    data_dir = get_slug_paths(tmp_path, "myslug").data
+    final_path = data_dir / "blob.bin"
     assert final_path.read_bytes() == payload, (
         "on-disk bytes should match the request body verbatim (binary-safe)"
     )
     # No tmp file should remain on disk.
-    tmp_artifacts = list((tmp_path / "myslug.data").glob(".*.tmp"))
+    tmp_artifacts = list(data_dir.glob(".*.tmp"))
     assert tmp_artifacts == [], f"no .tmp artifacts should remain; found {tmp_artifacts}"
 
 
@@ -118,8 +120,8 @@ def test_atomic_write_cleans_tmp_on_partial_failure(
     """
     from notebook_host import admin as admin_module
 
-    target_dir = tmp_path / "myslug.data"
-    target_dir.mkdir()
+    target_dir = get_slug_paths(tmp_path, "myslug").data
+    target_dir.mkdir(parents=True)
     target = target_dir / "blob.bin"
 
     real_replace = os.replace
@@ -180,7 +182,7 @@ def test_put_data_overwrites_existing(tmp_path: Path, monkeypatch: pytest.Monkey
         headers={"Authorization": AUTH},
     )
     assert r2.status_code == 200, "second PUT should succeed"
-    final = (tmp_path / "over.data" / "file.bin").read_bytes()
+    final = (get_slug_paths(tmp_path, "over").data / "file.bin").read_bytes()
     assert final == second, (
         "second body should win on overwrite; tmp+rename leaves no partial state"
     )
@@ -227,7 +229,7 @@ def test_put_data_oversize_returns_413(tmp_path: Path, monkeypatch: pytest.Monke
     )
     assert resp.status_code == 413, f"oversize body should return 413; got {resp.status_code}"
     assert "max_attachment_bytes_ceiling" in resp.text, "detail should reference the cap"
-    assert not (tmp_path / "myslug.data" / "big.bin").exists(), (
+    assert not (get_slug_paths(tmp_path, "myslug").data / "big.bin").exists(), (
         "no file should be written when the size cap is exceeded"
     )
 
@@ -270,7 +272,8 @@ async def test_concurrent_put_data_and_source_serialize(
         f"source PUT should succeed under contention; got {r_source.status_code}: {r_source.text}"
     )
     # On-disk artifacts from both ops exist.
-    assert (tmp_path / "race.data" / "d.csv").read_bytes() == b"x,y\n", (
+    race_paths = get_slug_paths(tmp_path, "race")
+    assert (race_paths.data / "d.csv").read_bytes() == b"x,y\n", (
         "data file should be readable after concurrent PUTs"
     )
-    assert (tmp_path / "race.py").exists(), "source file should exist after concurrent PUTs"
+    assert race_paths.notebook.exists(), "source file should exist after concurrent PUTs"

--- a/apps/notebook-host/tests/test_attach_data.py
+++ b/apps/notebook-host/tests/test_attach_data.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+import runpy
 import subprocess
 import unittest.mock
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +22,17 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from notebook_host.jail import SlugPaths, get_slug_paths
 
+# `--import-mode=importlib` (root pyproject.toml) doesn't add this directory
+# to sys.path, and there's no `__init__.py` here (one would collide with the
+# top-level `tests` package name already claimed by `packages/core/tests`).
+# `runpy` loads `conftest.py` by file path without touching sys.path or
+# sys.modules, so a full monorepo `pytest` collection can't collide with
+# similar sys.path tricks in other adapters' tests (see
+# `packages/adapters/mcp/tests/tools/conftest.py`).
+set_unjailed_test_env: Callable[[pytest.MonkeyPatch], None] = runpy.run_path(
+    str(Path(__file__).parent / "conftest.py")
+)["set_unjailed_test_env"]
+
 AUTH = "Bearer test-secret"
 NO_AUTH = "Bearer wrong-secret"
 
@@ -28,7 +41,12 @@ def _make_stub_spawner() -> unittest.mock.MagicMock:
     """Return a stub spawner that records calls and returns a fake Popen."""
 
     def spawner(
-        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
+        slug: str,
+        paths: SlugPaths,
+        port: int,
+        *,
+        mode: str = "edit",
+        jail_uid: int | None = None,
     ) -> subprocess.Popen[bytes]:
         mock_proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
         mock_proc.poll.return_value = None
@@ -52,6 +70,7 @@ def _make_test_app(
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8501")
     monkeypatch.setenv("DAIMON_NOTEBOOK__SPAWN_TIMEOUT_SECONDS", "2.0")
+    set_unjailed_test_env(monkeypatch)
 
     settings = load_settings(_env_file=None)
     stub_spawner = _make_stub_spawner()
@@ -145,6 +164,33 @@ def test_atomic_write_cleans_tmp_on_partial_failure(
     monkeypatch.setattr(admin_module.os, "replace", real_replace)
     admin_module._atomic_write_bytes(target, b"recovered")  # pyright: ignore[reportPrivateUsage]
     assert target.read_bytes() == b"recovered"
+
+
+def test_put_data_before_publish_lands_under_data_dir_owned_by_resolved_uid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An attachment PUT before any publish creates data/<name>, chowned to the resolved uid.
+
+    Forces ``resolve_jail_uid`` to return this process's own uid rather than
+    going through the real jail-availability check — a self-chown succeeds
+    without root, so this exercises the real ``os.chown`` call end to end.
+    """
+    import notebook_host.admin as admin_mod
+
+    self_uid = os.getuid()
+    monkeypatch.setattr(admin_mod, "resolve_jail_uid", lambda *a, **kw: self_uid)  # noqa: ARG005
+
+    client, _, _, _ = _make_test_app(tmp_path, monkeypatch)
+    resp = client.put(
+        "/admin/notebooks/pre-publish/data/x.csv",
+        content=b"a,b\n1,2\n",
+        headers={"Authorization": AUTH},
+    )
+    assert resp.status_code == 200, f"attachment before publish should succeed; got {resp.text}"
+
+    final_path = get_slug_paths(tmp_path, "pre-publish").data / "x.csv"
+    assert final_path.exists(), "attachment should land under data_dir/<slug>/data/"
+    assert final_path.stat().st_uid == self_uid, "the file should be owned by the resolved uid"
 
 
 def test_put_data_does_not_spawn_marimo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/notebook-host/tests/test_blogs_admin.py
+++ b/apps/notebook-host/tests/test_blogs_admin.py
@@ -10,13 +10,14 @@ from typing import Any
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from notebook_host.jail import SlugPaths, get_slug_paths
 
 AUTH = "Bearer test-secret"
 
 
 def _make_blog_app(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> tuple[TestClient, Any, list[tuple[str, Path, int, str]]]:
+) -> tuple[TestClient, Any, list[tuple[str, SlugPaths, int, str]]]:
     """App with a stub spawner that records mode. Returns (client, state, calls)."""
     import notebook_host.admin as admin_mod
     from notebook_host.admin import AdminState, create_admin_router
@@ -29,12 +30,12 @@ def _make_blog_app(
     monkeypatch.setenv("DAIMON_NOTEBOOK__SPAWN_TIMEOUT_SECONDS", "2.0")
     settings = load_settings(_env_file=None)
 
-    calls: list[tuple[str, Path, int, str]] = []
+    calls: list[tuple[str, SlugPaths, int, str]] = []
 
     def spawner(
-        slug: str, file_path: Path, port: int, *, mode: str = "edit"
+        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
     ) -> subprocess.Popen[bytes]:
-        calls.append((slug, file_path, port, mode))
+        calls.append((slug, paths, port, mode))
         proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
         proc.poll.return_value = None  # alive
         proc.pid = 4321
@@ -109,4 +110,6 @@ def test_delete_blog_unregisters_and_kills(tmp_path: Path, monkeypatch: pytest.M
         "delete must drop the registry entry"
     )
     assert "pre-radar" not in state.processes, "delete must drop the tracked process"
-    assert not (tmp_path / "pre-radar.py").exists(), "delete must remove the source file"
+    assert not get_slug_paths(tmp_path, "pre-radar").notebook.exists(), (
+        "delete must remove the source file"
+    )

--- a/apps/notebook-host/tests/test_blogs_admin.py
+++ b/apps/notebook-host/tests/test_blogs_admin.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import runpy
 import subprocess
 import unittest.mock
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +13,17 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from notebook_host.jail import SlugPaths, get_slug_paths
+
+# `--import-mode=importlib` (root pyproject.toml) doesn't add this directory
+# to sys.path, and there's no `__init__.py` here (one would collide with the
+# top-level `tests` package name already claimed by `packages/core/tests`).
+# `runpy` loads `conftest.py` by file path without touching sys.path or
+# sys.modules, so a full monorepo `pytest` collection can't collide with
+# similar sys.path tricks in other adapters' tests (see
+# `packages/adapters/mcp/tests/tools/conftest.py`).
+set_unjailed_test_env: Callable[[pytest.MonkeyPatch], None] = runpy.run_path(
+    str(Path(__file__).parent / "conftest.py")
+)["set_unjailed_test_env"]
 
 AUTH = "Bearer test-secret"
 
@@ -28,12 +41,18 @@ def _make_blog_app(
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8500")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8503")
     monkeypatch.setenv("DAIMON_NOTEBOOK__SPAWN_TIMEOUT_SECONDS", "2.0")
+    set_unjailed_test_env(monkeypatch)
     settings = load_settings(_env_file=None)
 
     calls: list[tuple[str, SlugPaths, int, str]] = []
 
     def spawner(
-        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
+        slug: str,
+        paths: SlugPaths,
+        port: int,
+        *,
+        mode: str = "edit",
+        jail_uid: int | None = None,
     ) -> subprocess.Popen[bytes]:
         calls.append((slug, paths, port, mode))
         proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)

--- a/apps/notebook-host/tests/test_consumed_store.py
+++ b/apps/notebook-host/tests/test_consumed_store.py
@@ -1,0 +1,75 @@
+"""Tests for notebook_host.consumed_store — durable, pruned single-use jti registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from notebook_host.consumed_store import (
+    burn_jti,
+    is_consumed,
+    load_consumed,
+    prune_consumed,
+    save_consumed,
+)
+
+
+def test_load_consumed_returns_empty_when_file_missing(tmp_path: Path) -> None:
+    assert load_consumed(tmp_path / "missing.json") == {}, (
+        "missing registry must produce an empty map, not an error"
+    )
+
+
+def test_load_consumed_returns_empty_when_file_malformed(tmp_path: Path) -> None:
+    path = tmp_path / "consumed.json"
+    path.write_text("{not valid json")
+    assert load_consumed(path) == {}, "malformed registry must produce an empty map"
+
+
+def test_save_then_load_consumed_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "consumed.json"
+    records = {"jti-a": 1700000100, "jti-b": 1700000200}
+    save_consumed(path, records)
+    assert load_consumed(path) == records, "round-trip must preserve every jti:exp pair"
+
+
+def test_prune_consumed_drops_expired_and_keeps_unexpired(tmp_path: Path) -> None:
+    records = {"expired": 100, "not-expired": 200, "boundary": 150}
+    pruned = prune_consumed(records, now=150)
+    assert pruned == {"not-expired": 200}, (
+        "entries with exp <= now must be dropped; exp > now must be kept"
+    )
+    assert records == {"expired": 100, "not-expired": 200, "boundary": 150}, (
+        "prune_consumed must not mutate its input"
+    )
+
+
+def test_burn_jti_returns_true_then_false_for_same_jti(tmp_path: Path) -> None:
+    path = tmp_path / "consumed.json"
+    first = burn_jti(path, "j1", exp=2_000_000_000, now=1_000)
+    second = burn_jti(path, "j1", exp=2_000_000_000, now=1_000)
+    assert first is True, "the first burn of a jti must succeed"
+    assert second is False, "replaying the same jti must not burn again"
+
+
+def test_burn_jti_prunes_expired_entries_so_the_file_does_not_grow_without_bound(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "consumed.json"
+    now = 1_000
+    burn_jti(path, "old-1", exp=now - 300, now=now)
+    burn_jti(path, "old-2", exp=now - 200, now=now)
+    burn_jti(path, "old-3", exp=now - 100, now=now)
+
+    burn_jti(path, "fresh", exp=now + 300, now=now)
+
+    assert len(load_consumed(path)) == 1, (
+        "burning a new jti must prune every already-expired entry, not just skip them"
+    )
+    assert load_consumed(path) == {"fresh": now + 300}
+
+
+def test_is_consumed_reflects_burned_state(tmp_path: Path) -> None:
+    path = tmp_path / "consumed.json"
+    assert is_consumed(path, "j1") is False, "an unburned jti is not consumed"
+    burn_jti(path, "j1", exp=2_000_000_000, now=1_000)
+    assert is_consumed(path, "j1") is True, "a burned jti is consumed"

--- a/apps/notebook-host/tests/test_jail.py
+++ b/apps/notebook-host/tests/test_jail.py
@@ -1,0 +1,78 @@
+"""Tests for notebook_host.jail: SlugPaths contract, tree lifecycle, uid pool."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from notebook_host.jail import get_slug_paths
+
+
+def test_get_slug_paths_computes_the_documented_layout() -> None:
+    """get_slug_paths maps a slug onto the fixed six-path layout."""
+    paths = get_slug_paths(Path("/d"), "abc")
+    assert paths.root == Path("/d/abc"), "root should be data_dir / slug"
+    assert paths.notebook == Path("/d/abc/notebook.py"), (
+        "notebook basename is fixed regardless of slug"
+    )
+    assert paths.data == Path("/d/abc/data"), "data should be root / 'data'"
+    assert paths.workspace == Path("/d/abc/workspace"), "workspace should be root / 'workspace'"
+    assert paths.home == Path("/d/abc/home"), "home should be root / 'home'"
+    assert paths.log == Path("/d/abc/marimo.log"), "log should be root / 'marimo.log'"
+
+
+def test_get_slug_paths_performs_no_filesystem_access(tmp_path: Path) -> None:
+    """get_slug_paths is pure: calling it against a missing data_dir creates nothing."""
+    missing = tmp_path / "does-not-exist"
+    get_slug_paths(missing, "abc")
+    assert not missing.exists(), "get_slug_paths must not touch the filesystem"
+
+
+def test_ensure_slug_jail_creates_all_four_dirs_at_mode_0700(tmp_path: Path) -> None:
+    """ensure_slug_jail creates root/data/workspace/home, each mode 0700."""
+    from notebook_host.jail import ensure_slug_jail
+
+    paths = ensure_slug_jail(tmp_path, "abc")
+    for d in (paths.root, paths.data, paths.workspace, paths.home):
+        assert d.is_dir(), f"{d} should exist and be a directory"
+        assert d.stat().st_mode & 0o777 == 0o700, f"{d} should be mode 0700"
+
+
+def test_ensure_slug_jail_is_idempotent_and_preserves_existing_data(tmp_path: Path) -> None:
+    """Calling ensure_slug_jail twice succeeds and leaves data/ files untouched."""
+    from notebook_host.jail import ensure_slug_jail
+
+    paths = ensure_slug_jail(tmp_path, "abc")
+    marker = paths.data / "marker.txt"
+    marker.write_text("hello")
+
+    ensure_slug_jail(tmp_path, "abc")
+
+    assert marker.read_text() == "hello", (
+        "a pre-existing file under data/ must survive a repeat ensure_slug_jail call"
+    )
+
+
+def test_ensure_slug_jail_chowns_to_self_uid_without_root(tmp_path: Path) -> None:
+    """ensure_slug_jail(..., uid=os.getuid()) succeeds via self-chown, no root needed."""
+    from notebook_host.jail import ensure_slug_jail
+
+    paths = ensure_slug_jail(tmp_path, "abc", uid=os.getuid())
+    for d in (paths.root, paths.data, paths.workspace, paths.home):
+        assert d.stat().st_uid == os.getuid(), f"{d} should be owned by the caller's uid"
+
+
+def test_remove_slug_tree_deletes_everything(tmp_path: Path) -> None:
+    """remove_slug_tree removes the whole per-slug root in one call."""
+    from notebook_host.jail import ensure_slug_jail, remove_slug_tree
+
+    ensure_slug_jail(tmp_path, "abc")
+    remove_slug_tree(tmp_path, "abc")
+    assert not (tmp_path / "abc").exists(), "the slug's root should be gone"
+
+
+def test_remove_slug_tree_on_absent_tree_does_not_raise(tmp_path: Path) -> None:
+    """remove_slug_tree is a no-op (not an error) when the tree never existed."""
+    from notebook_host.jail import remove_slug_tree
+
+    remove_slug_tree(tmp_path, "never-existed")  # must not raise

--- a/apps/notebook-host/tests/test_jail.py
+++ b/apps/notebook-host/tests/test_jail.py
@@ -322,3 +322,53 @@ def test_build_jailed_preexec_returns_a_callable_for_any_uid() -> None:
 
     preexec = build_jailed_preexec(1000, rlimit_as_bytes=None, rlimit_cpu_seconds=None)
     assert callable(preexec), "build_jailed_preexec must always return a callable"
+
+
+# ─── target mode set: 0711 parent / 0600 registries / 0700 slug tree ─────────
+#
+# The root-gated tests in test_jail_privilege.py prove these modes actually
+# enforce the isolation boundary (uid drops require CAP_SETUID, unavailable
+# in default CI), but they never run unprivileged. This test defends the
+# mode VALUES themselves without root, so a regression — parent mode drift,
+# a registry write reverting to the default umask, an accidental change to
+# the slug tree mode — fails in the default suite rather than only under a
+# root-gated run that never executes in CI.
+
+
+def test_data_dir_slug_tree_and_registry_modes_match_the_documented_target(tmp_path: Path) -> None:
+    """Non-root proof of the corrected mode set, using the real production write paths."""
+    from notebook_host.blogs_store import BlogRecord, save_blogs
+    from notebook_host.jail import (
+        DATA_DIR_MODE,
+        SLUG_TREE_MODE,
+        ensure_slug_jail,
+        lock_data_dir_root,
+        save_uid_registry,
+    )
+    from notebook_host.pids_store import save_pids
+
+    paths = ensure_slug_jail(tmp_path, "abc")
+    lock_data_dir_root(tmp_path)
+
+    blogs = tmp_path / "blogs.json"
+    pids = tmp_path / "pids.json"
+    uids = tmp_path / "uids.json"
+    save_blogs(blogs, {"abc": BlogRecord(slug="abc", created_at=1.0)})
+    save_pids(pids, {})
+    save_uid_registry(uids, {"abc": 100000})
+
+    assert DATA_DIR_MODE == 0o711, "the documented parent mode constant must be 0711"
+    assert tmp_path.stat().st_mode & 0o777 == 0o711, (
+        "data_dir must be locked to 0711 — traversable by any uid, listable by none"
+    )
+    assert SLUG_TREE_MODE == 0o700, (
+        "the documented slug tree mode constant must be unchanged at 0700"
+    )
+    for d in (paths.root, paths.data, paths.workspace, paths.home):
+        assert d.stat().st_mode & 0o777 == 0o700, (
+            f"{d} must remain the real 0700 isolation boundary"
+        )
+    for registry in (blogs, pids, uids):
+        assert registry.stat().st_mode & 0o777 == 0o600, (
+            f"{registry.name} must be written at mode 0600, not the default-umask mode"
+        )

--- a/apps/notebook-host/tests/test_jail.py
+++ b/apps/notebook-host/tests/test_jail.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 
+import pytest
 from notebook_host.jail import get_slug_paths
 
 
@@ -210,3 +211,114 @@ def test_save_uid_registry_writes_atomically_via_tmp_and_replace(tmp_path: Path)
     )
     on_disk = json.loads(path.read_text())
     assert on_disk == {"a": 100000, "b": 100001}, "the file's raw JSON should match the records"
+
+
+# ─── remove_slug_tree uid release ─────────────────────────────────────────────
+
+
+def test_remove_slug_tree_with_uids_file_releases_the_slug(tmp_path: Path) -> None:
+    """remove_slug_tree(..., uids_file=p) drops the slug from the uid registry too."""
+    from notebook_host.jail import (
+        ensure_slug_jail,
+        get_or_create_slug_uid,
+        load_uid_registry,
+        remove_slug_tree,
+    )
+
+    uids_file = tmp_path / "uids.json"
+    ensure_slug_jail(tmp_path, "abc")
+    get_or_create_slug_uid(uids_file, "abc", start=100000, end=100005)
+
+    remove_slug_tree(tmp_path, "abc", uids_file=uids_file)
+
+    assert "abc" not in load_uid_registry(uids_file), (
+        "remove_slug_tree with uids_file must release the slug's uid"
+    )
+
+
+def test_remove_slug_tree_without_uids_file_leaves_registry_untouched(tmp_path: Path) -> None:
+    """remove_slug_tree with no uids_file kwarg does not touch the uid registry."""
+    from notebook_host.jail import (
+        ensure_slug_jail,
+        get_or_create_slug_uid,
+        load_uid_registry,
+        remove_slug_tree,
+    )
+
+    uids_file = tmp_path / "uids.json"
+    ensure_slug_jail(tmp_path, "abc")
+    get_or_create_slug_uid(uids_file, "abc", start=100000, end=100005)
+
+    remove_slug_tree(tmp_path, "abc")
+
+    assert "abc" in load_uid_registry(uids_file), (
+        "remove_slug_tree without uids_file must leave the uid registry unchanged"
+    )
+
+
+# ─── privilege drop: can_apply_jail / resolve_jail_uid / build_jailed_preexec ─
+
+
+def test_resolve_jail_uid_raises_when_jail_unavailable_and_not_allowed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """can_apply_jail() False + allow_unjailed=False raises JailUnavailableError."""
+    from notebook_host import jail
+
+    monkeypatch.setattr(jail, "can_apply_jail", lambda: False)
+    with pytest.raises(jail.JailUnavailableError) as exc_info:
+        jail.resolve_jail_uid(
+            tmp_path / "uids.json", "abc", start=100000, end=100005, allow_unjailed=False
+        )
+    assert "allow_unjailed_spawn" in str(exc_info.value), (
+        "the fail-closed error must name the deliberate opt-out setting"
+    )
+
+
+def test_resolve_jail_uid_returns_none_when_jail_unavailable_and_allowed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """can_apply_jail() False + allow_unjailed=True returns None (spawn unjailed)."""
+    from notebook_host import jail
+
+    monkeypatch.setattr(jail, "can_apply_jail", lambda: False)
+    result = jail.resolve_jail_uid(
+        tmp_path / "uids.json", "abc", start=100000, end=100005, allow_unjailed=True
+    )
+    assert result is None, "an explicit opt-out on an unjailable host must return None, not raise"
+
+
+def test_resolve_jail_uid_returns_a_stable_int_when_jail_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """can_apply_jail() True resolves (and persists) a real uid from the pool."""
+    from notebook_host import jail
+
+    monkeypatch.setattr(jail, "can_apply_jail", lambda: True)
+    uids_file = tmp_path / "uids.json"
+    first = jail.resolve_jail_uid(uids_file, "abc", start=100000, end=100005, allow_unjailed=False)
+    second = jail.resolve_jail_uid(uids_file, "abc", start=100000, end=100005, allow_unjailed=False)
+    assert isinstance(first, int), "a jailable host must resolve to a real uid, not None"
+    assert first == second, "the same slug must resolve to the same uid across calls"
+
+
+def test_resolve_jail_uid_propagates_pool_exhaustion_even_when_unjailed_allowed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A full uid pool raises UidPoolExhaustedError, never degrading to None."""
+    from notebook_host import jail
+
+    monkeypatch.setattr(jail, "can_apply_jail", lambda: True)
+    uids_file = tmp_path / "uids.json"
+    jail.get_or_create_slug_uid(uids_file, "a", start=100000, end=100000)
+
+    with pytest.raises(jail.UidPoolExhaustedError):
+        jail.resolve_jail_uid(uids_file, "b", start=100000, end=100000, allow_unjailed=True)
+
+
+def test_build_jailed_preexec_returns_a_callable_for_any_uid() -> None:
+    """build_jailed_preexec never returns None — build-time only, not invoked here."""
+    from notebook_host.jail import build_jailed_preexec
+
+    preexec = build_jailed_preexec(1000, rlimit_as_bytes=None, rlimit_cpu_seconds=None)
+    assert callable(preexec), "build_jailed_preexec must always return a callable"

--- a/apps/notebook-host/tests/test_jail.py
+++ b/apps/notebook-host/tests/test_jail.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -76,3 +77,136 @@ def test_remove_slug_tree_on_absent_tree_does_not_raise(tmp_path: Path) -> None:
     from notebook_host.jail import remove_slug_tree
 
     remove_slug_tree(tmp_path, "never-existed")  # must not raise
+
+
+# ─── uid pool ────────────────────────────────────────────────────────────────
+
+
+def test_allocate_uid_returns_lowest_free_value_in_range() -> None:
+    """A fresh slug gets the lowest unused uid in [start, end]."""
+    from notebook_host.jail import allocate_uid
+
+    assert allocate_uid({}, "a", start=100000, end=100002) == 100000, (
+        "first allocation in an empty registry should be start"
+    )
+    assert allocate_uid({"a": 100000}, "b", start=100000, end=100002) == 100001, (
+        "next distinct slug should get the next free uid"
+    )
+
+
+def test_allocate_uid_is_idempotent_for_an_already_registered_slug() -> None:
+    """A slug already in the registry keeps its uid even if a lower one is free."""
+    from notebook_host.jail import allocate_uid
+
+    registry = {"a": 100005}
+    assert allocate_uid(registry, "a", start=100000, end=100010) == 100005, (
+        "an already-registered slug must return its existing uid, not the lowest free one"
+    )
+
+
+def test_allocate_uid_raises_when_pool_exhausted() -> None:
+    """Asking for a uid when every value in range is taken raises, naming the range."""
+    from notebook_host.jail import UidPoolExhaustedError, allocate_uid
+
+    registry = {"a": 100000, "b": 100001}
+    try:
+        allocate_uid(registry, "c", start=100000, end=100001)
+    except UidPoolExhaustedError as exc:
+        message = str(exc)
+        assert "100000" in message, "exhaustion error should name the range start"
+        assert "100001" in message, "exhaustion error should name the range end"
+    else:
+        raise AssertionError("expected UidPoolExhaustedError when the pool is full")
+
+
+def test_allocate_uid_does_not_mutate_its_input() -> None:
+    """allocate_uid is pure: the caller's registry dict is unchanged after the call."""
+    from notebook_host.jail import allocate_uid
+
+    registry = {"a": 100000}
+    before = dict(registry)
+    allocate_uid(registry, "b", start=100000, end=100005)
+    assert registry == before, "allocate_uid must not mutate the registry it was given"
+
+
+def test_load_uid_registry_missing_file_returns_empty(tmp_path: Path) -> None:
+    """A missing registry file loads as an empty dict, same posture as load_pids."""
+    from notebook_host.jail import load_uid_registry
+
+    assert load_uid_registry(tmp_path / "missing.json") == {}, (
+        "a missing uids.json should load as {}"
+    )
+
+
+def test_load_uid_registry_malformed_file_returns_empty(tmp_path: Path) -> None:
+    """A file that isn't valid JSON loads as an empty dict rather than raising."""
+    from notebook_host.jail import load_uid_registry
+
+    path = tmp_path / "uids.json"
+    path.write_text("not json{")
+    assert load_uid_registry(path) == {}, "malformed JSON should load as {}"
+
+
+def test_load_uid_registry_skips_invalid_entries(tmp_path: Path) -> None:
+    """Non-str keys, non-int values, and bool values (an int subclass) are skipped."""
+    from notebook_host.jail import load_uid_registry
+
+    path = tmp_path / "uids.json"
+    path.write_text('{"a": 1, "b": "x", "c": true, "12": 3}')
+    # JSON object keys are always strings, so the plan's "non-str key" case is
+    # expressed here as the numeral-shaped string "12"; only the
+    # type-mismatched values ("b": str, "c": bool) get filtered.
+    assert load_uid_registry(path) == {"a": 1, "12": 3}, (
+        "only entries with a str key and a genuine int (non-bool) value should survive"
+    )
+
+
+def test_get_or_create_slug_uid_is_stable_across_calls(tmp_path: Path) -> None:
+    """Calling get_or_create_slug_uid twice for the same slug returns the same uid."""
+    from notebook_host.jail import get_or_create_slug_uid
+
+    path = tmp_path / "uids.json"
+    first = get_or_create_slug_uid(path, "a", start=100000, end=100999)
+    contents_after_first = path.read_text()
+    second = get_or_create_slug_uid(path, "a", start=100000, end=100999)
+
+    assert first == second, "the same slug must always get the same uid"
+    assert path.read_text() == contents_after_first, (
+        "a hit (no new allocation) must not rewrite the registry file"
+    )
+
+
+def test_release_slug_uid_frees_the_slot_for_reuse(tmp_path: Path) -> None:
+    """After release, the slug is gone from the registry and its uid may be reused."""
+    from notebook_host.jail import get_or_create_slug_uid, load_uid_registry, release_slug_uid
+
+    path = tmp_path / "uids.json"
+    freed_uid = get_or_create_slug_uid(path, "a", start=100000, end=100000)
+
+    release_slug_uid(path, "a")
+
+    assert "a" not in load_uid_registry(path), "released slug must be gone from the registry"
+    reused = get_or_create_slug_uid(path, "b", start=100000, end=100000)
+    assert reused == freed_uid, "a released uid must become available to a new slug"
+
+
+def test_release_slug_uid_on_unknown_slug_is_a_noop(tmp_path: Path) -> None:
+    """release_slug_uid for a slug never registered does not raise or create a file."""
+    from notebook_host.jail import release_slug_uid
+
+    path = tmp_path / "uids.json"
+    release_slug_uid(path, "never-existed")  # must not raise
+    assert not path.exists(), "releasing an unknown slug must not create the registry file"
+
+
+def test_save_uid_registry_writes_atomically_via_tmp_and_replace(tmp_path: Path) -> None:
+    """save_uid_registry writes the exact records, readable back via load_uid_registry."""
+    from notebook_host.jail import load_uid_registry, save_uid_registry
+
+    path = tmp_path / "uids.json"
+    save_uid_registry(path, {"a": 100000, "b": 100001})
+    assert load_uid_registry(path) == {"a": 100000, "b": 100001}, (
+        "save then load should round-trip the registry"
+    )
+    on_disk = json.loads(path.read_text())
+    assert on_disk == {"a": 100000, "b": 100001}, "the file's raw JSON should match the records"

--- a/apps/notebook-host/tests/test_jail_privilege.py
+++ b/apps/notebook-host/tests/test_jail_privilege.py
@@ -1,0 +1,242 @@
+"""Root-gated proof that the per-notebook uid jail actually holds.
+
+These tests do not run in default CI and are not expected to. The
+``pytest-notebook-host`` job runs on an unprivileged GitHub runner, and the
+root ``addopts`` in ``pyproject.toml`` already deselect the ``slow`` marker
+every test in this module carries. Dropping into another uid via
+``os.setuid`` requires ``CAP_SETUID``, which an unprivileged process never
+has — so unlike the rest of the suite, these cannot be faked with a
+monkeypatched ``preexec_fn``; they exist specifically to prove the property
+the monkeypatched tests elsewhere in this tree cannot.
+
+Run them explicitly, as root:
+
+    sudo -E uv run pytest apps/notebook-host/tests/test_jail_privilege.py -m slow
+
+or inside a container built from ``apps/notebook-host/Dockerfile``, which
+runs as root by default.
+
+An automated home for these belongs with the already-anticipated
+notebook-host ``slow`` tier on a Linux runner (tracked as a future
+requirement) — this plan does not add that CI job.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from notebook_host.jail import build_jailed_preexec, ensure_slug_jail
+from notebook_host.lifecycle import scrub_env
+
+_UID_A = 100001
+_UID_B = 100002
+
+
+def _run_as_uid(
+    uid: int, code: str, *, cwd: str | None = None, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run ``code`` in a child process dropped into ``uid`` via preexec_fn."""
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        cwd=cwd,
+        env=env,
+        preexec_fn=build_jailed_preexec(uid, rlimit_as_bytes=None, rlimit_cpu_seconds=None),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+_READ_CODE = """
+import json
+try:
+    with open({path!r}) as f:
+        data = f.read()
+except PermissionError:
+    print(json.dumps({{"error": "PermissionError"}}))
+except OSError as e:
+    print(json.dumps({{"error": "OSError:" + type(e).__name__}}))
+else:
+    print(json.dumps({{"data": data}}))
+"""
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
+def test_child_drops_to_uid_gid_and_clears_supplementary_groups(tmp_path: Path) -> None:
+    """The child reports getuid()==uid, getgid()==uid, and an empty supplementary group list.
+
+    The groups assertion is the one that catches a missing or misordered
+    ``setgroups([])`` — without it the child keeps 0 (root) in its
+    supplementary list even after setuid/setgid drop the primary identity.
+    """
+    paths = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    code = "import json, os; print(json.dumps({'uid': os.getuid(), 'gid': os.getgid(), 'groups': os.getgroups()}))"
+    result = _run_as_uid(_UID_A, code, cwd=str(paths.workspace))
+    assert result.returncode == 0, f"child should exit cleanly; stderr={result.stderr}"
+    identity = json.loads(result.stdout)
+    assert identity["uid"] == _UID_A, "child should report the dropped uid"
+    assert identity["gid"] == _UID_A, (
+        "child should report the dropped gid (== uid, no separate allocation)"
+    )
+    assert identity["groups"] == [], (
+        "supplementary groups must be empty — a missing setgroups([]) would leave root's groups intact"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
+def test_own_subtree_reachable_via_relative_path(tmp_path: Path) -> None:
+    """With cwd inside its own workspace, a jailed process can read its own data/ via a relative path."""
+    paths = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    seeded = paths.data / "x.txt"
+    seeded.write_bytes(b"hello-from-a")
+    os.chown(seeded, _UID_A, _UID_A)
+    os.chmod(seeded, 0o600)
+
+    code = _READ_CODE.format(path="../data/x.txt")
+    result = _run_as_uid(_UID_A, code, cwd=str(paths.workspace))
+    assert result.returncode == 0, f"child should exit cleanly; stderr={result.stderr}"
+    body = json.loads(result.stdout)
+    assert body.get("data") == "hello-from-a", (
+        f"own-subtree read should succeed and return the seeded bytes, got {body}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
+def test_cross_slug_relative_escape_denied(tmp_path: Path) -> None:
+    """A relative '..' traversal into a sibling slug's data is denied."""
+    paths_a = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    paths_b = ensure_slug_jail(tmp_path, "slug-b", uid=_UID_B)
+    secret = paths_b.data / "secret.txt"
+    secret.write_bytes(b"top-secret")
+    os.chown(secret, _UID_B, _UID_B)
+    os.chmod(secret, 0o600)
+    # data_dir itself is the 0700 root:root boundary every slug root sits under.
+    os.chown(tmp_path, 0, 0)
+    os.chmod(tmp_path, 0o700)
+
+    code = _READ_CODE.format(path="../../slug-b/data/secret.txt")
+    result = _run_as_uid(_UID_A, code, cwd=str(paths_a.workspace))
+    assert result.returncode == 0, f"child should exit cleanly; stderr={result.stderr}"
+    body = json.loads(result.stdout)
+    assert body.get("error") == "PermissionError", (
+        f"a relative cross-slug escape must raise PermissionError, got {body}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
+def test_cross_slug_absolute_escape_denied(tmp_path: Path) -> None:
+    """An absolute-path read into a sibling slug's data is denied — same wall as the relative case."""
+    paths_a = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    paths_b = ensure_slug_jail(tmp_path, "slug-b", uid=_UID_B)
+    secret = paths_b.data / "secret.txt"
+    secret.write_bytes(b"top-secret")
+    os.chown(secret, _UID_B, _UID_B)
+    os.chmod(secret, 0o600)
+    os.chown(tmp_path, 0, 0)
+    os.chmod(tmp_path, 0o700)
+
+    code = _READ_CODE.format(path=str(secret))
+    result = _run_as_uid(_UID_A, code, cwd=str(paths_a.workspace))
+    assert result.returncode == 0, f"child should exit cleanly; stderr={result.stderr}"
+    body = json.loads(result.stdout)
+    assert body.get("error") == "PermissionError", (
+        f"an absolute cross-slug escape must raise PermissionError, got {body}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
+def test_registry_files_unreachable(tmp_path: Path) -> None:
+    """blogs.json and uids.json — host-owned state outside every jail — are unreadable by a jailed uid."""
+    paths_a = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    blogs = tmp_path / "blogs.json"
+    uids = tmp_path / "uids.json"
+    blogs.write_text("{}", encoding="utf-8")
+    uids.write_text("{}", encoding="utf-8")
+    os.chown(blogs, 0, 0)
+    os.chown(uids, 0, 0)
+    os.chmod(blogs, 0o600)
+    os.chmod(uids, 0o600)
+    os.chown(tmp_path, 0, 0)
+    os.chmod(tmp_path, 0o700)
+
+    for registry_path in (blogs, uids):
+        code = _READ_CODE.format(path=str(registry_path))
+        result = _run_as_uid(_UID_A, code, cwd=str(paths_a.workspace))
+        assert result.returncode == 0, f"child should exit cleanly; stderr={result.stderr}"
+        body = json.loads(result.stdout)
+        assert body.get("error") == "PermissionError", (
+            f"{registry_path.name} must be unreadable by a jailed uid, got {body}"
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
+def test_proc_environ_closed_across_uids(tmp_path: Path) -> None:
+    """A jailed uid cannot read another uid's (or root's) /proc/<pid>/environ.
+
+    Closes scouting finding 5: same-uid env-scrub alone would not stop this;
+    the uid split is what actually denies it, verified here directly rather
+    than assumed.
+    """
+    long_lived = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", "import time; time.sleep(20)"],
+        preexec_fn=build_jailed_preexec(_UID_A, rlimit_as_bytes=None, rlimit_cpu_seconds=None),
+    )
+    try:
+        time.sleep(0.5)  # give the child a moment to actually be running
+        for target_pid in (long_lived.pid, os.getpid()):
+            code = _READ_CODE.format(path=f"/proc/{target_pid}/environ")
+            result = _run_as_uid(_UID_B, code)
+            assert result.returncode == 0, f"child should exit cleanly; stderr={result.stderr}"
+            body = json.loads(result.stdout)
+            assert body.get("error") == "PermissionError", (
+                f"/proc/{target_pid}/environ must be unreadable by a different uid, got {body}"
+            )
+    finally:
+        long_lived.kill()
+        long_lived.wait(timeout=5)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
+def test_uv_and_marimo_run_under_the_dropped_uid(tmp_path: Path) -> None:
+    """uv run --with marimo actually works under a dropped uid, given a per-slug HOME.
+
+    This is the single most important test in the phase — it is the thing
+    that was predicted to sink the whole mechanism (CONTEXT.md D-02).
+    """
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv not on PATH")
+    paths = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    env = scrub_env(dict(os.environ))
+    env["HOME"] = str(paths.home)
+
+    result = subprocess.run(  # noqa: S603
+        [uv, "run", "--with", "marimo", "marimo", "--version"],
+        cwd=str(paths.workspace),
+        env=env,
+        preexec_fn=build_jailed_preexec(_UID_A, rlimit_as_bytes=None, rlimit_cpu_seconds=None),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"uv run --with marimo should succeed under the dropped uid: {combined}"
+    )
+    assert "Permission denied" not in combined, (
+        f"the dropped-uid run must not hit a permission error: {combined}"
+    )

--- a/apps/notebook-host/tests/test_jail_privilege.py
+++ b/apps/notebook-host/tests/test_jail_privilege.py
@@ -32,8 +32,16 @@ import time
 from pathlib import Path
 
 import pytest
-from notebook_host.jail import build_jailed_preexec, ensure_slug_jail
+from notebook_host.blogs_store import BlogRecord, save_blogs
+from notebook_host.jail import (
+    DATA_DIR_MODE,
+    build_jailed_preexec,
+    ensure_slug_jail,
+    lock_data_dir_root,
+    save_uid_registry,
+)
 from notebook_host.lifecycle import scrub_env
+from notebook_host.pids_store import save_pids
 
 _UID_A = 100001
 _UID_B = 100002
@@ -94,8 +102,15 @@ def test_child_drops_to_uid_gid_and_clears_supplementary_groups(tmp_path: Path) 
 @pytest.mark.slow
 @pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
 def test_own_subtree_reachable_via_relative_path(tmp_path: Path) -> None:
-    """With cwd inside its own workspace, a jailed process can read its own data/ via a relative path."""
+    """With cwd inside its own workspace, a jailed process can read its own data/ via a relative path.
+
+    ``data_dir`` (``tmp_path``) is locked to the real production mode
+    (``DATA_DIR_MODE`` / 0711) here, not left at whatever the pytest fixture
+    happens to default to — this proves reachability against the actual
+    constraint a dropped uid faces in production, not an accidental one.
+    """
     paths = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    lock_data_dir_root(tmp_path)
     seeded = paths.data / "x.txt"
     seeded.write_bytes(b"hello-from-a")
     os.chown(seeded, _UID_A, _UID_A)
@@ -112,17 +127,50 @@ def test_own_subtree_reachable_via_relative_path(tmp_path: Path) -> None:
 
 @pytest.mark.slow
 @pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
+def test_own_subtree_reachable_via_absolute_path(tmp_path: Path) -> None:
+    """A jailed process can reach its own subtree by ABSOLUTE path, under the real data_dir mode.
+
+    This is the exact property plan 05's live rehearsal found broken: under
+    the old (incorrect) ``data_dir`` mode of 0700, resolving an absolute path
+    requires the ``x`` bit on every component, so a dropped uid could not
+    even reach its OWN ``HOME`` — every non-break-glass ``uv run`` spawn
+    failed. Testing only cross-slug denial (as this module did before) let
+    that unusable jail look correct; this test defends the other half.
+    """
+    paths = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    lock_data_dir_root(tmp_path)
+    seeded = paths.home / "x.txt"
+    seeded.write_bytes(b"hello-from-a-home")
+    os.chown(seeded, _UID_A, _UID_A)
+    os.chmod(seeded, 0o600)
+
+    code = _READ_CODE.format(path=str(seeded))
+    result = _run_as_uid(_UID_A, code)  # no cwd inside the tree — pure absolute resolution
+    assert result.returncode == 0, f"child should exit cleanly; stderr={result.stderr}"
+    body = json.loads(result.stdout)
+    assert body.get("data") == "hello-from-a-home", (
+        f"own-subtree absolute-path read should succeed and return the seeded bytes, got {body}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
 def test_cross_slug_relative_escape_denied(tmp_path: Path) -> None:
-    """A relative '..' traversal into a sibling slug's data is denied."""
+    """A relative '..' traversal into a sibling slug's data is denied.
+
+    ``data_dir`` is locked to the real production mode (0711, traversable)
+    here, not the old incorrect 0700 — this proves the denial comes from
+    ``slug-b``'s own 0700 boundary, which is the actual isolation mechanism,
+    not from an accidentally-untraversable parent.
+    """
     paths_a = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
     paths_b = ensure_slug_jail(tmp_path, "slug-b", uid=_UID_B)
     secret = paths_b.data / "secret.txt"
     secret.write_bytes(b"top-secret")
     os.chown(secret, _UID_B, _UID_B)
     os.chmod(secret, 0o600)
-    # data_dir itself is the 0700 root:root boundary every slug root sits under.
     os.chown(tmp_path, 0, 0)
-    os.chmod(tmp_path, 0o700)
+    lock_data_dir_root(tmp_path)
 
     code = _READ_CODE.format(path="../../slug-b/data/secret.txt")
     result = _run_as_uid(_UID_A, code, cwd=str(paths_a.workspace))
@@ -136,7 +184,15 @@ def test_cross_slug_relative_escape_denied(tmp_path: Path) -> None:
 @pytest.mark.slow
 @pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
 def test_cross_slug_absolute_escape_denied(tmp_path: Path) -> None:
-    """An absolute-path read into a sibling slug's data is denied — same wall as the relative case."""
+    """An absolute-path read into a sibling slug's data is denied — same wall as the relative case.
+
+    ``data_dir`` is locked to the real production mode (0711, traversable) —
+    an absolute path CAN resolve through it, but ``slug-b``'s own 0700
+    boundary still denies the read. This is the case plan 05's rehearsal
+    proved broken under the old 0700 parent mode (nothing could resolve
+    ANY absolute path through it, own subtree included); this test proves
+    the corrected mode still holds the cross-slug wall.
+    """
     paths_a = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
     paths_b = ensure_slug_jail(tmp_path, "slug-b", uid=_UID_B)
     secret = paths_b.data / "secret.txt"
@@ -144,7 +200,7 @@ def test_cross_slug_absolute_escape_denied(tmp_path: Path) -> None:
     os.chown(secret, _UID_B, _UID_B)
     os.chmod(secret, 0o600)
     os.chown(tmp_path, 0, 0)
-    os.chmod(tmp_path, 0o700)
+    lock_data_dir_root(tmp_path)
 
     code = _READ_CODE.format(path=str(secret))
     result = _run_as_uid(_UID_A, code, cwd=str(paths_a.workspace))
@@ -158,26 +214,36 @@ def test_cross_slug_absolute_escape_denied(tmp_path: Path) -> None:
 @pytest.mark.slow
 @pytest.mark.skipif(os.geteuid() != 0, reason="uid drop requires root")
 def test_registry_files_unreachable(tmp_path: Path) -> None:
-    """blogs.json and uids.json — host-owned state outside every jail — are unreadable by a jailed uid."""
+    """blogs.json/pids.json/uids.json are unreadable by a jailed uid, by their OWN mode.
+
+    ``data_dir`` is locked to the real production mode (0711, traversable) —
+    the old test locked it to 0700, which made this assertion pass for the
+    wrong reason (an untraversable parent, not the file's own mode). The
+    files are written through the real production save_* functions rather
+    than hand-authored, so this also proves those functions actually emit
+    0600 on disk, not merely that a manually-chmod'ed file would be denied.
+    """
     paths_a = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
     blogs = tmp_path / "blogs.json"
+    pids = tmp_path / "pids.json"
     uids = tmp_path / "uids.json"
-    blogs.write_text("{}", encoding="utf-8")
-    uids.write_text("{}", encoding="utf-8")
-    os.chown(blogs, 0, 0)
-    os.chown(uids, 0, 0)
-    os.chmod(blogs, 0o600)
-    os.chmod(uids, 0o600)
+    save_blogs(blogs, {"slug-a": BlogRecord(slug="slug-a", created_at=1.0)})
+    save_pids(pids, {})
+    save_uid_registry(uids, {"slug-a": _UID_A})
     os.chown(tmp_path, 0, 0)
-    os.chmod(tmp_path, 0o700)
+    lock_data_dir_root(tmp_path)
 
-    for registry_path in (blogs, uids):
+    for registry_path in (blogs, pids, uids):
+        assert registry_path.stat().st_mode & 0o777 == 0o600, (
+            f"{registry_path.name} must actually be written at mode 0600 by the real save path"
+        )
         code = _READ_CODE.format(path=str(registry_path))
         result = _run_as_uid(_UID_A, code, cwd=str(paths_a.workspace))
         assert result.returncode == 0, f"child should exit cleanly; stderr={result.stderr}"
         body = json.loads(result.stdout)
         assert body.get("error") == "PermissionError", (
-            f"{registry_path.name} must be unreadable by a jailed uid, got {body}"
+            f"{registry_path.name} must be unreadable by a jailed uid via its own mode "
+            f"(data_dir is traversable at {oct(DATA_DIR_MODE)}), got {body}"
         )
 
 
@@ -215,12 +281,18 @@ def test_uv_and_marimo_run_under_the_dropped_uid(tmp_path: Path) -> None:
     """uv run --with marimo actually works under a dropped uid, given a per-slug HOME.
 
     This is the single most important test in the phase — it is the thing
-    that was predicted to sink the whole mechanism (CONTEXT.md D-02).
+    that was predicted to sink the whole mechanism (CONTEXT.md D-02), and the
+    thing plan 05's real-container rehearsal proved WAS broken: this test did
+    not lock ``data_dir`` to its real production mode, so it validated `uv`
+    against a permission state production never actually has. It now calls
+    ``lock_data_dir_root`` (the exact function ``migration.py`` calls on every
+    boot) before spawning, closing that gap.
     """
     uv = shutil.which("uv")
     if uv is None:
         pytest.skip("uv not on PATH")
     paths = ensure_slug_jail(tmp_path, "slug-a", uid=_UID_A)
+    lock_data_dir_root(tmp_path)
     env = scrub_env(dict(os.environ))
     env["HOME"] = str(paths.home)
 

--- a/apps/notebook-host/tests/test_lifecycle.py
+++ b/apps/notebook-host/tests/test_lifecycle.py
@@ -749,6 +749,204 @@ def test_spawn_marimo_passes_preexec_fn(monkeypatch: pytest.MonkeyPatch, tmp_pat
     )
 
 
+# ─── HOME / jail_uid wiring ────────────────────────────────────────────────────
+
+
+def _capture_spawn_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, **spawn_kwargs: object
+) -> dict[str, str]:
+    from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
+
+    monkeypatch.setattr(
+        lifecycle.shutil,
+        "which",
+        lambda _x: "/usr/bin/uv",  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+    captured: dict[str, object] = {}
+    sentinel_proc = _make_fake_popen()
+
+    def fake_popen(*args: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return sentinel_proc
+
+    monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100, **spawn_kwargs)  # pyright: ignore[reportArgumentType]
+    env = captured.get("env")
+    assert isinstance(env, dict), "spawn_marimo must pass env= to Popen"
+    return env
+
+
+def test_spawn_marimo_sets_home_to_slug_home_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """spawn_marimo always sets HOME to paths.home, jailed or not."""
+    from notebook_host.jail import get_slug_paths
+
+    env = _capture_spawn_env(monkeypatch, tmp_path)
+    paths = get_slug_paths(tmp_path, "myslug")
+    assert env["HOME"] == str(paths.home), (
+        "HOME must point into the slug's own tree, or uv's cache write fails"
+    )
+
+
+def test_spawn_marimo_preserves_virtual_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """VIRTUAL_ENV survives scrub_env unchanged — it's what keeps the baked stack."""
+    monkeypatch.setenv("VIRTUAL_ENV", "/app/.venv")
+    env = _capture_spawn_env(monkeypatch, tmp_path)
+    assert env["VIRTUAL_ENV"] == "/app/.venv", (
+        "VIRTUAL_ENV must flow through unchanged so headerless notebooks keep "
+        "the baked pandas/numpy/pymc stack"
+    )
+
+
+def test_spawn_marimo_env_still_has_no_daimon_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The DAIMON_* scrub guarantee is unbroken by the HOME/jail_uid additions."""
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "shhhh")
+    env = _capture_spawn_env(monkeypatch, tmp_path)
+    daimon_keys = [k for k in env if k.startswith("DAIMON_")]
+    assert daimon_keys == [], f"all DAIMON_-prefixed vars must still be stripped; got {daimon_keys}"
+
+
+def test_spawn_marimo_with_jail_uid_none_uses_rlimit_only_preexec(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """jail_uid=None with no rlimits configured on Linux yields preexec_fn=None,
+    exactly matching _make_preexec's own pre-existing behaviour."""
+    from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
+
+    monkeypatch.setattr(lifecycle.sys, "platform", "linux")
+    monkeypatch.setattr(
+        lifecycle.shutil,
+        "which",
+        lambda _x: "/usr/bin/uv",  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+    captured: dict[str, object] = {}
+    sentinel_proc = _make_fake_popen()
+
+    def fake_popen(*args: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return sentinel_proc
+
+    monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100, jail_uid=None)
+
+    assert captured.get("preexec_fn") is None, (
+        "jail_uid=None with no rlimits must leave preexec_fn None, unchanged from before "
+        "the jail existed"
+    )
+
+
+def test_spawn_marimo_with_jail_uid_set_always_has_a_preexec_fn(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """jail_uid=4242 yields a non-None preexec_fn even with both rlimits None —
+    a path where the old rlimit-only preexec would have returned None."""
+    from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
+
+    monkeypatch.setattr(
+        lifecycle.shutil,
+        "which",
+        lambda _x: "/usr/bin/uv",  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+    captured: dict[str, object] = {}
+    sentinel_proc = _make_fake_popen()
+
+    def fake_popen(*args: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return sentinel_proc
+
+    monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100, jail_uid=4242)
+
+    assert captured.get("preexec_fn") is not None, (
+        "jail_uid set must always yield a preexec_fn, even with no rlimits configured"
+    )
+
+
+def test_validate_notebook_with_jail_uid_chowns_the_temp_export_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """validate_notebook(jail_uid=...) chowns its TemporaryDirectory to that uid."""
+    from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
+
+    monkeypatch.setattr(
+        lifecycle.shutil,
+        "which",
+        lambda _x: "/usr/bin/uv",  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+    chown_calls: list[tuple[str, int, int]] = []
+
+    def fake_chown(path: object, uid: int, gid: int) -> None:
+        chown_calls.append((str(path), uid, gid))
+
+    monkeypatch.setattr(lifecycle.os, "chown", fake_chown)
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(lifecycle.subprocess, "run", fake_run)
+
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.validate_notebook("myslug", paths, timeout_s=5.0, jail_uid=4242)
+
+    assert len(chown_calls) == 1, f"expected exactly one os.chown call, got {chown_calls}"
+    chowned_path, uid, gid = chown_calls[0]
+    assert chowned_path, "chown must target a real path (the export temp dir)"
+    assert uid == 4242, "chown must target the jail uid"
+    assert gid == 4242, "chown must target the matching primary group (gid == uid)"
+
+
+def test_validate_notebook_without_jail_uid_never_calls_chown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """validate_notebook(jail_uid=None) does not call os.chown at all."""
+    from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
+
+    monkeypatch.setattr(
+        lifecycle.shutil,
+        "which",
+        lambda _x: "/usr/bin/uv",  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+    chown_calls: list[object] = []
+    monkeypatch.setattr(
+        lifecycle.os,
+        "chown",
+        lambda *a, **kw: chown_calls.append((a, kw)),  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(lifecycle.subprocess, "run", fake_run)
+
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.validate_notebook("myslug", paths, timeout_s=5.0, jail_uid=None)
+
+    assert chown_calls == [], "jail_uid=None must never call os.chown"
+
+
 # ─── sandbox / inline-script-metadata tests ──────────────────────────────────
 
 

--- a/apps/notebook-host/tests/test_lifecycle.py
+++ b/apps/notebook-host/tests/test_lifecycle.py
@@ -378,14 +378,16 @@ async def test_spawn_marimo_then_kill(tmp_path: Path) -> None:
     """spawn_marimo + wait_for_port returns True; kill makes is_alive() False."""
     import time
 
+    from notebook_host.jail import get_slug_paths
     from notebook_host.lifecycle import NotebookProcess, kill, spawn_marimo, wait_for_port
 
     slug = "test-nb"
     port = 8199
-    file_path = tmp_path / f"{slug}.py"
-    file_path.write_text(NOTEBOOK_TEMPLATE % slug, encoding="utf-8")
+    paths = get_slug_paths(tmp_path, slug)
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text(NOTEBOOK_TEMPLATE % slug, encoding="utf-8")
 
-    proc = spawn_marimo(slug, file_path, port)
+    proc = spawn_marimo(slug, paths, port)
     np = NotebookProcess(
         slug=slug,
         port=port,
@@ -452,134 +454,168 @@ def test_make_preexec_returns_callable_on_linux_with_limits(
     )
 
 
-# ─── _prepare_workspace (43-02) ───────────────────────────────────────────────
+# ─── _prepare_workspace (nested per-slug layout) ──────────────────────────────
 
 
 def test_prepare_workspace_creates_workspace_dir(tmp_path: Path) -> None:
-    """_prepare_workspace creates <slug>_workspace/ next to file_path."""
+    """_prepare_workspace creates data_dir/<slug>/workspace/."""
+    from notebook_host.jail import get_slug_paths
     from notebook_host.lifecycle import _prepare_workspace  # pyright: ignore[reportPrivateUsage]
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    workspace = _prepare_workspace(file_path, "myslug")
-    assert workspace == tmp_path / "myslug_workspace", (
-        "workspace dir should be <data_dir>/<slug>_workspace"
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    workspace = _prepare_workspace(paths)
+    assert workspace == tmp_path / "myslug" / "workspace", (
+        "workspace dir should be data_dir/<slug>/workspace"
     )
     assert workspace.is_dir(), "workspace dir should exist and be a directory"
 
 
 def test_prepare_workspace_creates_data_dir(tmp_path: Path) -> None:
-    """_prepare_workspace creates <slug>.data/ if it does not exist."""
+    """_prepare_workspace creates data_dir/<slug>/data/ if it does not exist."""
+    from notebook_host.jail import get_slug_paths
     from notebook_host.lifecycle import _prepare_workspace  # pyright: ignore[reportPrivateUsage]
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    _prepare_workspace(file_path, "myslug")
-    assert (tmp_path / "myslug.data").is_dir(), (
-        "<slug>.data/ should be created so attach-after-publish works"
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    _prepare_workspace(paths)
+    assert (tmp_path / "myslug" / "data").is_dir(), (
+        "data_dir/<slug>/data/ should be created so attach-after-publish works"
     )
 
 
 def test_prepare_workspace_leaves_existing_data_dir_untouched(tmp_path: Path) -> None:
-    """_prepare_workspace does not wipe pre-existing files in <slug>.data/."""
+    """_prepare_workspace does not wipe pre-existing files in data_dir/<slug>/data/."""
+    from notebook_host.jail import get_slug_paths
     from notebook_host.lifecycle import _prepare_workspace  # pyright: ignore[reportPrivateUsage]
 
-    data_dir = tmp_path / "myslug.data"
-    data_dir.mkdir()
-    (data_dir / "existing.csv").write_bytes(b"col,val\n1,2\n")
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.data.mkdir(parents=True)
+    (paths.data / "existing.csv").write_bytes(b"col,val\n1,2\n")
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    _prepare_workspace(file_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    _prepare_workspace(paths)
 
-    assert (data_dir / "existing.csv").read_bytes() == b"col,val\n1,2\n", (
+    assert (paths.data / "existing.csv").read_bytes() == b"col,val\n1,2\n", (
         "pre-existing attachment must survive workspace setup (publish-after-attach)"
     )
 
 
 def test_prepare_workspace_creates_data_symlink(tmp_path: Path) -> None:
-    """workspace/data is a symlink to ../<slug>.data."""
+    """workspace/data is a symlink to ../data."""
     import os as _os
 
+    from notebook_host.jail import get_slug_paths
     from notebook_host.lifecycle import _prepare_workspace  # pyright: ignore[reportPrivateUsage]
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    workspace = _prepare_workspace(file_path, "myslug")
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    workspace = _prepare_workspace(paths)
 
     data_link = workspace / "data"
     assert data_link.is_symlink(), "workspace/data should be a symlink"
-    assert _os.readlink(data_link) == str(Path("..") / "myslug.data"), (
-        "data symlink target should be the relative path ../<slug>.data"
+    assert _os.readlink(data_link) == str(Path("..") / "data"), (
+        "data symlink target should be the relative path ../data"
     )
     # And it must resolve to the actual data dir.
-    assert data_link.resolve() == (tmp_path / "myslug.data").resolve(), (
-        "data symlink should resolve to <data_dir>/<slug>.data"
+    assert data_link.resolve() == paths.data.resolve(), (
+        "data symlink should resolve to data_dir/<slug>/data"
     )
 
 
 def test_prepare_workspace_creates_source_symlink(tmp_path: Path) -> None:
-    """workspace/<slug>.py is a symlink to ../<slug>.py (D2 basename invariant)."""
+    """workspace/notebook.py is a symlink to ../notebook.py (basename invariant)."""
     import os as _os
 
+    from notebook_host.jail import get_slug_paths
     from notebook_host.lifecycle import _prepare_workspace  # pyright: ignore[reportPrivateUsage]
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    workspace = _prepare_workspace(file_path, "myslug")
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    workspace = _prepare_workspace(paths)
 
-    source_link = workspace / "myslug.py"
-    assert source_link.is_symlink(), "workspace/<slug>.py should be a symlink"
-    assert _os.readlink(source_link) == str(Path("..") / "myslug.py"), (
-        "source symlink target should be ../<slug>.py"
+    source_link = workspace / "notebook.py"
+    assert source_link.is_symlink(), "workspace/notebook.py should be a symlink"
+    assert _os.readlink(source_link) == str(Path("..") / "notebook.py"), (
+        "source symlink target should be ../notebook.py"
     )
-    assert source_link.resolve() == file_path.resolve(), (
+    assert source_link.resolve() == paths.notebook.resolve(), (
         "source symlink must resolve to the real source file"
     )
 
 
 def test_prepare_workspace_is_idempotent(tmp_path: Path) -> None:
     """Calling _prepare_workspace twice produces the same final state, no errors."""
+    from notebook_host.jail import get_slug_paths
     from notebook_host.lifecycle import _prepare_workspace  # pyright: ignore[reportPrivateUsage]
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    workspace1 = _prepare_workspace(file_path, "myslug")
-    workspace2 = _prepare_workspace(file_path, "myslug")
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    workspace1 = _prepare_workspace(paths)
+    workspace2 = _prepare_workspace(paths)
 
     assert workspace1 == workspace2, "two calls should return the same workspace path"
     assert (workspace2 / "data").is_symlink(), "data symlink should still exist after re-prepare"
-    assert (workspace2 / "myslug.py").is_symlink(), (
+    assert (workspace2 / "notebook.py").is_symlink(), (
         "source symlink should still exist after re-prepare"
     )
     # And they still resolve correctly.
-    assert (workspace2 / "data").resolve() == (tmp_path / "myslug.data").resolve()
-    assert (workspace2 / "myslug.py").resolve() == file_path.resolve()
+    assert (workspace2 / "data").resolve() == paths.data.resolve()
+    assert (workspace2 / "notebook.py").resolve() == paths.notebook.resolve()
 
 
 def test_prepare_workspace_replaces_stale_symlink(tmp_path: Path) -> None:
     """A stale symlink pointing nowhere is replaced cleanly (crash-recovery shape)."""
+    from notebook_host.jail import get_slug_paths
     from notebook_host.lifecycle import _prepare_workspace  # pyright: ignore[reportPrivateUsage]
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    workspace = tmp_path / "myslug_workspace"
-    workspace.mkdir()
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    workspace = tmp_path / "myslug" / "workspace"
+    workspace.mkdir(parents=True)
     # Pre-create a broken symlink at the location we'll want.
     bad_link = workspace / "data"
     bad_link.symlink_to(Path("..") / "nope-does-not-exist")
 
-    _prepare_workspace(file_path, "myslug")
+    _prepare_workspace(paths)
 
     assert (workspace / "data").is_symlink(), "data symlink must still be a symlink"
-    assert (workspace / "data").resolve() == (tmp_path / "myslug.data").resolve(), (
+    assert (workspace / "data").resolve() == paths.data.resolve(), (
         "stale broken symlink must be replaced with the correct target"
     )
 
 
+def test_prepare_workspace_symlinks_resolve_inside_slug_root(tmp_path: Path) -> None:
+    """Every entry under workspace/ resolves to a path inside paths.root — the containment
+    invariant that replaces the old design's deliberate `..`-past-the-root traversal."""
+    from notebook_host.jail import get_slug_paths
+    from notebook_host.lifecycle import _prepare_workspace  # pyright: ignore[reportPrivateUsage]
+
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    workspace = _prepare_workspace(paths)
+
+    root_resolved = paths.root.resolve()
+    entries = list(workspace.iterdir())
+    assert entries, "workspace should contain the two wired symlinks"
+    for entry in entries:
+        assert entry.resolve().is_relative_to(root_resolved), (
+            f"{entry} resolves outside the slug root {root_resolved} — isolation boundary violated"
+        )
+
+
 def test_spawn_marimo_uses_workspace_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """spawn_marimo sets Popen cwd= to <data_dir>/<slug>_workspace, not data_dir."""
+    """spawn_marimo sets Popen cwd= to data_dir/<slug>/workspace, not data_dir/<slug>."""
     from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
 
     monkeypatch.setattr(
         lifecycle.shutil,
@@ -596,26 +632,22 @@ def test_spawn_marimo_uses_workspace_cwd(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
     monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    lifecycle.spawn_marimo("myslug", file_path, 8100)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100)
 
-    assert captured.get("cwd") == str(tmp_path / "myslug_workspace"), (
-        "Popen cwd should be the per-slug workspace dir, not file_path.parent"
+    assert captured.get("cwd") == str(tmp_path / "myslug" / "workspace"), (
+        "Popen cwd should be the per-slug workspace dir, not the slug root"
     )
-    # marimo edit must receive file_path.name (basename), not the full path.
-    cmd = captured.get("args")
-    if cmd is None:
-        # Popen positional arg is the cmd list (we used *args).
-        # fake_popen signature didn't capture positional — re-call with shape.
-        pass
 
 
 def test_spawn_marimo_still_uses_basename_arg(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """spawn_marimo passes file_path.name (not full path) to marimo edit."""
+    """spawn_marimo passes the literal 'notebook.py' (not the full path) to marimo edit."""
     from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
 
     monkeypatch.setattr(
         lifecycle.shutil,
@@ -632,13 +664,14 @@ def test_spawn_marimo_still_uses_basename_arg(
 
     monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    lifecycle.spawn_marimo("myslug", file_path, 8100)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100)
 
     # marimo edit <basename> — the basename appears, the full path does not.
-    assert "myslug.py" in captured_args, "marimo edit arg should be the basename"
-    assert str(file_path) not in captured_args, (
+    assert "notebook.py" in captured_args, "marimo edit arg should be the basename"
+    assert str(paths.notebook) not in captured_args, (
         "absolute path must not appear; basename + workspace cwd is the contract"
     )
 
@@ -648,6 +681,7 @@ def test_spawn_marimo_creates_workspace_and_data_dirs(
 ) -> None:
     """spawn_marimo side-effect: workspace + data dir + symlinks exist after call."""
     from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
 
     monkeypatch.setattr(
         lifecycle.shutil,
@@ -661,23 +695,28 @@ def test_spawn_marimo_creates_workspace_and_data_dirs(
         lambda *a, **kw: sentinel,  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
     )
 
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    lifecycle.spawn_marimo("myslug", file_path, 8100)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100)
 
-    assert (tmp_path / "myslug_workspace").is_dir(), "workspace dir must exist after spawn"
-    assert (tmp_path / "myslug.data").is_dir(), "data dir must exist after spawn"
-    assert (tmp_path / "myslug_workspace" / "data").is_symlink(), (
+    assert (tmp_path / "myslug" / "workspace").is_dir(), "workspace dir must exist after spawn"
+    assert (tmp_path / "myslug" / "data").is_dir(), "data dir must exist after spawn"
+    assert (tmp_path / "myslug" / "workspace" / "data").is_symlink(), (
         "data symlink must exist after spawn"
     )
-    assert (tmp_path / "myslug_workspace" / "myslug.py").is_symlink(), (
+    assert (tmp_path / "myslug" / "workspace" / "notebook.py").is_symlink(), (
         "source symlink must exist after spawn"
+    )
+    assert (tmp_path / "myslug" / "marimo.log").exists(), (
+        "marimo log should be opened inside the slug root"
     )
 
 
 def test_spawn_marimo_passes_preexec_fn(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """spawn_marimo wires preexec_fn into subprocess.Popen when limits + Linux."""
     from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
 
     monkeypatch.setattr(lifecycle.sys, "platform", "linux")
     monkeypatch.setattr(
@@ -695,11 +734,12 @@ def test_spawn_marimo_passes_preexec_fn(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
 
-    file_path = tmp_path / "x.py"
-    file_path.write_text("")
+    paths = get_slug_paths(tmp_path, "slug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("")
     lifecycle.spawn_marimo(
         "slug",
-        file_path,
+        paths,
         8100,
         rlimit_as_bytes=4_000_000_000,
         rlimit_cpu_seconds=3600,
@@ -744,6 +784,7 @@ def _capture_spawn_cmd(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, sandbox: bool
 ) -> list[str]:
     from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
 
     monkeypatch.setattr(
         lifecycle.shutil,
@@ -758,9 +799,10 @@ def _capture_spawn_cmd(
         return sentinel_proc
 
     monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    lifecycle.spawn_marimo("myslug", file_path, 8100, sandbox=sandbox)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100, sandbox=sandbox)
     return captured_args
 
 
@@ -772,7 +814,7 @@ def test_spawn_marimo_inserts_sandbox_flag_after_edit_when_sandbox(
     assert cmd[cmd.index("edit") + 1] == "--sandbox", (
         "--sandbox must immediately follow `edit`, before the notebook basename"
     )
-    assert cmd.index("--sandbox") < cmd.index("myslug.py"), (
+    assert cmd.index("--sandbox") < cmd.index("notebook.py"), (
         "--sandbox must precede the file arg so marimo treats it as a flag, not the target"
     )
 
@@ -851,6 +893,7 @@ def test_spawn_marimo_uses_run_subcommand_when_mode_run(
 ) -> None:
     """spawn_marimo(mode='run') emits `marimo run`, never `marimo edit`."""
     from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
 
     monkeypatch.setattr(
         lifecycle.shutil,
@@ -865,9 +908,10 @@ def test_spawn_marimo_uses_run_subcommand_when_mode_run(
         return sentinel
 
     monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    lifecycle.spawn_marimo("myslug", file_path, 8100, mode="run")
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100, mode="run")
 
     assert "run" in captured, "mode='run' must invoke `marimo run`"
     assert "edit" not in captured, "mode='run' must not invoke `marimo edit`"
@@ -881,6 +925,7 @@ def test_spawn_marimo_defaults_to_edit_mode(
 ) -> None:
     """Without an explicit mode, spawn_marimo still emits `marimo edit` (back-compat)."""
     from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
 
     monkeypatch.setattr(
         lifecycle.shutil,
@@ -895,9 +940,10 @@ def test_spawn_marimo_defaults_to_edit_mode(
         return sentinel
 
     monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    lifecycle.spawn_marimo("myslug", file_path, 8100)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100)
 
     assert _marimo_subcommand(captured) == "edit", "default mode must be edit"
 
@@ -907,6 +953,7 @@ def test_spawn_marimo_run_mode_with_sandbox_places_flag_after_run(
 ) -> None:
     """--sandbox must follow `run` and precede the basename (same rule as edit)."""
     from notebook_host import lifecycle
+    from notebook_host.jail import get_slug_paths
 
     monkeypatch.setattr(
         lifecycle.shutil,
@@ -921,16 +968,17 @@ def test_spawn_marimo_run_mode_with_sandbox_places_flag_after_run(
         return sentinel
 
     monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
-    file_path = tmp_path / "myslug.py"
-    file_path.write_text("# stub", encoding="utf-8")
-    lifecycle.spawn_marimo("myslug", file_path, 8100, mode="run", sandbox=True)
+    paths = get_slug_paths(tmp_path, "myslug")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# stub", encoding="utf-8")
+    lifecycle.spawn_marimo("myslug", paths, 8100, mode="run", sandbox=True)
 
     assert _marimo_subcommand(captured) == "run", "marimo subcommand must be `run`"
     marimo_subcommand_idx = len(captured) - 1 - captured[::-1].index("marimo") + 1
     assert captured[marimo_subcommand_idx + 1] == "--sandbox", (
         "--sandbox must immediately follow `run`"
     )
-    assert captured.index("--sandbox") < captured.index("myslug.py"), (
+    assert captured.index("--sandbox") < captured.index("notebook.py"), (
         "--sandbox must precede the notebook basename"
     )
 

--- a/apps/notebook-host/tests/test_lifecycle.py
+++ b/apps/notebook-host/tests/test_lifecycle.py
@@ -53,6 +53,10 @@ def test_settings_defaults_match_documented_values() -> None:
     assert settings.data_dir == Path("/data/notebooks"), (
         "data_dir default should be Path('/data/notebooks')"
     )
+    assert settings.jail_uid_start == 100000, "jail_uid_start default should be 100000"
+    assert settings.jail_uid_end == 100999, "jail_uid_end default should be 100999"
+    assert settings.allow_unjailed_spawn is False, "allow_unjailed_spawn default should be False"
+    assert settings.uids_file is None, "uids_file default should be unset"
 
 
 def test_settings_env_override_applied(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -84,6 +88,38 @@ def test_resolved_blogs_file_honors_explicit_override(monkeypatch: pytest.Monkey
     settings = load_settings(_env_file=None)
     assert settings.resolved_blogs_file == Path("/tmp/custom-blogs.json"), (
         "explicit blogs_file path must be used verbatim"
+    )
+
+
+def test_resolved_uids_file_defaults_to_data_dir_uids_json() -> None:
+    """uids_file unset -> resolved_uids_file is data_dir / 'uids.json'."""
+    from notebook_host.config import load_settings
+
+    settings = load_settings(_env_file=None)
+    assert settings.resolved_uids_file == settings.data_dir / "uids.json", (
+        "default uid registry must live next to the source files on the volume"
+    )
+
+
+def test_resolved_uids_file_honors_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit DAIMON_NOTEBOOK__UIDS_FILE wins over the data_dir default."""
+    monkeypatch.setenv("DAIMON_NOTEBOOK__UIDS_FILE", "/tmp/custom-uids.json")
+    from notebook_host.config import load_settings
+
+    settings = load_settings(_env_file=None)
+    assert settings.resolved_uids_file == Path("/tmp/custom-uids.json"), (
+        "explicit uids_file path must be used verbatim"
+    )
+
+
+def test_allow_unjailed_spawn_env_override_applied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DAIMON_NOTEBOOK__ALLOW_UNJAILED_SPAWN=true reflects on resolved Settings."""
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ALLOW_UNJAILED_SPAWN", "true")
+    from notebook_host.config import load_settings
+
+    settings = load_settings(_env_file=None)
+    assert settings.allow_unjailed_spawn is True, (
+        "allow_unjailed_spawn should reflect the env override value"
     )
 
 

--- a/apps/notebook-host/tests/test_main.py
+++ b/apps/notebook-host/tests/test_main.py
@@ -242,6 +242,109 @@ async def test_create_app_lifespan_boots_when_break_glass_set(
         assert resp.status_code == 200, "the break-glass opt-out should let an unjailable host boot"
 
 
+# ─── boot migration (D-03: an existing flat deployment stays servable) ─────
+
+
+async def test_create_app_lifespan_migrates_flat_layout_and_respawns_blog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A host booted against a pre-upgrade flat data_dir respawns the blog from
+    its migrated nested source.
+
+    This is the test that proves D-03's actual promise: an existing blog
+    keeps serving at the same URL across the upgrade.
+    """
+    import notebook_host.main as main_mod
+    from notebook_host.blogs_store import BlogRecord, register_blog
+    from notebook_host.config import load_settings
+
+    monkeypatch.setenv("DAIMON_NOTEBOOK__DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "test-secret")
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8610")
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8613")
+    set_unjailed_test_env(monkeypatch)
+    settings = load_settings(_env_file=None)
+
+    (tmp_path / "pre-radar.py").write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
+    register_blog(tmp_path / "blogs.json", BlogRecord(slug="pre-radar", created_at=1.0))
+
+    calls: list[tuple[str, SlugPaths, str]] = []
+
+    def fake_spawn_marimo(
+        slug: str,
+        paths: SlugPaths,
+        port: int,
+        *,
+        mode: str = "edit",
+        sandbox: bool = False,
+        rlimit_as_bytes: int | None = None,
+        rlimit_cpu_seconds: int | None = None,
+        jail_uid: int | None = None,
+    ) -> subprocess.Popen[bytes]:
+        calls.append((slug, paths, mode))
+        proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
+        proc.poll.return_value = None
+        proc.pid = 8888
+        return proc  # type: ignore[return-value]
+
+    async def fake_wait(port: int, slug: str, timeout_s: float) -> bool:
+        return True
+
+    monkeypatch.setattr(main_mod, "spawn_marimo", fake_spawn_marimo)
+    monkeypatch.setattr(main_mod, "wait_for_port", fake_wait)
+
+    with TestClient(main_mod.create_app(settings)):
+        pass
+
+    assert len(calls) == 1, "the migrated blog must be respawned exactly once at boot"
+    slug, paths, mode = calls[0]
+    assert slug == "pre-radar", "the respawned slug must be the one registered in blogs.json"
+    assert mode == "run", "boot respawn of a registered blog must use run mode"
+    assert paths.notebook == tmp_path / "pre-radar" / "notebook.py", (
+        "the spawner must receive paths pointing at the migrated nested source, not the "
+        "old flat file"
+    )
+    assert not (tmp_path / "pre-radar.py").exists(), (
+        "the flat legacy source must be gone once the boot migration has run"
+    )
+
+
+async def test_create_app_lifespan_aborts_when_migration_raises_uid_pool_exhausted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A migration that cannot allocate a uid for every legacy slug must abort the boot.
+
+    Not respawn what it can and leave the rest — that would silently produce
+    a half-isolated host.
+    """
+    import notebook_host.main as main_mod
+    from notebook_host.config import load_settings
+    from notebook_host.jail import UidPoolExhaustedError
+
+    monkeypatch.setenv("DAIMON_NOTEBOOK__DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "test-secret")
+    set_unjailed_test_env(monkeypatch)
+    settings = load_settings(_env_file=None)
+
+    def raising_migrate(*args: object, **kwargs: object) -> list[str]:
+        raise UidPoolExhaustedError("pool exhausted")
+
+    spawn_calls: list[object] = []
+
+    def spy_spawn_marimo(*args: object, **kwargs: object) -> subprocess.Popen[bytes]:
+        spawn_calls.append((args, kwargs))
+        proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
+        return proc  # type: ignore[return-value]
+
+    monkeypatch.setattr(main_mod, "migrate_flat_layout", raising_migrate)
+    monkeypatch.setattr(main_mod, "spawn_marimo", spy_spawn_marimo)
+
+    with pytest.raises(UidPoolExhaustedError), TestClient(main_mod.create_app(settings)):
+        pass
+
+    assert spawn_calls == [], "no spawn may occur once the migration has raised"
+
+
 def _dead_proc() -> subprocess.Popen[bytes]:
     proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
     proc.poll.return_value = 0  # dead

--- a/apps/notebook-host/tests/test_main.py
+++ b/apps/notebook-host/tests/test_main.py
@@ -2,13 +2,27 @@
 
 from __future__ import annotations
 
+import runpy
 import subprocess
 import unittest.mock
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import pytest
+from fastapi.testclient import TestClient
 from notebook_host.jail import SlugPaths, get_slug_paths
+
+# `--import-mode=importlib` (root pyproject.toml) doesn't add this directory
+# to sys.path, and there's no `__init__.py` here (one would collide with the
+# top-level `tests` package name already claimed by `packages/core/tests`).
+# `runpy` loads `conftest.py` by file path without touching sys.path or
+# sys.modules, so a full monorepo `pytest` collection can't collide with
+# similar sys.path tricks in other adapters' tests (see
+# `packages/adapters/mcp/tests/tools/conftest.py`).
+set_unjailed_test_env: Callable[[pytest.MonkeyPatch], None] = runpy.run_path(
+    str(Path(__file__).parent / "conftest.py")
+)["set_unjailed_test_env"]
 
 pytestmark = pytest.mark.asyncio
 
@@ -26,12 +40,18 @@ def _make_state(
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "8600")
     monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "8603")
     monkeypatch.setenv("DAIMON_NOTEBOOK__SPAWN_TIMEOUT_SECONDS", "2.0")
+    set_unjailed_test_env(monkeypatch)
     settings = load_settings(_env_file=None)
 
     calls: list[tuple[str, SlugPaths, int, str]] = []
 
     def spawner(
-        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
+        slug: str,
+        paths: SlugPaths,
+        port: int,
+        *,
+        mode: str = "edit",
+        jail_uid: int | None = None,
     ) -> subprocess.Popen[bytes]:
         calls.append((slug, paths, port, mode))
         proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
@@ -179,6 +199,47 @@ async def test_sweep_once_reconciles_registered_blog_missing_from_processes(
     assert state.processes["pre-orphan"].is_alive(), "reconciled blog must be alive"
     assert calls[-1][3] == "run", "reconcile respawn must use run mode"
     assert mutated is True, "respawning an orphaned blog mutates state"
+
+
+# ─── fail-closed boot gate (D-05) ────────────────────────────────────────────
+# These deliberately do NOT call set_unjailed_test_env — they pin the
+# production default (fail-closed) rather than opting out of it.
+
+
+async def test_create_app_lifespan_raises_when_jail_unavailable_and_no_break_glass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A host that cannot jail refuses to boot at all, per D-05."""
+    import notebook_host.main as main_mod
+    from notebook_host.config import load_settings
+    from notebook_host.jail import JailUnavailableError
+
+    monkeypatch.setenv("DAIMON_NOTEBOOK__DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "test-secret")
+    # allow_unjailed_spawn is deliberately left unset — production default (False).
+    settings = load_settings(_env_file=None)
+    monkeypatch.setattr(main_mod, "can_apply_jail", lambda: False)
+
+    with pytest.raises(JailUnavailableError), TestClient(main_mod.create_app(settings)):
+        pass
+
+
+async def test_create_app_lifespan_boots_when_break_glass_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same unjailable host boots once the break-glass setting is on."""
+    import notebook_host.main as main_mod
+    from notebook_host.config import load_settings
+
+    monkeypatch.setenv("DAIMON_NOTEBOOK__DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DAIMON_NOTEBOOK__ADMIN_SECRET", "test-secret")
+    set_unjailed_test_env(monkeypatch)
+    settings = load_settings(_env_file=None)
+    monkeypatch.setattr(main_mod, "can_apply_jail", lambda: False)
+
+    with TestClient(main_mod.create_app(settings)) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200, "the break-glass opt-out should let an unjailable host boot"
 
 
 def _dead_proc() -> subprocess.Popen[bytes]:

--- a/apps/notebook-host/tests/test_main.py
+++ b/apps/notebook-host/tests/test_main.py
@@ -8,13 +8,14 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from notebook_host.jail import SlugPaths, get_slug_paths
 
 pytestmark = pytest.mark.asyncio
 
 
 def _make_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, alive: bool = True
-) -> tuple[Any, list[tuple[str, Path, int, str]]]:
+) -> tuple[Any, list[tuple[str, SlugPaths, int, str]]]:
     """AdminState with a mode-recording stub spawner + monkeypatched wait_for_port."""
     import notebook_host.main as main_mod
     from notebook_host.admin import AdminState
@@ -27,12 +28,12 @@ def _make_state(
     monkeypatch.setenv("DAIMON_NOTEBOOK__SPAWN_TIMEOUT_SECONDS", "2.0")
     settings = load_settings(_env_file=None)
 
-    calls: list[tuple[str, Path, int, str]] = []
+    calls: list[tuple[str, SlugPaths, int, str]] = []
 
     def spawner(
-        slug: str, file_path: Path, port: int, *, mode: str = "edit"
+        slug: str, paths: SlugPaths, port: int, *, mode: str = "edit"
     ) -> subprocess.Popen[bytes]:
-        calls.append((slug, file_path, port, mode))
+        calls.append((slug, paths, port, mode))
         proc: unittest.mock.MagicMock = unittest.mock.MagicMock(spec=subprocess.Popen)
         proc.poll.return_value = None if alive else 0
         proc.pid = 7777
@@ -53,7 +54,9 @@ async def test_respawn_registered_blogs_spawns_run_mode_from_disk(
     from notebook_host.main import _respawn_registered_blogs  # pyright: ignore[reportPrivateUsage]
 
     state, calls = _make_state(tmp_path, monkeypatch)
-    (tmp_path / "pre-radar.py").write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
+    paths = get_slug_paths(tmp_path, "pre-radar")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
     register_blog(tmp_path / "blogs.json", BlogRecord(slug="pre-radar", created_at=1.0))
 
     respawned = await _respawn_registered_blogs(state)
@@ -85,7 +88,9 @@ async def test_sweep_once_respawns_dead_blog(
     from notebook_host.main import _sweep_once  # pyright: ignore[reportPrivateUsage]
 
     state, calls = _make_state(tmp_path, monkeypatch, alive=True)
-    (tmp_path / "pre-radar.py").write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
+    paths = get_slug_paths(tmp_path, "pre-radar")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
     # Place a DEAD run-mode process directly in state to simulate a crashed kernel.
     dead = state.make_process(
         "pre-radar",
@@ -108,14 +113,48 @@ async def test_sweep_once_reaps_dead_edit_notebook(
     from notebook_host.main import _sweep_once  # pyright: ignore[reportPrivateUsage]
 
     state, _calls = _make_state(tmp_path, monkeypatch)
-    (tmp_path / "ephemeral.py").write_text("# x", encoding="utf-8")
+    paths = get_slug_paths(tmp_path, "ephemeral")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# x", encoding="utf-8")
     dead = state.make_process("ephemeral", 8601, _dead_proc(), mode="edit")
     state.processes["ephemeral"] = dead
 
     await _sweep_once(state)
 
     assert "ephemeral" not in state.processes, "a dead edit-mode notebook must still be reaped"
-    assert not (tmp_path / "ephemeral.py").exists(), "reaping an edit notebook deletes its source"
+    assert not paths.notebook.exists(), "reaping an edit notebook deletes its source"
+
+
+async def test_sweep_once_removes_attachments_and_workspace_when_reaping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The background sweep's reap branch removes the whole slug tree, not just the source.
+
+    Pins the closed MEDIUM finding: the old reap branch only unlinked the
+    source, leaking attachments and the workspace on the persistent volume
+    forever once the slug was popped from state.processes.
+    """
+    from notebook_host.main import _sweep_once  # pyright: ignore[reportPrivateUsage]
+
+    state, _calls = _make_state(tmp_path, monkeypatch)
+    paths = get_slug_paths(tmp_path, "leaky")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("# x", encoding="utf-8")
+    paths.data.mkdir(parents=True, exist_ok=True)
+    (paths.data / "big.nc").write_bytes(b"a" * 1024)
+    paths.workspace.mkdir(parents=True, exist_ok=True)
+    (paths.workspace / "data").symlink_to(Path("..") / "data")
+    (paths.workspace / "notebook.py").symlink_to(Path("..") / "notebook.py")
+
+    dead = state.make_process("leaky", 8602, _dead_proc(), mode="edit")
+    state.processes["leaky"] = dead
+
+    await _sweep_once(state)
+
+    assert "leaky" not in state.processes, "a dead edit-mode notebook must be reaped"
+    assert paths.root.exists() is False, (
+        "the whole slug tree — source, attachment, and workspace — must be gone after one sweep"
+    )
 
 
 async def test_sweep_once_reconciles_registered_blog_missing_from_processes(
@@ -125,7 +164,9 @@ async def test_sweep_once_reconciles_registered_blog_missing_from_processes(
     from notebook_host.main import _sweep_once  # pyright: ignore[reportPrivateUsage]
 
     state, calls = _make_state(tmp_path, monkeypatch)
-    (tmp_path / "pre-orphan.py").write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
+    paths = get_slug_paths(tmp_path, "pre-orphan")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
     # Registered in blogs.json, but NOT in state.processes (a prior respawn failed).
     register_blog(tmp_path / "blogs.json", BlogRecord(slug="pre-orphan", created_at=1.0))
     assert "pre-orphan" not in state.processes

--- a/apps/notebook-host/tests/test_main.py
+++ b/apps/notebook-host/tests/test_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import runpy
 import subprocess
 import unittest.mock
@@ -199,6 +200,87 @@ async def test_sweep_once_reconciles_registered_blog_missing_from_processes(
     assert state.processes["pre-orphan"].is_alive(), "reconciled blog must be alive"
     assert calls[-1][3] == "run", "reconcile respawn must use run mode"
     assert mutated is True, "respawning an orphaned blog mutates state"
+
+
+async def test_sweep_skips_slug_unregistered_between_outer_scan_and_inner_reread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The self-heal loop's outer `load_blogs` is a stale candidate scan.
+
+    If the slug was unregistered between that scan and the inner re-read taken
+    under the lock, the sweep must not respawn it.
+    """
+    import notebook_host.main as main_mod
+    from notebook_host.main import _sweep_once  # pyright: ignore[reportPrivateUsage]
+
+    state, calls = _make_state(tmp_path, monkeypatch)
+    call_count = 0
+    real_load_blogs = main_mod.load_blogs
+
+    def fake_load_blogs(path: Path) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            from notebook_host.blogs_store import BlogRecord
+
+            return {"ghost-blog": BlogRecord(slug="ghost-blog", created_at=1.0)}
+        return real_load_blogs(path)  # empty — nothing was ever actually registered
+
+    monkeypatch.setattr(main_mod, "load_blogs", fake_load_blogs)
+
+    mutated = await _sweep_once(state)
+
+    assert calls == [], "the spawner must never be called for a slug that vanished under the lock"
+    assert mutated is False, "skipping a stale candidate is not a mutation"
+
+
+async def test_sweep_does_not_respawn_a_blog_deleted_under_the_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A delete that unregisters a blog while holding its slug lock must not be
+    undone by a sweep tick that was already mid-flight for that slug.
+
+    Driven deterministically: the test itself holds `state.lock_for(slug)` —
+    the same lock object `delete_blog` acquires in production — forcing the
+    sweep task to block on it exactly as it would against a real concurrent
+    delete. While the sweep is blocked, the test performs the delete's
+    registry/tree mutations (what `delete_blog` does under this same lock),
+    then releases — letting the sweep's inner re-read observe the slug gone.
+    """
+    from notebook_host.blogs_store import BlogRecord, load_blogs, register_blog, unregister_blog
+    from notebook_host.jail import remove_slug_tree
+    from notebook_host.main import _sweep_once  # pyright: ignore[reportPrivateUsage]
+
+    state, _calls = _make_state(tmp_path, monkeypatch)
+    slug = "doomed"
+    paths = get_slug_paths(tmp_path, slug)
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
+    register_blog(tmp_path / "blogs.json", BlogRecord(slug=slug, created_at=1.0))
+    # Registered but absent from state.processes — a self-heal candidate,
+    # exactly the shape a blog has right after delete_blog's unregister step
+    # but before its tree removal finishes.
+    assert slug not in state.processes
+
+    lock = state.lock_for(slug)
+    await lock.acquire()
+    try:
+        sweep_task = asyncio.create_task(_sweep_once(state))
+        # Give the sweep task a turn so it reaches the (now-blocked) lock
+        # acquire inside the self-heal loop.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        unregister_blog(tmp_path / "blogs.json", slug)
+        remove_slug_tree(tmp_path, slug, uids_file=state.settings.resolved_uids_file)
+    finally:
+        lock.release()
+
+    mutated = await sweep_task
+
+    assert slug not in state.processes, "a blog deleted under the lock must not be respawned"
+    assert slug not in load_blogs(tmp_path / "blogs.json"), "registry stays clear"
+    assert not paths.root.exists(), "the deleted tree must not be recreated by the sweep"
+    assert mutated is False, "skipping a deleted-under-the-lock slug is not a mutation"
 
 
 # ─── fail-closed boot gate (D-05) ────────────────────────────────────────────

--- a/apps/notebook-host/tests/test_migration.py
+++ b/apps/notebook-host/tests/test_migration.py
@@ -326,3 +326,54 @@ def test_migrate_never_touches_registry_files(tmp_path: Path) -> None:
 
     assert json.loads((tmp_path / "blogs.json").read_text()) == blogs
     assert json.loads((tmp_path / "pids.json").read_text()) == pids
+
+
+def test_migrate_locks_registry_files_inherited_at_default_umask(tmp_path: Path) -> None:
+    """A registry written by a pre-jail release must not stay world-readable.
+
+    The stores lock their tmp file before the atomic rename, so anything this
+    host writes is already 0600. The gap this covers is the file a host
+    *inherits*: the same boot that raises data_dir to 0711 stops the parent
+    from hiding it, so a 0644 blogs.json becomes readable by every jailed
+    notebook — and it lists every slug.
+    """
+    (tmp_path / "a.py").write_bytes(b"import marimo as mo\napp = mo.App()")
+    blogs = tmp_path / "blogs.json"
+    pids = tmp_path / "pids.json"
+    blogs.write_text("{}")
+    pids.write_text("{}")
+    blogs.chmod(0o644)
+    pids.chmod(0o644)
+
+    migrate_flat_layout(
+        tmp_path,
+        uids_file=_uids_file(tmp_path),
+        uid_start=_UID_START,
+        uid_end=_UID_END,
+        allow_unjailed=True,
+        registry_files=(blogs, pids),
+    )
+
+    assert blogs.stat().st_mode & 0o777 == 0o600, (
+        "an inherited blogs.json must be locked to 0600 by the migration, not "
+        "left at its default-umask mode until some later write happens to fix it"
+    )
+    assert pids.stat().st_mode & 0o777 == 0o600, (
+        "an inherited pids.json must be locked to 0600 by the migration"
+    )
+
+
+def test_migrate_tolerates_registry_files_that_do_not_exist_yet(tmp_path: Path) -> None:
+    """A first-ever boot has no registries on disk; locking them must not fail."""
+    (tmp_path / "a.py").write_bytes(b"import marimo as mo\napp = mo.App()")
+
+    migrated = migrate_flat_layout(
+        tmp_path,
+        uids_file=_uids_file(tmp_path),
+        uid_start=_UID_START,
+        uid_end=_UID_END,
+        allow_unjailed=True,
+        registry_files=(tmp_path / "blogs.json", tmp_path / "pids.json"),
+    )
+
+    assert migrated == ["a"], "migration should proceed with absent registries"

--- a/apps/notebook-host/tests/test_migration.py
+++ b/apps/notebook-host/tests/test_migration.py
@@ -1,0 +1,326 @@
+"""Tests for notebook_host.migration — the crash-safe flat-to-nested boot migration.
+
+Every interrupted intermediate filesystem state is constructed directly in
+``tmp_path`` rather than by actually killing a process, so these tests are
+deterministic and don't race a real SIGKILL. Each proves the migration
+converges to the fully-migrated shape from that state, per the plan's
+known-risk note that the algorithm was reasoned, not reproduced, at planning
+time.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from notebook_host.jail import UidPoolExhaustedError
+from notebook_host.migration import migrate_flat_layout
+
+_UID_START = 100000
+_UID_END = 100999
+
+
+def _uids_file(tmp_path: Path) -> Path:
+    return tmp_path / "uids.json"
+
+
+def _migrate(tmp_path: Path, *, uid_start: int = _UID_START, uid_end: int = _UID_END) -> list[str]:
+    return migrate_flat_layout(
+        tmp_path,
+        uids_file=_uids_file(tmp_path),
+        uid_start=uid_start,
+        uid_end=uid_end,
+        allow_unjailed=True,
+    )
+
+
+def _assert_no_leftovers(tmp_path: Path) -> None:
+    assert list(tmp_path.glob(".migrating-*")) == [], (
+        "no staging directory should survive a converged migration"
+    )
+    assert list(tmp_path.glob("*.py")) == [], "no flat source should survive a converged migration"
+    assert list(tmp_path.glob("*_workspace")) == [], (
+        "no flat disposable workspace should survive a converged migration"
+    )
+    assert list(tmp_path.glob("*.marimo.log")) == [], (
+        "no flat disposable log should survive a converged migration"
+    )
+
+
+# ─── state 1: untouched flat tree ───────────────────────────────────────────
+
+
+def test_migrate_untouched_flat_tree_converges_and_second_call_is_noop(tmp_path: Path) -> None:
+    """The ordinary case: a full flat layout moves onto the nested shape in one call."""
+    (tmp_path / "a.py").write_bytes(b"import marimo as mo\napp = mo.App()")
+    (tmp_path / "a.data").mkdir()
+    (tmp_path / "a.data" / "x.csv").write_bytes(b"col1,col2\n1,2\n")
+    (tmp_path / "a_workspace").mkdir()
+    (tmp_path / "a_workspace" / "junk").write_bytes(b"disposable")
+    (tmp_path / "a.marimo.log").write_bytes(b"old log")
+    blogs_payload = {"a": {"slug": "a", "created_at": 1.0}}
+    pids_payload: dict[str, object] = {}
+    (tmp_path / "blogs.json").write_text(json.dumps(blogs_payload))
+    (tmp_path / "pids.json").write_text(json.dumps(pids_payload))
+
+    migrated = _migrate(tmp_path)
+
+    assert migrated == ["a"], "the one legacy slug must be reported as migrated"
+    assert (
+        tmp_path / "a" / "notebook.py"
+    ).read_bytes() == b"import marimo as mo\napp = mo.App()", (
+        "the notebook source must survive the move with identical bytes"
+    )
+    assert (tmp_path / "a" / "data" / "x.csv").read_bytes() == b"col1,col2\n1,2\n", (
+        "the attachment must survive the move with identical bytes"
+    )
+    assert (tmp_path / "a" / "workspace").is_dir(), "workspace must exist in the nested tree"
+    assert (tmp_path / "a" / "home").is_dir(), "home must exist in the nested tree"
+    assert not (tmp_path / "a.py").exists(), "the flat source must be gone"
+    assert not (tmp_path / "a.data").exists(), "the flat attachment dir must be gone"
+    assert not (tmp_path / "a_workspace").exists(), "the flat disposable workspace must be gone"
+    assert not (tmp_path / "a.marimo.log").exists(), "the flat disposable log must be gone"
+    assert json.loads((tmp_path / "blogs.json").read_text()) == blogs_payload, (
+        "blogs.json must never be treated as a slug and must be left byte-identical"
+    )
+    assert json.loads((tmp_path / "pids.json").read_text()) == pids_payload, (
+        "pids.json must never be treated as a slug and must be left byte-identical"
+    )
+    assert tmp_path.stat().st_mode & 0o777 == 0o700, "data_dir itself must be locked to 0700"
+    for d in (
+        tmp_path / "a",
+        tmp_path / "a" / "data",
+        tmp_path / "a" / "workspace",
+        tmp_path / "a" / "home",
+    ):
+        assert d.stat().st_mode & 0o777 == 0o700, f"{d} must be mode 0700"
+    _assert_no_leftovers(tmp_path)
+
+    second = _migrate(tmp_path)
+    assert second == [], "a second call on an already-migrated tree must be a no-op"
+    _assert_no_leftovers(tmp_path)
+
+
+# ─── state 2: killed after staging.mkdir, before anything moved ────────────
+
+
+def test_migrate_resumes_staging_created_but_empty(tmp_path: Path) -> None:
+    """staging/ exists and is empty; the flat source and attachments are untouched.
+
+    Pass 1 must leave the empty staging dir alone; pass 2 must complete it.
+    """
+    (tmp_path / ".migrating-a").mkdir()
+    (tmp_path / "a.py").write_bytes(b"source bytes")
+    (tmp_path / "a.data").mkdir()
+    (tmp_path / "a.data" / "x.csv").write_bytes(b"attachment bytes")
+
+    migrated = _migrate(tmp_path)
+
+    assert migrated == ["a"], "the slug must converge and be reported as migrated"
+    assert (tmp_path / "a" / "notebook.py").read_bytes() == b"source bytes", (
+        "the source must end up in the final tree with identical bytes"
+    )
+    assert (tmp_path / "a" / "data" / "x.csv").read_bytes() == b"attachment bytes", (
+        "the attachment must end up in the final tree with identical bytes"
+    )
+    _assert_no_leftovers(tmp_path)
+
+
+# ─── state 3: killed after data moved in, before the source moved ──────────
+
+
+def test_migrate_resumes_staging_with_data_moved_but_source_still_flat(tmp_path: Path) -> None:
+    """staging/data/ already holds the attachment; a.py is still flat; a.data is gone.
+
+    This is the state that would lose the attachment if pass 1 deleted a
+    staging directory lacking notebook.py.
+    """
+    staging = tmp_path / ".migrating-a"
+    staging.mkdir()
+    (staging / "data").mkdir()
+    (staging / "data" / "x.csv").write_bytes(b"attachment bytes")
+    (tmp_path / "a.py").write_bytes(b"source bytes")
+    # a.data does NOT exist — it already moved into staging/data.
+
+    migrated = _migrate(tmp_path)
+
+    assert migrated == ["a"], "the slug must converge and be reported as migrated"
+    assert (tmp_path / "a" / "data" / "x.csv").read_bytes() == b"attachment bytes", (
+        "the attachment must survive at a/data/x.csv — this is the case that loses data "
+        "if pass 1 ever deletes a staging dir lacking notebook.py"
+    )
+    assert (tmp_path / "a" / "notebook.py").read_bytes() == b"source bytes", (
+        "the source must be moved in and end up in the final tree"
+    )
+    _assert_no_leftovers(tmp_path)
+
+
+# ─── state 4: killed after the source moved in, before the promote rename ──
+
+
+def test_migrate_promotes_staging_with_source_already_moved_in(tmp_path: Path) -> None:
+    """staging/{notebook.py,data/,workspace/,home/} all exist; nothing flat remains.
+
+    Pass 1 must promote this staging directory by rename, without pass 2
+    ever seeing a.py again.
+    """
+    staging = tmp_path / ".migrating-a"
+    staging.mkdir()
+    (staging / "notebook.py").write_bytes(b"source bytes")
+    (staging / "data").mkdir()
+    (staging / "workspace").mkdir()
+    (staging / "home").mkdir()
+
+    migrated = _migrate(tmp_path)
+
+    assert migrated == ["a"], "the slug must be reported as migrated via the pass-1 promote path"
+    assert (tmp_path / "a" / "notebook.py").read_bytes() == b"source bytes", (
+        "the promoted notebook must have the original bytes"
+    )
+    _assert_no_leftovers(tmp_path)
+
+
+# ─── state 5: killed after the promote, before pass 3 ──────────────────────
+
+
+def test_migrate_cleans_disposable_leftovers_after_final_tree_already_promoted(
+    tmp_path: Path,
+) -> None:
+    """a/ is already fully promoted; a_workspace/ and a.marimo.log are still flat.
+
+    Both flat leftovers must be removed and the already-promoted tree left
+    untouched.
+    """
+    final = tmp_path / "a"
+    final.mkdir()
+    (final / "notebook.py").write_bytes(b"already promoted")
+    (final / "data").mkdir()
+    (final / "workspace").mkdir()
+    (final / "home").mkdir()
+    (tmp_path / "a_workspace").mkdir()
+    (tmp_path / "a_workspace" / "junk").write_bytes(b"disposable")
+    (tmp_path / "a.marimo.log").write_bytes(b"old log")
+
+    migrated = _migrate(tmp_path)
+
+    assert migrated == [], "an already-promoted slug is not re-reported as migrated"
+    assert (final / "notebook.py").read_bytes() == b"already promoted", (
+        "the already-promoted tree must be untouched"
+    )
+    assert not (tmp_path / "a_workspace").exists(), "the flat disposable workspace must be removed"
+    assert not (tmp_path / "a.marimo.log").exists(), "the flat disposable log must be removed"
+    _assert_no_leftovers(tmp_path)
+
+
+# ─── state 6: both a staging dir and a completed final dir exist ───────────
+
+
+def test_migrate_discards_staging_copy_when_final_tree_already_exists(tmp_path: Path) -> None:
+    """Both .migrating-a/ and a/ exist. Pass 1 discards the staging copy.
+
+    The final tree's notebook.py bytes must be the ones that were already in
+    a/, not the (different) ones in the staging copy.
+    """
+    final = tmp_path / "a"
+    final.mkdir()
+    (final / "notebook.py").write_bytes(b"winner bytes")
+    (final / "data").mkdir()
+    (final / "workspace").mkdir()
+    (final / "home").mkdir()
+
+    staging = tmp_path / ".migrating-a"
+    staging.mkdir()
+    (staging / "notebook.py").write_bytes(b"stale garbage bytes")
+
+    migrated = _migrate(tmp_path)
+
+    assert migrated == [], "the already-final slug must not be re-reported as migrated"
+    assert (final / "notebook.py").read_bytes() == b"winner bytes", (
+        "the final tree must win the race; the staging copy is garbage"
+    )
+    _assert_no_leftovers(tmp_path)
+
+
+# ─── state 7: two slugs at different stages simultaneously ─────────────────
+
+
+def test_migrate_converges_two_slugs_at_different_stages_in_one_call(tmp_path: Path) -> None:
+    """slug 'a' is untouched flat; slug 'b' is mid-staging. Both converge in one call."""
+    (tmp_path / "a.py").write_bytes(b"a source")
+
+    staging_b = tmp_path / ".migrating-b"
+    staging_b.mkdir()
+    (staging_b / "notebook.py").write_bytes(b"b source")
+    (staging_b / "data").mkdir()
+    (staging_b / "workspace").mkdir()
+    (staging_b / "home").mkdir()
+
+    migrated = _migrate(tmp_path)
+
+    assert set(migrated) == {"a", "b"}, "both slugs must converge and be reported as migrated"
+    assert (tmp_path / "a" / "notebook.py").read_bytes() == b"a source"
+    assert (tmp_path / "b" / "notebook.py").read_bytes() == b"b source"
+    _assert_no_leftovers(tmp_path)
+
+
+# ─── state 8: uid pool exhaustion ───────────────────────────────────────────
+
+
+def test_migrate_raises_uid_pool_exhausted_instead_of_skipping_the_slug(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A full uid pool must abort the migration loudly, not silently skip the slug.
+
+    This is the propagation test that stops a future reader from "fixing" a
+    boot failure here with a swallowing try/except.
+    """
+    import notebook_host.jail as jail_mod
+
+    monkeypatch.setattr(jail_mod, "can_apply_jail", lambda: True)
+    _uids_file(tmp_path).write_text(json.dumps({"other-slug": _UID_START}))
+    (tmp_path / "b.py").write_bytes(b"fresh slug source")
+
+    with pytest.raises(UidPoolExhaustedError):
+        _migrate(tmp_path, uid_start=_UID_START, uid_end=_UID_START)
+
+
+# ─── additional coverage from the task-1 acceptance criteria ───────────────
+
+
+def test_migrate_slug_with_no_legacy_data_dir_gets_an_empty_data_dir(tmp_path: Path) -> None:
+    """A slug with no .data/ directory migrates successfully with an empty data/."""
+    (tmp_path / "a.py").write_bytes(b"no attachments here")
+
+    migrated = _migrate(tmp_path)
+
+    assert migrated == ["a"]
+    assert (tmp_path / "a" / "data").is_dir(), "data/ must be created even with no legacy .data/"
+    assert list((tmp_path / "a" / "data").iterdir()) == [], "data/ must be empty"
+
+
+def test_migrate_skips_unparseable_slug_without_aborting_the_run(tmp_path: Path) -> None:
+    """A file that doesn't pass safe_slug is skipped with a warning, not fatal."""
+    (tmp_path / "not a slug!.py").write_bytes(b"junk")
+    (tmp_path / "good.py").write_bytes(b"good source")
+
+    migrated = _migrate(tmp_path)
+
+    assert migrated == ["good"], "the valid slug must still migrate despite the invalid sibling"
+    assert (tmp_path / "not a slug!.py").exists(), (
+        "the unparseable file must be left in place for an operator to inspect"
+    )
+
+
+def test_migrate_never_touches_registry_files(tmp_path: Path) -> None:
+    """blogs.json, pids.json and uids.json are never treated as slugs."""
+    blogs = {"z": {"slug": "z", "created_at": 1.0}}
+    pids: dict[str, object] = {"z": {"slug": "z", "pid": 1, "port": 8100, "started_at": 1.0}}
+    (tmp_path / "blogs.json").write_text(json.dumps(blogs))
+    (tmp_path / "pids.json").write_text(json.dumps(pids))
+    (tmp_path / "z.py").write_bytes(b"z source")
+
+    _migrate(tmp_path)
+
+    assert json.loads((tmp_path / "blogs.json").read_text()) == blogs
+    assert json.loads((tmp_path / "pids.json").read_text()) == pids

--- a/apps/notebook-host/tests/test_migration.py
+++ b/apps/notebook-host/tests/test_migration.py
@@ -87,7 +87,9 @@ def test_migrate_untouched_flat_tree_converges_and_second_call_is_noop(tmp_path:
     assert json.loads((tmp_path / "pids.json").read_text()) == pids_payload, (
         "pids.json must never be treated as a slug and must be left byte-identical"
     )
-    assert tmp_path.stat().st_mode & 0o777 == 0o700, "data_dir itself must be locked to 0700"
+    assert tmp_path.stat().st_mode & 0o777 == 0o711, (
+        "data_dir itself must be locked to 0711 (traversable, not listable)"
+    )
     for d in (
         tmp_path / "a",
         tmp_path / "a" / "data",

--- a/apps/notebook-host/tests/test_pids_store.py
+++ b/apps/notebook-host/tests/test_pids_store.py
@@ -10,6 +10,7 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
 from notebook_host.pids_store import (
     PidRecord,
     load_pids,
@@ -96,12 +97,21 @@ def test_reap_orphans_skips_dead_pids(tmp_path: Path) -> None:
     assert load_pids(path) == {}, "pids file must be cleared after sweep"
 
 
-def test_reap_orphans_kills_live_process(tmp_path: Path) -> None:
-    """A live PID listed in pids.json is SIGTERM'd and disappears."""
-    # Spawn a real child we can prove was killed. Use a long-running
-    # python so it doesn't exit on its own before reap runs.
-    child = subprocess.Popen(
-        [sys.executable, "-c", "import time; time.sleep(30)"],
+@pytest.mark.skipif(sys.platform != "linux", reason="identity check reads /proc, Linux only")
+def test_reap_orphans_kills_live_process_whose_cmdline_matches_slug(tmp_path: Path) -> None:
+    """A live PID whose cmdline still identifies it as that slug's marimo is SIGTERM'd."""
+    # Spawn a real child we can prove was killed. Its argv carries the same
+    # markers spawn_marimo's cmd does (`marimo` + `--base-url /n/<slug>`), so
+    # the identity check recognizes it without needing marimo installed.
+    child = subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            "import time; time.sleep(30)",
+            "--base-url",
+            "/n/live",
+            "marimo",
+        ],
     )
     try:
         path = tmp_path / "pids.json"
@@ -113,7 +123,7 @@ def test_reap_orphans_kills_live_process(tmp_path: Path) -> None:
         reaped = reap_orphans(path, term_wait_seconds=3.0)
 
         assert [r.slug for r in reaped] == ["live"], (
-            "a live PID listed in pids.json must be reported as reaped"
+            "a live PID whose cmdline still names this slug's marimo must be reaped"
         )
         # The child should now be dead — give it a moment to exit cleanly
         # under SIGTERM and confirm via wait().
@@ -127,6 +137,52 @@ def test_reap_orphans_kills_live_process(tmp_path: Path) -> None:
         if child.poll() is None:
             with contextlib.suppress(ProcessLookupError):
                 os.kill(child.pid, 9)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="identity check reads /proc, Linux only")
+def test_reap_orphans_does_not_signal_live_pid_whose_cmdline_does_not_match_slug(
+    tmp_path: Path,
+) -> None:
+    """A live PID whose cmdline does not name the recorded slug must not be signalled.
+
+    Regression test for the defect: PIDs are recycled by the OS, so a
+    persisted record's PID can now belong to an unrelated process (here, the
+    test process itself). Liveness alone must not be treated as proof of
+    identity.
+    """
+    path = tmp_path / "pids.json"
+    own_pid = os.getpid()
+    save_pids(
+        path,
+        {"stale": PidRecord(slug="stale", pid=own_pid, port=8100, started_at=time.time())},
+    )
+
+    reaped = reap_orphans(path, term_wait_seconds=0.2)
+
+    assert reaped == [], "a PID whose cmdline does not match the recorded slug must not be reaped"
+    assert os.kill(own_pid, 0) is None, "the test process itself must still be alive"
+    assert load_pids(path) == {}, "the stale record is still cleared from the file"
+
+
+def test_reap_orphans_on_non_linux_platform_signals_nothing_and_still_empties_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a platform without /proc, no identity can be confirmed, so nothing is signalled."""
+    import notebook_host.pids_store as pids_store_mod
+
+    monkeypatch.setattr(pids_store_mod.sys, "platform", "darwin")
+    path = tmp_path / "pids.json"
+    own_pid = os.getpid()
+    save_pids(
+        path,
+        {"stale": PidRecord(slug="stale", pid=own_pid, port=8100, started_at=time.time())},
+    )
+
+    reaped = reap_orphans(path, term_wait_seconds=0.2)
+
+    assert reaped == [], "non-Linux platforms cannot verify identity, so nothing is signalled"
+    assert os.kill(own_pid, 0) is None, "the test process itself must still be alive"
+    assert load_pids(path) == {}, "the file is still emptied even when nothing was signalled"
 
 
 def test_record_from_process_accepts_float_timestamp() -> None:

--- a/apps/notebook-host/tests/test_validation.py
+++ b/apps/notebook-host/tests/test_validation.py
@@ -15,6 +15,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+from notebook_host.jail import get_slug_paths
 from notebook_host.lifecycle import validate_notebook
 
 pytestmark = pytest.mark.skipif(
@@ -57,16 +58,18 @@ def _():
 
 
 def test_validate_notebook_passes_clean_notebook(tmp_path: Path) -> None:
-    path = tmp_path / "clean.py"
-    path.write_text(_CLEAN)
-    result = validate_notebook("clean", path, timeout_s=120.0)
+    paths = get_slug_paths(tmp_path, "clean")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text(_CLEAN)
+    result = validate_notebook("clean", paths, timeout_s=120.0)
     assert result.ok, f"a clean notebook should validate; got errors: {result.errors}"
 
 
 def test_validate_notebook_flags_loop_variable_collision(tmp_path: Path) -> None:
-    path = tmp_path / "collision.py"
-    path.write_text(_COLLISION)
-    result = validate_notebook("collision", path, timeout_s=120.0)
+    paths = get_slug_paths(tmp_path, "collision")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text(_COLLISION)
+    result = validate_notebook("collision", paths, timeout_s=120.0)
     assert not result.ok, "a cross-cell loop-variable collision must fail validation"
     assert any("MultipleDefinitionError" in e for e in result.errors), (
         f"the collision should be reported as MultipleDefinitionError; got: {result.errors}"
@@ -93,9 +96,10 @@ def _():
 
 def test_validate_notebook_sandbox_installs_declared_dependency(tmp_path: Path) -> None:
     """A PEP 723 dep outside the baked set imports cleanly under --sandbox."""
-    path = tmp_path / "sandbox.py"
-    path.write_text(_SANDBOX_DEP)
-    result = validate_notebook("sandbox", path, timeout_s=180.0, sandbox=True)
+    paths = get_slug_paths(tmp_path, "sandbox")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text(_SANDBOX_DEP)
+    result = validate_notebook("sandbox", paths, timeout_s=180.0, sandbox=True)
     assert result.ok, (
         f"a declared dependency must be installed and importable under --sandbox; "
         f"got errors: {result.errors}"
@@ -106,9 +110,10 @@ def test_validate_notebook_without_sandbox_cannot_import_undeclared_dependency(
     tmp_path: Path,
 ) -> None:
     """Control: the same import fails on the baked env — sandbox is what fixes it."""
-    path = tmp_path / "no_sandbox.py"
-    path.write_text(_SANDBOX_DEP)
-    result = validate_notebook("no_sandbox", path, timeout_s=120.0, sandbox=False)
+    paths = get_slug_paths(tmp_path, "no_sandbox")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text(_SANDBOX_DEP)
+    result = validate_notebook("no_sandbox", paths, timeout_s=120.0, sandbox=False)
     assert not result.ok, (
         "cowsay is not baked into the host env; the import must fail without sandbox"
     )


### PR DESCRIPTION
## Summary

Gives every published notebook on the shared marimo host its own uid and its own
directory, so a notebook can no longer read another notebook's files — or lift the
admin bearer out of the host process.

Before this, every marimo process ran as root out of a flat directory. Isolation was
env-scrub plus rlimits; nothing restricted the filesystem. A notebook could open a
sibling's source and attachments by path, and because every process shared the host's
uid, it could also read `/proc/<host-pid>/environ`. `--sandbox` builds an isolated uv
venv, not a filesystem sandbox.

Isolation is now **per notebook**, which is strictly stronger than the per-tenant
boundary originally scoped. The host cannot express tenancy at all: the slug prefix is
a one-way hash computed in `daimon-core`, and `notebook_host` may not import `daimon`
(import-linter contract). Adding a tenant field to the host API was considered and
rejected — a larger API and migration change for a weaker guarantee. Accepted cost: a
tenant's own notebooks cannot share files. Nothing relied on that.

## Changes

**Layout.** `jail.py` owns the on-disk shape. Each slug gets
`data_dir/<slug>/{notebook.py,data/,workspace/,home/}` at `0700`, owned by a per-slug
uid drawn from a persisted registry. `data_dir` itself is `0711` — traversable so a
dropped uid can reach its own tree, unlistable so it cannot enumerate slugs. Host-owned
registries (`blogs.json`, `pids.json`, `uids.json`, `consumed.json`) sit outside every
jail at `0600`.

A persisted uid registry rather than a hash of the slug: blogs are permanent and
accumulate for the life of a deployment, so a hash into any convenient range carries
real birthday-collision risk, and a collision silently defeats isolation for both
colliding slugs.

**Privilege drop.** `setgroups([]) → setgid → setuid`, applied before rlimits, in a
function kept structurally separate from the existing rlimit gate — the two carry
opposite failure policies. Rlimits warn and degrade, which is fine for a resource cap
and not acceptable for a security control. The jail fails closed: a host that cannot
apply it refuses to boot unless an operator sets an explicit break-glass, which
defaults off. `HOME` points into the slug's own tree (`uv run --with marimo` needs a
writable cache) while `VIRTUAL_ENV` passes through untouched, so headerless notebooks
keep the baked pandas/numpy/pymc stack.

**Migration.** Existing deployments migrate at boot rather than breaking: a one-shot,
idempotent pass moves each flat slug into its own tree and keeps every blog serving at
its original URL. It must survive being killed at any step, since deploys replace the
container, so there is a test per interrupted intermediate state.

**Cleanup and lifecycle.** Deleting a slug is now one `remove_slug_tree` call instead of
three unlinks across four sites that disagreed about which to delete — that alone closes
a leak where reaping removed a notebook's source but left its attachments and workspace
behind. Also fixed: a delete racing the sweep's self-heal could leave a respawned,
unreapable process serving a deleted blog; orphan reaping signalled a pid without
checking it was still the process the record was written for; and burned capability
tokens neither survived a restart nor got pruned.

## Verification

- Full `apps/notebook-host` suite: 219 passed, 4 skipped, 9 deselected
- pyright strict (project-wide), ruff, import-linter 6/6 — clean
- Boundary behavior exercised in a container built from `apps/notebook-host/Dockerfile`,
  running as root against a seeded legacy flat `data_dir`: real kernel enforcement, real
  uid drop. Cross-slug reads denied by absolute path, by relative `..`, and for the
  notebook source; own subtree and own attachments reachable; `data_dir` not
  enumerable; `/proc/<pid>/environ` denied; `uv` and the baked stack running under the
  dropped uid; migration byte-preserving and convergent from a half-finished run.

Two defects were found this way that the unit suite could not see, both fixed here:

1. Locking `data_dir` to `0700` made the jail non-functional — resolving an absolute
   path needs the `x` bit on every component, so a dropped uid could not traverse into
   *its own* subtree. Hence `0711`.
2. The boot migration left registry files it *inherited* at their original `0644`. The
   stores chmod before their atomic rename, so files the host writes are fine, but a
   `blogs.json` carried over from an older release stayed world-readable in the same
   boot that made the parent traversable. A jailed notebook read it in full.

## Known residual

The tests that prove the boundary under real kernel enforcement
(`tests/test_jail_privilege.py`) are `slow`-marked and skip off root, and the
notebook-host CI job runs unprivileged — so **they do not run in CI**. The property was
verified by hand in a root container for this branch, but nothing automated defends it
going forward. A privileged `slow`-tier job is the durable fix and is tracked as a todo;
reviewers should know the green checkmark does not cover it.

Separately, `/n/{slug}/*` remains unauthenticated. That governs *who reaches* a notebook
rather than *what a notebook reaches*, so it is deliberately out of scope here and
tracked for its own change. Worth noting the rationale was corrected during this work:
named slugs are not 128-bit secrets. The bare-token form only applies when no slug is
supplied; on the normal path the prefix is a deterministic hash of the principal and
appears in every URL that principal has ever shared, so anyone who has seen one link can
guess another from its name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
