### PR TITLE
feat: allow-list several QA bots; ungate create_environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,8 +43,8 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_DISCORD__HEALTH_PORT=8081
 # When True (default), each Discord thread keeps a separate agent session per calling user, so no user inherits another user's session identity or permissions in a shared thread. When False, a single session is shared by every caller in the thread — a legacy fallback, not recommended for production. Setting this False also exposes credentials: the shared session's token is minted for the thread starter's account, so any participant can prompt the agent into calling get_cli_token and receive the starter's bound PAT as plaintext.
 # DAIMON_DISCORD__PER_CALLER_THREAD_SESSIONS=True
-# Discord user id of a single automated QA bot allowed to start turns by mention. Bot-authored mentions are rejected by default; this allow-lists exactly one so a harness can drive the mention path end-to-end without a human. Leave unset outside test deployments -- an allow-listed bot spends real credit. Setting it to the bot's own id is refused at the gate, since that would make every turn trigger the next one.
-# DAIMON_DISCORD__QA_BOT_USER_ID=
+# Discord user ids of automated QA bots allowed to start turns by mention. Bot-authored mentions are rejected by default; these are allow-listed so a harness can drive the mention path end-to-end without a human. Several are supported because admin-gated tools need a caller holding Manage Server while the refusal paths need one without it. Leave empty outside test deployments -- an allow-listed bot spends real credit. As a tuple field this must be set as a JSON array, e.g. '["123","456"]'. daimon's own id is refused at the gate even if listed.
+# DAIMON_DISCORD__QA_BOT_USER_IDS=
 # The bot's presented name across user-facing Discord render sites (@mentions, setup messages, help text, privacy panel copy). Defaults to 'daimon' so unset deployments render byte-identical output. Set to a distinct name (e.g. 'daimon-staging') so a non-production deployment is visibly distinct in-channel.
 # DAIMON_DISCORD__BOT_DISPLAY_NAME=daimon
 

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -524,7 +524,7 @@ class DaimonBot(commands.Bot):
             and any(user.id == self.user.id for user in message.mentions),
             guild_id=str(message.guild.id) if message.guild else None,
             self_user_id=str(self.user.id) if self.user is not None else None,
-            qa_bot_user_id=discord_settings.qa_bot_user_id if discord_settings else None,
+            qa_bot_user_ids=discord_settings.qa_bot_user_ids if discord_settings else (),
         ):
             return
         if self.draining:

--- a/packages/adapters/discord/daimon/adapters/discord/gating.py
+++ b/packages/adapters/discord/daimon/adapters/discord/gating.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
+
 
 def should_process_message(
     *,
@@ -10,13 +12,13 @@ def should_process_message(
     bot_mentioned: bool,
     guild_id: str | None,
     self_user_id: str | None = None,
-    qa_bot_user_id: str | None = None,
+    qa_bot_user_ids: Collection[str] = (),
 ) -> bool:
     """Pre-DB gate checks for on_message. Returns True if message passes all non-DB filters."""
     if author_is_bot and not _is_allowed_bot_author(
         author_id=author_id,
         self_user_id=self_user_id,
-        qa_bot_user_id=qa_bot_user_id,
+        qa_bot_user_ids=qa_bot_user_ids,
     ):
         return False
     if not bot_mentioned:
@@ -28,22 +30,25 @@ def _is_allowed_bot_author(
     *,
     author_id: str,
     self_user_id: str | None,
-    qa_bot_user_id: str | None,
+    qa_bot_user_ids: Collection[str],
 ) -> bool:
     """Whether a bot-authored mention may start a turn.
 
-    Bots are rejected by default. A deployment may allow-list exactly one bot
-    -- an automated QA driver -- so a harness can exercise the mention path
+    Bots are rejected by default. A deployment may allow-list specific bots --
+    automated QA drivers -- so a harness can exercise the mention path
     end-to-end without a human. Discord forbids bots from invoking application
     commands or component interactions, so a mention is the only turn trigger
     reachable by automation at all.
 
-    Allow-listing the bot's own id is refused rather than honored: daimon's
-    answers mention the caller, so a self-allow-list would have every turn
-    trigger the next one without bound.
+    Several ids are allowed because the admin-gated tools need a caller who
+    holds Manage Server and the refusal paths need one who does not; a single
+    driver cannot be both, and toggling a live bot's permissions mid-run makes
+    the two outcomes indistinguishable from a flaky gate.
+
+    daimon's own id is never honored, even if listed: its answers mention the
+    caller, so allow-listing itself would have every turn trigger the next one
+    without bound.
     """
-    if qa_bot_user_id is None:
+    if self_user_id is not None and author_id == self_user_id:
         return False
-    if self_user_id is not None and qa_bot_user_id == self_user_id:
-        return False
-    return author_id == qa_bot_user_id
+    return author_id in qa_bot_user_ids

--- a/packages/adapters/discord/tests/test_gating.py
+++ b/packages/adapters/discord/tests/test_gating.py
@@ -7,6 +7,7 @@ from daimon.adapters.discord.gating import should_process_message
 DAIMON_ID = "111"
 HUMAN_ID = "222"
 QA_BOT_ID = "333"
+QA_ADMIN_BOT_ID = "555"
 OTHER_BOT_ID = "444"
 
 
@@ -47,7 +48,7 @@ def test_gate_rejects_bot_author_when_no_qa_bot_configured() -> None:
         bot_mentioned=True,
         guild_id="g1",
         self_user_id=DAIMON_ID,
-        qa_bot_user_id=None,
+        qa_bot_user_ids=(),
     ), "with no allow-list, every bot-authored mention is rejected"
 
 
