### PR TITLE
feat(discord): allow one configured bot to start turns by mention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,8 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_DISCORD__HEALTH_PORT=8081
 # When True (default), each Discord thread keeps a separate agent session per calling user, so no user inherits another user's session identity or permissions in a shared thread. When False, a single session is shared by every caller in the thread — a legacy fallback, not recommended for production. Setting this False also exposes credentials: the shared session's token is minted for the thread starter's account, so any participant can prompt the agent into calling get_cli_token and receive the starter's bound PAT as plaintext.
 # DAIMON_DISCORD__PER_CALLER_THREAD_SESSIONS=True
+# Discord user id of a single automated QA bot allowed to start turns by mention. Bot-authored mentions are rejected by default; this allow-lists exactly one so a harness can drive the mention path end-to-end without a human. Leave unset outside test deployments -- an allow-listed bot spends real credit. Setting it to the bot's own id is refused at the gate, since that would make every turn trigger the next one.
+# DAIMON_DISCORD__QA_BOT_USER_ID=
 # The bot's presented name across user-facing Discord render sites (@mentions, setup messages, help text, privacy panel copy). Defaults to 'daimon' so unset deployments render byte-identical output. Set to a distinct name (e.g. 'daimon-staging') so a non-production deployment is visibly distinct in-channel.
 # DAIMON_DISCORD__BOT_DISPLAY_NAME=daimon
 

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -512,8 +512,10 @@ class DaimonBot(commands.Bot):
     async def on_message(self, message: discord.Message) -> None:
         """Gate on mention, resolve TenantContext once + run the non-ready self-heal gate,
         then orchestrate a turn in a thread."""
+        discord_settings = self.runtime.settings.discord
         if not should_process_message(
             author_is_bot=message.author.bot,
+            author_id=str(message.author.id),
             # Explicit @-mention only. `mentioned_in` returns True for @everyone/@here
             # (it short-circuits on message.mention_everyone), which would make the bot
             # reply to every mass ping. message.mentions excludes @everyone/@here and
@@ -521,6 +523,8 @@ class DaimonBot(commands.Bot):
             bot_mentioned=self.user is not None
             and any(user.id == self.user.id for user in message.mentions),
             guild_id=str(message.guild.id) if message.guild else None,
+            self_user_id=str(self.user.id) if self.user is not None else None,
+            qa_bot_user_id=discord_settings.qa_bot_user_id if discord_settings else None,
         ):
             return
         if self.draining:

--- a/packages/adapters/discord/daimon/adapters/discord/gating.py
+++ b/packages/adapters/discord/daimon/adapters/discord/gating.py
@@ -6,12 +6,44 @@ from __future__ import annotations
 def should_process_message(
     *,
     author_is_bot: bool,
+    author_id: str,
     bot_mentioned: bool,
     guild_id: str | None,
+    self_user_id: str | None = None,
+    qa_bot_user_id: str | None = None,
 ) -> bool:
     """Pre-DB gate checks for on_message. Returns True if message passes all non-DB filters."""
-    if author_is_bot:
+    if author_is_bot and not _is_allowed_bot_author(
+        author_id=author_id,
+        self_user_id=self_user_id,
+        qa_bot_user_id=qa_bot_user_id,
+    ):
         return False
     if not bot_mentioned:
         return False
     return guild_id is not None
+
+
+def _is_allowed_bot_author(
+    *,
+    author_id: str,
+    self_user_id: str | None,
+    qa_bot_user_id: str | None,
+) -> bool:
+    """Whether a bot-authored mention may start a turn.
+
+    Bots are rejected by default. A deployment may allow-list exactly one bot
+    -- an automated QA driver -- so a harness can exercise the mention path
+    end-to-end without a human. Discord forbids bots from invoking application
+    commands or component interactions, so a mention is the only turn trigger
+    reachable by automation at all.
+
+    Allow-listing the bot's own id is refused rather than honored: daimon's
+    answers mention the caller, so a self-allow-list would have every turn
+    trigger the next one without bound.
+    """
+    if qa_bot_user_id is None:
+        return False
+    if self_user_id is not None and qa_bot_user_id == self_user_id:
+        return False
+    return author_id == qa_bot_user_id

