### PR TITLE
Re-check admin at click time on every panel control that writes shared state

### DIFF
--- a/packages/adapters/cli/daimon/adapters/cli/commands/agents.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/agents.py
@@ -13,6 +13,7 @@ from daimon.adapters.cli.output import emit_rows
 from daimon.adapters.cli.prompt import confirm_or_abort
 from daimon.adapters.cli.runtime import CliRuntime, build_runtime
 from daimon.adapters.cli.tenant import discover_tenant
+from daimon.core.agent_lifecycle import archive_memory_store_best_effort
 from daimon.core.config import load_settings
 from daimon.core.defaults.ma_index import (
     find_agent_by_daimon_tag,
@@ -30,8 +31,10 @@ from daimon.core.defaults.metadata import (
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
 from daimon.core.defaults.reconcile_agents import reconcile_agent
 from daimon.core.errors import SpecError, StoreError
+from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.specs import load_agent_spec, merge_default_agent_toolset
 from daimon.core.stores.identity import get_or_create_cli_principal
+from daimon.core.stores.scoped_config_write import clear_agent_references
 from daimon.core.stores.tenants import list_tenants_by_platform
 from pydantic import BaseModel
 from rich.console import Console
@@ -259,6 +262,14 @@ def agents_archive_command(
 
 
 async def agents_archive(*, rt: CliRuntime, console: Console, name: str, yes: bool) -> None:
+    """Archive an agent, its memory store, and every scope row that names it.
+
+    Same three-step shape as the Discord and Slack panel deletes: archive the
+    MA agent, archive its memory store best-effort, then clear the scope rows.
+    Without the clear, a channel or tenant default naming this agent survives
+    the archive and turn resolution misses instead of falling through the
+    cascade.
+    """
     confirm_or_abort(console, f"archive agent {name!r}?", yes=yes)
     async with rt.sessionmaker() as session, session.begin():
         tenant_id = await discover_tenant(session)
@@ -270,6 +281,19 @@ async def agents_archive(*, rt: CliRuntime, console: Console, name: str, yes: bo
     if agent is None:
         raise StoreError(f"no agent named {name!r} in your account or system defaults.")
     await rt.anthropic.beta.agents.archive(agent.id)
+    await archive_memory_store_best_effort(
+        anthropic=rt.anthropic,
+        sessionmaker=rt.sessionmaker,
+        tenant_id=tenant_id,
+        agent_id=derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(agent.id)),
+        log_context={"tenant_id": str(tenant_id), "agent_name": name, "ma_agent_id": agent.id},
+    )
+    # After the MA archive, never before: a failure here leaves an archived
+    # agent with stale scope rows rather than a live agent with cleared ones.
+    # Deliberately unguarded — a failure must reach run_cli's error boundary
+    # rather than degrade silently.
+    async with rt.sessionmaker.begin() as session:
+        await clear_agent_references(session, tenant_id=tenant_id, agent_name=name)
     console.print(f"[green]✓ archived agent {name!r}[/green]")
 
 

--- a/packages/adapters/cli/tests/commands/test_agents.py
+++ b/packages/adapters/cli/tests/commands/test_agents.py
@@ -36,8 +36,10 @@ from daimon.core.config import Settings
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
 from daimon.core.errors import SpecError, StoreError
 from daimon.core.ma_resolver import new_resolver_cache
-from daimon.core.scope import DeploymentDefault
+from daimon.core.scope import ChannelScopeRef, DeploymentDefault
 from daimon.core.stores.identity import get_or_create_cli_principal
+from daimon.core.stores.scoped_config_read import get_scope
+from daimon.core.stores.scoped_config_write import set_fields
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import MARouter, list_response
 from rich.console import Console
@@ -601,6 +603,59 @@ async def test_agents_archive_calls_sdk_archive(
     assert len(archive_paths) == 1, f"expected 1 archive call, got {len(archive_paths)}"
     assert archive_paths[0].endswith("/ag_doomed/archive"), (
         f"archive must use MA agent id in URL, got {archive_paths[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agents_archive_clears_scope_rows_naming_the_archived_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A channel default naming the archived agent must not survive the archive.
+
+    Same contract the Discord, Slack and MCP delete surfaces hold: without the
+    clear, the next turn in that channel resolves to an archived agent instead
+    of falling through to the tenant tier.
+    """
+    async with db_session_factory() as s, s.begin():
+        tenant = await make_tenant(s, platform="cli", workspace_id="local")
+        await get_or_create_cli_principal(s, tenant_id=tenant.id, os_user="testuser")
+        tenant_id = tenant.id
+        await set_fields(
+            s,
+            scope=ChannelScopeRef(tenant_id=tenant_id, channel_id="c1"),
+            tenant_id=tenant_id,
+            agent_name="doomed",
+        )
+        await set_fields(
+            s,
+            scope=ChannelScopeRef(tenant_id=tenant_id, channel_id="c2"),
+            tenant_id=tenant_id,
+            agent_name="survivor",
+        )
+
+    agent_data = _agent_json(agent_id="ag_doomed", name="doomed", tenant_id=tenant_id)
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, m: list_response([agent_data]))
+    router.add(
+        "POST", r"/v1/agents/ag_doomed/archive", lambda req, m: httpx.Response(200, json=agent_data)
+    )
+
+    console = Console(file=StringIO(), force_terminal=False, highlight=False, width=120)
+    rt = _build_rt(db_session_factory, router)
+
+    await agents_archive(rt=rt, console=console, name="doomed", yes=True)
+
+    async with db_session_factory() as s:
+        cleared = await get_scope(s, scope=ChannelScopeRef(tenant_id=tenant_id, channel_id="c1"))
+        untouched = await get_scope(s, scope=ChannelScopeRef(tenant_id=tenant_id, channel_id="c2"))
+
+    assert cleared is None, (
+        "the channel row naming the archived agent must be gone so resolution "
+        "falls through the cascade"
+    )
+    assert untouched is not None and untouched.agent_name == "survivor", (
+        "a channel row naming a different agent must survive the archive"
     )
 
 

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
@@ -26,6 +26,13 @@ the field it writes is part of the agent spec:
 
 A new mutating control belongs to one of those two sets. Pick its gate from the
 set the field is in, not from the button it happens to sit next to.
+
+The one deliberate exception is `credential_modals.py`, whose write is bounded
+by a single-use `credential_requests` token rather than by guild-admin status:
+the agent asks a specific member for a specific key, and consuming the token is
+what authorizes exactly that one write. It is not reachable from this panel and
+is not an exception you can extend — a control a member reaches by clicking has
+no such token and belongs to one of the two sets above.
 """
 
 from __future__ import annotations

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
@@ -1,13 +1,31 @@
-"""Click-time authorization gate for the panel's spec-mutating writes.
+"""Click-time authorization gates for the panel's mutating writes.
 
-`EditView`'s spec controls are disabled when the render-time snapshot says a
-control shouldn't be usable — that snapshot is a rendering hint, not a
-boundary. This module is the boundary: every callback that would write an
-agent's prompt, model, skills, or MCP servers calls
-`refuse_if_reachable_and_not_admin` first, which re-derives both admin status
-and reachability from live state rather than trusting anything the view was
-constructed with, so a stale open panel or a demoted admin cannot write a
-change the rendered panel had already forbidden.
+`EditView`'s controls are disabled when the render-time snapshot says a control
+shouldn't be usable — that snapshot is a rendering hint, not a boundary. This
+module is the boundary: the gates here re-derive admin status and reachability
+from live state rather than trusting anything the view was constructed with, so
+a stale open panel or a demoted admin cannot write a change the rendered panel
+had already forbidden.
+
+Two gates live here, and which one a write routes through follows from whether
+the field it writes is part of the agent spec:
+
+- Spec fields — prompt, model, skills, MCP servers — route through
+  `refuse_if_reachable_and_not_admin`. That gate refuses a defaults-managed
+  agent even for an admin, because a panel spec edit never stamps the
+  reconciler's spec hash: an admin bypass would leave permanent, silent drift
+  against the repo defaults that reconcile never notices.
+
+- Per-agent attachments — the repo binding and the env vars — route through
+  `refuse_if_shared_and_not_admin`. Attachments never enter the agent spec, so
+  the system-agent absolutism above does not apply to them, and an admin
+  binding a repo to the seeded agent is the first-run onboarding step. That
+  gate is still closed to non-admins on any shared agent, whether the agent is
+  shared because it ships with the deployment or because something currently
+  resolves to it.
+
+A new mutating control belongs to one of those two sets. Pick its gate from the
+set the field is in, not from the button it happens to sit next to.
 """
 
 from __future__ import annotations
@@ -30,6 +48,12 @@ _SYSTEM_AGENT_MESSAGE = (
 _REACHABLE_AGENT_MESSAGE = (
     "This agent is currently the default for this channel or the server, so "
     "changing its setup needs Manage Server. Fork it to make an editable copy."
+)
+_SHARED_AGENT_MESSAGE = (
+    "This agent is shared — it either ships with the deployment or is the "
+    "current default for this channel or the server — so changing its repo or "
+    "environment variables needs Manage Server. Fork it to make an editable "
+    "copy; the fork starts with no environment variables of its own."
 )
 
 
@@ -78,5 +102,52 @@ async def refuse_if_reachable_and_not_admin(
         )
     if reachable:
         await _send_ephemeral(interaction, _REACHABLE_AGENT_MESSAGE)
+        return True
+    return False
+
+
+async def refuse_if_shared_and_not_admin(
+    interaction: discord.Interaction,  # type: ignore[type-arg]  # discord.Interaction default generic arg; only response/followup/guild_id are used
+    *,
+    runtime: DiscordRuntime,
+    entry: RosterEntry | None,
+) -> bool:
+    """Click-time re-check shared by every callback writing a per-agent attachment.
+
+    Returns True when the caller must return immediately (the write is
+    refused); False when the write may proceed. Order, each short-circuiting:
+
+    1. No target selected -> refuse silently (belt and braces; every call
+       site already narrows `entry` past its own `selected is None` check).
+    2. A live guild admin -> allow, before any MA or database read. This is
+       the one step ordered differently from `refuse_if_reachable_and_not_admin`,
+       and it is what keeps an admin able to bind a repo to the seeded agent.
+    3. The target is a system agent -> refuse; it belongs to the deployment
+       and every member of the install shares it.
+    4. Otherwise, read reachability fresh from the database and refuse when
+       the target currently resolves for some channel or the workspace.
+
+    Both refusals carry the same message on purpose: telling the caller which
+    limb fired would say nothing they can act on, and either way the fix is the
+    same — ask an admin, or fork.
+    """
+    if entry is None:
+        log.debug("agent_setup.authz.no_target")
+        return True
+    if is_guild_admin(interaction):  # pyright: ignore[reportArgumentType]  # discord.Interaction vs Interaction[commands.Bot]; is_guild_admin only reads user/guild
+        return False
+    if entry.is_system:
+        await _send_ephemeral(interaction, _SHARED_AGENT_MESSAGE)
+        return True
+    tenant_id = await resolve_tenant_for_panel(runtime, interaction)
+    async with runtime.sessionmaker() as session:
+        reachable = await is_agent_reachable_in_tenant(
+            session,
+            tenant_id=tenant_id,
+            agent_name=entry.name,
+            default=runtime.deployment_default,
+        )
+    if reachable:
+        await _send_ephemeral(interaction, _SHARED_AGENT_MESSAGE)
         return True
     return False

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -60,8 +60,10 @@ def build_credentials_container(
 
     Env variables are per-agent daimon state (agent_files, keyed by
     tenant/agent/key) and are never part of the agent spec, so provenance
-    (system-agent or not) does not gate them — every member, on every agent,
-    including the seeded default, can view and manage this sub-view.
+    (system-agent or not) does not gate *rendering* them: every member, on
+    every agent including the seeded default, can open this sub-view and read
+    the key names. The two writes are a different question and are refused at
+    click time on a shared agent — see `_on_remove` and `PasteSecretModal`.
     """
     container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container()
     container.add_item(
@@ -282,6 +284,19 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         return _cb
 
     async def _on_remove(self, interaction: discord.Interaction, key_name: str) -> None:
+        # Read and write split apart here on purpose: this gate belongs on the
+        # two writes, NOT in `interaction_check`, which guards opening the list
+        # too. The container carries key NAMES only, so a member seeing that the
+        # shared agent has a variable set can ask an admin for the right thing —
+        # and can tell whether a missing variable is why their turn failed.
+        # Removing one is the destructive half and stops here.
+        # Runs before the click log so a refused removal does not record the key
+        # name, and before defer() so the refusal owns the first response rather
+        # than showing a thinking indicator it will not fulfil.
+        if await authz.refuse_if_shared_and_not_admin(
+            interaction, runtime=self._runtime, entry=self._state.selected
+        ):
+            return
         # key_name is the secret KEY NAME the option carried — never a value.
         _log.info("credentials.remove.click", key=key_name)
         await interaction.response.defer(ephemeral=True, thinking=True)
@@ -353,8 +368,9 @@ def _build_remove_select(secret_names: list[str]) -> discord.ui.Select[Credentia
 
     Each option's ``label``/``value`` carries ONLY the secret KEY NAME — never a
     value, never a per-key custom_id. Disabled (empty placeholder) only when
-    there are no secrets — env vars are per-agent daimon state, never part of
-    the agent spec, so provenance does not gate removal here.
+    there are no secrets; a shared agent's select still renders enabled and
+    refuses on click, because a greyed control teaches nothing while the
+    refusal carries the reason and the fork advice.
     """
     if len(secret_names) == 0:
         return discord.ui.Select(

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -23,8 +23,9 @@ import uuid
 from collections.abc import Awaitable, Callable
 
 import structlog
+from daimon.adapters.discord.agent_setup import authz
 from daimon.adapters.discord.agent_setup.expiry import ExpiringView
-from daimon.adapters.discord.agent_setup.state import PanelState
+from daimon.adapters.discord.agent_setup.state import PanelState, RosterEntry
 from daimon.adapters.discord.errors import generate_request_id, render_error
 from daimon.adapters.discord.layout import hairline, header
 from daimon.adapters.discord.runtime import DiscordRuntime
@@ -94,13 +95,18 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
         runtime: DiscordRuntime,
         tenant_id: uuid.UUID,
         agent_id: uuid.UUID,
+        entry: RosterEntry | None,
         on_added: OnAdded,
     ) -> None:
         super().__init__()
-        # Modal has no `.view` reference — store deps explicitly.
+        # Modal has no `.view` reference — store deps explicitly. `entry` has no
+        # default on purpose: it is the submit gate's target, and a construction
+        # site that forgot it would silently build an ungated modal, so pyright
+        # must reject it rather than let it through.
         self._runtime = runtime
         self._tenant_id = tenant_id
         self._agent_id = agent_id
+        self._entry = entry
         self._on_added = on_added
         self.content_input: discord.ui.TextInput[PasteSecretModal] = discord.ui.TextInput(
             label="KEY=VALUE lines",
@@ -112,6 +118,16 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
         self.add_item(self.content_input)
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
+        # Submit time is the boundary: a modal opened before the caller lost
+        # Manage Server must not write, and `put_agent_file` is an upsert whose
+        # files are mounted read-write on every session of a shared agent.
+        # Before defer() so the refusal owns the first response, and before the
+        # pasted content is read at all, so nothing derived from it — not a key
+        # name, not a value — exists on the refusal path.
+        if await authz.refuse_if_shared_and_not_admin(
+            interaction, runtime=self._runtime, entry=self._entry
+        ):
+            return
         await interaction.response.defer(ephemeral=True, thinking=True)
         raw = str(self.content_input.value or "")
 
@@ -292,6 +308,10 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
                 runtime=self._runtime,
                 tenant_id=self._tenant_id,
                 agent_id=self._agent_id,
+                # `EditView._on_env_vars` derives this sub-view's agent_id from
+                # the same `state.selected`, so the gate's target and the write's
+                # target are always the same agent.
+                entry=self._state.selected,
                 on_added=self._reload_and_rerender,
             )
         )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
@@ -316,8 +316,14 @@ class EditView(ExpiringView, discord.ui.LayoutView):
         # spec_editable gates the same controls on reachability instead: an
         # agent nobody has scoped is every member's scratchpad; once some
         # channel or the workspace points at it, only an admin may change its
-        # spec. Env vars and GitHub… are per-agent attachments, never part of
-        # the spec, so neither guard applies to them.
+        # spec. Env vars and GitHub… are per-agent attachments: they never
+        # enter the agent spec, so the is_system absolutism above does not
+        # apply to them — an admin binding a repo to the built-in agent is a
+        # supported first-run step. They are subject to their own shared-state
+        # guard instead, which refuses a non-admin whenever the target is a
+        # system agent or currently reachable. That is why their buttons render
+        # enabled while the spec controls render disabled: the refusal happens
+        # on click, not at render.
         is_system = bool(state.selected and state.selected.is_system)
         spec_editable = state.is_admin or not state.is_selected_reachable()
         spec_controls_disabled = is_system or not spec_editable
@@ -423,6 +429,14 @@ class EditView(ExpiringView, discord.ui.LayoutView):
 
     async def _on_github(self, interaction: discord.Interaction) -> None:
         log.info("agent_setup.edit.github.click", agent_name=self._selected_name())
+        # Refuse before the modal opens so a member who may not bind this
+        # agent's repo never types a GitHub token into a form that will be
+        # rejected. RepoAuthModal.on_submit re-checks; that call is the
+        # boundary, this one keeps the credential out of the payload.
+        if await authz.refuse_if_shared_and_not_admin(
+            interaction, runtime=self.runtime, entry=self.state.selected
+        ):
+            return
         await interaction.response.send_modal(
             RepoAuthModal(self.state, runtime=self.runtime, allowed_user_id=self.allowed_user_id)
         )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -247,6 +247,15 @@ class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
                 "Enter a repo URL, a GitHub token, or both.", ephemeral=True
             )
             return
+        # Submit time is the boundary: a modal opened before the caller lost
+        # Manage Server must not write. Runs before defer() so the refusal owns
+        # the first response, and before the log line below so a refused
+        # submission leaves no record of the masked token or of a repo URL the
+        # caller had no authority to bind.
+        if await authz.refuse_if_shared_and_not_admin(
+            interaction, runtime=self.runtime, entry=self.state.selected
+        ):
+            return
         _log.info(
             "agent_setup.repo_auth.submit",
             agent_name=agent_name,

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -29,6 +29,7 @@ from daimon.adapters.discord.agent_setup.write import (
     load_tenant_roster,
     validate_model_id,
 )
+from daimon.adapters.discord.checks import refuse_if_not_admin
 from daimon.adapters.discord.errors import generate_request_id, render_error
 from daimon.adapters.discord.layout import hairline, header
 from daimon.adapters.discord.runtime import DiscordRuntime
@@ -651,6 +652,14 @@ class AgentSetupView(ExpiringView, discord.ui.LayoutView):
         from daimon.adapters.discord.agent_setup.mcp_access import send_connect_via_mcp
 
         log.info("agent_setup.connect_mcp_btn.click", agent_name=self._selected_name())
+        # state.is_admin is a snapshot from panel-open, and every interaction
+        # rebuilds this view with a fresh timeout — so re-derive admin from the
+        # live interaction before minting a 90-day bearer for the tenant's MCP
+        # surface. The check sits here rather than in interaction_check because
+        # that method guards the whole view, including the member row (New /
+        # Fork / Edit) that is deliberately open to everyone.
+        if await refuse_if_not_admin(interaction):  # pyright: ignore[reportArgumentType]  # discord.Interaction vs Interaction[commands.Bot]; refuse_if_not_admin only reads user/guild/response
+            return
         await send_connect_via_mcp(
             interaction,
             runtime=self.runtime,
@@ -683,6 +692,14 @@ class AgentSetupView(ExpiringView, discord.ui.LayoutView):
     async def _on_delete(self, interaction: discord.Interaction) -> None:
         target_name = self.state.selected.name if self.state.selected else None
         log.info("agent_setup.delete_btn.click", agent_name=target_name)
+        # The same live re-check as Connect via MCP, and it runs first: before
+        # the selection check, so a refused caller learns nothing about what is
+        # selected, and before defer(), so the refusal owns the interaction's
+        # first response. Not in interaction_check, which guards the member row
+        # (New / Fork / Edit) too — an admin gate there would lock members out
+        # of the panel entirely.
+        if await refuse_if_not_admin(interaction):  # pyright: ignore[reportArgumentType]  # discord.Interaction vs Interaction[commands.Bot]; refuse_if_not_admin only reads user/guild/response
+            return
         if self.state.selected is None or target_name is None:
             await interaction.response.send_message("Nothing to delete.", ephemeral=True)
             return

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
@@ -51,6 +51,7 @@ from daimon.core.specs import (
     merge_default_agent_toolset,
 )
 from daimon.core.stores.agent_github_binding import set_agent_github_binding
+from daimon.core.stores.scoped_config_write import clear_agent_references
 from pydantic import ValidationError
 
 from .state import PanelState, RosterEntry
@@ -473,7 +474,12 @@ async def fork_agent(
 
 
 async def delete_agent(runtime: DiscordRuntime, *, tenant_id: uuid.UUID, name: str) -> None:
-    """Archive the MA agent matching `name` under the given tenant."""
+    """Archive the MA agent matching `name` under the given tenant.
+
+    Channel and server scope rows naming the agent are cleared as part of the
+    delete, so turn resolution falls through the cascade instead of resolving to
+    a deleted agent.
+    """
     agent = await find_agent_by_daimon_tag(runtime.anthropic, tenant_id=tenant_id, name=name)
     if agent is None:
         raise DaimonError(f"No agent named **{name}** found.")
@@ -485,6 +491,12 @@ async def delete_agent(runtime: DiscordRuntime, *, tenant_id: uuid.UUID, name: s
         agent_id=derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(agent.id)),
         log_context={"tenant_id": str(tenant_id), "agent_name": name, "ma_agent_id": agent.id},
     )
+    # After the MA archive, never before: a failure here leaves an archived
+    # agent with stale scope rows rather than a live agent with cleared ones.
+    # Deliberately unguarded — a failure must reach the callback's error
+    # boundary rather than degrade silently.
+    async with runtime.sessionmaker.begin() as session:
+        await clear_agent_references(session, tenant_id=tenant_id, agent_name=name)
 
 
 def _build_runtime_fernet(runtime: DiscordRuntime) -> MultiFernet:

--- a/packages/adapters/discord/daimon/adapters/discord/billing_panel/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/billing_panel/panel.py
@@ -1,10 +1,17 @@
 """BillingPanelView + build_billing_container + buttons for /billing.
 
-Discord-native admin check (manage_guild | administrator | owner) is re-resolved
-on every Refresh via `is_guild_admin` (D-UX-04). Admin view shows a top-up
-string select ($10/$25/$50/$100) and a UserSelect member-spend lookup that POST to
-the MCP /billing/checkout route via an authenticated internal token. Discord never
-imports stripe (TOPUP-02/OQ#4 rec (a)).
+The Discord-native admin check (manage_guild | administrator | owner) is
+re-derived from the live interaction on every render AND on every admin-select
+click — it is never trusted from the rendered view. `is_admin` on the view is a
+render hint that decides whether the two admin selects appear at all; the
+boundary is the click-time admin gate from `checks.py`, called as the first act
+of each of those callbacks before any HTTP call or usage read. Every
+interaction rebuilds the view with a fresh timeout, so a member who was an admin
+when the panel opened may not be one when they click.
+
+Admin view shows a top-up string select ($10/$25/$50/$100) and a UserSelect
+member-spend lookup that POST to the MCP /billing/checkout route via an
+authenticated internal token. Discord never imports stripe.
 """
 
 from __future__ import annotations
@@ -24,6 +31,7 @@ from daimon.adapters.discord.billing_panel.state import (
     COLOR_OVER_CAP,
     BillingPanelState,
 )
+from daimon.adapters.discord.checks import refuse_if_not_admin
 from daimon.adapters.discord.errors import generate_request_id, render_error
 from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.errors import DaimonError
@@ -237,6 +245,10 @@ class _TopUpSelect(discord.ui.Select["BillingPanelView"]):
     async def callback(self, interaction: discord.Interaction) -> None:
         if self.view is None or interaction.guild_id is None:
             return
+        # The view's is_admin decided whether this select rendered; it does not
+        # decide whether the click may mint a checkout link.
+        if await refuse_if_not_admin(interaction):  # pyright: ignore[reportArgumentType]  # narrowing to the Bot-bound interaction inside our adapter
+            return
         try:
             amount = int(self.values[0])
             url = await _create_checkout(
@@ -267,6 +279,10 @@ class _MemberLookupSelect(discord.ui.UserSelect["BillingPanelView"]):
 
     async def callback(self, interaction: discord.Interaction) -> None:
         if self.view is None or interaction.guild_id is None:
+            return
+        # Per-member spend is exactly what load_billing_snapshot's member branch
+        # withholds — the gate has to run before the usage reads, not at render.
+        if await refuse_if_not_admin(interaction):  # pyright: ignore[reportArgumentType]  # narrowing to the Bot-bound interaction inside our adapter
             return
         try:
             selected = self.values[0]

--- a/packages/adapters/discord/daimon/adapters/discord/billing_panel/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/billing_panel/panel.py
@@ -248,7 +248,7 @@ class _TopUpSelect(discord.ui.Select["BillingPanelView"]):
                 f"Top up ${amount}: complete payment here (link is private):\n{url}",
                 ephemeral=True,
             )
-        except (DaimonError, discord.HTTPException) as exc:
+        except (DaimonError, discord.HTTPException, httpx.HTTPStatusError) as exc:
             rid = generate_request_id()
             await interaction.response.send_message(
                 render_error(exc, request_id=rid), ephemeral=True

--- a/packages/adapters/discord/daimon/adapters/discord/checks.py
+++ b/packages/adapters/discord/daimon/adapters/discord/checks.py
@@ -26,6 +26,8 @@ from discord.ext import commands
 
 P = ParamSpec("P")
 
+_ADMIN_ONLY_MESSAGE = "That action needs Manage Server — ask a server admin to do it."
+
 
 def is_member_guild_admin(member: discord.Member, *, guild_owner_id: int | None) -> bool:
     """Return True if the member is a guild admin by Discord-native permissions.
@@ -49,6 +51,29 @@ def is_guild_admin(interaction: Interaction[commands.Bot]) -> bool:
     guild = interaction.guild
     owner_id = guild.owner_id if guild is not None else None
     return is_member_guild_admin(user, guild_owner_id=owner_id)
+
+
+async def refuse_if_not_admin(interaction: Interaction[commands.Bot]) -> bool:
+    """Click-time admin re-check for a callback whose blast radius exceeds the clicker's own agent.
+
+    Returns True when the caller must return immediately (the action is
+    refused); False when it may proceed.
+
+    Whatever admin state a view was rendered with is a hint — every interaction
+    rebuilds the view with a fresh timeout, so a member who was an admin when
+    the panel opened may not be one now. This is the boundary, and it reads the
+    live interaction rather than anything the view carried.
+
+    Call it before any ``defer()`` or response in the callback, so the refusal
+    owns the interaction's first response.
+    """
+    if is_guild_admin(interaction):
+        return False
+    if interaction.response.is_done():
+        await interaction.followup.send(_ADMIN_ONLY_MESSAGE, ephemeral=True)
+    else:
+        await interaction.response.send_message(_ADMIN_ONLY_MESSAGE, ephemeral=True)
+    return True
 
 
 async def resolve_tenant_for_interaction(

--- a/packages/adapters/discord/daimon/adapters/discord/commands/billing.py
+++ b/packages/adapters/discord/daimon/adapters/discord/commands/billing.py
@@ -77,6 +77,7 @@ class BillingCog(commands.Cog):
                     external_id=str(interaction.user.id),
                 )
                 account_id = principal.account_id
+                await session.commit()
             view = BillingPanelView(
                 state,
                 runtime=runtime,

--- a/packages/adapters/discord/tests/agent_setup/test_authz.py
+++ b/packages/adapters/discord/tests/agent_setup/test_authz.py
@@ -1,4 +1,4 @@
-"""Tests for refuse_if_reachable_and_not_admin — the click-time write-path gate."""
+"""Tests for the click-time write-path gates: the spec gate and the attachment gate."""
 
 from __future__ import annotations
 
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
-from daimon.adapters.discord.agent_setup.authz import refuse_if_reachable_and_not_admin
+from daimon.adapters.discord.agent_setup.authz import (
+    refuse_if_reachable_and_not_admin,
+    refuse_if_shared_and_not_admin,
+)
 from daimon.adapters.discord.agent_setup.state import RosterEntry
 from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.ma_resolver import new_resolver_cache
@@ -183,6 +186,131 @@ async def test_system_agent_refusal_uses_followup_when_already_acked() -> None:
     refused = await refuse_if_reachable_and_not_admin(interaction, runtime=runtime, entry=entry)
 
     assert refused is True
+    session_factory.assert_not_called()
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_called_once()
+    assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True
+
+
+# ---------------------------------------------------------------------------
+# refuse_if_shared_and_not_admin — the attachment gate (repo binding, env vars)
+# ---------------------------------------------------------------------------
+
+
+async def test_shared_gate_no_target_refuses_silently_without_db_read() -> None:
+    session_factory = MagicMock()
+    runtime = _runtime(sessionmaker=session_factory)
+    interaction = _member_interaction()
+
+    refused = await refuse_if_shared_and_not_admin(interaction, runtime=runtime, entry=None)
+
+    assert refused is True, "no selected agent must refuse"
+    session_factory.assert_not_called()
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_shared_gate_admin_passes_on_a_system_agent() -> None:
+    session_factory = MagicMock()
+    runtime = _runtime(sessionmaker=session_factory)
+    interaction = _admin_interaction()
+    entry = _entry("daimon", is_system=True)
+
+    refused = await refuse_if_shared_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is False, (
+        "an admin must be able to attach a repo to the seeded agent — that is the "
+        "first-run onboarding step, and the spec gate's system-agent absolutism "
+        "must not leak into the attachment gate"
+    )
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_shared_gate_admin_passes_on_a_reachable_agent_without_touching_the_database() -> (
+    None
+):
+    session_factory = MagicMock()
+    entry = _entry("bot")
+    runtime = _runtime(
+        sessionmaker=session_factory,
+        deployment_default=DeploymentDefault(agent_name=entry.name),
+    )
+    interaction = _admin_interaction()
+
+    refused = await refuse_if_shared_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is False, "a live admin must pass even when the target is the current default"
+    session_factory.assert_not_called()
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_shared_gate_non_admin_refuses_on_a_system_agent() -> None:
+    session_factory = MagicMock()
+    runtime = _runtime(sessionmaker=session_factory)
+    interaction = _member_interaction()
+    entry = _entry("daimon", is_system=True)
+
+    refused = await refuse_if_shared_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is True, "a member must not write attachments on the deployment's own agent"
+    session_factory.assert_not_called()
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+    interaction.followup.send.assert_not_called()
+
+
+async def test_shared_gate_non_admin_refuses_on_a_reachable_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 222004
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    entry = _entry("bot")
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        deployment_default=DeploymentDefault(agent_name=entry.name),
+    )
+    interaction = _member_interaction(guild_id=guild_id)
+
+    refused = await refuse_if_shared_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is True, "the workspace's current default agent must refuse a non-admin"
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+    interaction.followup.send.assert_not_called()
+
+
+async def test_shared_gate_non_admin_passes_on_an_unreachable_non_system_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 222005
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    runtime = _runtime(sessionmaker=db_session_factory)
+    interaction = _member_interaction(guild_id=guild_id)
+    entry = _entry("bot")
+
+    refused = await refuse_if_shared_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is False, (
+        "an agent that is neither seeded nor currently resolved by anything is "
+        "the member's own to attach a repo to"
+    )
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_shared_gate_refusal_uses_followup_when_already_acked() -> None:
+    session_factory = MagicMock()
+    runtime = _runtime(sessionmaker=session_factory)
+    interaction = _member_interaction(acked=True)
+    entry = _entry("daimon", is_system=True)
+
+    refused = await refuse_if_shared_and_not_admin(interaction, runtime=runtime, entry=entry)
+
+    assert refused is True, "an acked interaction must still refuse"
     session_factory.assert_not_called()
     interaction.response.send_message.assert_not_called()
     interaction.followup.send.assert_called_once()

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -51,6 +51,46 @@ def _state(entry: RosterEntry, account_id: uuid.UUID) -> PanelState:
     return PanelState(roster=[entry], selected=entry, account_id=account_id)
 
 
+def _interaction(user_id: int = 42, *, is_admin: bool = True, guild_id: int = 12345) -> MagicMock:
+    """A discord.Interaction stand-in, a live guild admin by default so the
+    env-var write gate short-circuits without a DB read. Tests proving the
+    shared-agent refusal pass ``is_admin=False`` and register a tenant for the
+    guild, because that path reads reachability from Postgres."""
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = user_id
+    interaction.user.guild_permissions.administrator = is_admin
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    return interaction
+
+
+def _runtime(
+    sessionmaker: Any,
+    *,
+    deployment_default: DeploymentDefault | None = None,
+) -> DiscordRuntime:
+    settings = MagicMock()
+    settings.mcp.public_url = None
+    return DiscordRuntime(
+        settings=settings,
+        anthropic=build_stub_anthropic(),
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=deployment_default or DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+    )
+
+
 def _walk_buttons(view: discord.ui.LayoutView) -> list[discord.ui.Button[Any]]:
     """Walk the full LayoutView tree and collect all Button items."""
     return [item for item in view.walk_children() if isinstance(item, discord.ui.Button)]
@@ -250,7 +290,9 @@ def test_subview_remove_select_option_carries_key_name_never_value(account_id: u
 def test_subview_system_agent_enables_mutations(account_id: uuid.UUID) -> None:
     """Env vars are per-agent daimon state, never part of the agent spec, so a
     system agent's remove select and add button are enabled exactly like a
-    user agent's — provenance does not gate this sub-view."""
+    user agent's — provenance does not gate this sub-view's rendering. The
+    enabled state is deliberate: the refusal happens at click time and carries
+    the reason, which a greyed control cannot."""
     entry = _entry("sys", is_system=True)
     view = CredentialsSubView(
         runtime=MagicMock(spec=DiscordRuntime),
@@ -297,28 +339,20 @@ async def test_paste_modal_stores_each_pair_and_never_logs_value(
     _tid = tenant.id
     agent_id = uuid.uuid4()
 
-    runtime = DiscordRuntime(
-        settings=MagicMock(),
-        anthropic=build_stub_anthropic(),
-        sessionmaker=db_session_factory,
-        notebook_rate_limiter=RateLimiter(max_requests=999),
-        billing_config=None,
-        deployment_default=DeploymentDefault(),
-        resolver_cache=new_resolver_cache(),
-        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
-    )
+    runtime = _runtime(db_session_factory)
     on_added = AsyncMock()
     modal = PasteSecretModal(
-        runtime=runtime, tenant_id=tenant.id, agent_id=agent_id, on_added=on_added
+        runtime=runtime,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        entry=_entry("bot"),
+        on_added=on_added,
     )
     modal.content_input._value = (  # pyright: ignore[reportPrivateUsage]
         f"# a comment\nXERO_API_KEY={_SECRET_VALUE}\n\nTOGGL_TOKEN=second-value\n"
     )
 
-    interaction = MagicMock()
-    interaction.user.id = 42
-    interaction.response.defer = AsyncMock()
-    interaction.followup.send = AsyncMock()
+    interaction = _interaction()
 
     cap = structlog.testing.LogCapture()
     structlog.configure(processors=[cap])
@@ -358,25 +392,17 @@ async def test_paste_modal_rejects_invalid_key_and_writes_nothing(
     _tid = tenant.id
     agent_id = uuid.uuid4()
 
-    runtime = DiscordRuntime(
-        settings=MagicMock(),
-        anthropic=build_stub_anthropic(),
-        sessionmaker=db_session_factory,
-        notebook_rate_limiter=RateLimiter(max_requests=999),
-        billing_config=None,
-        deployment_default=DeploymentDefault(),
-        resolver_cache=new_resolver_cache(),
-        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
-    )
+    runtime = _runtime(db_session_factory)
     modal = PasteSecretModal(
-        runtime=runtime, tenant_id=tenant.id, agent_id=agent_id, on_added=AsyncMock()
+        runtime=runtime,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        entry=_entry("bot"),
+        on_added=AsyncMock(),
     )
     modal.content_input._value = "123BAD=value\nGOOD_KEY=val"  # pyright: ignore[reportPrivateUsage]
 
-    interaction = MagicMock()
-    interaction.user.id = 42
-    interaction.response.defer = AsyncMock()
-    interaction.followup.send = AsyncMock()
+    interaction = _interaction()
 
     await modal.on_submit(interaction)
 
@@ -384,6 +410,150 @@ async def test_paste_modal_rejects_invalid_key_and_writes_nothing(
     assert rows == [], "fail-fast on an invalid key writes nothing"
     msg = interaction.followup.send.call_args.args[0]
     assert "Secret name must match" in msg, "invalid-key toast shown"
+
+
+# --- PasteSecretModal: click-time gate on a shared agent -------------------
+
+
+@pytest.mark.asyncio
+async def test_paste_modal_refuses_write_on_reachable_agent_for_non_admin(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """put_agent_file is an upsert and its files are mounted read-write on every
+    session of the agent, so a non-admin pasting over an agent the workspace
+    currently resolves to would silently replace secrets everyone depends on."""
+    guild_id = 920401
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    agent_id = uuid.uuid4()
+
+    entry = _entry("bot")
+    runtime = _runtime(db_session_factory, deployment_default=DeploymentDefault(agent_name="bot"))
+    modal = PasteSecretModal(
+        runtime=runtime,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        entry=entry,
+        on_added=AsyncMock(),
+    )
+    modal.content_input._value = f"XERO_API_KEY={_SECRET_VALUE}"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    await modal.on_submit(interaction)
+
+    async with db_session_factory() as session:
+        rows = await list_agent_files(session, tenant_id=tenant.id, agent_id=agent_id)
+    assert rows == [], "a non-admin must write no env var onto a currently-reachable agent"
+    interaction.response.defer.assert_not_called()
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_paste_modal_refuses_write_on_system_agent_for_non_admin(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The deployment's built-in agent is shared by everyone in the install
+    whether or not anything currently scopes to it, so its env vars are closed
+    to non-admins on provenance alone."""
+    guild_id = 920402
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    agent_id = uuid.uuid4()
+
+    runtime = _runtime(db_session_factory)
+    modal = PasteSecretModal(
+        runtime=runtime,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        entry=_entry("daimon", is_system=True),
+        on_added=AsyncMock(),
+    )
+    modal.content_input._value = f"XERO_API_KEY={_SECRET_VALUE}"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    await modal.on_submit(interaction)
+
+    async with db_session_factory() as session:
+        rows = await list_agent_files(session, tenant_id=tenant.id, agent_id=agent_id)
+    assert rows == [], "a non-admin must write no env var onto the built-in agent"
+    interaction.response.defer.assert_not_called()
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_paste_modal_still_writes_on_reachable_system_agent_for_admin(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Setting the built-in default agent's variables is how an admin finishes
+    onboarding, and that agent is both a system agent and the workspace's
+    default. The gate must not close that path."""
+    guild_id = 920403
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    agent_id = uuid.uuid4()
+
+    runtime = _runtime(
+        db_session_factory, deployment_default=DeploymentDefault(agent_name="daimon")
+    )
+    modal = PasteSecretModal(
+        runtime=runtime,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        entry=_entry("daimon", is_system=True),
+        on_added=AsyncMock(),
+    )
+    modal.content_input._value = f"XERO_API_KEY={_SECRET_VALUE}"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=True, guild_id=guild_id)
+    await modal.on_submit(interaction)
+
+    async with db_session_factory() as session:
+        stored = await get_agent_file(
+            session, tenant_id=tenant.id, agent_id=agent_id, key="XERO_API_KEY"
+        )
+    assert stored is not None and stored.content == _SECRET_VALUE, (
+        "an admin must still set the built-in default agent's env vars"
+    )
+
+
+@pytest.mark.asyncio
+async def test_paste_modal_refusal_logs_no_key_names_or_values(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The module's hygiene invariant holds on the refusal path too: the gate
+    runs before the pasted content is read, so neither the key names nor the
+    values reach the log stream."""
+    guild_id = 920404
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    runtime = _runtime(db_session_factory)
+    modal = PasteSecretModal(
+        runtime=runtime,
+        tenant_id=tenant.id,
+        agent_id=uuid.uuid4(),
+        entry=_entry("daimon", is_system=True),
+        on_added=AsyncMock(),
+    )
+    modal.content_input._value = (  # pyright: ignore[reportPrivateUsage]
+        f"XERO_API_KEY={_SECRET_VALUE}\nTOGGL_TOKEN=second-value"
+    )
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        await modal.on_submit(interaction)
+    finally:
+        structlog.reset_defaults()
+
+    for captured in cap.entries:
+        rendered = repr(captured)
+        assert _SECRET_VALUE not in rendered, "a refused paste must not log a secret value"
+        assert "XERO_API_KEY" not in rendered, "a refused paste must not log a key name either"
+        assert "TOGGL_TOKEN" not in rendered, "a refused paste must not log a key name either"
 
 
 # --- ✕ remove (real DB) -----------------------------------------------------
@@ -407,16 +577,7 @@ async def test_remove_deletes_the_key_and_rerenders(
         )
 
     entry = _entry("bot")
-    runtime = DiscordRuntime(
-        settings=MagicMock(),
-        anthropic=build_stub_anthropic(),
-        sessionmaker=db_session_factory,
-        notebook_rate_limiter=RateLimiter(max_requests=999),
-        billing_config=None,
-        deployment_default=DeploymentDefault(),
-        resolver_cache=new_resolver_cache(),
-        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
-    )
+    runtime = _runtime(db_session_factory)
     view = CredentialsSubView(
         runtime=runtime,
         state=_state(entry, account_id),
@@ -426,11 +587,7 @@ async def test_remove_deletes_the_key_and_rerenders(
         secret_names=["XERO_API_KEY", "KEEP_ME"],
     )
 
-    interaction = MagicMock()
-    interaction.user.id = 42
-    interaction.response.defer = AsyncMock()
-    interaction.followup.send = AsyncMock()
-    interaction.edit_original_response = AsyncMock()
+    interaction = _interaction()
 
     # Drive the remove through the select callback (the new entry point).
     select = _remove_select(view)
@@ -445,6 +602,100 @@ async def test_remove_deletes_the_key_and_rerenders(
     # The re-render view must not leak the surviving value.
     rerender_kwargs = interaction.edit_original_response.call_args.kwargs
     assert _SECRET_VALUE not in str(rerender_kwargs), "no value in re-render call kwargs"
+
+
+@pytest.mark.asyncio
+async def test_remove_refuses_delete_on_reachable_agent_for_non_admin(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    account_id: uuid.UUID,
+) -> None:
+    """One click on the remove select destroys a credential every session of a
+    shared agent depends on, so a non-admin is refused on an agent the
+    workspace currently resolves to."""
+    guild_id = 920405
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    agent_id = uuid.uuid4()
+    async with db_session_factory() as s, s.begin():
+        await put_agent_file(
+            s, tenant_id=tenant.id, agent_id=agent_id, key="XERO_API_KEY", content=_SECRET_VALUE
+        )
+        await put_agent_file(
+            s, tenant_id=tenant.id, agent_id=agent_id, key="KEEP_ME", content="keep"
+        )
+
+    entry = _entry("bot")
+    runtime = _runtime(db_session_factory, deployment_default=DeploymentDefault(agent_name="bot"))
+    view = CredentialsSubView(
+        runtime=runtime,
+        state=_state(entry, account_id),
+        allowed_user_id=42,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        secret_names=["XERO_API_KEY", "KEEP_ME"],
+    )
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    select = _remove_select(view)
+    select._values = ["XERO_API_KEY"]  # pyright: ignore[reportPrivateUsage]  # simulate a user pick
+    assert select.callback is not None
+    await select.callback(interaction)
+
+    async with db_session_factory() as session:
+        rows = await list_agent_files(session, tenant_id=tenant.id, agent_id=agent_id)
+    assert sorted(r.key for r in rows) == ["KEEP_ME", "XERO_API_KEY"], (
+        "a refused removal must delete nothing"
+    )
+    interaction.response.defer.assert_not_called()
+    interaction.edit_original_response.assert_not_called()
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_remove_still_deletes_on_reachable_system_agent_for_admin(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    account_id: uuid.UUID,
+) -> None:
+    """The onboarding sibling of the paste-side positive: an admin must still
+    be able to clear a stale variable off the built-in default agent."""
+    guild_id = 920406
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+    agent_id = uuid.uuid4()
+    async with db_session_factory() as s, s.begin():
+        await put_agent_file(
+            s, tenant_id=tenant.id, agent_id=agent_id, key="XERO_API_KEY", content=_SECRET_VALUE
+        )
+        await put_agent_file(
+            s, tenant_id=tenant.id, agent_id=agent_id, key="KEEP_ME", content="keep"
+        )
+
+    entry = _entry("daimon", is_system=True)
+    runtime = _runtime(
+        db_session_factory, deployment_default=DeploymentDefault(agent_name="daimon")
+    )
+    view = CredentialsSubView(
+        runtime=runtime,
+        state=_state(entry, account_id),
+        allowed_user_id=42,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        secret_names=["XERO_API_KEY", "KEEP_ME"],
+    )
+
+    interaction = _interaction(is_admin=True, guild_id=guild_id)
+    select = _remove_select(view)
+    select._values = ["XERO_API_KEY"]  # pyright: ignore[reportPrivateUsage]  # simulate a user pick
+    assert select.callback is not None
+    await select.callback(interaction)
+
+    async with db_session_factory() as session:
+        rows = await list_agent_files(session, tenant_id=tenant.id, agent_id=agent_id)
+    assert [r.key for r in rows] == ["KEEP_ME"], (
+        "an admin must still remove a variable from the built-in default agent"
+    )
+    interaction.edit_original_response.assert_awaited()  # sub-view re-rendered in place
 
 
 # --- back navigation --------------------------------------------------------
@@ -560,9 +811,73 @@ async def test_editview_env_vars_button_opens_subview(
     assert _SECRET_VALUE not in all_text, "the opened view lists the key masked, never its value"
 
 
+@pytest.mark.asyncio
+async def test_subview_opens_and_lists_key_names_for_a_non_admin_on_a_shared_agent(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    account_id: uuid.UUID,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the two writes are gated. A member opening the env-vars list on the
+    shared built-in agent still sees the key names — that is what lets them ask
+    an admin for the right variable, and tell whether a missing one is why their
+    turn failed. The container carries names only, so nothing secret crosses."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="920407")
+
+    ma_agent_id = "agent_017shared"
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=ma_agent_id)
+    async with db_session_factory() as s, s.begin():
+        await put_agent_file(
+            s, tenant_id=tenant.id, agent_id=agent_id, key="XERO_API_KEY", content=_SECRET_VALUE
+        )
+
+    now = dt.datetime.now(dt.UTC)
+    real_agent = BetaManagedAgentsAgent(
+        id=ma_agent_id,
+        type="agent",
+        name="daimon",
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6"),
+        metadata={},
+        description=None,
+        created_at=now,
+        updated_at=now,
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    )
+
+    async def fake_find(*_a: Any, **_k: Any) -> BetaManagedAgentsAgent:
+        return real_agent
+
+    monkeypatch.setattr(edit_view_mod, "find_agent_by_daimon_tag", fake_find)
+    monkeypatch.setattr(edit_view_mod, "_resolve_tenant", AsyncMock(return_value=tenant.id))
+
+    runtime = _runtime(
+        db_session_factory, deployment_default=DeploymentDefault(agent_name="daimon")
+    )
+    entry = _entry("daimon", is_system=True)
+    edit_view = EditView(_state(entry, account_id), runtime=runtime, allowed_user_id=42)
+
+    interaction = _interaction(is_admin=False, guild_id=920407)
+
+    await edit_view._on_env_vars(interaction)  # pyright: ignore[reportPrivateUsage]
+
+    interaction.response.edit_message.assert_awaited_once()
+    sub_view = interaction.response.edit_message.call_args.kwargs["view"]
+    assert isinstance(sub_view, CredentialsSubView), "a non-admin still reaches the sub-view"
+    all_text = _container_all_text(sub_view)
+    assert "XERO_API_KEY" in all_text, "a member must see which variables the shared agent has"
+    assert _SECRET_VALUE not in all_text, "no value may cross into the rendered container"
+    interaction.response.send_message.assert_not_called()
+
+
 def test_editview_env_vars_button_enabled_for_system_agent(account_id: uuid.UUID) -> None:
     """Env vars are per-agent daimon state, never part of the agent spec, so
-    the button is enabled for the seeded/system agent exactly like any other."""
+    the button is enabled for the seeded/system agent exactly like any other.
+    The enabled state is deliberate — opening the list stays open to every
+    member, and the two writes inside refuse at click time."""
     settings = MagicMock()
     settings.mcp.public_url = None
     runtime = DiscordRuntime(

--- a/packages/adapters/discord/tests/agent_setup/test_delete_agent_memory.py
+++ b/packages/adapters/discord/tests/agent_setup/test_delete_agent_memory.py
@@ -12,10 +12,13 @@ import pytest
 from daimon.adapters.discord.agent_setup.write import delete_agent
 from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.scope import ChannelScopeRef
 from daimon.core.stores.agent_memory_stores import (
     get_memory_store_id,
     insert_memory_store,
 )
+from daimon.core.stores.scoped_config_read import get_scope
+from daimon.core.stores.scoped_config_write import set_fields
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import (
     FakeMemoryStoreState,
@@ -156,3 +159,83 @@ async def test_delete_agent_succeeds_when_store_archive_fails(
     assert mem_state.stores[store.id]["archived_at"] is None
     async with db_session_factory() as s:
         assert await get_memory_store_id(s, tenant_id=tenant.id, agent_id=agent_uuid) == store.id
+
+
+async def test_delete_agent_clears_channel_default_naming_the_agent(
+    db_session, db_session_factory
+) -> None:
+    """Deleting the channel's current default must not leave a row naming a dead agent.
+
+    A channel_config row pointing at an archived agent makes every turn in that
+    channel fail to resolve until an admin re-scopes by hand.
+    """
+    tenant = await make_tenant(db_session)
+    scope = ChannelScopeRef(tenant_id=tenant.id, channel_id="C_DELETED_DEFAULT")
+    await set_fields(db_session, scope=scope, tenant_id=tenant.id, agent_name="doomed")
+    await db_session.commit()
+
+    client = build_fake_anthropic(
+        combine_handlers(
+            _make_archive_agent_handler(),
+            make_fake_memory_store_handler(FakeMemoryStoreState()),
+            make_fake_ma_handler(),
+        )
+    )
+    await client.beta.agents.create(
+        name="doomed",
+        model="claude-sonnet-4-6",
+        metadata={"daimon_tenant": str(tenant.id), "daimon_name": "doomed"},
+    )
+
+    runtime = MagicMock(spec=DiscordRuntime)
+    runtime.anthropic = client
+    runtime.sessionmaker = db_session_factory
+
+    await delete_agent(runtime, tenant_id=tenant.id, name="doomed")
+
+    async with db_session_factory() as s:
+        assert await get_scope(s, scope=scope) is None, (
+            "the channel row naming the deleted agent must be gone so resolution "
+            "falls through the cascade instead of naming a dead agent"
+        )
+
+
+async def test_delete_agent_leaves_scope_rows_naming_another_agent_untouched(
+    db_session, db_session_factory
+) -> None:
+    """Only rows naming the deleted agent move; a sibling channel keeps its default."""
+    tenant = await make_tenant(db_session)
+    doomed_scope = ChannelScopeRef(tenant_id=tenant.id, channel_id="C_DOOMED")
+    survivor_scope = ChannelScopeRef(tenant_id=tenant.id, channel_id="C_SURVIVOR")
+    await set_fields(db_session, scope=doomed_scope, tenant_id=tenant.id, agent_name="doomed")
+    await set_fields(db_session, scope=survivor_scope, tenant_id=tenant.id, agent_name="keeper")
+    await db_session.commit()
+
+    client = build_fake_anthropic(
+        combine_handlers(
+            _make_archive_agent_handler(),
+            make_fake_memory_store_handler(FakeMemoryStoreState()),
+            make_fake_ma_handler(),
+        )
+    )
+    await client.beta.agents.create(
+        name="doomed",
+        model="claude-sonnet-4-6",
+        metadata={"daimon_tenant": str(tenant.id), "daimon_name": "doomed"},
+    )
+
+    runtime = MagicMock(spec=DiscordRuntime)
+    runtime.anthropic = client
+    runtime.sessionmaker = db_session_factory
+
+    await delete_agent(runtime, tenant_id=tenant.id, name="doomed")
+
+    async with db_session_factory() as s:
+        assert await get_scope(s, scope=doomed_scope) is None, (
+            "the channel row naming the deleted agent must be gone"
+        )
+        survivor = await get_scope(s, scope=survivor_scope)
+        assert survivor is not None, "a channel row naming a different agent must survive"
+        assert survivor.agent_name == "keeper", (
+            "a channel row naming a different agent must keep its agent_name"
+        )

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -555,7 +555,11 @@ def test_edit_view_non_admin_reachable_non_system_disables_spec_controls(
     account_id: uuid.UUID,
 ) -> None:
     """A non-admin editing a reachable, non-system agent gets the five
-    spec-touching controls disabled; GitHub… and Env vars stay enabled."""
+    spec-touching controls disabled; GitHub… and Env vars stay enabled.
+
+    Enabled is not unguarded: the attachment gate refuses those two on click,
+    so the caller reads why they cannot bind a repo instead of staring at a
+    greyed-out button."""
     from daimon.core.specs import SkillRef
 
     selected = _entry_with_mcps(
@@ -942,6 +946,82 @@ async def test_mcp_remove_select_refuses_write_on_system_agent_even_for_admin(
     assert len(remaining) == 1, "a system agent's mcp_servers must never be removed from the panel"
     interaction.response.send_message.assert_called_once()
     assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_edit_view_github_button_refuses_for_non_admin_on_reachable_agent(
+    account_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The GitHub… button stays clickable for everyone, but a non-admin
+    clicking it on a currently-reachable agent gets the refusal instead of the
+    modal — so no GitHub token is ever typed into a form that would be
+    rejected on submit."""
+    from daimon.core.scope import DeploymentDefault
+    from daimon.testing.factories import make_tenant
+
+    guild_id = 910103
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    selected = _entry("bot")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+    runtime.sessionmaker = db_session_factory
+    runtime.deployment_default = DeploymentDefault(agent_name="bot")
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    github_btn = _find_button(view, "GitHub…")
+    assert github_btn.disabled is False, "GitHub… must stay clickable for a non-admin"
+    assert github_btn.callback is not None
+
+    interaction = _non_admin_interaction(guild_id=guild_id)
+    interaction.response.send_modal = AsyncMock()
+    await github_btn.callback(interaction)
+
+    interaction.response.send_modal.assert_not_called()
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_edit_view_github_button_opens_modal_for_admin_on_system_agent(
+    account_id: uuid.UUID,
+) -> None:
+    """An admin may bind a repo to the deployment's built-in agent — that is
+    the first-run step — so the button opens the modal even though the target
+    is both a system agent and the workspace's default."""
+    from daimon.adapters.discord.agent_setup.modals import RepoAuthModal
+    from daimon.core.scope import DeploymentDefault
+
+    selected = RosterEntry(
+        name="daimon",
+        model="claude-sonnet-4-6",
+        spec=AgentSpec(name="daimon", model="claude-sonnet-4-6"),
+        is_system=True,
+    )
+    state = PanelState(
+        roster=[selected],
+        selected=selected,
+        account_id=account_id,
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+    runtime = MagicMock()
+    runtime.settings.mcp.public_url = None
+
+    view = EditView(state, runtime=runtime, allowed_user_id=42)
+    github_btn = _find_button(view, "GitHub…")
+    assert github_btn.callback is not None
+
+    interaction = _admin_interaction()
+    interaction.response.send_modal = AsyncMock()
+    await github_btn.callback(interaction)
+
+    interaction.response.send_modal.assert_called_once()
+    modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(modal, RepoAuthModal), "an admin must still reach the repo-bind modal"
+    interaction.response.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -1025,12 +1025,13 @@ async def test_edit_view_github_button_opens_modal_for_admin_on_system_agent(
 
 
 @pytest.mark.asyncio
-async def test_env_vars_paste_modal_still_writes_on_reachable_agent_for_non_admin(
+async def test_env_vars_paste_modal_refuses_on_reachable_agent_for_non_admin(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Env vars are a per-agent attachment, never part of the agent spec — the
-    new click-time gate must not reach this path even for a reachable agent
-    edited by a non-admin."""
+    """`put_agent_file` is an upsert and the files are mounted read-write on
+    every session of the agent, so a non-admin pasting over the workspace's
+    current default agent would overwrite secrets everyone in the install
+    depends on. The Env vars button still opens for them; the write does not."""
     from daimon.adapters.discord.agent_setup.credentials import PasteSecretModal
     from daimon.core.ma_identity import derive_agent_uuid
     from daimon.core.ma_resolver import new_resolver_cache
@@ -1039,8 +1040,9 @@ async def test_env_vars_paste_modal_still_writes_on_reachable_agent_for_non_admi
     from daimon.core.stores.agent_files import get_agent_file
     from daimon.testing.factories import make_tenant
 
+    guild_id = 910301
     async with db_session_factory() as session, session.begin():
-        tenant = await make_tenant(session, platform="discord", workspace_id="env-vars-still-open")
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
     agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id="agent_env_test")
 
     settings = MagicMock()
@@ -1051,8 +1053,7 @@ async def test_env_vars_paste_modal_still_writes_on_reachable_agent_for_non_admi
         sessionmaker=db_session_factory,
         notebook_rate_limiter=RateLimiter(max_requests=999),
         billing_config=None,
-        # A non-admin caller editing the workspace's current default agent —
-        # env vars stay writable regardless.
+        # The target agent is the workspace's current default, so it is shared.
         deployment_default=DeploymentDefault(agent_name="daimon"),
         resolver_cache=new_resolver_cache(),
         turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
@@ -1062,13 +1063,15 @@ async def test_env_vars_paste_modal_still_writes_on_reachable_agent_for_non_admi
         return None
 
     modal = PasteSecretModal(
-        runtime=runtime, tenant_id=tenant.id, agent_id=agent_id, on_added=_noop
+        runtime=runtime,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        entry=_entry("daimon"),
+        on_added=_noop,
     )
     modal.content_input._value = "XERO_API_KEY=abc123"  # pyright: ignore[reportPrivateUsage]
 
-    interaction = MagicMock()
-    interaction.response.defer = AsyncMock()
-    interaction.followup.send = AsyncMock()
+    interaction = _non_admin_interaction(guild_id=guild_id)
 
     await modal.on_submit(interaction)
 
@@ -1076,4 +1079,7 @@ async def test_env_vars_paste_modal_still_writes_on_reachable_agent_for_non_admi
         row = await get_agent_file(
             session, tenant_id=tenant.id, agent_id=agent_id, key="XERO_API_KEY"
         )
-    assert row is not None, "env var write must succeed even on the workspace's default agent"
+    assert row is None, "a non-admin must not write env vars onto the workspace's default agent"
+    interaction.response.defer.assert_not_called()
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True

--- a/packages/adapters/discord/tests/agent_setup/test_lifecycle.py
+++ b/packages/adapters/discord/tests/agent_setup/test_lifecycle.py
@@ -461,8 +461,12 @@ async def test_delete_archives_ma_agent_and_jumps_selection(
     view = AgentSetupView(state, runtime=runtime, allowed_user_id=42)
 
     delete_btn = _find_button(view, "Delete")
+    # Live guild admin: the callback re-checks admin status at click time before
+    # deleting anything, and this test's subject is the delete behind that gate.
     interaction = MagicMock()
+    interaction.user = MagicMock(spec=discord.Member)
     interaction.user.id = 42
+    interaction.user.guild_permissions.administrator = True
     interaction.response.defer = AsyncMock()
     interaction.response.edit_message = AsyncMock()
     interaction.edit_original_response = AsyncMock()
@@ -526,8 +530,12 @@ async def test_delete_last_agent_disables_section_buttons(
     view = AgentSetupView(state, runtime=runtime, allowed_user_id=42)
 
     delete_btn = _find_button(view, "Delete")
+    # Live guild admin: the callback re-checks admin status at click time before
+    # deleting anything, and this test's subject is the delete behind that gate.
     interaction = MagicMock()
+    interaction.user = MagicMock(spec=discord.Member)
     interaction.user.id = 42
+    interaction.user.guild_permissions.administrator = True
     interaction.response.defer = AsyncMock()
     interaction.response.edit_message = AsyncMock()
     interaction.edit_original_response = AsyncMock()

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -1987,14 +1987,17 @@ def test_repo_auth_modal_field_labels_fit_discord_limits(
     )
 
 
-# ----- 13. Click-time authz gate on the spec-mutating write callbacks -------
+# ----- 13. Click-time authz gate on the mutating write callbacks ------------
 #
 # AgentSectionModal and AddSkillModal each carry a write to the agent spec
 # (system/model, skills). A non-admin caller must be refused at submit time
 # when the target is currently reachable or is a system agent — the guard is
 # re-derived from live state, never from any render-time snapshot.
-# RepoAuthModal is deliberately NOT gated (a per-agent attachment, not part
-# of the spec).
+# RepoAuthModal is guarded too, but through the shared-state guard rather than
+# the spec guard: it never writes the agent spec, so an admin may still bind a
+# repo to the built-in agent — the first-run onboarding step — while a
+# non-admin is refused whenever the target is a system agent or is currently
+# reachable.
 
 
 @pytest.mark.asyncio
@@ -2130,12 +2133,12 @@ async def test_add_skill_modal_refuses_write_on_system_agent_even_for_admin(
 
 
 @pytest.mark.asyncio
-async def test_repo_auth_modal_still_writes_binding_on_reachable_system_agent_for_non_admin(
+async def test_repo_auth_modal_refuses_binding_on_reachable_system_agent_for_non_admin(
     monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
 ) -> None:
-    """The repo binding is a per-agent attachment, never part of the agent
-    spec — the new click-time gate must not reach this path even
-    for a reachable system agent edited by a non-admin."""
+    """A repo binding is shared state: everyone in the install talks to the
+    deployment's built-in agent, so a non-admin re-pointing it at a repo of
+    their choosing is refused at submit time."""
     set_binding_called = False
 
     async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
@@ -2177,6 +2180,219 @@ async def test_repo_auth_modal_still_writes_binding_on_reachable_system_agent_fo
     interaction = _interaction(is_admin=False)
     await modal.on_submit(interaction)
 
-    assert set_binding_called, (
-        "repo binding must still write on a reachable system agent for a non-admin caller"
+    assert set_binding_called is False, (
+        "a non-admin must not bind a repo to the deployment's built-in agent"
+    )
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_repo_auth_modal_still_writes_binding_on_reachable_system_agent_for_admin(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """Pointing the built-in default agent at a repo is the first thing an
+    admin does on a fresh install, and the built-in agent is both a system
+    agent and the workspace's default. That bind must keep working."""
+    set_binding_called = False
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        return True
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_binding_called
+        set_binding_called = True
+        return MagicMock()
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("daimon", is_system=True)
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    sm = MagicMock()
+    sm.begin.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+    sm.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(),
+        tenant_id=tenant_id,
+        sessionmaker=sm,
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/public-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=True)
+    await modal.on_submit(interaction)
+
+    assert set_binding_called is True, (
+        "an admin binding a repo to the built-in default agent must still write the binding"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repo_auth_modal_refuses_binding_on_reachable_non_system_agent_for_non_admin(
+    monkeypatch: pytest.MonkeyPatch,
+    account_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A user-created agent that something currently resolves to is shared the
+    moment it is scoped, so its repo binding closes to non-admins even though
+    the agent carries no system provenance."""
+    set_binding_called = False
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        return True
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_binding_called
+        set_binding_called = True
+        return MagicMock()
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(uuid.uuid4())
+
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    guild_id = 910201
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    selected = _entry("bot")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(),
+        tenant_id=uuid.uuid4(),
+        sessionmaker=db_session_factory,
+        deployment_default=DeploymentDefault(agent_name="bot"),
+    )
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/public-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    await modal.on_submit(interaction)
+
+    assert set_binding_called is False, (
+        "a non-admin must not re-point a currently-reachable agent's repo"
+    )
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_repo_auth_modal_writes_binding_on_unreachable_agent_for_non_admin(
+    monkeypatch: pytest.MonkeyPatch,
+    account_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An agent nobody has scoped is the member's own scratchpad — the gate
+    closes shared agents, not every agent a member owns."""
+    set_binding_called = False
+
+    async def fake_is_public(http_client: Any, *, owner_repo: str) -> bool:
+        return True
+
+    async def fake_set_binding(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_binding_called
+        set_binding_called = True
+        return MagicMock()
+
+    async def fake_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:
+        return MagicMock()
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(uuid.uuid4())
+
+    monkeypatch.setattr(modals_mod, "is_public_repo", fake_is_public)
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", fake_set_binding)
+    monkeypatch.setattr(modals_mod, "call_reconcile_for_panel", fake_reconcile)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    guild_id = 910202
+    async with db_session_factory() as session, session.begin():
+        await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+
+    selected = _entry("scratchpad")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(),
+        tenant_id=uuid.uuid4(),
+        sessionmaker=db_session_factory,
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/public-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False, guild_id=guild_id)
+    await modal.on_submit(interaction)
+
+    assert set_binding_called is True, (
+        "a non-admin must still bind a repo to an agent nothing currently resolves to"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repo_auth_modal_refusal_logs_no_masked_token(
+    monkeypatch: pytest.MonkeyPatch, tenant_id: uuid.UUID, account_id: uuid.UUID
+) -> None:
+    """A refused submit must not leave the submitted token in the log stream,
+    even masked — the gate runs before the submit log line."""
+
+    async def unexpected_set_binding(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("no binding may be written on a refused submit")
+
+    async def fake_find(*args: Any, **kwargs: Any) -> Any:
+        return _fake_ma_agent_for_bind(tenant_id)
+
+    monkeypatch.setattr(modals_mod, "set_agent_repo_binding", unexpected_set_binding)
+    monkeypatch.setattr(modals_mod, "find_agent_by_daimon_tag", fake_find)
+
+    selected = _entry("daimon", is_system=True)
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id)
+    runtime = _runtime_for_view(
+        anthropic=build_stub_anthropic(),
+        tenant_id=tenant_id,
+        deployment_default=DeploymentDefault(agent_name="daimon"),
+    )
+
+    modal = RepoAuthModal(state, runtime=runtime, allowed_user_id=42)
+    modal.url_in._value = "https://github.com/me/private-repo"  # pyright: ignore[reportPrivateUsage]
+    modal.branch_in._value = "main"  # pyright: ignore[reportPrivateUsage]
+    modal.pat_in._value = "ghp_refusedtoken1234"  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction(is_admin=False)
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        await modal.on_submit(interaction)
+    finally:
+        structlog.reset_defaults()
+
+    assert all("pat_masked" not in entry for entry in cap.entries), (
+        "a refused submit must emit no log entry carrying the token, masked or not"
+    )
+    assert all("ghp_refusedtoken1234" not in str(entry) for entry in cap.entries), (
+        "the plaintext token must never reach the log stream"
     )

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -44,6 +44,46 @@ def _make_runtime_with_settings(*, fallback_pat: object = None) -> DiscordRuntim
     return runtime
 
 
+def _admin_interaction(user_id: int = 42) -> MagicMock:
+    """Interaction whose caller is a live guild admin (administrator permission).
+
+    ``is_guild_admin`` short-circuits on the permission, so no guild owner_id or
+    DB read is involved.
+    """
+    interaction = MagicMock()
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = user_id
+    interaction.user.guild_permissions.administrator = True
+    interaction.guild.owner_id = user_id + 1
+    interaction.guild_id = 2001
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    return interaction
+
+
+def _non_admin_interaction(user_id: int = 42) -> MagicMock:
+    """Interaction whose caller is a live non-admin: no administrator, no
+    manage_guild, and not the guild owner — the demoted-admin shape."""
+    interaction = MagicMock()
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = user_id
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = user_id + 1
+    interaction.guild_id = 2001
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    return interaction
+
+
 def _container_text(container: discord.ui.Container[discord.ui.LayoutView]) -> str:
     """Collect all TextDisplay content from a V2 Container (depth-first)."""
     parts: list[str] = []
@@ -1135,9 +1175,9 @@ async def test_delete_btn_routes_failure_through_render_error(
 
     monkeypatch.setattr(panel_mod, "_resolve_tenant", _boom)
 
-    interaction = MagicMock()
-    interaction.response.defer = AsyncMock()
-    interaction.followup.send = AsyncMock()
+    # Live admin: the callback's click-time admin re-check runs before anything
+    # else, and this test's subject is the failure path behind it.
+    interaction = _admin_interaction()
 
     await view.delete_btn.callback(interaction)
 
@@ -1407,11 +1447,9 @@ async def test_delete_failure_captures_to_sentry_with_tenant_context_and_swallow
 
     monkeypatch.setattr(panel_mod, "capture_exception_with_scope", fake_capture)
 
-    interaction = MagicMock()
-    interaction.user.id = 42
-    interaction.guild_id = 2001
-    interaction.response.defer = AsyncMock()
-    interaction.followup.send = AsyncMock()
+    # Live admin: the callback's click-time admin re-check runs before the
+    # delete, and this test's subject is the capture behind it.
+    interaction = _admin_interaction()
 
     # Must not raise — swallow preserved.
     await view.delete_btn.callback(interaction)
@@ -1500,3 +1538,193 @@ async def test_superseded_panel_view_does_not_rewrite_the_message(
 
     await view_b.on_timeout()
     mock_interaction.edit_original_response.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Admin row: click-time admin re-check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_btn_refuses_a_demoted_admin_without_deleting(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A caller who was an admin at render time but is not one now deletes nothing."""
+    import daimon.adapters.discord.agent_setup.panel as panel_mod
+
+    async def _unexpected_delete(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("delete_agent must not be reached for a non-admin caller")
+
+    monkeypatch.setattr(panel_mod, "delete_agent", _unexpected_delete)
+
+    selected = _entry("alice")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id, is_admin=True)
+    view = AgentSetupView(state, runtime=_make_runtime_with_settings(), allowed_user_id=42)
+    interaction = _non_admin_interaction()
+
+    await view.delete_btn.callback(interaction)
+
+    interaction.response.send_message.assert_called_once()
+    message = interaction.response.send_message.call_args.args[0]
+    assert "Manage Server" in message, "the refusal must name the permission the caller lacks"
+    # The refusal must own the interaction's first response — no defer precedes it.
+    interaction.response.defer.assert_not_called()
+    interaction.followup.send.assert_not_called()
+    interaction.edit_original_response.assert_not_called()
+    assert state.roster == [selected], "a refused delete must leave the roster untouched"
+
+
+@pytest.mark.asyncio
+async def test_delete_btn_refusal_precedes_the_nothing_to_delete_branch(
+    account_id: uuid.UUID,
+) -> None:
+    """With nothing selected AND a non-admin caller, the admin refusal is what is sent.
+
+    Pins the ordering: a non-admin must not learn whether an agent is selected.
+    """
+    state = PanelState(
+        roster=[_entry("alice")], selected=None, account_id=account_id, is_admin=True
+    )
+    view = AgentSetupView(state, runtime=_make_runtime_with_settings(), allowed_user_id=42)
+    interaction = _non_admin_interaction()
+
+    await view.delete_btn.callback(interaction)
+
+    interaction.response.send_message.assert_called_once()
+    message = interaction.response.send_message.call_args.args[0]
+    assert "Manage Server" in message, "the admin gate must fire before the selection check"
+    assert "Nothing to delete." not in message, (
+        "a non-admin must not learn whether an agent is selected"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_btn_still_deletes_for_a_live_admin(
+    account_id: uuid.UUID, tenant_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate is not a blanket ban: a live admin's delete still runs end to end."""
+    import daimon.adapters.discord.agent_setup.panel as panel_mod
+    from daimon.core.stores.domain import AgentRepoBindingRow
+
+    deleted_names: list[str] = []
+
+    async def _spy_delete(*_args: Any, **kwargs: Any) -> None:
+        deleted_names.append(str(kwargs["name"]))
+
+    async def _fake_secret_count(*_args: Any, **_kwargs: Any) -> int:
+        return 0
+
+    async def _fake_github_login(*_args: Any, **_kwargs: Any) -> str | None:
+        return None
+
+    async def _fake_repo_binding(*_args: Any, **_kwargs: Any) -> AgentRepoBindingRow | None:
+        return None
+
+    monkeypatch.setattr(panel_mod, "delete_agent", _spy_delete)
+    monkeypatch.setattr(panel_mod, "load_secret_count", _fake_secret_count)
+    monkeypatch.setattr(panel_mod, "load_selected_github_login", _fake_github_login)
+    monkeypatch.setattr(panel_mod, "load_repo_binding", _fake_repo_binding)
+
+    selected = _entry("alice")
+    state = PanelState(
+        roster=[selected, _entry("bob")],
+        selected=selected,
+        account_id=account_id,
+        is_admin=True,
+    )
+    view = AgentSetupView(state, runtime=_make_runtime_with_settings(), allowed_user_id=42)
+    interaction = _admin_interaction()
+
+    await view.delete_btn.callback(interaction)
+
+    assert deleted_names == ["alice"], "a live admin's delete must still reach delete_agent"
+    interaction.response.defer.assert_called_once()
+    interaction.followup.send.assert_not_called()
+    interaction.edit_original_response.assert_called_once()
+    assert "alice" not in {e.name for e in state.roster}, (
+        "the deleted agent must be dropped from the roster"
+    )
+    assert tenant_id is not None, "the autouse tenant stub supplies the id threaded into the delete"
+
+
+@pytest.mark.asyncio
+async def test_connect_via_mcp_refuses_a_demoted_admin_without_minting_a_bearer(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A demoted admin clicking Connect via MCP is issued no bearer token."""
+    import daimon.adapters.discord.agent_setup.mcp_access as mcp_access_mod
+
+    async def _unexpected_connect(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("send_connect_via_mcp must not be reached for a non-admin caller")
+
+    monkeypatch.setattr(mcp_access_mod, "send_connect_via_mcp", _unexpected_connect)
+
+    selected = _entry("alice")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id, is_admin=True)
+    view = AgentSetupView(state, runtime=_make_runtime_with_settings(), allowed_user_id=42)
+    interaction = _non_admin_interaction()
+
+    await view.connect_mcp_btn.callback(interaction)
+
+    interaction.response.send_message.assert_called_once()
+    message = interaction.response.send_message.call_args.args[0]
+    assert "Manage Server" in message, "the refusal must name the permission the caller lacks"
+    assert "Bearer" not in message, "a refused caller must receive no token material"
+    interaction.response.defer.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_connect_via_mcp_still_works_for_a_live_admin(
+    account_id: uuid.UUID, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live admin still reaches the bearer-minting handler unchanged."""
+    import daimon.adapters.discord.agent_setup.mcp_access as mcp_access_mod
+
+    connect_calls: list[dict[str, Any]] = []
+
+    async def _spy_connect(*_args: Any, **kwargs: Any) -> None:
+        connect_calls.append(kwargs)
+
+    monkeypatch.setattr(mcp_access_mod, "send_connect_via_mcp", _spy_connect)
+
+    selected = _entry("alice")
+    state = PanelState(roster=[selected], selected=selected, account_id=account_id, is_admin=True)
+    view = AgentSetupView(state, runtime=_make_runtime_with_settings(), allowed_user_id=42)
+    interaction = _admin_interaction()
+
+    await view.connect_mcp_btn.callback(interaction)
+
+    assert len(connect_calls) == 1, "a live admin must still reach send_connect_via_mcp"
+    assert connect_calls[0]["state"] is state, "the handler must receive the panel's own state"
+    interaction.response.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_panel_member_row_is_still_usable_by_a_non_admin(account_id: uuid.UUID) -> None:
+    """The admin re-check stays in the two admin-row callbacks, never in interaction_check.
+
+    A view-level admin gate would lock ordinary members out of New / Fork / Edit,
+    which the panel deliberately offers to everyone. This test fails if the check
+    is ever moved up into the view.
+    """
+    import daimon.adapters.discord.agent_setup.panel as panel_mod
+
+    state = PanelState(roster=[_entry("alice")], selected=None, account_id=account_id)
+    view = AgentSetupView(state, runtime=_make_runtime_with_settings(), allowed_user_id=42)
+    interaction = _non_admin_interaction(user_id=42)
+
+    passed = await view.interaction_check(interaction)
+    assert passed is True, (
+        "the view-level check is invoker-only; an admin gate there would lock members out"
+    )
+
+    new_btn = _find_button(view, "New")
+    await new_btn.callback(interaction)
+
+    interaction.response.send_modal.assert_called_once()
+    modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(modal, panel_mod.NewAgentModal), (
+        "a non-admin must still reach the New agent modal"
+    )
+    interaction.response.send_message.assert_not_called()

--- a/packages/adapters/discord/tests/agent_setup/test_write.py
+++ b/packages/adapters/discord/tests/agent_setup/test_write.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Any
 from unittest.mock import MagicMock
 
+import discord
 import httpx
 import pytest
 import structlog
@@ -1342,7 +1343,12 @@ async def test_apply_repo_modal_persists_binding(
     modal.pat_in._value = ""  # pyright: ignore[reportPrivateUsage]  # no inline PAT — OAuth path
 
     interaction = MagicMock()
+    # A live guild admin, so the bind path's attachment gate short-circuits
+    # without a DB read — this test is about where the binding persists, not
+    # about who may write it.
+    interaction.user = MagicMock(spec=discord.Member)
     interaction.user.id = 42
+    interaction.user.guild_permissions.administrator = True
     interaction.response.defer = AsyncMock()
     interaction.edit_original_response = AsyncMock()
     interaction.followup.send = AsyncMock()

--- a/packages/adapters/discord/tests/billing_panel/test_panel.py
+++ b/packages/adapters/discord/tests/billing_panel/test_panel.py
@@ -81,6 +81,65 @@ def _find_select(
     return None
 
 
+def _joined_view_text(view: discord.ui.LayoutView) -> str:
+    """Collect all TextDisplay content anywhere in a LayoutView, joined with newlines."""
+    return "\n".join(
+        child.content for child in view.walk_children() if isinstance(child, discord.ui.TextDisplay)
+    )
+
+
+def _admin_interaction(*, guild_id: int, user_id: int = 42) -> MagicMock:
+    """A click from a live guild admin.
+
+    The caller has to be a spec'd `discord.Member` with a real permission flag:
+    the click-time gate reads the live interaction, so a bare MagicMock user is
+    not a Member and would be refused. `is_done()` is pinned False so any
+    refusal lands on `response.send_message`, not `followup.send`.
+    """
+    guild = MagicMock(spec=discord.Guild)
+    guild.owner_id = user_id + 1
+
+    user = MagicMock(spec=discord.Member)
+    user.id = user_id
+    user.guild_permissions.administrator = True
+    user.guild_permissions.manage_guild = True
+
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.guild = guild
+    interaction.user = user
+    interaction.response.is_done.return_value = False
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _non_admin_interaction(*, guild_id: int, user_id: int = 42) -> MagicMock:
+    """A click from a member who is not (or is no longer) a guild admin.
+
+    All three inputs the admin check reads are set: `administrator`,
+    `manage_guild`, and a guild owner that is somebody else. Leaving any of them
+    a bare mock attribute would make the caller a truthy admin and the refusal
+    test inert.
+    """
+    guild = MagicMock(spec=discord.Guild)
+    guild.owner_id = user_id + 1
+
+    user = MagicMock(spec=discord.Member)
+    user.id = user_id
+    user.guild_permissions.administrator = False
+    user.guild_permissions.manage_guild = False
+
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.guild = guild
+    interaction.user = user
+    interaction.response.is_done.return_value = False
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
 SINCE = datetime(2026, 5, 1, tzinfo=UTC)
 NOW = datetime(2026, 5, 14, 12, 0, tzinfo=UTC)
 
@@ -264,9 +323,7 @@ async def test_topup_select_callback_posts_to_mcp_checkout_and_sends_ephemeral_u
             break
     assert topup_select is not None, "admin view must contain a _TopUpSelect"
 
-    interaction = MagicMock()
-    interaction.guild_id = int(guild_id)
-    interaction.response.send_message = AsyncMock()
+    interaction = _admin_interaction(guild_id=int(guild_id))
     # Simulate selecting "$10"
     topup_select._values = ["10"]  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -350,9 +407,7 @@ async def test_topup_checkout_token_carries_no_admin_or_internal_claim(
         since=SINCE,
     )
     topup_select = next(item for item in view.walk_children() if isinstance(item, _TopUpSelect))
-    interaction = MagicMock()
-    interaction.guild_id = 888000000000000001
-    interaction.response.send_message = AsyncMock()
+    interaction = _admin_interaction(guild_id=888000000000000001)
     topup_select._values = ["10"]  # pyright: ignore[reportAttributeAccessIssue]
 
     with _mock.patch(
@@ -373,6 +428,215 @@ async def test_topup_checkout_token_carries_no_admin_or_internal_claim(
     assert "internal" not in claims, (
         "billing checkout bearer must not carry the internal admin discriminator (CR-01)"
     )
+
+
+@pytest.mark.asyncio
+async def test_topup_select_renders_an_error_when_the_checkout_call_returns_a_non_2xx_status(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A failing checkout POST must reach the panel's error renderer.
+
+    `_create_checkout` calls `raise_for_status()`. Before the except tuple was
+    widened, the resulting `httpx.HTTPStatusError` escaped the callback into
+    discord.py's dispatcher, which shows the admin "This interaction failed" and
+    no request id — the failure operators most need to be able to trace.
+    """
+    import httpx
+    from daimon.adapters.discord.billing_panel.panel import _TopUpSelect
+    from daimon.core.config import McpSettings
+    from pydantic import HttpUrl, SecretStr
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "unknown account"}, request=request)
+
+    mock_transport = httpx.MockTransport(_handle)
+    import unittest.mock as _mock
+
+    mock_settings = MagicMock()
+    mock_settings.mcp = McpSettings(
+        public_url=HttpUrl("http://mcp-internal:8000/mcp"),
+        jwt_secret=SecretStr("test-secret-for-button-callback-32b"),
+    )
+    runtime = MagicMock(spec=DiscordRuntime)
+    runtime.settings = mock_settings
+    runtime.sessionmaker = db_session_factory
+
+    view = BillingPanelView(
+        _make_state(is_admin=True),
+        runtime=runtime,
+        allowed_user_id=42,
+        is_admin=True,
+        account_id=_TEST_ACCOUNT_ID,
+        now=NOW,
+        since=SINCE,
+    )
+    topup_select = next(item for item in view.walk_children() if isinstance(item, _TopUpSelect))
+    interaction = _admin_interaction(guild_id=888000000000000001)
+    topup_select._values = ["10"]  # pyright: ignore[reportAttributeAccessIssue]
+
+    with _mock.patch(
+        "daimon.adapters.discord.billing_panel.panel.httpx.AsyncClient",
+        return_value=httpx.AsyncClient(transport=mock_transport),
+    ):
+        await topup_select.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    call_args = interaction.response.send_message.call_args
+    assert call_args.kwargs.get("ephemeral") is True, "the failure notice must be ephemeral"
+    sent_text = call_args.args[0] if call_args.args else ""
+    assert "rid: " in sent_text, (
+        "a failed checkout must render with a request id the operator can trace in logs"
+    )
+    assert "checkout.stripe.com" not in sent_text, "no checkout URL may be sent on a failure"
+    assert db_session is not None
+
+
+@pytest.mark.asyncio
+async def test_topup_select_refuses_a_demoted_admin_without_creating_a_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A member who was an admin when the panel rendered must mint no checkout link.
+
+    The panel is self-renewing (every interaction rebuilds it with a fresh
+    timeout), so the render-time `is_admin` snapshot is indefinitely stale.
+    `_create_checkout` is replaced with a raiser: a gate that sends an ephemeral
+    and then falls through would still fail this test.
+    """
+    from daimon.adapters.discord.billing_panel import panel as panel_module
+    from daimon.adapters.discord.billing_panel.panel import _TopUpSelect
+
+    async def _explode(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("a non-admin click must never reach _create_checkout")
+
+    monkeypatch.setattr(panel_module, "_create_checkout", _explode)
+
+    view = BillingPanelView(
+        _make_state(is_admin=True),
+        runtime=_make_runtime(),
+        allowed_user_id=42,
+        is_admin=True,
+        account_id=_TEST_ACCOUNT_ID,
+        now=NOW,
+        since=SINCE,
+    )
+    topup_select = next(item for item in view.walk_children() if isinstance(item, _TopUpSelect))
+    interaction = _non_admin_interaction(guild_id=888000000000000001)
+    topup_select._values = ["10"]  # pyright: ignore[reportAttributeAccessIssue]
+
+    await topup_select.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    sent_text = interaction.response.send_message.call_args.args[0]
+    assert "Manage Server" in sent_text, (
+        f"the refusal must tell the member what permission is missing; got: {sent_text!r}"
+    )
+    assert "checkout.stripe.com" not in sent_text, "no checkout URL may be handed to a non-admin"
+    interaction.followup.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_member_lookup_select_refuses_a_demoted_admin_without_reading_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-member spend is exactly what load_billing_snapshot's member branch withholds.
+
+    Both usage reads are replaced with raisers, and the runtime's sessionmaker
+    raises too, so the gate must refuse before the panel opens a session at all.
+    """
+    from daimon.adapters.discord.billing_panel import panel as panel_module
+    from daimon.adapters.discord.billing_panel.panel import _MemberLookupSelect
+
+    async def _explode_cost(*_args: object, **_kwargs: object) -> float:
+        raise AssertionError("a non-admin click must never read another member's spend")
+
+    async def _explode_turns(*_args: object, **_kwargs: object) -> int:
+        raise AssertionError("a non-admin click must never read another member's turn count")
+
+    monkeypatch.setattr(panel_module, "cost_for_user_in_tenant_since", _explode_cost)
+    monkeypatch.setattr(panel_module, "turn_count_for_user_in_tenant_since", _explode_turns)
+
+    runtime = MagicMock(spec=DiscordRuntime)
+    runtime.sessionmaker = MagicMock(
+        side_effect=AssertionError("a refused lookup must not open a session")
+    )
+
+    view = BillingPanelView(
+        _make_state(is_admin=True),
+        runtime=runtime,
+        allowed_user_id=42,
+        is_admin=True,
+        account_id=_TEST_ACCOUNT_ID,
+        now=NOW,
+        since=SINCE,
+    )
+    lookup_select = next(
+        item for item in view.walk_children() if isinstance(item, _MemberLookupSelect)
+    )
+    target = MagicMock(spec=discord.Member)
+    target.id = 100000000000000007
+    target.display_name = "bob"
+    lookup_select._values = [target]  # pyright: ignore[reportAttributeAccessIssue]
+
+    interaction = _non_admin_interaction(guild_id=888000000000000001)
+
+    await lookup_select.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    call_args = interaction.response.send_message.call_args
+    sent_text = call_args.args[0]
+    assert "Manage Server" in sent_text, (
+        f"the refusal must tell the member what permission is missing; got: {sent_text!r}"
+    )
+    assert "view" not in call_args.kwargs, "no spend card may be rendered for a non-admin"
+    interaction.followup.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_member_lookup_select_still_renders_spend_for_a_live_admin(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The gate must not cost a live admin the lookup the panel exists to offer."""
+    from daimon.adapters.discord.billing_panel.panel import _MemberLookupSelect
+
+    runtime = MagicMock(spec=DiscordRuntime)
+    runtime.sessionmaker = db_session_factory
+
+    view = BillingPanelView(
+        _make_state(is_admin=True),
+        runtime=runtime,
+        allowed_user_id=42,
+        is_admin=True,
+        account_id=_TEST_ACCOUNT_ID,
+        now=NOW,
+        since=SINCE,
+    )
+    lookup_select = next(
+        item for item in view.walk_children() if isinstance(item, _MemberLookupSelect)
+    )
+    target = MagicMock(spec=discord.Member)
+    target.id = 100000000000000007
+    target.display_name = "bob"
+    lookup_select._values = [target]  # pyright: ignore[reportAttributeAccessIssue]
+
+    interaction = _admin_interaction(guild_id=888000000000000001)
+
+    await lookup_select.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    call_args = interaction.response.send_message.call_args
+    assert call_args.kwargs.get("ephemeral") is True, "the spend card must stay ephemeral"
+    rendered = call_args.kwargs.get("view")
+    assert isinstance(rendered, discord.ui.LayoutView), (
+        "a live admin's lookup must still render the member-spend card"
+    )
+    text = _joined_view_text(rendered)
+    assert "bob" in text, "the card must name the looked-up member"
+    assert "no usage this period" in text, (
+        "a member with no seeded usage must render the zero-spend copy, not a refusal"
+    )
+    assert db_session is not None
 
 
 # ---- V2 container builder tests (B8 design) ----

--- a/packages/adapters/discord/tests/commands/test_billing.py
+++ b/packages/adapters/discord/tests/commands/test_billing.py
@@ -1,0 +1,136 @@
+"""Tests for `/billing`'s principal persistence.
+
+The command mints a platform principal (and the account row behind it) for a
+first-time caller, then hands `principal.account_id` to `BillingPanelView`. The
+panel later mints a checkout JWT naming that account. If the handler's session
+never commits, the account rolls back while its uuid lives on in the view — the
+JWT then authenticates against a row that does not exist and the checkout route
+401s. Both tests read back through a FRESH session so they see only what
+survived the handler's transaction.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+from daimon.adapters.discord.billing_panel.panel import BillingPanelView
+from daimon.adapters.discord.commands.billing import BillingCog
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.accounts import account_exists
+from daimon.core.stores.identity import find_platform_principal
+from daimon.testing.factories import make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+def _make_runtime(sessionmaker: async_sessionmaker[AsyncSession]) -> DiscordRuntime:
+    settings = MagicMock()
+    settings.mcp.public_url = None
+    return DiscordRuntime(
+        settings=settings,
+        anthropic=MagicMock(),  # pyright: ignore[reportArgumentType]  # /billing makes no MA call
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # command tests never run a turn
+    )
+
+
+def _make_interaction(runtime: DiscordRuntime, *, guild_id: int, user_id: int) -> MagicMock:
+    """A registered-guild interaction from a plain (non-admin) member.
+
+    The caller is a spec'd `discord.Member` with both permission flags off and a
+    differing guild owner, so `is_guild_admin` resolves False and the handler
+    takes `load_billing_snapshot`'s member branch. Principal creation is on that
+    branch too — it does not depend on admin.
+    """
+    guild = MagicMock(spec=discord.Guild)
+    guild.owner_id = user_id + 1
+
+    user = MagicMock(spec=discord.Member)
+    user.id = user_id
+    user.guild_permissions.administrator = False
+    user.guild_permissions.manage_guild = False
+
+    interaction = MagicMock()
+    interaction.client.runtime = runtime
+    interaction.guild_id = guild_id
+    interaction.guild = guild
+    interaction.user = user
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+async def test_billing_command_persists_the_platform_principal_for_a_first_time_user(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 710000001
+    user_id = 100000000000000042
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(guild_id))
+    async with db_session_factory() as setup_session:
+        await make_tenant(setup_session, platform="discord", workspace_id=str(guild_id))
+        await setup_session.commit()
+
+    runtime = _make_runtime(db_session_factory)
+    interaction = _make_interaction(runtime, guild_id=guild_id, user_id=user_id)
+    cog = BillingCog(MagicMock())
+
+    await cog.billing.callback(cog, interaction)  # pyright: ignore[reportArgumentType]
+
+    async with db_session_factory() as fresh_session:
+        principal = await find_platform_principal(
+            fresh_session,
+            tenant_id=tenant_id,
+            platform="discord",
+            external_id=str(user_id),
+        )
+        assert principal is not None, (
+            "/billing must leave the platform principal it created behind — "
+            "an uncommitted session rolls the row back while the panel keeps its uuid"
+        )
+        assert await account_exists(fresh_session, account_id=principal.account_id), (
+            "the account the top-up JWT names must exist after the handler returns"
+        )
+
+
+async def test_billing_command_panel_account_id_matches_the_persisted_account(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    guild_id = 710000002
+    user_id = 100000000000000043
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(guild_id))
+    async with db_session_factory() as setup_session:
+        await make_tenant(setup_session, platform="discord", workspace_id=str(guild_id))
+        await setup_session.commit()
+
+    runtime = _make_runtime(db_session_factory)
+    interaction = _make_interaction(runtime, guild_id=guild_id, user_id=user_id)
+    cog = BillingCog(MagicMock())
+
+    await cog.billing.callback(cog, interaction)  # pyright: ignore[reportArgumentType]
+
+    interaction.followup.send.assert_awaited_once()
+    view = interaction.followup.send.call_args.kwargs.get("view")
+    assert isinstance(view, BillingPanelView), (
+        "a registered guild must render the billing panel, not an error followup"
+    )
+
+    async with db_session_factory() as fresh_session:
+        principal = await find_platform_principal(
+            fresh_session,
+            tenant_id=tenant_id,
+            platform="discord",
+            external_id=str(user_id),
+        )
+    assert principal is not None, "the handler must have persisted a principal"
+    assert view.account_id == principal.account_id, (
+        "the account id the panel carries into the checkout JWT must be the "
+        "persisted principal's account, not a uuid that only ever existed in memory"
+    )

--- a/packages/adapters/discord/tests/test_checks.py
+++ b/packages/adapters/discord/tests/test_checks.py
@@ -1,12 +1,14 @@
-"""Tests for gating decorators: require_registered_guild."""
+"""Tests for the gating decorators and the click-time admin gate."""
 
 from __future__ import annotations
 
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 from daimon.adapters.discord.checks import (
+    refuse_if_not_admin,
     require_registered_guild,
     resolve_tenant_for_interaction,
 )
@@ -160,3 +162,71 @@ class TestResolveTenantForInteraction:
         interaction = _make_interaction(guild_id=None, sessionmaker=db_session_factory)
         resolved = await resolve_tenant_for_interaction(interaction.client, interaction)
         assert resolved is None, "guild_id None should resolve to None"
+
+
+# ---------------------------------------------------------------------------
+# refuse_if_not_admin
+# ---------------------------------------------------------------------------
+
+
+def _admin_gate_interaction(
+    *, is_admin: bool, is_member: bool = True, acked: bool = False
+) -> MagicMock:
+    """Build a mock Interaction with the minimum attributes refuse_if_not_admin touches."""
+    interaction = MagicMock()
+    interaction.user = MagicMock(spec=discord.Member) if is_member else MagicMock()
+    interaction.user.id = 1 if is_admin else 2
+    interaction.user.guild_permissions.administrator = is_admin
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.is_done.return_value = acked
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+async def test_refuse_if_not_admin_passes_a_live_guild_admin_silently() -> None:
+    interaction = _admin_gate_interaction(is_admin=True)
+
+    refused = await refuse_if_not_admin(interaction)
+
+    assert refused is False, "a live guild admin must pass the gate"
+    interaction.response.send_message.assert_not_awaited()
+    interaction.followup.send.assert_not_awaited()
+
+
+async def test_refuse_if_not_admin_refuses_a_member_with_one_ephemeral() -> None:
+    interaction = _admin_gate_interaction(is_admin=False)
+
+    refused = await refuse_if_not_admin(interaction)
+
+    assert refused is True, "an ordinary member must be refused"
+    interaction.response.send_message.assert_awaited_once()
+    assert "Manage Server" in interaction.response.send_message.call_args.args[0], (
+        "the refusal should name the permission the member is missing"
+    )
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True, (
+        "the refusal must be ephemeral"
+    )
+    interaction.followup.send.assert_not_awaited()
+
+
+async def test_refuse_if_not_admin_refuses_a_non_member_user() -> None:
+    interaction = _admin_gate_interaction(is_admin=True, is_member=False)
+
+    refused = await refuse_if_not_admin(interaction)
+
+    assert refused is True, "a DM-context User is not a guild admin and must be refused"
+    interaction.response.send_message.assert_awaited_once()
+    assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+async def test_refuse_if_not_admin_uses_followup_when_already_acked() -> None:
+    interaction = _admin_gate_interaction(is_admin=False, acked=True)
+
+    refused = await refuse_if_not_admin(interaction)
+
+    assert refused is True, "an acked interaction must still refuse"
+    interaction.response.send_message.assert_not_awaited()
+    interaction.followup.send.assert_awaited_once()
+    assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -61,6 +61,7 @@ from daimon.core.specs import (
     SkillRepo,
     merge_default_agent_toolset,
 )
+from daimon.core.stores.scoped_config_write import clear_agent_references
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, ValidationError
@@ -680,6 +681,12 @@ async def _archive_agent_impl(
             agent_name=name,
             ma_agent_id=agent.id,
         )
+    # Outside the best-effort degrade on purpose: a transient memory-store
+    # failure must not skip the scope clear, or every turn in the affected
+    # channel — or the whole install, for the workspace row — keeps resolving
+    # to an archived agent. A failure here surfaces to the tool caller.
+    async with runtime.session_factory() as session, session.begin():
+        await clear_agent_references(session, tenant_id=auth.tenant_id, agent_name=name)
 
 
 def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
@@ -810,5 +817,9 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
     @mcp.tool(tags={"admin"})
     async def archive_agent(ctx: Context, name: str) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Archive the MA agent and delete from the tenant pool."""
+        """Archive the MA agent and delete from the tenant pool.
+
+        Also clears any channel or workspace default naming the agent, so turns
+        in those scopes fall back to the next tier instead of failing to resolve.
+        """
         await _archive_agent_impl(runtime, await _auth(ctx), name)

--- a/packages/adapters/mcp/tests/tools/test_agents.py
+++ b/packages/adapters/mcp/tests/tools/test_agents.py
@@ -40,10 +40,11 @@ from daimon.adapters.mcp.tools.agents import (
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
 from daimon.core.github_credentials import build_multifernet, get_pat, upsert_credential_encrypted
 from daimon.core.ma_identity import derive_agent_uuid
-from daimon.core.scope import DeploymentDefault, TenantScopeRef
+from daimon.core.scope import ChannelScopeRef, DeploymentDefault, TenantScopeRef
 from daimon.core.specs import AgentSpec, SkillRef, SkillRepo
 from daimon.core.stores.agent_github_binding import set_agent_github_binding
 from daimon.core.stores.agent_repo_binding import set_binding
+from daimon.core.stores.scoped_config_read import get_scope
 from daimon.core.stores.scoped_config_write import set_fields
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import MARouter, build_fake_anthropic, json_body, list_response
@@ -920,6 +921,107 @@ async def test_archive_agent_impl_succeeds_when_store_archive_fails(
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant.id, role=Role.ADMIN, is_admin=True)
     # Must not raise despite the 500 from the memory-store archive.
     await _archive_agent_impl(_runtime(client, session_factory=db_session_factory), auth, "doomed")
+
+
+def _archive_router(tenant_id: uuid.UUID, account_id: uuid.UUID) -> MARouter:
+    """Router serving the agent lookup and the archive call for `doomed`."""
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _req, _m: list_response(
+            [
+                make_ma_agent(
+                    id="ag_d",
+                    name="doomed",
+                    metadata={
+                        "daimon_tenant": str(tenant_id),
+                        "daimon_name": "doomed",
+                        "daimon_account": str(account_id),
+                    },
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add(
+        "POST",
+        r"/v1/agents/([^/]+)/archive",
+        lambda _req, m: httpx.Response(
+            200, json=make_ma_agent(id=m.group(1)).model_dump(mode="json")
+        ),
+    )
+    return router
+
+
+async def test_archive_agent_clears_scope_rows_naming_the_agent(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Archiving the tenant's default must not leave scope rows naming a dead agent."""
+    tenant = await make_tenant(db_session)
+    account_id = uuid.uuid4()
+    tenant_scope = TenantScopeRef(tenant_id=tenant.id)
+    channel_scope = ChannelScopeRef(tenant_id=tenant.id, channel_id="C_ARCHIVED_DEFAULT")
+    await set_fields(db_session, scope=tenant_scope, tenant_id=tenant.id, agent_name="doomed")
+    await set_fields(db_session, scope=channel_scope, tenant_id=tenant.id, agent_name="doomed")
+    await db_session.commit()
+
+    client = build_fake_anthropic(_archive_router(tenant.id, account_id).dispatch)
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant.id, role=Role.ADMIN, is_admin=True)
+
+    await _archive_agent_impl(_runtime(client, session_factory=db_session_factory), auth, "doomed")
+
+    async with db_session_factory() as s:
+        assert await get_scope(s, scope=tenant_scope) is None, (
+            "the workspace default naming the archived agent must be cleared so "
+            "resolution falls through to the deployment default"
+        )
+        assert await get_scope(s, scope=channel_scope) is None, (
+            "the channel default naming the archived agent must be cleared too"
+        )
+
+
+async def test_archive_agent_clears_scope_rows_even_when_the_memory_store_archive_fails(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The scope clear sits outside the best-effort memory-store degrade.
+
+    A transient memory-store archive failure must not silently skip the clear —
+    that would leave the whole install unable to resolve a turn.
+    """
+    from daimon.core.stores.agent_memory_stores import insert_memory_store
+
+    tenant = await make_tenant(db_session)
+    account_id = uuid.uuid4()
+    tenant_scope = TenantScopeRef(tenant_id=tenant.id)
+    await set_fields(db_session, scope=tenant_scope, tenant_id=tenant.id, agent_name="doomed")
+    await insert_memory_store(
+        db_session,
+        tenant_id=tenant.id,
+        agent_id=derive_agent_uuid(tenant_id=tenant.id, ma_agent_id="ag_d"),
+        memory_store_id="memstore_X",
+    )
+    await db_session.commit()
+
+    router = _archive_router(tenant.id, account_id)
+    router.add(
+        "POST",
+        r"/v1/memory_stores/([^/]+)/archive",
+        lambda _req, _m: httpx.Response(
+            500,
+            json={"type": "error", "error": {"type": "api_error", "message": "boom"}},
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant.id, role=Role.ADMIN, is_admin=True)
+
+    await _archive_agent_impl(_runtime(client, session_factory=db_session_factory), auth, "doomed")
+
+    async with db_session_factory() as s:
+        assert await get_scope(s, scope=tenant_scope) is None, (
+            "the scope clear must still run when the memory-store archive fails"
+        )
 
 
 async def test_create_agent_impl_stamps_daimon_account_when_called() -> None:

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
@@ -1073,10 +1073,12 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Remove secret — always open: env-variable credentials are a
-        # per-agent attachment, not part of the agent spec. No refusal for any
-        # caller; is_admin/can_edit_spec are resolved only for the L1 stale
-        # fallback and the L2 re-render's build_l2_view kwargs.
+        # Remove secret — env-variable credentials are a per-agent attachment,
+        # so this routes through the shared-state gate rather than the spec
+        # gate: an admin may remove a secret from the built-in agent, but a
+        # non-admin may not remove one from any agent the workspace currently
+        # depends on. The is_admin resolved below is not that check — it feeds
+        # only the L1 stale fallback and the L2 re-render's build_l2_view kwargs.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__remove_secret":
             is_admin = await resolve_is_admin(
@@ -1089,6 +1091,17 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
 
             agent_name_for_remove = selected_agent_name or ""
             if not agent_name_for_remove:
+                return
+
+            if await gate.refuse_if_shared_and_not_admin(
+                runtime,
+                client,
+                tenant_id=tenant_id,
+                agent_name=agent_name_for_remove,
+                channel_id=channel_id,
+                user_id=user_id,
+                dev_allow_all=_dev_allow_all_admin(runtime),
+            ):
                 return
 
             ma_agent = await find_agent_by_daimon_tag(

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
@@ -19,10 +19,22 @@ Handler contract:
 Security — the gate follows the blast radius of what each branch touches,
 never a blanket admin check ("hiding ≠ gating" principle: every refusal is
 decided post-ack, server-side, never trusted from the rendered view):
-  - Always open, no refusal for any caller: new, fork, edit (L1→L2 push),
-    edit_repo_form, paste_secrets, remove_secret. Repo bindings and env
-    variables are per-agent attachments that never enter the agent spec;
-    building/configuring an unscoped agent has no tenant-wide blast radius.
+  - Open to every caller: new, fork, edit (L1→L2 push), and the paste_secrets
+    form push. Building an unscoped agent has no tenant-wide blast radius, and
+    the paste-secrets form prompts for nothing at push time — the write it
+    submits is refused at submission instead.
+  - Shared-state gated via ``refuse_if_shared_and_not_admin`` in
+    ``agent_setup.gate``: edit_repo_form and remove_secret. Repo bindings and
+    env variables are per-agent attachments that never enter the agent spec, so
+    they are exempt from the spec gate's absolutism about defaults-managed
+    agents — an admin configuring the workspace's built-in agent is a supported
+    first-run step. A non-admin is refused whenever the target is the built-in
+    agent or one the workspace currently depends on, because a repo re-point or
+    a secret deletion changes state every member's turns rely on.
+    edit_repo_form is gated at the push because that form prompts for a GitHub
+    personal access token and no credential should transit for a write that is
+    going to be refused; the corresponding submissions are gated again in the
+    submit module, which is the actual write boundary.
   - Field-conditional via the shared reachability gate in ``agent_setup.gate``:
     remove_skill, remove_mcp, edit_agent_form, add_skill, add_mcp. These touch
     the agent spec (system/model/skills/mcp_servers), so a non-admin is
@@ -1376,12 +1388,26 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Edit Repo Form — push L3 edit-repo form. Always open: the
-        # repo binding is a per-agent attachment, not part of the agent spec.
+        # Edit Repo Form — push L3 edit-repo form, gated on shared state at the
+        # push. Pushing a form is not itself a write; the reason the gate sits
+        # here is that this form prompts for a GitHub personal access token, and
+        # no credential should transit for a write that is going to be refused.
+        # The submission is gated again, which is the actual write boundary.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__edit_repo_form":
             agent_name_for_repo = selected_agent_name or ""
             if not agent_name_for_repo:
+                return
+
+            if await gate.refuse_if_shared_and_not_admin(
+                runtime,
+                client,
+                tenant_id=tenant_id,
+                agent_name=agent_name_for_repo,
+                channel_id=channel_id,
+                user_id=user_id,
+                dev_allow_all=_dev_allow_all_admin(runtime),
+            ):
                 return
 
             is_admin = await resolve_is_admin(
@@ -1520,9 +1546,11 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             )
 
         # -----------------------------------------------------------------------
-        # Paste Secrets — push L3 paste-secrets form. Always open:
-        # env-variable credentials are a per-agent attachment, not part of
-        # the agent spec.
+        # Paste Secrets — push L3 paste-secrets form, deliberately ungated at
+        # the push, unlike the adjacent edit-repo form: this form prompts for
+        # nothing at push time, so no credential can transit for a write that
+        # will be refused. Every member gets the form; the write it submits is
+        # refused at submission instead, which is the actual write boundary.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__paste_secrets":
             agent_name_for_secrets = selected_agent_name or ""

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
@@ -40,11 +40,18 @@ from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
 from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
 from slack_sdk.web.async_client import AsyncWebClient
 
-__all__ = ["refuse_if_reachable_and_not_admin"]
+__all__ = ["refuse_if_reachable_and_not_admin", "refuse_if_shared_and_not_admin"]
 
 _SEEDED_AGENT_MESSAGE = (
     ":lock: This is the workspace's built-in agent, so its setup cannot be changed "
     "from here — not even by an admin. Fork it to get an editable copy you own."
+)
+
+_SHARED_AGENT_MESSAGE = (
+    ":lock: This agent is shared — it is either the workspace's built-in agent or the "
+    "current default for this workspace or a channel — so changing its repo or its "
+    "environment variables needs workspace-admin permission. Fork it to get an "
+    "editable copy you own; the fork starts with no environment variables of its own."
 )
 
 
@@ -125,5 +132,87 @@ async def refuse_if_reachable_and_not_admin(
             "channel, so changing its setup needs workspace-admin permission. "
             "Creating or forking your own agent is not restricted."
         ),
+    )
+    return True
+
+
+async def refuse_if_shared_and_not_admin(
+    runtime: SlackRuntime,
+    web_client: AsyncWebClient,
+    *,
+    tenant_id: uuid.UUID,
+    agent_name: str,
+    channel_id: str,
+    user_id: str,
+    dev_allow_all: bool = False,
+) -> bool:
+    """Refuse an attachment write against a shared agent by a non-admin.
+
+    ``refuse_if_shared_and_not_admin`` is the gate for per-agent attachments --
+    the repo binding, the inline token, env-variable credentials. Spec-touching
+    writes route through ``refuse_if_reachable_and_not_admin`` instead.
+
+    Returns ``True`` when the caller must return early (refused); ``False``
+    when the caller should proceed. Order, each short-circuiting:
+
+    1. A live workspace admin -> allow, before any MA or DB read. This is the
+       one step ordered differently from ``refuse_if_reachable_and_not_admin``,
+       and it is what keeps an admin able to bind a repo to the workspace's
+       built-in agent -- the first-run onboarding step.
+    2. The target is a defaults-managed agent -> refuse; it ships with the
+       deployment and every member of the workspace shares it.
+    3. Otherwise read reachability fresh from the DB and refuse when the
+       target currently resolves for the workspace or some channel. An
+       unreachable agent has no shared state to defend, so any member may
+       configure it.
+
+    Both refusals carry the same message on purpose: telling the caller which
+    limb fired would say nothing they can act on, and either way the fix is the
+    same -- ask an admin, or fork.
+
+    Args:
+        runtime:        Injected ``SlackRuntime`` (sessionmaker, deployment
+                        default).
+        web_client:     Per-event ``AsyncWebClient``.
+        tenant_id:      Derived from the verified Socket Mode workspace id --
+                        never accepted from the interactive payload.
+        agent_name:     The target agent's name -- used only as a
+                        tenant-scoped lookup key.
+        channel_id:     Invoking channel, for the refusal ephemeral.
+        user_id:        Invoking user, for the admin check and the ephemeral.
+        dev_allow_all:  Testing-only admin-gate override, threaded through
+                        unchanged from ``_dev_allow_all_admin(runtime)``.
+
+    Returns:
+        ``True`` if the caller must refuse and return early, ``False`` to
+        proceed.
+    """
+    is_admin = await resolve_is_admin(web_client, user_id=user_id, dev_allow_all=dev_allow_all)
+    if is_admin:
+        return False
+
+    seeded = await find_agent_by_daimon_tag(runtime.anthropic, tenant_id=tenant_id, name=agent_name)
+    if seeded is not None and seeded.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
+        await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+            channel=channel_id or user_id,
+            user=user_id,
+            text=_SHARED_AGENT_MESSAGE,
+        )
+        return True
+
+    async with runtime.sessionmaker() as session:
+        reachable = await is_agent_reachable_in_tenant(
+            session,
+            tenant_id=tenant_id,
+            agent_name=agent_name,
+            default=runtime.deployment_default,
+        )
+    if not reachable:
+        return False
+
+    await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+        channel=channel_id or user_id,
+        user=user_id,
+        text=_SHARED_AGENT_MESSAGE,
     )
     return True

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
@@ -1,32 +1,41 @@
-"""Shared post-ack reachability refusal helper for Slack /agent-setup.
+"""Shared post-ack authorization gates for Slack /agent-setup.
 
 Field-follows-the-gate rule for the next contributor wiring up a new
-mutating action: skills and MCP servers are part of the agent spec an
-admin approved when the agent became reachable (a channel or workspace
-default), so mutating those fields on a currently-reachable agent stays
-admin-only. Repo bindings and env-variable credentials are per-agent
-attachments that never enter the agent spec, so they stay open on every
-agent regardless of reachability -- callers touching only those fields
-must not route through this helper at all.
+mutating action. Two gates live here, and which one a write routes through
+follows from whether the field it writes is part of the agent spec:
 
-``refuse_if_reachable_and_not_admin`` resolves admin status live via
-``resolve_is_admin`` (never trusts anything carried in the rendered view
-or in ``private_metadata``) and re-reads reachability fresh from the DB on
-every call -- no caching, matching the panel's existing re-resolve
-discipline for admin status.
+- Spec fields -- skills, MCP servers, the model, the system prompt -- route
+  through ``refuse_if_reachable_and_not_admin``. That gate refuses a
+  defaults-managed agent unconditionally, admins included, because a panel
+  edit never stamps the reconciler's spec hash: the resulting drift would
+  survive every later reconcile with no way back. Forking is the editable
+  path. Below that, a non-admin is refused whenever the target is currently
+  reachable (a channel or workspace default) -- an unreachable agent has no
+  live gate to defend, so any member may configure it.
 
-It refuses in two cases, checked in this order:
+- Per-agent attachments -- the repo binding, the inline token, env-variable
+  credentials -- route through ``refuse_if_shared_and_not_admin``. They never
+  enter the agent spec, so the defaults-managed absolutism above does not
+  apply to them: an admin binding a repo to the workspace's built-in agent is
+  a supported first-run step. They are NOT open to non-admins on a shared
+  agent, though, because a repo re-point or a secret overwrite changes state
+  every member of the workspace depends on.
 
-1. The target is a defaults-managed agent -- refused unconditionally, for
-   admins too. Editing one from a panel never stamps the reconciler's spec
-   hash, so the edit would survive every later reconcile and drift the agent
-   from the shipped defaults with no way back. Forking is the editable path.
-2. The caller is not a workspace admin and the target is currently
-   reachable (a channel or workspace default). An unreachable agent has no
-   live gate to defend, so any member may configure it.
+A new mutating action routes through exactly one of the two. "No gate" is
+not one of the options.
 
-Both checks live here rather than at the call sites so a newly-wired
-mutating action inherits them by routing through this one helper.
+The two open-time behaviours differ on purpose. The edit-repo form is gated
+when it is pushed, because that form prompts for a GitHub personal access
+token and no such credential should transit for a write that is going to be
+refused anyway. The paste-secrets form prompts for nothing on push, so it is
+gated at submission only -- the boundary that actually writes.
+
+Both gates resolve admin status live via ``resolve_is_admin`` (never trusting
+anything carried in the rendered view or in ``private_metadata``) and re-read
+reachability fresh from the DB on every call -- no caching, matching the
+panel's existing re-resolve discipline for admin status. Both live here rather
+than at the call sites so a newly-wired mutating action inherits its checks by
+routing through one helper.
 """
 
 from __future__ import annotations

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
@@ -785,9 +785,12 @@ async def run_edit_repo_submission(
 ) -> None:
     """Post-ack: update repo binding and/or inline PAT for the agent.
 
-    Repo binding and the inline PAT are per-agent attachments that never
-    enter the agent spec, so this form is open to every workspace member —
-    including against the workspace's current default agent. Blank PAT
+    Repo binding and the inline token are per-agent attachments that never
+    enter the agent spec, so they are exempt from the spec gate's built-in
+    agent absolutism — an admin binding a repo to the built-in agent is a
+    supported first-run step. They are refused for a non-admin whenever the
+    target is the built-in agent or a current default, though, because a repo
+    re-point changes what the whole workspace's shared agent clones. Blank PAT
     field = keep stored token (never overwrites).
 
     No binding write happens without a successful GitHub probe against the
@@ -798,6 +801,23 @@ async def run_edit_repo_submission(
     """
     try:
         tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        # One gate at the top covers every write below it — the replace-token
+        # bind, the keep-token re-point and its proof re-establish, and the
+        # first-time-bind fallback — and it runs before the GitHub probe, so a
+        # refused submission never puts the member's token on the wire.
+        refused = await gate.refuse_if_shared_and_not_admin(
+            runtime,
+            web_client,
+            tenant_id=tenant_id,
+            agent_name=agent_name,
+            channel_id=channel_id,
+            user_id=user_id,
+            dev_allow_all=_dev_allow_all_admin(runtime),
+        )
+        if refused:
+            return
+
         account_id = derive_guild_account_uuid(tenant_id=tenant_id)
 
         ma_agent = await find_agent_by_daimon_tag(

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
@@ -16,10 +16,18 @@ Pattern mirrors ``privacy_panel/submit.py`` exactly — same Decision dataclass
 shape, same evaluate-then-spawn discipline, same boundary catch tuple.
 
 Threat register:
-- Creation (new agent, fork) and per-agent attachments (repo binding, env
-  variables) are open to every workspace member — there is nothing an admin
-  has approved for a brand-new agent, and attachments never enter the agent
-  spec. Configuration that touches the agent spec an admin approved (model,
+- Creation (new agent, fork) is open to every workspace member — there is
+  nothing an admin has approved for a brand-new agent.
+- Per-agent attachments (repo binding, inline token, env variables) never
+  enter the agent spec, so they are exempt from the spec gate's absolutism
+  about defaults-managed agents — an admin configuring the workspace's
+  built-in agent is a supported first-run step. They are NOT open to
+  non-admins on a shared agent: ``run_edit_repo_submission`` and
+  ``run_paste_secrets_submission`` both re-check
+  ``refuse_if_shared_and_not_admin`` fresh, after the ack, before any MA
+  request or store write, because a repo re-point or a secret overwrite
+  changes state every member's turns depend on.
+- Configuration that touches the agent spec an admin approved (model,
   system prompt, skills, MCP servers) re-checks the shared ``agent_setup.gate``
   helper fresh, after the ack, before any MA request or store write.
 - Secret VALUES are validated then passed to the
@@ -1271,14 +1279,33 @@ async def run_paste_secrets_submission(
 ) -> None:
     """Post-ack: write validated secrets to agent_files store.
 
-    Env-variable credentials are a per-agent attachment that never enters
-    the agent spec, so this form is open to every workspace member —
-    including against the workspace's current default agent.
+    Env-variable credentials are a per-agent attachment that never enters the
+    agent spec, so they are exempt from the spec gate's built-in agent
+    absolutism — an admin populating the built-in agent's environment is a
+    supported first-run step. They are refused for a non-admin whenever the
+    target is the built-in agent or a current default, though, because
+    put_agent_file is an upsert and the resulting file is mounted read-write
+    on every session of that shared agent.
     CRITICAL: only key NAMES appear in logs and ephemeral.
     Secret values are consumed here and never propagated further.
     """
     try:
         tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        # Ahead of the MA lookup, the pairs read, and every write — so a
+        # refused submission makes no MA request and logs nothing derived from
+        # the submitted pairs.
+        refused = await gate.refuse_if_shared_and_not_admin(
+            runtime,
+            web_client,
+            tenant_id=tenant_id,
+            agent_name=agent_name,
+            channel_id=channel_id,
+            user_id=user_id,
+            dev_allow_all=_dev_allow_all_admin(runtime),
+        )
+        if refused:
+            return
 
         ma_agent = await find_agent_by_daimon_tag(
             runtime.anthropic, tenant_id=tenant_id, name=agent_name

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/write.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/write.py
@@ -56,7 +56,7 @@ from daimon.core.specs import (
 )
 from daimon.core.stores.agent_github_binding import set_agent_github_binding
 from daimon.core.stores.scoped_config_read import get_scope
-from daimon.core.stores.scoped_config_write import set_fields, unset_fields
+from daimon.core.stores.scoped_config_write import clear_agent_references, set_fields, unset_fields
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -295,7 +295,12 @@ async def fork_agent(
 
 
 async def delete_agent(runtime: SlackRuntime, *, tenant_id: uuid.UUID, name: str) -> None:
-    """Archive the MA agent matching ``name`` under the given tenant."""
+    """Archive the MA agent matching ``name`` under the given tenant.
+
+    Channel and workspace scope rows naming the agent are cleared as part of the
+    delete, so turn resolution falls through the cascade instead of resolving to
+    a deleted agent.
+    """
     agent = await find_agent_by_daimon_tag(runtime.anthropic, tenant_id=tenant_id, name=name)
     if agent is None:
         raise DaimonError(f"No agent named *{name}* found.")
@@ -307,6 +312,12 @@ async def delete_agent(runtime: SlackRuntime, *, tenant_id: uuid.UUID, name: str
         agent_id=derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(agent.id)),
         log_context={"tenant_id": str(tenant_id), "agent_name": name, "ma_agent_id": agent.id},
     )
+    # After the MA archive, never before: a failure here leaves an archived
+    # agent with stale scope rows rather than a live agent with cleared ones.
+    # Deliberately unguarded — a failure must reach the action's error boundary
+    # rather than degrade silently.
+    async with runtime.sessionmaker.begin() as session:
+        await clear_agent_references(session, tenant_id=tenant_id, agent_name=name)
 
 
 async def replace_agent_resources_for_panel(

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
@@ -12,7 +12,9 @@ Covers the five required behaviors from 83-05 plan:
              NOT call views.update or views.push
 
 Also covers the field-follows-the-gate authorization matrix (10-06): the
-always-open branches (new/fork/edit/edit_repo_form/paste_secrets/remove_secret),
+branches open to every caller (new/fork/edit/paste_secrets), the branches
+gated on shared state by ``refuse_if_shared_and_not_admin``
+(edit_repo_form/remove_secret),
 the admin-only-unconditional branches (delete/scope:*/connect_mcp), and the
 field-conditional branches gated by ``refuse_if_reachable_and_not_admin``
 (remove_skill/remove_mcp/edit_agent_form/add_skill/add_mcp) — each proved for
@@ -43,7 +45,9 @@ from daimon.adapters.slack.agent_setup.actions import (
 from daimon.adapters.slack.runtime import SlackRuntime
 from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
 from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.scope import ChannelConfigRow, ChannelScopeRef, TenantScopeRef
+from daimon.core.stores.agent_files import get_agent_file, put_agent_file
 from daimon.core.stores.scoped_config_read import get_scope
 from daimon.core.stores.scoped_config_write import set_fields
 from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
@@ -990,9 +994,15 @@ def _assert_reachability_refusal(client_fake: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Always-open branches: new, fork, edit, edit_repo_form,
-# paste_secrets, remove_secret -- no refusal for any caller, admin or not.
-# `new` is covered above; the remaining five follow.
+# Branches open to every caller: new, fork, edit, and the paste_secrets form
+# push -- the last of those is refused at submission rather than at the push,
+# so its open-time test below asserts the push on purpose. `new` is covered
+# above; fork, edit, and paste_secrets follow.
+#
+# Branches gated on shared state via refuse_if_shared_and_not_admin:
+# edit_repo_form and remove_secret. Each has a non-admin refusal test against a
+# workspace-default agent and an admin-positive sibling proving the same action
+# still succeeds for an admin.
 # ---------------------------------------------------------------------------
 
 
@@ -1037,15 +1047,22 @@ async def test_handle_agent_setup_action_edit_non_admin_pushes_l2_no_ephemeral(
 
 
 @pytest.mark.asyncio
-async def test_handle_agent_setup_action_edit_repo_form_non_admin_pushes_form_no_ephemeral(
+async def test_handle_agent_setup_action_edit_repo_form_non_admin_on_default_agent_refuses_with_ephemeral(
     db_session: AsyncSession,
     db_session_factory: async_sessionmaker[AsyncSession],
     fake_slack_web_client: object,
 ) -> None:
+    """A non-admin never sees the edit-repo form for the workspace's default agent.
+
+    The form prompts for a GitHub personal access token, so the refusal has to
+    land at the push -- once the form is on screen the member has already been
+    asked for a credential the submission would refuse to use.
+    """
     tenant_id, fernet_key, _ = await _seed_team(db_session)
     agent_payload = _agent_payload(tenant_id=tenant_id)
     handler = _make_ma_handler_with_agents([agent_payload])
     runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
 
     payload = _action_payload(
         "agent_setup__edit_repo_form", selected_agent_name=_AGENT_NAME, active_section="repo_auth"
@@ -1053,10 +1070,48 @@ async def test_handle_agent_setup_action_edit_repo_form_non_admin_pushes_form_no
     await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
 
     client_fake: Any = fake_slack_web_client
-    assert _get_push_callback_id(client_fake) == "agent_setup__edit_repo", (
-        "non-admin agent_setup__edit_repo_form must push the edit-repo form"
+    assert not _has_push(client_fake), (
+        "non-admin agent_setup__edit_repo_form on the workspace default must NOT push the "
+        "token-collecting form"
     )
-    _assert_no_refusal(client_fake)
+    texts = _ephemeral_texts(client_fake)
+    assert len(texts) == 1, f"exactly one refusal ephemeral must be posted, got {texts!r}"
+    assert "workspace-admin" in texts[0], (
+        f"the refusal must name the permission the caller lacks, got {texts[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_edit_repo_form_admin_on_default_agent_pushes_form(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """An admin still gets the edit-repo form for the workspace's default agent.
+
+    Binding a repo to the agent the whole workspace uses is the ordinary
+    first-run step; the gate refuses non-admins, not admins.
+    """
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
+
+    payload = _action_payload(
+        "agent_setup__edit_repo_form", selected_agent_name=_AGENT_NAME, active_section="repo_auth"
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    assert _get_push_callback_id(client_fake) == "agent_setup__edit_repo", (
+        "admin agent_setup__edit_repo_form on the workspace default must still push the form"
+    )
+    assert not _ephemeral_texts(client_fake), (
+        "an admin must not be refused on the workspace default agent"
+    )
 
 
 @pytest.mark.asyncio
@@ -1065,10 +1120,19 @@ async def test_handle_agent_setup_action_paste_secrets_non_admin_pushes_form_no_
     db_session_factory: async_sessionmaker[AsyncSession],
     fake_slack_web_client: object,
 ) -> None:
+    """The paste-secrets form is pushed for every member, unlike the edit-repo form.
+
+    It prompts for nothing at push time, so nothing is at risk in showing it;
+    the write it submits is refused at submission when the target is shared. If
+    this test starts failing, a gate was added where none belongs -- fix the
+    handler, not the test.
+    """
     tenant_id, fernet_key, _ = await _seed_team(db_session)
     agent_payload = _agent_payload(tenant_id=tenant_id)
     handler = _make_ma_handler_with_agents([agent_payload])
     runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+    # Shared target on purpose: this is the case a push-time gate would refuse.
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
 
     payload = _action_payload(
         "agent_setup__paste_secrets", selected_agent_name=_AGENT_NAME, active_section="secrets"
@@ -1083,18 +1147,32 @@ async def test_handle_agent_setup_action_paste_secrets_non_admin_pushes_form_no_
 
 
 @pytest.mark.asyncio
-async def test_handle_agent_setup_action_remove_secret_non_admin_writes_and_updates_no_ephemeral(
+async def test_handle_agent_setup_action_remove_secret_non_admin_on_default_agent_refuses_and_writes_nothing(
     db_session: AsyncSession,
     db_session_factory: async_sessionmaker[AsyncSession],
     fake_slack_web_client: object,
 ) -> None:
-    """remove_secret is always open: env variables are a per-agent
-    attachment, never part of the agent spec -- even on a reachable agent."""
+    """A non-admin cannot delete an env variable from the workspace's default agent.
+
+    Removing a variable the shared agent's integrations depend on is
+    destructive and silent -- the next turn simply loses it -- so the gate has
+    to fire before the delete, not after.
+    """
     tenant_id, fernet_key, _ = await _seed_team(db_session)
     agent_payload = _agent_payload(tenant_id=tenant_id)
     handler = _make_ma_handler_with_agents([agent_payload])
     runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
     await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=_MA_AGENT_ID)
+    async with db_session_factory() as session, session.begin():
+        await put_agent_file(
+            session,
+            tenant_id=tenant_id,
+            agent_id=agent_uuid,
+            key="SOME_KEY",
+            content="some-value",
+        )
 
     payload = _action_payload(
         "agent_setup__remove_secret",
@@ -1104,11 +1182,67 @@ async def test_handle_agent_setup_action_remove_secret_non_admin_writes_and_upda
     )
     await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
 
-    client_fake: Any = fake_slack_web_client
-    assert _has_update(client_fake), (
-        "non-admin remove_secret on a reachable agent must still re-render L2"
+    async with db_session_factory() as session:
+        surviving = await get_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_uuid, key="SOME_KEY"
+        )
+    assert surviving is not None, (
+        "non-admin remove_secret on the workspace default must delete no agent file"
     )
-    _assert_no_refusal(client_fake)
+
+    client_fake: Any = fake_slack_web_client
+    texts = _ephemeral_texts(client_fake)
+    assert len(texts) == 1, f"exactly one refusal ephemeral must be posted, got {texts!r}"
+    assert "workspace-admin" in texts[0], (
+        f"the refusal must name the permission the caller lacks, got {texts[0]!r}"
+    )
+    assert "SOME_KEY" not in texts[0], (
+        f"the refusal must not echo the secret key back to the channel, got {texts[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_remove_secret_admin_on_default_agent_deletes_the_file(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """An admin still removes env variables from the workspace's default agent."""
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+    agent_payload = _agent_payload(tenant_id=tenant_id)
+    handler = _make_ma_handler_with_agents([agent_payload])
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=_MA_AGENT_ID)
+    async with db_session_factory() as session, session.begin():
+        await put_agent_file(
+            session,
+            tenant_id=tenant_id,
+            agent_id=agent_uuid,
+            key="SOME_KEY",
+            content="some-value",
+        )
+
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
+
+    payload = _action_payload(
+        "agent_setup__remove_secret",
+        selected_agent_name=_AGENT_NAME,
+        active_section="secrets",
+        action_extra={"selected_option": {"value": "SOME_KEY"}},
+    )
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    async with db_session_factory() as session:
+        removed = await get_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_uuid, key="SOME_KEY"
+        )
+    assert removed is None, (
+        "admin remove_secret on the workspace default must delete the agent file"
+    )
+    assert _has_update(client_fake), "admin remove_secret must re-render L2 after the delete"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_gate.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_gate.py
@@ -7,6 +7,10 @@ Covers refuse_if_reachable_and_not_admin's four behaviors:
   - any caller, including an admin, against a defaults-managed agent ->
     refused, pointing at forking as the editable path
 
+and refuse_if_shared_and_not_admin's branch ordering, which differs in one
+place: the admin short-circuit runs first, so an admin can still attach a repo
+to the workspace's built-in agent.
+
 All cases use a real Postgres schema (db_session_factory) + the
 transport-level FakeSlackWebClient from conftest (no AsyncMock on
 client.* methods) for the Slack side, and real scoped_config_write rows
@@ -26,7 +30,10 @@ import pytest
 import yarl
 from aioresponses import aioresponses as AioResponsesMock
 from anthropic.types.beta import BetaManagedAgentsAgent
-from daimon.adapters.slack.agent_setup.gate import refuse_if_reachable_and_not_admin
+from daimon.adapters.slack.agent_setup.gate import (
+    refuse_if_reachable_and_not_admin,
+    refuse_if_shared_and_not_admin,
+)
 from daimon.adapters.slack.runtime import SlackRuntime
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_MANAGED,
@@ -315,3 +322,276 @@ async def test_gate_refuses_a_workspace_admin_editing_the_defaults_managed_agent
         text = (kwargs.get("json") or {}).get("text", "")
         assert "built-in agent" in text, "ephemeral should say the agent is built in"
         assert "Fork" in text, "ephemeral should point at forking as the editable path"
+
+
+async def test_shared_gate_admin_passes_on_a_defaults_managed_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An admin may write attachments on the workspace's built-in agent.
+
+    Binding a repo to the built-in agent is the first-run onboarding step, so
+    the admin short-circuit has to run before the defaults-managed lookup. If
+    the two are ever reordered the lookup fires, the agent reads as managed,
+    and onboarding breaks -- which is what the MA call counter pins here.
+    """
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await session.commit()
+
+    ma_calls: list[str] = []
+    serve_seeded_agent = _seeded_agent_handler(tenant_id=tenant.id, agent_name=_AGENT_NAME)
+
+    def counting_handler(request: httpx.Request) -> httpx.Response:
+        ma_calls.append(request.url.path)
+        return serve_seeded_agent(request)
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _runtime_with_failing_sessionmaker()
+        object.__setattr__(runtime, "anthropic", build_fake_anthropic(counting_handler))
+
+        refused = await refuse_if_shared_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is False, (
+            "an admin must still be able to attach a repo to the built-in agent"
+        )
+        assert ma_calls == [], "the admin short-circuit must precede the defaults-managed lookup"
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        assert post_key not in mock.requests, "admin path must not post any ephemeral"
+
+
+async def test_shared_gate_admin_passes_on_a_reachable_agent_without_reading_the_database(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Admin caller on a workspace-default agent -> proceed, no DB read.
+
+    The agent is genuinely reachable in the database, but the runtime handed
+    to the gate raises if its sessionmaker is called, so a pass here proves the
+    admin short-circuit returns before the reachability read.
+    """
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await make_tenant_config(session, tenant=tenant, agent_name=_AGENT_NAME, mode="agent")
+        await session.commit()
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _runtime_with_failing_sessionmaker()
+
+        refused = await refuse_if_shared_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is False, "an admin caller must never be refused an attachment write"
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        assert post_key not in mock.requests, "admin path must not post any ephemeral"
+
+
+async def test_shared_gate_non_admin_refuses_on_a_defaults_managed_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Non-admin + the workspace's built-in agent -> refused, one ephemeral."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await session.commit()
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_non_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _build_runtime(db_session_factory)
+        object.__setattr__(
+            runtime,
+            "anthropic",
+            build_fake_anthropic(
+                _seeded_agent_handler(tenant_id=tenant.id, agent_name=_AGENT_NAME)
+            ),
+        )
+
+        refused = await refuse_if_shared_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is True, "a member must not rewrite the built-in agent's attachments"
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        matches = mock.requests.get(post_key, [])
+        assert len(matches) == 1, f"expected exactly one ephemeral, got {len(matches)}"
+
+        text = (matches[0][1].get("json") or {}).get("text", "")
+        assert "workspace-admin permission" in text, (
+            "ephemeral should name the permission the caller lacks"
+        )
+
+
+async def test_shared_gate_non_admin_refuses_on_a_reachable_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Non-admin + a workspace-default agent -> refused, one ephemeral."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await make_tenant_config(session, tenant=tenant, agent_name=_AGENT_NAME, mode="agent")
+        await session.commit()
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_non_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _build_runtime(db_session_factory)
+
+        refused = await refuse_if_shared_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is True, (
+            "a member must not repoint or overwrite a shared agent's attachments"
+        )
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        matches = mock.requests.get(post_key, [])
+        assert len(matches) == 1, f"expected exactly one ephemeral, got {len(matches)}"
+
+        text = (matches[0][1].get("json") or {}).get("text", "")
+        assert "workspace-admin permission" in text, (
+            "ephemeral should name the permission the caller lacks"
+        )
+
+
+async def test_shared_gate_non_admin_passes_on_an_unreachable_unmanaged_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Non-admin + an agent nothing resolves to -> proceed, no ephemeral.
+
+    An unreachable, unmanaged agent is not shared state, so its owner may
+    bind a repo or paste secrets without an admin.
+    """
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await session.commit()
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_non_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _build_runtime(db_session_factory)
+
+        refused = await refuse_if_shared_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+        )
+
+        assert refused is False, "an unshared agent's attachments stay member-writable"
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        assert post_key not in mock.requests, "pass-through case must not post any ephemeral"
+
+
+async def test_shared_gate_dev_allow_all_lets_a_non_admin_through(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """dev_allow_all=True treats a non-admin as admin, matching the spec gate."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        await make_tenant_config(session, tenant=tenant, agent_name=_AGENT_NAME, mode="agent")
+        await session.commit()
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=_non_admin_users_info_payload(),
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            f"{_SLACK_API_BASE}/chat.postEphemeral",
+            payload={"ok": True},
+            repeat=True,
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        runtime = _build_runtime(db_session_factory)
+
+        refused = await refuse_if_shared_and_not_admin(
+            runtime,
+            client,
+            tenant_id=tenant.id,
+            agent_name=_AGENT_NAME,
+            channel_id=_CHANNEL_ID,
+            user_id=_USER_ID,
+            dev_allow_all=True,
+        )
+
+        assert refused is False, "the dev admin-gate override must open the attachment gate too"
+
+        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
+        assert post_key not in mock.requests, "the override path must not post any ephemeral"

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
@@ -7,9 +7,12 @@ Covers:
 - run_* handlers via FakeSlackWebClient:
   - run_new_agent_submission (admin, write succeeds) posts :white_check_mark: ephemeral; no views_update
   - run_paste_secrets_submission (admin, 2 pairs) posts count ephemeral without secret values; no views_update
-  - the four always-open paths (new/fork/edit_repo/paste_secrets): a non-admin
-    submission succeeds with no permission-refusal ephemeral, including against
-    the workspace's currently-default agent for the two per-agent attachments
+  - creation (new/fork): a non-admin submission succeeds with no
+    permission-refusal ephemeral
+  - the two per-agent attachment submissions (edit_repo/paste_secrets): a
+    non-admin proceeds only when the target agent is neither defaults-managed
+    nor currently reachable, is refused before any MA request otherwise, and
+    an admin succeeds against the workspace's currently-default agent
   - the three field-conditional paths (edit_agent/add_skill/add_mcp): a
     non-admin submission proceeds on an unreachable agent and is refused
     before any MA request on a reachable one, via the shared
@@ -26,6 +29,8 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+import structlog
+import structlog.testing
 import yarl
 from cryptography.fernet import Fernet
 from daimon.adapters.slack.agent_setup import submit as submit_mod
@@ -586,7 +591,9 @@ def _ephemeral_texts(client_fake: Any) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Task 1 — the four always-open paths: non-admin succeeds, no refusal ephemeral
+# Creation paths, open to every member; and the two per-agent attachment
+# paths, refused for a non-admin on a shared agent — each with an
+# admin-positive sibling proving the shared-agent write still works
 # ---------------------------------------------------------------------------
 
 
@@ -692,12 +699,17 @@ async def test_run_fork_agent_submission_when_non_admin_forks_agent_with_no_refu
 
 
 @pytest.mark.asyncio
-async def test_run_edit_repo_submission_when_non_admin_and_agent_is_workspace_default_binds_repo(
+async def test_run_edit_repo_submission_when_non_admin_and_agent_is_workspace_default_refuses_bind(
     fake_slack_web_client: Any,
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Repo binding is a per-agent attachment, so it stays open for a
-    non-admin even against the workspace's currently-default agent."""
+    """A repo re-point changes what the whole workspace's shared agent clones,
+    so a non-admin is refused against the currently-default agent — and refused
+    early enough that no GitHub probe is ever made.
+
+    The runtime's GitHub transport is the never-called handler: an outbound
+    probe would raise rather than quietly succeed, which is what pins the gate
+    ahead of the probe rather than merely ahead of the write."""
     from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
     from daimon.core.stores.agent_repo_binding import get_binding
 
@@ -713,6 +725,72 @@ async def test_run_edit_repo_submission_when_non_admin_and_agent_is_workspace_de
 
     client_fake: Any = fake_slack_web_client
     # conftest default users.info is non-admin; no override.
+
+    runtime = SlackRuntime(
+        settings=_build_edit_repo_settings(app_id=None),
+        anthropic=build_fake_anthropic(
+            _build_edit_repo_ma_handler(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+        ),
+        sessionmaker=db_session_factory,
+        billing_config=None,
+        http_client=_build_http_client(),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+    await run_edit_repo_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="repo",
+        extra={
+            "repo_url": "https://github.com/example/default-agent.git",
+            "pat": "",
+            "pat_replace": False,
+        },
+    )
+
+    async with db_session_factory() as session:
+        row = await get_binding(session, tenant_id=tenant_id, agent_id=agent_uuid)
+
+    assert row is None, "no binding may be written for a non-admin on a workspace-default agent"
+
+    texts = _ephemeral_texts(client_fake)
+    assert any("workspace-admin" in t for t in texts), (
+        "the refusal ephemeral must say the change needs workspace-admin permission"
+    )
+    assert not any(":white_check_mark:" in t for t in texts), (
+        "a refused bind must not post a success confirmation"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_edit_repo_submission_when_admin_and_agent_is_workspace_default_binds_repo(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An admin binding a repo to the workspace's default agent is the
+    first-run onboarding step and must keep working — the attachment gate
+    short-circuits on live admin status before it looks at shared-ness."""
+    from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
+    from daimon.core.stores.agent_repo_binding import get_binding
+
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=_TEAM_ID)
+    ma_agent_id = f"agent_{'f' * 24}"
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+
+    async with db_session_factory() as session:
+        await make_tenant(session, platform="slack", workspace_id=_TEAM_ID, id=tenant_id)
+        await session.commit()
+    await _seed_guild_account(db_session_factory, tenant_id=tenant_id)
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
 
     runtime = SlackRuntime(
         settings=_build_edit_repo_settings(app_id=None),
@@ -745,35 +823,22 @@ async def test_run_edit_repo_submission_when_non_admin_and_agent_is_workspace_de
     async with db_session_factory() as session:
         row = await get_binding(session, tenant_id=tenant_id, agent_id=agent_uuid)
 
-    assert row is not None, "binding should be written even against a workspace-default agent"
-    assert row.repo_url == "example/default-agent"
+    assert row is not None, "an admin's bind against the workspace-default agent must be written"
+    assert row.repo_url == "example/default-agent", (
+        "the binding must carry the submitted repo, not a stale one"
+    )
 
     texts = _ephemeral_texts(client_fake)
     assert any(":white_check_mark:" in t for t in texts), (
-        "repo binding must succeed for a non-admin on a workspace-default agent"
+        "an admin's bind must post the success confirmation"
     )
     assert not any("workspace-admin" in t for t in texts), (
-        "no reachability refusal ephemeral should be posted for a per-agent attachment"
+        "an admin must not see the shared-agent refusal"
     )
 
 
-@pytest.mark.asyncio
-async def test_run_paste_secrets_submission_when_non_admin_and_agent_is_workspace_default_writes_secrets(
-    fake_slack_web_client: Any,
-    db_session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """Env variables are a per-agent attachment, so they stay open for a
-    non-admin even against the workspace's currently-default agent."""
-    async with db_session_factory() as session:
-        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
-        tenant_id = tenant.id
-        await session.commit()
-    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
-
-    client_fake: Any = fake_slack_web_client
-    # conftest default users.info is non-admin; no override.
-
-    ma_agent_id = f"agent_{'g' * 24}"
+def _paste_secrets_ma_handler(*, tenant_id: Any, ma_agent_id: str) -> Any:
+    """Serve a single tenant-tagged agent for run_paste_secrets_submission."""
     agent_data = _agent_payload_for_gate_tests(tenant_id=tenant_id, agent_id=ma_agent_id)
 
     def _handler(request: httpx.Request) -> httpx.Response:
@@ -785,7 +850,35 @@ async def test_run_paste_secrets_submission_when_non_admin_and_agent_is_workspac
             return httpx.Response(200, json={"data": [], "has_more": False})
         return httpx.Response(404, json={"error": f"unhandled {method} {path}"})
 
-    runtime = _build_runtime_with_db(db_session_factory, anthropic_handler=_handler)
+    return _handler
+
+
+@pytest.mark.asyncio
+async def test_run_paste_secrets_submission_when_non_admin_and_agent_is_workspace_default_refuses_write(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """put_agent_file is an upsert and the file it writes is mounted
+    read-write on every session of the shared agent, so a non-admin is refused
+    against the currently-default agent and no file exists afterwards."""
+    from daimon.core.ma_identity import derive_agent_uuid
+    from daimon.core.stores.agent_files import list_agent_files
+
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        tenant_id = tenant.id
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    client_fake: Any = fake_slack_web_client
+    # conftest default users.info is non-admin; no override.
+
+    ma_agent_id = f"agent_{'g' * 24}"
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+    runtime = _build_runtime_with_db(
+        db_session_factory,
+        anthropic_handler=_paste_secrets_ma_handler(tenant_id=tenant_id, ma_agent_id=ma_agent_id),
+    )
 
     await run_paste_secrets_submission(
         runtime,
@@ -799,12 +892,123 @@ async def test_run_paste_secrets_submission_when_non_admin_and_agent_is_workspac
         extra={"pairs": [("OPEN_KEY", "open_val")]},
     )
 
+    async with db_session_factory() as session:
+        files = await list_agent_files(session, tenant_id=tenant_id, agent_id=agent_uuid)
+
+    assert files == [], "a refused paste must write no agent file at all"
+
     texts = _ephemeral_texts(client_fake)
-    assert any(":white_check_mark:" in t for t in texts), (
-        "paste-secrets must succeed for a non-admin on a workspace-default agent"
+    assert any("workspace-admin" in t for t in texts), (
+        "the refusal ephemeral must say the change needs workspace-admin permission"
     )
-    assert not any("workspace-admin" in t for t in texts), (
-        "no reachability refusal ephemeral should be posted for a per-agent attachment"
+    assert not any(":white_check_mark:" in t for t in texts), (
+        "a refused paste must not post a success confirmation"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_paste_secrets_submission_when_admin_and_agent_is_workspace_default_writes_secrets(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An admin populating the workspace-default agent's environment still
+    works, and the confirmation still carries the key name only."""
+    from daimon.core.ma_identity import derive_agent_uuid
+    from daimon.core.stores.agent_files import get_agent_file
+
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        tenant_id = tenant.id
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
+
+    ma_agent_id = f"agent_{'g' * 24}"
+    agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+    runtime = _build_runtime_with_db(
+        db_session_factory,
+        anthropic_handler=_paste_secrets_ma_handler(tenant_id=tenant_id, ma_agent_id=ma_agent_id),
+    )
+
+    secret_value = "admin_written_value"
+    await run_paste_secrets_submission(
+        runtime,
+        client_fake.client,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        view_id="V_SUBMIT_TEST",
+        agent_name=_AGENT_NAME,
+        parent_section="secrets",
+        extra={"pairs": [("SHARED_KEY", secret_value)]},
+    )
+
+    async with db_session_factory() as session:
+        row = await get_agent_file(
+            session, tenant_id=tenant_id, agent_id=agent_uuid, key="SHARED_KEY"
+        )
+
+    assert row is not None, "an admin's paste against the workspace-default agent must be written"
+    assert row.content == secret_value, "the stored file must carry the submitted value"
+
+    texts = _ephemeral_texts(client_fake)
+    assert any("SHARED_KEY" in t for t in texts), (
+        "the confirmation must name the key that was written"
+    )
+    assert not any(secret_value in t for t in texts), (
+        "the confirmation must never carry the secret value"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_paste_secrets_submission_refusal_logs_no_key_names(
+    fake_slack_web_client: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The gate precedes every log line derived from the submitted pairs, so a
+    refused paste leaks neither key names nor values to the operator log."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
+        tenant_id = tenant.id
+        await session.commit()
+    await _mark_reachable(db_session_factory, tenant_id=tenant_id, agent_name=_AGENT_NAME)
+
+    client_fake: Any = fake_slack_web_client
+    # conftest default users.info is non-admin; no override.
+
+    ma_agent_id = f"agent_{'g' * 24}"
+    runtime = _build_runtime_with_db(
+        db_session_factory,
+        anthropic_handler=_paste_secrets_ma_handler(tenant_id=tenant_id, ma_agent_id=ma_agent_id),
+    )
+
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        await run_paste_secrets_submission(
+            runtime,
+            client_fake.client,
+            team_id=_TEAM_ID,
+            user_id=_USER_ID,
+            channel_id=_CHANNEL_ID,
+            view_id="V_SUBMIT_TEST",
+            agent_name=_AGENT_NAME,
+            parent_section="secrets",
+            extra={"pairs": [("REFUSED_KEY", "refused_value")]},
+        )
+    finally:
+        structlog.reset_defaults()
+
+    assert all("keys" not in entry for entry in cap.entries), (
+        "a refused paste must emit no log entry carrying a keys field"
+    )
+    assert all("REFUSED_KEY" not in str(entry) for entry in cap.entries), (
+        "the submitted key name must never reach the log stream on the refusal path"
+    )
+    assert all("refused_value" not in str(entry) for entry in cap.entries), (
+        "the submitted secret value must never reach the log stream"
     )
 
 
@@ -1359,6 +1563,10 @@ def _build_edit_repo_settings(*, app_id: str | None, fernet_key: str | None = No
     settings.github = MagicMock()
     settings.github.app_id = app_id
     settings.github.oauth_scopes = ("repo",)
+    # Explicitly off: a MagicMock attribute is truthy, so leaving this unset
+    # makes _dev_allow_all_admin treat every caller as an admin and every
+    # admin gate inert while the suite stays green.
+    settings.slack.dev_allow_all_admin = False
     return settings
 
 

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_write.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_write.py
@@ -40,6 +40,7 @@ from daimon.core.stores.agent_github_binding import set_agent_github_binding
 from daimon.core.stores.agent_repo_binding import get_binding, set_binding
 from daimon.core.stores.github_credentials import delete_credential_for_principal
 from daimon.core.stores.scoped_config_read import get_scope
+from daimon.core.stores.scoped_config_write import set_fields
 from daimon.core.stores.tenants import get_tenant
 from daimon.testing.factories import make_account, make_tenant
 from daimon.testing.ma import (
@@ -744,3 +745,42 @@ async def test_delete_agent_succeeds_when_store_archive_fails(
     assert mem_state.stores[store.id]["archived_at"] is None
     async with db_session_factory() as s:
         assert await get_memory_store_id(s, tenant_id=tenant.id, agent_id=agent_uuid) == store.id
+
+
+async def test_delete_agent_clears_tenant_default_naming_the_agent(
+    db_session, db_session_factory
+) -> None:
+    """Deleting the workspace default must not leave a tenant row naming a dead agent.
+
+    A tenant_config row pointing at an archived agent breaks resolution for the
+    whole install until an admin re-scopes by hand.
+    """
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="T_DELETE_SCOPE")
+    scope = TenantScopeRef(tenant_id=tenant.id)
+    await set_fields(db_session, scope=scope, tenant_id=tenant.id, agent_name="doomed")
+    await db_session.commit()
+
+    client = build_fake_anthropic(
+        combine_handlers(
+            _make_archive_agent_handler(),
+            make_fake_memory_store_handler(FakeMemoryStoreState()),
+            make_fake_ma_handler(),
+        )
+    )
+    await client.beta.agents.create(
+        name="doomed",
+        model="claude-sonnet-4-6",
+        metadata={"daimon_tenant": str(tenant.id), "daimon_name": "doomed"},
+    )
+
+    runtime = MagicMock(spec=SlackRuntime)
+    runtime.anthropic = client
+    runtime.sessionmaker = db_session_factory
+
+    await write_mod.delete_agent(runtime, tenant_id=tenant.id, name="doomed")
+
+    async with db_session_factory() as s:
+        assert await get_scope(s, scope=scope) is None, (
+            "the tenant row naming the deleted agent must be gone so resolution "
+            "falls through to the deployment default"
+        )

--- a/packages/core/daimon/core/stores/scoped_config_write.py
+++ b/packages/core/daimon/core/stores/scoped_config_write.py
@@ -156,6 +156,70 @@ async def unset_fields(
         await session.flush()
 
 
+async def clear_agent_references(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    agent_name: str,
+) -> int:
+    """Clear every channel- and tenant-scope row in one tenant that names an agent.
+
+    Called when an agent goes away (deleted or archived). A scope row still
+    naming a dead agent makes resolution fail for that channel — or, for the
+    tenant row, for the whole install — until someone re-scopes by hand.
+    Clearing the name lets the cascade fall through to the next tier.
+
+    Every mutation is delegated to `unset_fields` rather than issued as a bulk
+    UPDATE, because `unset_fields` already owns the two rules that matter here:
+    a row whose config fields all become NULL is removed outright, and a row
+    carrying mode='user_active' survives the clear because that mode IS the
+    propagation. Agent deletion is a rare admin action, so the per-row loop
+    costs nothing worth optimizing away.
+
+    `user_config` is deliberately left alone: `resolve()` never consults the
+    user tier, so clearing it would change nothing observable.
+
+    Returns the number of scope rows cleared. The caller owns the transaction.
+    """
+    # Materialize the channel ids before mutating: unset_fields may remove rows,
+    # so iterating a live result set while it writes would be wrong.
+    channel_ids: list[str] = list(
+        (
+            await session.execute(
+                select(ChannelConfig.channel_id).where(
+                    ChannelConfig.tenant_id == tenant_id,
+                    ChannelConfig.agent_name == agent_name,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    tenant_row_matches = (
+        await session.execute(
+            select(TenantConfig.tenant_id).where(
+                TenantConfig.tenant_id == tenant_id,
+                TenantConfig.agent_name == agent_name,
+            )
+        )
+    ).scalar_one_or_none() is not None
+
+    for channel_id in channel_ids:
+        await unset_fields(
+            session,
+            scope=ChannelScopeRef(tenant_id=tenant_id, channel_id=channel_id),
+            fields=["agent_name"],
+        )
+    if tenant_row_matches:
+        await unset_fields(
+            session,
+            scope=TenantScopeRef(tenant_id=tenant_id),
+            fields=["agent_name"],
+        )
+
+    return len(channel_ids) + (1 if tenant_row_matches else 0)
+
+
 async def delete_propagation_row(
     session: AsyncSession,
     *,

--- a/packages/core/tests/stores/test_scoped_config_write.py
+++ b/packages/core/tests/stores/test_scoped_config_write.py
@@ -13,6 +13,7 @@ from daimon.core.scope import (
 )
 from daimon.core.stores.scoped_config_read import get_scope
 from daimon.core.stores.scoped_config_write import (
+    clear_agent_references,
     delete_propagation_row,
     propagate,
     set_fields,
@@ -667,3 +668,141 @@ async def test_delete_propagation_row_does_not_touch_other_tenants(
     await delete_propagation_row(db_session, scope=scope_t1)
     surviving = await get_scope(db_session, scope=scope_t2)
     assert surviving is not None, "deleting t1's row must not touch t2's row"
+
+
+# ---------------------------------------------------------------------------
+# clear_agent_references
+# ---------------------------------------------------------------------------
+
+
+async def test_clear_agent_references_deletes_channel_row_when_agent_was_its_only_field(
+    db_session: AsyncSession,
+) -> None:
+    t = await make_tenant(db_session)
+    scope = ChannelScopeRef(tenant_id=t.id, channel_id="c1")
+    await set_fields(db_session, scope=scope, tenant_id=t.id, agent_name="doomed")
+
+    cleared = await clear_agent_references(db_session, tenant_id=t.id, agent_name="doomed")
+
+    assert cleared == 1, "one channel row named the deleted agent"
+    row = await get_scope(db_session, scope=scope)
+    assert row is None, (
+        "a channel row whose only set field was the deleted agent must be removed "
+        "so resolution falls through to the next tier"
+    )
+
+
+async def test_clear_agent_references_preserves_channel_row_that_also_sets_environment_name(
+    db_session: AsyncSession,
+) -> None:
+    t = await make_tenant(db_session)
+    scope = ChannelScopeRef(tenant_id=t.id, channel_id="c1")
+    await set_fields(
+        db_session,
+        scope=scope,
+        tenant_id=t.id,
+        agent_name="doomed",
+        environment_name="prod",
+    )
+
+    cleared = await clear_agent_references(db_session, tenant_id=t.id, agent_name="doomed")
+
+    assert cleared == 1, "the channel row named the deleted agent"
+    row = await get_scope(db_session, scope=scope)
+    assert row is not None, "row still carries environment_name, so it must survive"
+    assert row.agent_name is None, "agent_name must be cleared"
+    assert row.environment_name == "prod", "environment_name must be left untouched"
+
+
+async def test_clear_agent_references_preserves_user_active_channel_row(
+    db_session: AsyncSession,
+) -> None:
+    t = await make_tenant(db_session)
+    scope = ChannelScopeRef(tenant_id=t.id, channel_id="c1")
+    await set_fields(
+        db_session,
+        scope=scope,
+        tenant_id=t.id,
+        mode="user_active",
+        agent_name="doomed",
+    )
+
+    cleared = await clear_agent_references(db_session, tenant_id=t.id, agent_name="doomed")
+
+    assert cleared == 1, "the user_active row named the deleted agent"
+    row = await get_scope(db_session, scope=scope)
+    assert row is not None, "a user_active row must survive the clear — its mode IS the propagation"
+    assert row.mode == "user_active", "mode must be left untouched"
+    assert row.agent_name is None, "agent_name must still be cleared on a user_active row"
+
+
+async def test_clear_agent_references_clears_tenant_default_row(
+    db_session: AsyncSession,
+) -> None:
+    t = await make_tenant(db_session)
+    scope = TenantScopeRef(tenant_id=t.id)
+    await set_fields(db_session, scope=scope, tenant_id=t.id, agent_name="doomed")
+
+    cleared = await clear_agent_references(db_session, tenant_id=t.id, agent_name="doomed")
+
+    assert cleared == 1, "the tenant-scope row must count toward the return value"
+    row = await get_scope(db_session, scope=scope)
+    assert row is None, "the workspace default row must be removed, not left naming a dead agent"
+
+
+async def test_clear_agent_references_leaves_rows_naming_a_different_agent_untouched(
+    db_session: AsyncSession,
+) -> None:
+    t = await make_tenant(db_session)
+    channel_scope = ChannelScopeRef(tenant_id=t.id, channel_id="c1")
+    tenant_scope = TenantScopeRef(tenant_id=t.id)
+    await set_fields(db_session, scope=channel_scope, tenant_id=t.id, agent_name="other")
+    await set_fields(db_session, scope=tenant_scope, tenant_id=t.id, agent_name="other")
+
+    cleared = await clear_agent_references(db_session, tenant_id=t.id, agent_name="doomed")
+
+    assert cleared == 0, "no row named the deleted agent"
+    channel_row = await get_scope(db_session, scope=channel_scope)
+    assert channel_row is not None and channel_row.agent_name == "other", (
+        "a channel row naming a different agent must be untouched"
+    )
+    tenant_row = await get_scope(db_session, scope=tenant_scope)
+    assert tenant_row is not None and tenant_row.agent_name == "other", (
+        "a tenant row naming a different agent must be untouched"
+    )
+
+
+async def test_clear_agent_references_is_scoped_to_the_given_tenant(
+    db_session: AsyncSession,
+) -> None:
+    t1 = await make_tenant(db_session)
+    t2 = await make_tenant(db_session)
+    scope_t1 = ChannelScopeRef(tenant_id=t1.id, channel_id="c1")
+    scope_t2 = ChannelScopeRef(tenant_id=t2.id, channel_id="c1")
+    tenant_scope_t2 = TenantScopeRef(tenant_id=t2.id)
+    await set_fields(db_session, scope=scope_t1, tenant_id=t1.id, agent_name="doomed")
+    await set_fields(db_session, scope=scope_t2, tenant_id=t2.id, agent_name="doomed")
+    await set_fields(db_session, scope=tenant_scope_t2, tenant_id=t2.id, agent_name="doomed")
+
+    cleared = await clear_agent_references(db_session, tenant_id=t1.id, agent_name="doomed")
+
+    assert cleared == 1, "only t1's single row may be counted"
+    assert await get_scope(db_session, scope=scope_t1) is None, "t1's row should be gone"
+    surviving_channel = await get_scope(db_session, scope=scope_t2)
+    assert surviving_channel is not None and surviving_channel.agent_name == "doomed", (
+        "another tenant's channel row naming the same agent must be untouched"
+    )
+    surviving_tenant = await get_scope(db_session, scope=tenant_scope_t2)
+    assert surviving_tenant is not None and surviving_tenant.agent_name == "doomed", (
+        "another tenant's tenant row naming the same agent must be untouched"
+    )
+
+
+async def test_clear_agent_references_returns_zero_when_nothing_matches(
+    db_session: AsyncSession,
+) -> None:
+    t = await make_tenant(db_session)
+
+    cleared = await clear_agent_references(db_session, tenant_id=t.id, agent_name="doomed")
+
+    assert cleared == 0, "a tenant with no scope rows at all must report zero clears"


### PR DESCRIPTION
Panel controls whose blast radius exceeds the clicking member's own agent are now re-checked against **live** admin status at click time, not at render time.

## The problem

Two distinct holes, both on the agent-setup panels:

1. **Stale authorization snapshot.** A panel rendered for an admin kept working after that admin was demoted — the buttons stayed enabled and the callbacks trusted the render-time check.
2. **Never gated at all.** Several write paths had no admin check on any path: Slack's paste-secrets submission, remove-secret and edit-repo form push; Discord's `PasteSecretModal.on_submit` and `CredentialsSubView._on_remove`. A regular member could write credentials to an agent the whole server depends on.

Two adjacent bugs surfaced while auditing the same surfaces:

3. The billing principal was created but never committed, so a first-time `/billing` user got a checkout link naming an account that did not exist — the route 401'd.
4. Deleting an agent left channel and tenant defaults naming it, so the next turn in that channel missed the resolver instead of falling through the scope cascade.

## What changed

**Two new click-time predicates**, one per adapter, resolving admin status live and re-reading agent state from the DB rather than trusting anything carried in the rendered view:

- `refuse_if_not_admin` — plain admin check, no agent state involved.
- `refuse_if_shared_and_not_admin` — for per-agent attachments (repo binding, env vars). Deliberately inverts one step relative to the spec gate: the live-admin short-circuit runs *before* the system-agent limb, which is what keeps an admin able to bind a repo to the seeded default agent during first-run onboarding.

**Gate placement is part of the fix.** `RepoAuthModal.on_submit` refuses before `defer()` *and* before the log line carrying the masked GitHub token — a refused submission puts no credential on the wire and emits no record of one. Slack's repo submission is gated upstream of the GitHub access probe.

**One deliberate asymmetry, documented in the module docstring:** the edit-repo form is gated when it is *pushed*, because that form prompts for a personal access token and no such credential should transit for a write that will be refused. The paste-secrets form prompts for nothing on push, so it is gated at submission only — the boundary that actually writes.

**Read stays open.** The env-vars list still opens for any member and shows key *names*; only the writes refuse.

**`clear_agent_references`** (new core store function) is called after the MA archive on all four deletion surfaces — both panels, the MCP tool, and the CLI. Placed after the archive, never before: a failure leaves an archived agent with stale rows rather than a live agent with cleared ones.

## Stale rule statements

Several module docstrings asserted that these surfaces were deliberately open — the statements that made the gap look intentional to the next reader. All rewritten to route fields to gates, plus an explicit note naming the one control the rule does not cover (the agent-initiated credential request, authorized by a single-use token rather than by admin status).

## Testing

4235 passed / 4 skipped. pyright 0 errors, ruff clean, import-linter 6/6.

Worth flagging for reviewers: **four separate gates initially passed their tests while being completely inert.** Causes were fixture-shaped — a bare `MagicMock` settings object making a dev-allow-all flag truthy, target agents that were neither system nor reachable so the predicate returned `False` regardless, and `is_done()` truthy on a bare mock routing replies to `followup`. Every gate in this PR was mutation-checked: delete the gate, confirm the specific refusal test goes red and the admin-positive sibling stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