@@ -58,7 +59,7 @@ def test_gate_admits_allow_listed_qa_bot() -> None:
         bot_mentioned=True,
         guild_id="g1",
         self_user_id=DAIMON_ID,
-        qa_bot_user_id=QA_BOT_ID,
+        qa_bot_user_ids=(QA_BOT_ID,),
     ), "the allow-listed QA bot's mention must start a turn like a human's"
 
 
@@ -69,8 +70,8 @@ def test_gate_rejects_unlisted_bot_when_qa_bot_configured() -> None:
         bot_mentioned=True,
         guild_id="g1",
         self_user_id=DAIMON_ID,
-        qa_bot_user_id=QA_BOT_ID,
-    ), "the allow-list admits exactly one bot, not bots in general"
+        qa_bot_user_ids=(QA_BOT_ID,),
+    ), "the allow-list admits only listed ids, never bots in general"
 
 
 def test_gate_rejects_self_authored_mention_when_allow_listed_to_own_id() -> None:
@@ -80,8 +81,31 @@ def test_gate_rejects_self_authored_mention_when_allow_listed_to_own_id() -> Non
         bot_mentioned=True,
         guild_id="g1",
         self_user_id=DAIMON_ID,
-        qa_bot_user_id=DAIMON_ID,
+        qa_bot_user_ids=(DAIMON_ID,),
     ), "allow-listing daimon's own id must not arm an unbounded self-trigger loop"
+
+
+def test_gate_admits_each_of_two_allow_listed_bots() -> None:
+    for author_id in (QA_BOT_ID, QA_ADMIN_BOT_ID):
+        assert should_process_message(
+            author_is_bot=True,
+            author_id=author_id,
+            bot_mentioned=True,
+            guild_id="g1",
+            self_user_id=DAIMON_ID,
+            qa_bot_user_ids=(QA_BOT_ID, QA_ADMIN_BOT_ID),
+        ), "both an admin and a non-admin driver must be able to start turns"
+
+
+def test_gate_rejects_self_authored_mention_when_listed_alongside_others() -> None:
+    assert not should_process_message(
+        author_is_bot=True,
+        author_id=DAIMON_ID,
+        bot_mentioned=True,
+        guild_id="g1",
+        self_user_id=DAIMON_ID,
+        qa_bot_user_ids=(QA_BOT_ID, DAIMON_ID),
+    ), "the self-trigger refusal must not be bypassable by padding the allow-list"
 
 
 def test_gate_rejects_qa_bot_when_not_mentioned() -> None:
@@ -91,7 +115,7 @@ def test_gate_rejects_qa_bot_when_not_mentioned() -> None:
         bot_mentioned=False,
         guild_id="g1",
         self_user_id=DAIMON_ID,
-        qa_bot_user_id=QA_BOT_ID,
+        qa_bot_user_ids=(QA_BOT_ID,),
     ), "the allow-list relaxes the bot-author check only, not the mention requirement"
 
 