--- a/packages/adapters/discord/tests/test_gating.py
+++ b/packages/adapters/discord/tests/test_gating.py
@@ -1,0 +1,106 @@
+"""Pre-DB message gate: who may start a turn by mention."""
+
+from __future__ import annotations
+
+from daimon.adapters.discord.gating import should_process_message
+
+DAIMON_ID = "111"
+HUMAN_ID = "222"
+QA_BOT_ID = "333"
+OTHER_BOT_ID = "444"
+
+
+def test_gate_admits_mentioning_human_in_guild() -> None:
+    assert should_process_message(
+        author_is_bot=False,
+        author_id=HUMAN_ID,
+        bot_mentioned=True,
+        guild_id="g1",
+        self_user_id=DAIMON_ID,
+    ), "a human's explicit mention in a guild is the ordinary turn trigger"
+
+
+def test_gate_rejects_human_when_not_mentioned() -> None:
+    assert not should_process_message(
+        author_is_bot=False,
+        author_id=HUMAN_ID,
+        bot_mentioned=False,
+        guild_id="g1",
+        self_user_id=DAIMON_ID,
+    ), "an unmentioned message must not start a turn"
+
+
+def test_gate_rejects_human_mention_in_dm() -> None:
+    assert not should_process_message(
+        author_is_bot=False,
+        author_id=HUMAN_ID,
+        bot_mentioned=True,
+        guild_id=None,
+        self_user_id=DAIMON_ID,
+    ), "DMs have no tenant, so they must not start a turn"
+
+
+def test_gate_rejects_bot_author_when_no_qa_bot_configured() -> None:
+    assert not should_process_message(
+        author_is_bot=True,
+        author_id=OTHER_BOT_ID,
+        bot_mentioned=True,
+        guild_id="g1",
+        self_user_id=DAIMON_ID,
+        qa_bot_user_id=None,
+    ), "with no allow-list, every bot-authored mention is rejected"
+
+
+def test_gate_admits_allow_listed_qa_bot() -> None:
+    assert should_process_message(
+        author_is_bot=True,
+        author_id=QA_BOT_ID,
+        bot_mentioned=True,
+        guild_id="g1",
+        self_user_id=DAIMON_ID,
+        qa_bot_user_id=QA_BOT_ID,
+    ), "the allow-listed QA bot's mention must start a turn like a human's"
+
+
+def test_gate_rejects_unlisted_bot_when_qa_bot_configured() -> None:
+    assert not should_process_message(
+        author_is_bot=True,
+        author_id=OTHER_BOT_ID,
+        bot_mentioned=True,
+        guild_id="g1",
+        self_user_id=DAIMON_ID,
+        qa_bot_user_id=QA_BOT_ID,
+    ), "the allow-list admits exactly one bot, not bots in general"
+
+
+def test_gate_rejects_self_authored_mention_when_allow_listed_to_own_id() -> None:
+    assert not should_process_message(
+        author_is_bot=True,
+        author_id=DAIMON_ID,
+        bot_mentioned=True,
+        guild_id="g1",
+        self_user_id=DAIMON_ID,
+        qa_bot_user_id=DAIMON_ID,
+    ), "allow-listing daimon's own id must not arm an unbounded self-trigger loop"
+
+
+def test_gate_rejects_qa_bot_when_not_mentioned() -> None:
+    assert not should_process_message(
+        author_is_bot=True,
+        author_id=QA_BOT_ID,
+        bot_mentioned=False,
+        guild_id="g1",
+        self_user_id=DAIMON_ID,
+        qa_bot_user_id=QA_BOT_ID,
+    ), "the allow-list relaxes the bot-author check only, not the mention requirement"
+
+
+def test_gate_rejects_qa_bot_in_dm() -> None:
+    assert not should_process_message(
+        author_is_bot=True,
+        author_id=QA_BOT_ID,
+        bot_mentioned=True,
+        guild_id=None,
+        self_user_id=DAIMON_ID,
+        qa_bot_user_id=QA_BOT_ID,
+    ), "the allow-list relaxes the bot-author check only, not the guild requirement"

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -155,6 +155,18 @@ class DiscordSettings(BaseModel):
             "starter's bound PAT as plaintext."
         ),
     )
+    qa_bot_user_id: str | None = Field(
+        default=None,
+        description=(
+            "Discord user id of a single automated QA bot allowed to start "
+            "turns by mention. Bot-authored mentions are rejected by default; "
+            "this allow-lists exactly one so a harness can drive the mention "
+            "path end-to-end without a human. Leave unset outside test "
+            "deployments -- an allow-listed bot spends real credit. Setting "
+            "it to the bot's own id is refused at the gate, since that would "
+            "make every turn trigger the next one."
+        ),
+    )
     bot_display_name: str = Field(
         default="daimon",
         # Constrained because the value flows into user-facing surfaces with


### PR DESCRIPTION
Bot-authored mentions are rejected unconditionally today, so no automated
harness can exercise the Discord mention path. That matters because mention is
the *only* turn trigger a bot can reach at all — Discord forbids bots from
invoking application commands or component interactions, so slash commands,
buttons, and modals are permanently out of reach for automation.

Adds an optional `DiscordSettings.qa_bot_user_id` that allow-lists exactly one
bot. Unset by default, so every existing deployment behaves identically.

Two guards worth noting:

- Allow-listing the bot's own id is refused at the gate rather than honored.
  daimon's answers mention the caller, so a self-allow-list would have every
  turn trigger the next one without bound.
- The allow-list relaxes the bot-author check only. The mention requirement and
  the guild requirement still apply, and there are tests for both.

The companion QA harness lives in the companion infra repo.

`packages/adapters/discord/tests/test_gating.py` is new — the gate had no
direct test file before, only incidental coverage via orchestration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)