@@ -102,5 +126,5 @@ def test_gate_rejects_qa_bot_in_dm() -> None:
         bot_mentioned=True,
         guild_id=None,
         self_user_id=DAIMON_ID,
-        qa_bot_user_id=QA_BOT_ID,
+        qa_bot_user_ids=(QA_BOT_ID,),
     ), "the allow-list relaxes the bot-author check only, not the guild requirement"

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/environments.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/environments.py
@@ -88,7 +88,12 @@ async def _create_environment_impl(
     auth: AuthIdentity,
     spec: EnvironmentSpec,
 ) -> EnvironmentInfo:
-    _require_admin(auth)
+    # Deliberately ungated, unlike update/archive below. A freshly created
+    # environment is inert: nothing routes to it until an admin scopes an agent
+    # onto a channel or the workspace via set_agent_default, which is gated. So
+    # the gate here bought no isolation while blocking the ordinary onboarding
+    # ask -- "make me an agent that can run pymc" -- for every non-admin.
+    # Matches create_agent / fork_agent, which are ungated for the same reason.
     await _reject_environment_name_collision(runtime, auth, spec.name)
     payload = spec.model_dump(exclude_none=True)
     payload["metadata"] = build_metadata(tenant_id=auth.tenant_id, name=spec.name)
@@ -130,8 +135,10 @@ async def _archive_environment_impl(
 
 def register_environment_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     # Reads are untagged and ungated — full visibility for every session,
-    # matching the agents/skills read tools (admin-tag/gate agreement: only
-    # mutating tools carry tags={"admin"} + the _require_admin impl gate).
+    # matching the agents/skills read tools. Mutations carry tags={"admin"} plus
+    # the _require_admin impl gate, with one deliberate exception:
+    # create_environment is ungated, because a new environment is inert until an
+    # admin scopes an agent onto it. See the comment on _create_environment_impl.
     @mcp.tool
     async def list_environments(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
@@ -145,7 +152,7 @@ def register_environment_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         """Return one environment by name."""
         return await _get_environment_impl(runtime, await _auth(ctx), name)
 
-    @mcp.tool(tags={"admin"})
+    @mcp.tool
     async def create_environment(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         spec: EnvironmentSpec,

--- a/packages/adapters/mcp/tests/test_rbac.py
+++ b/packages/adapters/mcp/tests/test_rbac.py
@@ -249,10 +249,15 @@ RELAXED_TOOL_NAMES = (
     "update_agent",
     "attach_mcp_server",
     "fork_agent",
+    "create_environment",
 )
-"""The four agents.py tools whose blast radius is one agent, not the whole
-tenant — relaxed onto the open (non-admin-visible, non-admin-callable)
-surface. Untagged, so a non-admin chat session's search surfaces them."""
+"""Tools whose blast radius is one agent, or nothing at all, rather than the
+whole tenant — relaxed onto the open (non-admin-visible, non-admin-callable)
+surface. Untagged, so a non-admin chat session's search surfaces them.
+
+`create_environment` is the "nothing at all" case: the environment it creates is
+unreachable until an admin scopes an agent onto it via the gated
+`set_agent_default`."""
 
 AGENT_IDENTITY_SCOPED_TOOL_NAMES = (
     "set_repo_binding",
@@ -407,11 +412,16 @@ STILL_ADMIN_TOOL_NAMES = (
     "clear_agent_default",
     "archive_agent",
     "sync_skills",
-    "create_environment",
     "update_environment",
     "archive_environment",
 )
-"""Tools whose blast radius is the whole tenant — stay admin-only after this plan."""
+"""Tools whose blast radius is the whole tenant, and stay admin-only.
+
+`create_environment` is deliberately absent: a new environment is inert until an
+admin scopes an agent onto it, so its blast radius is nothing until a gated call
+widens it. Mutating an environment others already resolve to is a different
+matter, which is why `update_environment` and `archive_environment` stay here.
+"""
 
 
 @pytest.mark.parametrize("tool_name", STILL_ADMIN_TOOL_NAMES)

--- a/packages/adapters/mcp/tests/tools/test_require_admin.py
+++ b/packages/adapters/mcp/tests/tools/test_require_admin.py
@@ -287,8 +287,13 @@ def _env_runtime(client: AsyncAnthropic) -> McpRuntime:
     )
 
 
-async def test_create_environment_impl_raises_when_not_admin() -> None:
-    """Non-admin caller is rejected before any MA call."""
+async def test_create_environment_impl_does_not_refuse_non_admin() -> None:
+    """Creating an environment is ungated -- it is inert until an admin scopes to it.
+
+    Asserts only that the admin gate does not fire; the call proceeds past it and
+    fails later on the stub client, which is enough to distinguish "refused up
+    front" from "allowed through".
+    """
     auth = AuthIdentity(
         account_id=uuid.uuid4(),
         tenant_id=uuid.uuid4(),
@@ -296,10 +301,11 @@ async def test_create_environment_impl_raises_when_not_admin() -> None:
         is_admin=False,
     )
     spec = EnvironmentSpec(name="e")
-    with pytest.raises(ToolError) as exc_info:
+    with pytest.raises(Exception) as exc_info:  # noqa: B017, PT011
         await _create_environment_impl(_env_runtime(MagicMock(spec=AsyncAnthropic)), auth, spec)
-    assert str(exc_info.value) == _D28_MESSAGE, (
-        "_create_environment_impl must refuse non-admin with admin-required message"
+    assert str(exc_info.value) != _D28_MESSAGE, (
+        "create_environment must not refuse a non-admin -- gating it blocks the "
+        "ordinary onboarding ask while buying no isolation"
     )
 
 

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -155,16 +155,18 @@ class DiscordSettings(BaseModel):
             "starter's bound PAT as plaintext."
         ),
     )
-    qa_bot_user_id: str | None = Field(
-        default=None,
+    qa_bot_user_ids: tuple[str, ...] = Field(
+        default=(),
         description=(
-            "Discord user id of a single automated QA bot allowed to start "
-            "turns by mention. Bot-authored mentions are rejected by default; "
-            "this allow-lists exactly one so a harness can drive the mention "
-            "path end-to-end without a human. Leave unset outside test "
-            "deployments -- an allow-listed bot spends real credit. Setting "
-            "it to the bot's own id is refused at the gate, since that would "
-            "make every turn trigger the next one."
+            "Discord user ids of automated QA bots allowed to start turns by "
+            "mention. Bot-authored mentions are rejected by default; these are "
+            "allow-listed so a harness can drive the mention path end-to-end "
+            "without a human. Several are supported because admin-gated tools "
+            "need a caller holding Manage Server while the refusal paths need "
+            "one without it. Leave empty outside test deployments -- an "
+            "allow-listed bot spends real credit. As a tuple field this must "
+            'be set as a JSON array, e.g. \'["123","456"]\'. daimon\'s own id '
+            "is refused at the gate even if listed."
         ),
     )
     bot_display_name: str = Field(


### PR DESCRIPTION
Two related changes, both surfaced while building automated QA of the Discord
adapter.

## Allow-list several QA bots instead of one

`DiscordSettings.qa_bot_user_id` becomes `qa_bot_user_ids`, a tuple — so it must
now be set as a JSON array. Still empty by default, so every deployment behaves
identically.

Why plural: exercising the admin-gated MCP tools needs a caller holding Manage
Server, and exercising their refusal paths needs one without it. A single driver
cannot be both, and toggling a live bot's permissions mid-run makes a refusal
indistinguishable from a flaky gate.

The self-trigger refusal moved ahead of the membership check rather than being
folded into it, so padding the allow-list with the bot's own id cannot bypass it.
There is a test for exactly that case.

## Ungate `create_environment`

A freshly created environment is inert — nothing routes to it until an admin
scopes an agent onto a channel or the workspace via `set_agent_default`, which
stays gated. So the admin gate here bought no isolation while blocking the
ordinary onboarding ask ("make me an agent that can run pymc") for every
non-admin. `create_agent` and `fork_agent` are already ungated on the same
reasoning.

`update_environment` and `archive_environment` stay admin-only: mutating an
environment other sessions already resolve to is a real tenant-wide blast
radius, unlike creating one nobody can reach.

The name moved from `STILL_ADMIN_TOOL_NAMES` to `RELAXED_TOOL_NAMES` rather than
just being deleted, so the change is asserted in both directions —
invisible-to-non-admin would otherwise have kept passing vacuously. Also
corrects the module comment that claimed every mutating tool carries the admin
tag, which this change makes false.

## Verification

949 discord + 670 mcp tests pass, pyright clean project-wide, import contracts
kept, `.env.example` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)