### PR TITLE
feat: bind a repo to an agent from chat, without the setup panel

### DIFF
--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -12,10 +12,13 @@ me set up", "configure me", "get me started"), walk through the following, in
 order, and confirm the shape with the user before you consider it done:
 
 1. **Repository.** Ask which GitHub repository they want the agent working
-   against. Repo binding cannot be done from a chat turn — a chat session
-   doesn't carry the identity the binding tool needs. Send them to
-   `/agent-setup` → the agent's **GitHub…** door instead, and say why in one
-   line (binding needs a fuller session than a chat turn carries).
+   against, then call
+   `request_repo_binding(agent_name, repo_url, purpose, channel_id)` — never
+   accept a GitHub token in chat (see "Credentials never travel through
+   chat" below). This posts a button naming the exact repo and agent; the
+   user completes the bind by clicking it, which opens a private form
+   asking for the branch and, only if the repo is private, a GitHub token.
+   They only need to paste a token if the repo isn't publicly readable.
 2. **Skills.** Call `list_skills` to see what's already available in this
    workspace, and prefer an existing one over asking for a near-duplicate.
    Attaching an existing skill to an agent works via
@@ -72,10 +75,11 @@ the `daimon agents archive` CLI command.
 
 ## Credentials never travel through chat
 
-`request_env_credential` and `request_mcp_credential` post a single-use,
-expiring button in the thread; clicking it opens a private modal where the
-user enters the value, so it never enters channel history or the session
-log. Both are Discord-only today — on Slack, credential entry goes through
+`request_env_credential`, `request_mcp_credential`, and
+`request_repo_binding` post a single-use, expiring button in the thread;
+clicking it opens a private modal where the user enters the value, so it
+never enters channel history or the session log. All three are Discord-only
+today — on Slack, credential entry and repo binding go through
 `/agent-setup` instead.
 
 If a user pastes a token or secret in chat anyway: acknowledge that you saw

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
@@ -27,12 +27,20 @@ the field it writes is part of the agent spec:
 A new mutating control belongs to one of those two sets. Pick its gate from the
 set the field is in, not from the button it happens to sit next to.
 
-The one deliberate exception is `credential_modals.py`, whose write is bounded
-by a single-use `credential_requests` token rather than by guild-admin status:
-the agent asks a specific member for a specific key, and consuming the token is
-what authorizes exactly that one write. It is not reachable from this panel and
-is not an exception you can extend — a control a member reaches by clicking has
-no such token and belongs to one of the two sets above.
+There are now two writes bounded by a single-use `credential_requests` token
+rather than by guild-admin status: `credential_modals.py`'s env/MCP credential
+writes, and the repo bind reached from a chat-posted request button. What
+admits a write to that class is the token, consumed by the write itself, not
+proximity to this panel — a control a member reaches by clicking with no such
+token still belongs to one of the two sets above.
+
+A token alone is sufficient authorization for an env secret or an MCP token:
+the requester supplies a value only they hold, scoped to one key on one agent.
+It is not sufficient for a repo binding, which changes what code the agent
+clones and runs and, on a shared agent, reaches every member of the install.
+So the repo-bind path additionally re-derives this module's
+`refuse_if_shared_and_not_admin` decision from primitives, at click time, in
+`credential_repo_bind.refuse_if_shared_and_not_admin_for_request`.
 """
 
 from __future__ import annotations

--- a/packages/adapters/discord/daimon/adapters/discord/credential_button.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_button.py
@@ -16,13 +16,37 @@ carries a persistent, dispatchable custom_id — everywhere else stays
 non-persistent (see `views.py`'s module docstring for the documented
 exception).
 
-Authorization is requester-only: `interaction_check` compares the clicking
-user's id against the id the request was minted for. There is deliberately
-NO admin gate here — the setup panel's mutation buttons are admin-only, but
-this flow intentionally widens that to "whoever the agent was talking to"
-for one-click UX. That makes the requester comparison in `interaction_check`
-the ONLY authorization on this write path. Do not "restore" an admin check
-here without a deliberate decision to change that.
+Authorization is requester-only for the env and MCP kinds: `interaction_check`
+compares the clicking user's id against the id the request was minted for,
+and there is deliberately NO admin gate for either — the setup panel's
+mutation buttons are admin-only, but this flow intentionally widens that to
+"whoever the agent was talking to" for one-click UX. Do not "restore" an
+admin check for either of those two kinds without a deliberate decision to
+change that.
+
+The repo kind is the deliberate exception: a repo binding changes what code
+the agent clones and runs and, on a shared agent, reaches every member of
+the install, so it is additionally gated on
+`credential_repo_bind.refuse_if_shared_and_not_admin_for_request` — run as a
+pre-filter in `callback` below, before the modal even opens, and again in
+`RepoBindModal.on_submit` before the atomic consume. `interaction_check`
+itself runs the same requester/expiry/single-use check for every kind,
+including this one; it carries no admin logic of its own.
+
+The repo kind's non-admin branch bounds that pre-filter with
+`_PRE_FILTER_TIMEOUT_SECONDS` and opens the modal anyway if it times out.
+That is sound only because `RepoBindModal.on_submit` repeats the identical
+gate before the consume — this pre-filter is advisory, not authoritative, so
+falling through never grants a write the submit-time check would not also
+grant. What a timeout costs is `T-18-18` reverting to its pre-revision shape
+for that one click: a member who will still be refused briefly sees the
+token field before the submit-time gate turns them away. Never confuse
+`is_done()`, used below to pick which half of the response already fired,
+with the actual defence against an interaction acknowledged while this
+pre-filter was running: `is_done()` only reflects an ack whose POST had
+already returned by the time a cancellation lands, and a POST that is still
+outstanding leaves it False. The `discord.HTTPException` code-40060 catch is
+what covers that outstanding-POST window instead.
 
 discord.py's own dispatcher swallows every exception raised inside
 `from_custom_id`, `interaction_check`, and `callback` (logs internally and
@@ -38,13 +62,23 @@ swallowing dispatcher.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from datetime import UTC, datetime
-from typing import Any, Self, cast
+from typing import Any, Final, Self, cast
 
 import structlog
 from daimon.adapters.discord.bot import DaimonBot
-from daimon.adapters.discord.credential_modals import EnvCredentialModal, McpCredentialModal
+from daimon.adapters.discord.checks import is_guild_admin
+from daimon.adapters.discord.credential_modals import (
+    EnvCredentialModal,
+    McpCredentialModal,
+    RepoBindModal,
+)
+from daimon.adapters.discord.credential_repo_bind import (
+    refuse_if_shared_and_not_admin_for_request,
+)
+from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.credential_requests import (
     CUSTOM_ID_TEMPLATE,
     CredentialRequestKind,
@@ -71,6 +105,20 @@ _EXPIRED = "This request expired — ask again."
 _ALREADY_USED = "This request was already used — ask again."
 _CHECK_FAILED = "Something went wrong checking this request — please try again."
 _CALLBACK_FAILED = "Something went wrong opening this form — please try again."
+
+_PRE_FILTER_TIMEOUT_SECONDS: Final[float] = 1.5
+"""Bound on the repo kind's non-admin pre-filter, measured from entry into
+`callback` rather than from interaction creation — so it can still overshoot
+the real 3-second ack budget; that is strictly better than no bound at all,
+and never unsafe (see the module docstring for why falling through on expiry
+is sound). Chosen against that 3-second budget, leaving room for
+`send_modal`'s own round trip and for whatever `from_custom_id` already
+spent reading the row. The underlying read
+(`refuse_if_shared_and_not_admin_for_request` -> `list_agents_by_tenant`)
+paginates the operator's entire MA org, so it costs the same on every click
+regardless of this bound; a retry after a timeout fails identically, which
+is why the fallback here is to open the modal rather than to ask the member
+to click again."""
 
 
 class CredentialRequestButton(
@@ -131,12 +179,15 @@ class CredentialRequestButton(
     async def interaction_check(  # type: ignore[override]  # see from_custom_id
         self, interaction: discord.Interaction[commands.Bot], /
     ) -> bool:
-        """Requester-only authorization plus fast expiry/single-use feedback.
+        """Requester/expiry/single-use check, common to every kind.
 
-        This is the ONLY authorization gate on the credential write — there is
-        no admin check. The authoritative single-use gate is the atomic
-        consume inside the modal's `on_submit`; rejecting an already-used or
-        expired row here is fast user feedback, not the security boundary.
+        This is fast user feedback, not the security boundary, for every
+        kind — the authoritative single-use gate is the atomic consume
+        inside the modal's `on_submit`; rejecting an already-used or expired
+        row here just saves the round trip. This method carries no admin
+        logic of its own: the repo kind's additional shared-agent admin gate
+        lives in `callback`'s pre-filter and in `RepoBindModal.on_submit`,
+        not here.
         """
         try:
             request_row = self.request_row
@@ -163,7 +214,14 @@ class CredentialRequestButton(
     async def callback(  # type: ignore[override]  # see from_custom_id
         self, interaction: discord.Interaction[commands.Bot]
     ) -> None:
-        """Open the env or MCP modal matching this request's kind."""
+        """Open the modal matching this request's kind.
+
+        The repo kind runs a non-admin pre-filter before the modal opens —
+        see the module docstring and `_PRE_FILTER_TIMEOUT_SECONDS`. Never
+        defers: opening a modal requires an un-acked interaction, so every
+        response below is the interaction's first (and, on the repo kind's
+        refusal path, only) response.
+        """
         try:
             request_row = self.request_row
             if request_row is None:
@@ -173,6 +231,8 @@ class CredentialRequestButton(
                 await interaction.response.send_modal(
                     EnvCredentialModal(runtime=bot.runtime, request_row=request_row)
                 )
+            elif request_row.kind == "repo":
+                await self._open_repo_modal(interaction, runtime=bot.runtime, row=request_row)
             else:
                 await interaction.response.send_modal(
                     McpCredentialModal(runtime=bot.runtime, request_row=request_row)
@@ -180,3 +240,56 @@ class CredentialRequestButton(
         except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary (see module docstring); discord.py's own dispatcher swallows anything raised here
             _log.exception("credential_button.callback_failed", err_type=type(err).__name__)
             await interaction.response.send_message(_CALLBACK_FAILED, ephemeral=True)
+
+    async def _open_repo_modal(
+        self,
+        interaction: discord.Interaction[commands.Bot],
+        *,
+        runtime: DiscordRuntime,
+        row: CredentialRequestRow,
+    ) -> None:
+        """The repo kind's dispatch arm: an admin pre-filter, then the modal.
+
+        A live guild admin (`is_guild_admin`, zero I/O) reaches `send_modal`
+        immediately. A non-admin instead runs the full
+        `refuse_if_shared_and_not_admin_for_request` gate, bounded by
+        `_PRE_FILTER_TIMEOUT_SECONDS` — see the module docstring for why
+        falling through to `send_modal` on a timeout is sound.
+        """
+        if is_guild_admin(interaction):
+            await interaction.response.send_modal(RepoBindModal(runtime=runtime, request_row=row))
+            return
+        try:
+            refused = await asyncio.wait_for(
+                refuse_if_shared_and_not_admin_for_request(
+                    interaction,
+                    runtime=runtime,
+                    tenant_id=row.tenant_id,
+                    agent_id=row.agent_id,
+                ),
+                timeout=_PRE_FILTER_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            _log.warning(
+                "credential_button.repo_pre_filter_timed_out",
+                tenant_id=str(row.tenant_id),
+                timeout_seconds=_PRE_FILTER_TIMEOUT_SECONDS,
+            )
+            if interaction.response.is_done():
+                return
+            try:
+                await interaction.response.send_modal(
+                    RepoBindModal(runtime=runtime, request_row=row)
+                )
+            except discord.HTTPException as http_err:
+                if http_err.code == 40060:
+                    _log.debug(
+                        "credential_button.repo_pre_filter_already_acked",
+                        tenant_id=str(row.tenant_id),
+                    )
+                    return
+                raise
+            return
+        if refused:
+            return
+        await interaction.response.send_modal(RepoBindModal(runtime=runtime, request_row=row))

--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -1,44 +1,68 @@
-"""EnvCredentialModal / McpCredentialModal — the two credential-button modals.
+"""EnvCredentialModal / McpCredentialModal / RepoBindModal — the three
+credential-button modals.
 
-Two separate modals, not one type-dispatching modal: an env secret and an MCP
-auth token are different resources with different write paths
-(`put_agent_file` vs `add_external_mcp_credential`), mirroring the two modals
-that already exist for the same writes (`agent_setup/credentials.py`'s
-`PasteSecretModal`, `agent_setup/modals_mcp.py`'s `AddMcpModal`). Each modal
-here collects exactly ONE field — the secret value itself — because every
-routing field (agent, key/server name) is already fixed by the consumed
-`credential_requests` row; the user never retypes it.
+Three separate modals, not one type-dispatching modal: an env secret, an MCP
+auth token, and a repo binding are different resources with different write
+paths (`put_agent_file` vs `add_external_mcp_credential` vs
+`agent_repo_binding.set_binding`), mirroring the modals that already exist
+for the same writes on the setup panel (`agent_setup/credentials.py`'s
+`PasteSecretModal`, `agent_setup/modals_mcp.py`'s `AddMcpModal`,
+`agent_setup/modals.py`'s `RepoAuthModal`). `EnvCredentialModal` and
+`McpCredentialModal` each collect exactly ONE field — the secret value
+itself — because every routing field (agent, key/server name) is already
+fixed by the consumed `credential_requests` row; the user never retypes it.
+`RepoBindModal` collects two fields (branch, optional token) because a repo
+binding has two writable parts and only one of them is a secret; the repo
+itself is likewise fixed by the row, never retyped.
 
 Secret hygiene, matching the structural guarantees `PasteSecretModal` already
 documents:
-- the value never reaches a log record (env logs the key name only; MCP logs
-  a masked tail only),
+- the value never reaches a log record (env logs the key name only; MCP and
+  repo log a masked tail only),
 - the value never reaches a `custom_id` (the button's custom_id carries only
-  the opaque request token, minted before either modal exists),
+  the opaque request token, minted before any modal exists),
 - the value never reaches a container/embed (a Modal TextInput has no
   render surface other than the ephemeral confirmation, which never echoes
   the value back),
 - there is no URL-fetch path and no attachment path.
 
-The atomic single-use consume runs BEFORE either write, so a request can
+The atomic single-use consume runs BEFORE every write, so a request can
 only ever produce one write no matter how many times its modal is
 (re)submitted — the loser of a race, or any resubmission, gets `None` back
 and writes nothing.
+
+`RepoBindModal`'s write is additionally admin-gated on a shared agent: token
+consumption alone is sufficient authorization for an env secret or an MCP
+token (the requester supplies a value only they hold, scoped to one key on
+one agent), but a repo binding changes what code the agent clones and runs
+and, on a shared agent, reaches every member of the install. So its
+`on_submit` also runs
+`credential_repo_bind.refuse_if_shared_and_not_admin_for_request` — once
+here, right after `defer` and before the consume, and once more as a
+pre-filter in `credential_button.py`'s `callback`, before the modal is even
+opened.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import httpx
 import structlog
 from daimon.adapters.discord.agent_setup.credentials import (
     _MAX_SECRET_VALUE_BYTES,  # pyright: ignore[reportPrivateUsage]  # reusing PasteSecretModal's byte cap rather than inventing a second number
 )
 from daimon.adapters.discord.agent_setup.write import mask_tail
+from daimon.adapters.discord.credential_repo_bind import (
+    refuse_if_shared_and_not_admin_for_request,
+    resolve_repo_binding_credential,
+)
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.errors import DaimonError
 from daimon.core.mcp_vault import add_external_mcp_credential
 from daimon.core.stores import credential_requests
 from daimon.core.stores.agent_files import put_agent_file
+from daimon.core.stores.agent_repo_binding import set_binding
 from daimon.core.stores.domain import CredentialRequestRow
 
 import discord
@@ -200,5 +224,122 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
         await interaction.followup.send(
             f"MCP credential added for `{mcp_server_url}`. Anyone who talks to "
             "this agent can use it.",
+            ephemeral=True,
+        )
+
+
+class RepoBindModal(discord.ui.Modal, title="Bind repo"):
+    """Bind repo modal: branch + optional token, gate, atomic consume, then
+    the shared credential resolution and the binding write.
+
+    The repo itself is never retyped here — it is fixed by the consumed
+    row's `target`, exactly as the env key and MCP server name are for the
+    two sibling modals. Unlike them, submitting this one is additionally
+    gated on `credential_repo_bind.refuse_if_shared_and_not_admin_for_request`
+    (see the module docstring): a member who was an admin, or whose target
+    was private, when the button was clicked may have lost either between
+    click and submit, so the gate runs again here, immediately after
+    `defer` and before the consume, rather than being trusted from the
+    pre-filter alone.
+    """
+
+    def __init__(self, *, runtime: DiscordRuntime, request_row: CredentialRequestRow) -> None:
+        super().__init__()
+        self._runtime = runtime
+        self._row = request_row
+        self.branch_in: discord.ui.TextInput[RepoBindModal] = discord.ui.TextInput(
+            label="Branch",
+            default="main",
+            max_length=255,
+        )
+        self.pat_in: discord.ui.TextInput[RepoBindModal] = discord.ui.TextInput(
+            label="GitHub token (optional)",
+            required=False,
+            max_length=255,
+            placeholder="Leave blank for a public repo",
+        )
+        self.add_item(self.branch_in)
+        self.add_item(self.pat_in)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
+        if await refuse_if_shared_and_not_admin_for_request(
+            interaction,
+            runtime=self._runtime,
+            tenant_id=self._row.tenant_id,
+            agent_id=self._row.agent_id,
+        ):
+            return
+
+        branch = str(self.branch_in.value or "").strip() or "main"
+        pat = str(self.pat_in.value or "").strip()
+
+        now = datetime.now(UTC)
+        async with self._runtime.sessionmaker() as session, session.begin():
+            consumed_row = await credential_requests.consume_credential_request(
+                session, token=self._row.token, now=now
+            )
+        if consumed_row is None:
+            await interaction.followup.send(_NO_LONGER_VALID, ephemeral=True)
+            return
+
+        # Log the repo and branch, and the token ONLY as a masked tail when
+        # present — never the plain value, never the (now-consumed) request
+        # token.
+        _log.info(
+            "credential_modal.repo.submit",
+            repo_url=consumed_row.target,
+            branch=branch,
+            pat_masked=mask_tail(pat) if pat else None,
+        )
+
+        try:
+            async with httpx.AsyncClient() as http_client:
+                ma_secret_ref, proof = await resolve_repo_binding_credential(
+                    self._runtime,
+                    http_client,
+                    agent_id=consumed_row.agent_id,
+                    account_id=consumed_row.account_id,
+                    repo_url=consumed_row.target,
+                    pasted_pat=pat or None,
+                    now=now,
+                )
+            async with self._runtime.sessionmaker.begin() as session:
+                await set_binding(
+                    session,
+                    tenant_id=consumed_row.tenant_id,
+                    agent_id=consumed_row.agent_id,
+                    repo_url=consumed_row.target,
+                    default_branch=branch,
+                    ma_secret_ref=ma_secret_ref,
+                    proof=proof,
+                )
+        except DaimonError as err:
+            # This copy is written for the user -- surface it verbatim, plus
+            # the fact that the request itself was used up either way.
+            await interaction.followup.send(
+                f"{err} The request was used up — ask again to retry.",
+                ephemeral=True,
+            )
+            return
+        except Exception as err:
+            _log.exception(
+                "credential_modal.repo_write_failed",
+                repo_url=consumed_row.target,
+                err_type=type(err).__name__,
+            )
+            # Surface only the exception class name — never the stringified
+            # exception, which for SDK/network errors can carry the request
+            # envelope (a token-leak surface). Full traceback goes to structlog.
+            await interaction.followup.send(
+                "Credential request consumed, but binding the repo failed "
+                f"(`{type(err).__name__}`). Ask for a new request to retry.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.followup.send(
+            f"Bound `{consumed_row.target}` on `{branch}`. Takes effect on the next session.",
             ephemeral=True,
         )

--- a/packages/adapters/discord/daimon/adapters/discord/credential_repo_bind.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_repo_bind.py
@@ -1,8 +1,9 @@
-"""Click-time authorization for the chat-initiated repo bind.
+"""Click-time authorization and clone-credential resolution for the
+chat-initiated repo bind.
 
 This module holds the shell halves of the chat-initiated repo bind: the
-click-time gate below, and — added by the plan that follows this one — the
-clone-credential resolution the write itself needs.
+click-time gate below, and the clone-credential resolution the write itself
+needs (`resolve_repo_binding_credential`).
 
 `refuse_if_shared_and_not_admin_for_request` re-derives the panel gate's
 (`refuse_if_shared_and_not_admin`) decision from primitives rather than
@@ -44,16 +45,23 @@ pre-filter itself.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from typing import Final
 
+import httpx
 import structlog
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import BetaManagedAgentsAgent
+from daimon.adapters.discord.agent_setup.write import load_agent_inline_pat, store_inline_pat
 from daimon.adapters.discord.checks import is_guild_admin
 from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.defaults.ma_index import list_agents_by_tenant
 from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
+from daimon.core.errors import DaimonError
+from daimon.core.github_repo_auth import normalize_owner_repo
+from daimon.core.github_visibility import is_public_repo, pat_can_access_repo
 from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
+from daimon.core.stores.domain import RepoAccessProof
 from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
 
 import discord
@@ -190,3 +198,84 @@ async def refuse_if_shared_and_not_admin_for_request(
         await _send_ephemeral(interaction, _SHARED_AGENT_MESSAGE)
         return True
     return False
+
+
+async def resolve_repo_binding_credential(
+    runtime: DiscordRuntime,
+    http_client: httpx.AsyncClient,
+    *,
+    agent_id: uuid.UUID,
+    account_id: uuid.UUID,
+    repo_url: str,
+    pasted_pat: str | None,
+    now: datetime,
+) -> tuple[str, RepoAccessProof]:
+    """Resolve the clone credential for a chat-initiated repo bind.
+
+    Mirrors `agent_setup.modals.RepoAuthModal`'s repo branch step for step —
+    same order, same messages, same precedence — because reusing the panel's
+    resolution rather than writing a second one is what closes the
+    ungated-repo-bind defect this decision guards against. There is
+    deliberately no GitHub App tier here: an App installation is keyed by the
+    repo, not by the tenant doing this bind, so its coverage proves nothing
+    about whether *this* binder may read the repo (the panel dropped this
+    same tier for the same reason, and re-adding it here would reopen the
+    cross-tenant private-repo read it closed).
+
+    Order, each short-circuiting:
+
+    1. A non-empty `pasted_pat` must grant access to `repo_url` itself
+       (`pat_can_access_repo`) before it is stored — a token that can't read
+       the repo it's meant to clone must never reach `store_inline_pat`.
+    2. Otherwise, a PAT already stored for this agent
+       (`load_agent_inline_pat`) has unconditional precedence in
+       `select_clone_auth`'s tier ordering, so — if one exists — it, not any
+       other coverage, is what will clone this repo. It is re-verified
+       against `repo_url` rather than trusted blindly: falling through to
+       the public probe on a mismatch would let a "successful" bind produce
+       a broken clone later.
+    3. Otherwise, `repo_url` must be verifiably public (`is_public_repo`):
+       the only credential that will ever clone an unauthenticated binding
+       is the operator's public-read-only fallback PAT, so an unpinned bind
+       can only be trusted against a repo anyone can read.
+
+    Raises `DaimonError` — never a sentinel — before any write when the
+    presented credential does not clear the repo it names. `http_client` is
+    injected; this function carries no `discord` type in its signature, so
+    it can be driven directly by a test with no Discord interaction at all.
+    """
+    owner_repo = normalize_owner_repo(repo_url)
+    pat = (pasted_pat or "").strip()
+    if pat:
+        has_access = await pat_can_access_repo(http_client, owner_repo=owner_repo, pat=pat)
+        if not has_access:
+            raise DaimonError(
+                "That token can't access this repo (or the repo doesn't "
+                "exist). Paste a PAT that has access, or connect GitHub."
+            )
+        ma_secret_ref = await store_inline_pat(
+            runtime, account_id=account_id, agent_id=agent_id, plaintext_pat=pat
+        )
+        return ma_secret_ref, RepoAccessProof(kind="pat", at=now, account_id=account_id)
+
+    existing_pat = await load_agent_inline_pat(runtime, agent_id=agent_id)
+    if existing_pat is not None:
+        covers_new_repo = await pat_can_access_repo(
+            http_client, owner_repo=owner_repo, pat=existing_pat
+        )
+        if not covers_new_repo:
+            raise DaimonError(
+                "This agent already has a stored GitHub token that can't "
+                "access this repo. Paste a token that can, or clear the "
+                "stored one, then bind again."
+            )
+        return f"inline-pat:{agent_id}", RepoAccessProof(kind="pat", at=now, account_id=account_id)
+
+    public = await is_public_repo(http_client, owner_repo=owner_repo)
+    if not public:
+        raise DaimonError(
+            "This repo isn't publicly readable (it's private, or it "
+            "doesn't exist) — paste a GitHub token that can read it to "
+            "bind it."
+        )
+    return "anon:", RepoAccessProof(kind="public", at=now, account_id=account_id)

--- a/packages/adapters/discord/daimon/adapters/discord/credential_repo_bind.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_repo_bind.py
@@ -1,0 +1,192 @@
+"""Click-time authorization for the chat-initiated repo bind.
+
+This module holds the shell halves of the chat-initiated repo bind: the
+click-time gate below, and — added by the plan that follows this one — the
+clone-credential resolution the write itself needs.
+
+`refuse_if_shared_and_not_admin_for_request` re-derives the panel gate's
+(`refuse_if_shared_and_not_admin`) decision from primitives rather than
+reusing it: a `credential_requests` row carries only a derived agent uuid,
+not the roster-entry value the panel gate expects, so there is nothing to
+hand it. The branch ORDER below is load-bearing and mirrors the panel
+gate's order exactly — reordering it changes who can bind a repo to what.
+
+The gate is called from two different response states and must work
+correctly from both:
+
+1. Before anything is acked, as a pre-filter ahead of opening the modal.
+   The admin branch precedes every MA and database read, so an admin still
+   opens the modal well inside the interaction budget. A refused member pays
+   the MA and database reads before any response — which is the point of
+   the pre-filter: a member who was always going to be refused is never
+   asked to paste a token into a form that gets thrown away.
+2. After the caller acks with a thinking response, immediately before the
+   single-use consume — this is the actual authorization boundary. The
+   pre-filter above does not replace it.
+
+Because of (1), this gate must **never** ack the interaction on its own —
+opening a modal is only possible from an un-acked interaction, so the
+pre-filter has to finish its reads and either fall through or answer on
+whichever half of `interaction.response.is_done()` is currently live,
+without itself changing that state. That is why every ephemeral send below
+routes through that same split rather than a fixed response call, and why
+this module works unmodified from both call sites.
+
+The pre-filter's caller bounds this gate with a timeout and opens the modal
+anyway if it expires. That is sound only because call site (2) repeats every
+check below before the write, so it is the real boundary — it is not a
+"retry recovers it" situation: the underlying read paginates the operator's
+entire MA org, so a slow read costs the same on every click, and a retry
+fails identically. The timeout and its full rationale live with the
+pre-filter itself.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Final
+
+import structlog
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import BetaManagedAgentsAgent
+from daimon.adapters.discord.checks import is_guild_admin
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.defaults.ma_index import list_agents_by_tenant
+from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
+from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
+from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
+
+import discord
+
+log = structlog.get_logger()
+
+# Kept character-identical to the panel gate's `_SHARED_AGENT_MESSAGE`
+# (agent_setup's authz module) on purpose — a test asserts the two strings
+# are equal, so a future edit to one without the other goes red rather than
+# drifting silently.
+_SHARED_AGENT_MESSAGE: Final[str] = (
+    "This agent is shared — it either ships with the deployment or is the "
+    "current default for this channel or the server — so changing its repo or "
+    "environment variables needs Manage Server. Fork it to make an editable "
+    "copy; the fork starts with no environment variables of its own."
+)
+
+
+_AGENT_GONE_MESSAGE: Final[str] = (
+    "That agent no longer exists — ask again and a fresh request will be posted."
+)
+
+_WRONG_GUILD_MESSAGE: Final[str] = (
+    "This request isn't for this server — ask again from the server it was posted in."
+)
+
+
+async def resolve_ma_agent_for_uuid(
+    client: AsyncAnthropic, *, tenant_id: uuid.UUID, agent_id: uuid.UUID
+) -> BetaManagedAgentsAgent | None:
+    """Reverse-resolve a derived agent uuid back to the MA agent it came from.
+
+    `derive_agent_uuid` is a one-way `uuid5` over `(tenant_id, ma_agent_id)`,
+    so there is no direct lookup from the derived uuid a `credential_requests`
+    row carries back to the MA agent id. The only available resolution is
+    forward: list every non-archived MA agent tagged with this tenant and
+    recompute the derived uuid for each until one matches. Returns `None`
+    when nothing matches — the agent was archived or deleted since the row
+    was minted.
+    """
+    agents = await list_agents_by_tenant(client, tenant_id=tenant_id)
+    for agent in agents:
+        if derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(agent.id)) == agent_id:
+            return agent
+    return None
+
+
+async def _send_ephemeral(interaction: discord.Interaction, content: str) -> None:  # type: ignore[type-arg]  # discord.Interaction default generic arg; only response/followup are used
+    if interaction.response.is_done():
+        await interaction.followup.send(content, ephemeral=True)
+    else:
+        await interaction.response.send_message(content, ephemeral=True)
+
+
+async def refuse_if_shared_and_not_admin_for_request(
+    interaction: discord.Interaction,  # type: ignore[type-arg]  # discord.Interaction default generic arg; only response/followup/guild_id/user are used
+    *,
+    runtime: DiscordRuntime,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+) -> bool:
+    """Click-time re-check for the chat-initiated repo-bind write.
+
+    Returns True when the caller must return immediately (the write is
+    refused); False when the write may proceed. Order, each short-circuiting:
+
+    1. Tenant re-derivation. Re-derive the tenant from the live interaction's
+       guild and compare it against the `tenant_id` argument the row was
+       minted with. This is pure and costs no I/O, so it precedes even the
+       admin check — without it, the tenant half of the decision would be
+       taken on trust from a row written at some earlier time rather than
+       re-derived from live state. Defense in depth: the posted button lives
+       in the channel the mint named, so a cross-guild click is not
+       reachable through normal use; this guard exists so it stays
+       unreachable by construction rather than by luck.
+    2. A live guild admin (`is_guild_admin`) -> allow, before any MA call and
+       before any database read. This ordering is what keeps an admin able
+       to bind a repo to the seeded agent — the first-run onboarding step
+       this whole path exists to enable.
+    3. Resolve the MA agent the row's derived uuid points at. No match ->
+       refuse, fail closed (the agent may have been archived or deleted
+       since the row was minted).
+    4. The resolved agent is defaults-managed
+       (`metadata.get(MA_METADATA_KEY_MANAGED) == "true"`) -> refuse; it
+       belongs to the deployment and every member of the install shares it.
+    5. Otherwise, read reachability fresh from the database and refuse when
+       the agent currently resolves for some channel or the workspace.
+    6. Otherwise allow.
+
+    Steps 2, 4, and 5 are `refuse_if_shared_and_not_admin`'s steps 2, 3, and
+    4 in the same order, driven off primitives instead of a roster entry.
+
+    The two shared-agent refusals (4 and 5) carry the same message on
+    purpose, exactly as in the panel gate: which limb fired is not
+    actionable, and the fix is the same either way — ask an admin, or bind
+    to a private agent instead.
+
+    This function never acks the interaction — see the module docstring.
+    """
+    if interaction.guild_id is None or (
+        derive_tenant_uuid(platform="discord", workspace_id=str(interaction.guild_id)) != tenant_id
+    ):
+        log.warning(
+            "credential_repo_bind.wrong_guild",
+            request_tenant_id=str(tenant_id),
+            interaction_guild_id=interaction.guild_id,
+        )
+        await _send_ephemeral(interaction, _WRONG_GUILD_MESSAGE)
+        return True
+    if is_guild_admin(interaction):  # pyright: ignore[reportArgumentType]  # discord.Interaction vs Interaction[commands.Bot]; is_guild_admin only reads user/guild
+        return False
+    agent = await resolve_ma_agent_for_uuid(
+        runtime.anthropic, tenant_id=tenant_id, agent_id=agent_id
+    )
+    if agent is None:
+        log.warning(
+            "credential_repo_bind.agent_gone",
+            tenant_id=str(tenant_id),
+            agent_id=str(agent_id),
+        )
+        await _send_ephemeral(interaction, _AGENT_GONE_MESSAGE)
+        return True
+    if agent.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
+        await _send_ephemeral(interaction, _SHARED_AGENT_MESSAGE)
+        return True
+    async with runtime.sessionmaker() as session:
+        reachable = await is_agent_reachable_in_tenant(
+            session,
+            tenant_id=tenant_id,
+            agent_name=agent.name,
+            default=runtime.deployment_default,
+        )
+    if reachable:
+        await _send_ephemeral(interaction, _SHARED_AGENT_MESSAGE)
+        return True
+    return False

--- a/packages/adapters/discord/tests/test_credential_button.py
+++ b/packages/adapters/discord/tests/test_credential_button.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -9,23 +10,57 @@ from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock
 
 import daimon.adapters.discord.credential_button as credential_button_mod
+import discord
+import httpx
 import structlog
+from anthropic.types.beta import BetaManagedAgentsAgent
 from daimon.adapters.discord.credential_button import CredentialRequestButton
-from daimon.adapters.discord.credential_modals import EnvCredentialModal, McpCredentialModal
+from daimon.adapters.discord.credential_modals import (
+    EnvCredentialModal,
+    McpCredentialModal,
+    RepoBindModal,
+)
+from daimon.adapters.discord.credential_repo_bind import _SHARED_AGENT_MESSAGE
 from daimon.core.credential_requests import build_button_label, build_custom_id, mint_request_token
-from daimon.core.stores.credential_requests import create_credential_request
+from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
+from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.agent_repo_binding import get_binding
+from daimon.core.stores.credential_requests import (
+    create_credential_request,
+    peek_credential_request,
+)
 from daimon.core.stores.domain import CredentialRequestRow
-from daimon.testing.factories import make_tenant
+from daimon.testing.factories import make_account, make_tenant
+from daimon.testing.ma import build_fake_anthropic, list_response
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 _REQUESTER_ID = "100000000000000001"
 _OTHER_USER_ID = "200000000000000002"
 
+# Matches tests/agent_setup/test_authz.py's _admin_interaction /
+# _member_interaction default guild_id -- every repo-kind gate test below
+# must agree with this so it lands on the branch it names, not the
+# wrong-guild one.
+_GUILD_ID = 111
 
-def _fake_bot(sessionmaker: Any) -> Any:
-    """A minimal stand-in for DaimonBot -- only `.runtime.sessionmaker` is read."""
-    return SimpleNamespace(runtime=SimpleNamespace(sessionmaker=sessionmaker))
+
+def _fake_bot(
+    sessionmaker: Any,
+    *,
+    anthropic: Any = None,
+    deployment_default: DeploymentDefault | None = None,
+) -> Any:
+    """A minimal stand-in for DaimonBot -- only
+    `.runtime.{sessionmaker,anthropic,deployment_default}` are read."""
+    return SimpleNamespace(
+        runtime=SimpleNamespace(
+            sessionmaker=sessionmaker,
+            anthropic=anthropic,
+            deployment_default=deployment_default or DeploymentDefault(),
+        )
+    )
 
 
 def _interaction(*, user_id: str, client: Any) -> MagicMock:
@@ -34,6 +69,38 @@ def _interaction(*, user_id: str, client: Any) -> MagicMock:
     interaction.client = client
     interaction.response.send_message = AsyncMock()
     interaction.response.send_modal = AsyncMock()
+    return interaction
+
+
+def _repo_admin_interaction(*, client: Any, guild_id: int = _GUILD_ID) -> MagicMock:
+    interaction = MagicMock()
+    interaction.client = client
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 1
+    interaction.user.guild_permissions.administrator = True
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.is_done.return_value = False
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _repo_member_interaction(*, client: Any, guild_id: int = _GUILD_ID) -> MagicMock:
+    interaction = MagicMock()
+    interaction.client = client
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 2
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.is_done.return_value = False
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.followup.send = AsyncMock()
     return interaction
 
 
@@ -47,10 +114,13 @@ def _match(token: str) -> Any:
 def _row(
     *,
     token: str,
-    kind: Literal["env", "mcp"] = "env",
+    kind: Literal["env", "mcp", "repo"] = "env",
     target: str = "OPENAI_API_KEY",
     mcp_server_url: str | None = None,
     requester_platform_user_id: str = _REQUESTER_ID,
+    tenant_id: uuid.UUID | None = None,
+    agent_id: uuid.UUID | None = None,
+    account_id: uuid.UUID | None = None,
     expires_at: datetime | None = None,
     used_at: datetime | None = None,
 ) -> CredentialRequestRow:
@@ -59,9 +129,9 @@ def _row(
     return CredentialRequestRow(
         token=token,
         kind=kind,
-        tenant_id=uuid.uuid4(),
-        agent_id=uuid.uuid4(),
-        account_id=uuid.uuid4(),
+        tenant_id=tenant_id or uuid.uuid4(),
+        agent_id=agent_id or uuid.uuid4(),
+        account_id=account_id or uuid.uuid4(),
         target=target,
         mcp_server_url=mcp_server_url,
         requester_platform_user_id=requester_platform_user_id,
@@ -70,6 +140,68 @@ def _row(
         expires_at=expires_at or (now + timedelta(minutes=30)),
         used_at=used_at,
     )
+
+
+def _make_agent(
+    *, ma_agent_id: str, tenant_id: uuid.UUID, name: str, managed: bool
+) -> BetaManagedAgentsAgent:
+    metadata = {"daimon_tenant": str(tenant_id)}
+    if managed:
+        metadata[MA_METADATA_KEY_MANAGED] = "true"
+    return BetaManagedAgentsAgent(
+        id=ma_agent_id,
+        type="agent",
+        name=name,
+        model={"id": "claude-sonnet-4-6"},
+        metadata=metadata,
+        description=None,
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    )
+
+
+def _list_agents_handler(agents: list[BetaManagedAgentsAgent]) -> Any:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return list_response([agent.model_dump(mode="json") for agent in agents])
+
+    return handler
+
+
+async def _seed_repo_row(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    ma_agent_id: str,
+    target: str = "github.com/o/repo-button",
+    guild_id: int = _GUILD_ID,
+) -> CredentialRequestRow:
+    """Seed a real `kind="repo"` request row aligned to `_GUILD_ID`, with a
+    real `accounts` row (the recorded `RepoAccessProof.account_id` an
+    on_submit test writes carries an FK to `accounts.id`)."""
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(guild_id))
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+    token = mint_request_token()
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+        account = await make_account(session, tenant=tenant)
+        row = await create_credential_request(
+            session,
+            token=token,
+            kind="repo",
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            account_id=account.id,
+            target=target,
+            mcp_server_url=None,
+            requester_platform_user_id=_REQUESTER_ID,
+            channel_id="chan-1",
+            expires_at=datetime.now(UTC) + timedelta(minutes=30),
+        )
+    return row
 
 
 async def _seed_request(
@@ -265,6 +397,143 @@ async def test_callback_dispatches_mcp_modal_for_mcp_kind() -> None:
     interaction.response.send_modal.assert_awaited_once()
     sent_modal = interaction.response.send_modal.call_args.args[0]
     assert isinstance(sent_modal, McpCredentialModal), "mcp-kind rows must open McpCredentialModal"
+
+
+# --- callback (repo kind) ----------------------------------------------------
+
+
+async def test_callback_repo_kind_admin_opens_repo_bind_modal_with_zero_ma_requests() -> None:
+    row = _row(token="repoadmin1234567890123", kind="repo", target="github.com/o/r")
+    item = CredentialRequestButton(token=row.token, label="Bind repo: o/r", request_row=row)
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return list_response([])
+
+    bot = _fake_bot(MagicMock(), anthropic=build_fake_anthropic(handler))
+    interaction = _repo_admin_interaction(client=bot)
+
+    await item.callback(interaction)
+
+    interaction.response.send_modal.assert_awaited_once()
+    sent_modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(sent_modal, RepoBindModal), "repo-kind rows must open RepoBindModal"
+    assert len(calls) == 0, "the admin pre-filter must precede every MA request, costing zero I/O"
+
+
+async def test_callback_repo_kind_member_against_defaults_managed_target_refuses_without_opening_modal(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_button_managed"
+    row = await _seed_repo_row(db_session_factory, ma_agent_id=ma_agent_id)
+    agent = _make_agent(
+        ma_agent_id=ma_agent_id, tenant_id=row.tenant_id, name="daimon", managed=True
+    )
+    bot = _fake_bot(
+        db_session_factory, anthropic=build_fake_anthropic(_list_agents_handler([agent]))
+    )
+    item = CredentialRequestButton(token=row.token, label="Bind repo: o/r", request_row=row)
+    interaction = _repo_member_interaction(client=bot)
+
+    await item.callback(interaction)
+
+    (
+        interaction.response.send_modal.assert_not_awaited(),
+        "a refused member must never see the token form",
+    )
+    assert interaction.response.send_message.call_args.args[0] == _SHARED_AGENT_MESSAGE, (
+        "the pre-filter's refusal must name the shared-agent message specifically"
+    )
+
+
+async def test_callback_repo_kind_member_against_non_managed_non_reachable_target_opens_modal(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_button_private"
+    row = await _seed_repo_row(db_session_factory, ma_agent_id=ma_agent_id)
+    agent = _make_agent(
+        ma_agent_id=ma_agent_id, tenant_id=row.tenant_id, name="mine", managed=False
+    )
+    bot = _fake_bot(
+        db_session_factory, anthropic=build_fake_anthropic(_list_agents_handler([agent]))
+    )
+    item = CredentialRequestButton(token=row.token, label="Bind repo: o/r", request_row=row)
+    interaction = _repo_member_interaction(client=bot)
+
+    await item.callback(interaction)
+
+    interaction.response.send_modal.assert_awaited_once()
+    sent_modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(sent_modal, RepoBindModal), (
+        "a member binding a repo to their own, unshared agent must reach the modal"
+    )
+
+
+async def test_callback_repo_kind_pre_filter_timeout_opens_modal_and_submit_time_gate_still_refuses(
+    monkeypatch: Any,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The pair this test proves: a timed-out pre-filter trades UX (the
+    refused member briefly sees the token field) for availability (the
+    button still opens), and never trades away authorization -- the
+    submit-time gate, driven by the real (unmocked) gate function, still
+    refuses and writes nothing."""
+    ma_agent_id = "agent_button_timeout"
+    row = await _seed_repo_row(db_session_factory, ma_agent_id=ma_agent_id)
+    agent = _make_agent(
+        ma_agent_id=ma_agent_id, tenant_id=row.tenant_id, name="daimon", managed=True
+    )
+    runtime_anthropic = build_fake_anthropic(_list_agents_handler([agent]))
+    bot = _fake_bot(db_session_factory, anthropic=runtime_anthropic)
+
+    monkeypatch.setattr(credential_button_mod, "_PRE_FILTER_TIMEOUT_SECONDS", 0.01)
+
+    async def _slow_gate(*_args: Any, **_kwargs: Any) -> bool:
+        await asyncio.sleep(1)
+        return False
+
+    monkeypatch.setattr(
+        credential_button_mod, "refuse_if_shared_and_not_admin_for_request", _slow_gate
+    )
+
+    item = CredentialRequestButton(token=row.token, label="Bind repo: o/r", request_row=row)
+    interaction = _repo_member_interaction(client=bot)
+
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        await item.callback(interaction)
+    finally:
+        structlog.reset_defaults()
+
+    interaction.response.send_modal.assert_awaited_once()
+    sent_modal = interaction.response.send_modal.call_args.args[0]
+    assert isinstance(sent_modal, RepoBindModal), "a timed-out pre-filter must still open the modal"
+    assert any(
+        entry.get("event") == "credential_button.repo_pre_filter_timed_out" for entry in cap.entries
+    ), "the timeout must be logged so an operator can see the pre-filter eroding"
+
+    submit_interaction = MagicMock()
+    submit_interaction.response.defer = AsyncMock()
+    submit_interaction.response.is_done.return_value = True
+    submit_interaction.response.send_message = AsyncMock()
+    submit_interaction.followup.send = AsyncMock()
+    submit_interaction.guild_id = _GUILD_ID
+    submit_interaction.user = MagicMock(spec=discord.Member)
+    submit_interaction.user.id = 2
+    submit_interaction.user.guild_permissions.administrator = False
+    submit_interaction.user.guild_permissions.manage_guild = False
+    submit_interaction.guild.owner_id = 999
+
+    await sent_modal.on_submit(submit_interaction)
+
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+        consumed = await peek_credential_request(session, token=row.token)
+    assert binding is None, "the submit-time gate must still refuse -- the write must never happen"
+    assert consumed is not None and consumed.used_at is None, "a refused submit must burn no token"
+    assert submit_interaction.followup.send.call_args.args[0] == _SHARED_AGENT_MESSAGE
 
 
 # --- dispatch matching (no DB) -----------------------------------------------

--- a/packages/adapters/discord/tests/test_credential_modals.py
+++ b/packages/adapters/discord/tests/test_credential_modals.py
@@ -1,5 +1,14 @@
-"""Tests for EnvCredentialModal / McpCredentialModal -- atomic consume then
-the existing write paths, with secret-hygiene assertions."""
+"""Tests for EnvCredentialModal / McpCredentialModal / RepoBindModal -- atomic
+consume then the existing write paths, with secret-hygiene assertions.
+
+`_admin_interaction` / `_member_interaction` are copied verbatim from
+`tests/agent_setup/test_authz.py` (same rationale as
+`test_credential_repo_bind.py`'s copy: `tests/` carries no `__init__.py`, so
+importing across sibling test files does not resolve when a file is run
+alone). `_GUILD_ID` matches those builders' own default `guild_id=111` so
+every seeded tenant and every interaction agree on the tenant a repo-bind
+gate test resolves against — see `_seed_repo_request`'s docstring for why
+that alignment matters."""
 
 from __future__ import annotations
 
@@ -9,24 +18,44 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import httpx
+import pytest
 import structlog
-from daimon.adapters.discord.credential_modals import EnvCredentialModal, McpCredentialModal
+from anthropic.types.beta import BetaManagedAgentsAgent
+from cryptography.fernet import Fernet
+from daimon.adapters.discord import credential_repo_bind as credential_repo_bind_mod
+from daimon.adapters.discord.credential_modals import (
+    EnvCredentialModal,
+    McpCredentialModal,
+    RepoBindModal,
+)
+from daimon.adapters.discord.credential_repo_bind import _SHARED_AGENT_MESSAGE
 from daimon.adapters.discord.runtime import DiscordRuntime
-from daimon.core.credential_requests import mint_request_token
+from daimon.core.credential_requests import build_custom_id, mint_request_token
+from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
+from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.notebooks._rate_limit import RateLimiter
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.agent_files import list_agent_files
-from daimon.core.stores.credential_requests import create_credential_request
+from daimon.core.stores.agent_repo_binding import get_binding
+from daimon.core.stores.credential_requests import (
+    create_credential_request,
+    peek_credential_request,
+)
 from daimon.core.stores.domain import CredentialRequestRow
-from daimon.testing.factories import make_tenant
-from daimon.testing.ma import build_stub_anthropic
+from daimon.testing.factories import make_account, make_tenant
+from daimon.testing.ma import build_fake_anthropic, build_stub_anthropic, list_response
 from pydantic import HttpUrl
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 _SECRET_VALUE = "super-secret-env-value-do-not-leak"
 _MCP_TOKEN = "super-secret-mcp-token-do-not-leak"
+
+# See the module docstring: matches tests/agent_setup/test_authz.py's
+# _admin_interaction / _member_interaction default guild_id.
+_GUILD_ID = 111
 
 
 def _runtime(
@@ -35,6 +64,8 @@ def _runtime(
     anthropic: Any = None,
     public_url: HttpUrl | None = None,
     jwt_secret: str | None = None,
+    crypto_keys: tuple[str, ...] = (),
+    oauth_scopes: tuple[str, ...] = ("repo", "read:user"),
 ) -> DiscordRuntime:
     settings = MagicMock()
     settings.mcp.public_url = public_url
@@ -44,6 +75,11 @@ def _runtime(
         settings.mcp.jwt_secret = secret_mock
     else:
         settings.mcp.jwt_secret = None
+    # Defaults to no crypto configured; RepoBindModal tests that exercise
+    # store_inline_pat / load_agent_inline_pat pass real crypto_keys so they
+    # can round-trip through a real MultiFernet.
+    settings.crypto.keys = tuple(MagicMock(get_secret_value=lambda k=k: k) for k in crypto_keys)
+    settings.github.oauth_scopes = oauth_scopes
     return DiscordRuntime(
         settings=settings,
         anthropic=anthropic if anthropic is not None else build_stub_anthropic(),
@@ -54,6 +90,136 @@ def _runtime(
         resolver_cache=new_resolver_cache(),
         turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # credential-modal tests never run a turn
     )
+
+
+def _admin_interaction(*, guild_id: int = _GUILD_ID) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 1
+    interaction.user.guild_permissions.administrator = True
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.defer = AsyncMock()
+    # RepoBindModal.on_submit always defers before the gate runs, so by the
+    # time any ephemeral is sent the interaction is acked -- is_done() is
+    # True, matching real Discord behaviour post-defer.
+    interaction.response.is_done.return_value = True
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    return interaction
+
+
+def _member_interaction(*, guild_id: int = _GUILD_ID) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 2
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.defer = AsyncMock()
+    interaction.response.is_done.return_value = True
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    return interaction
+
+
+def _make_agent(
+    *, ma_agent_id: str, tenant_id: uuid.UUID, name: str, managed: bool
+) -> BetaManagedAgentsAgent:
+    metadata = {"daimon_tenant": str(tenant_id)}
+    if managed:
+        metadata[MA_METADATA_KEY_MANAGED] = "true"
+    return BetaManagedAgentsAgent(
+        id=ma_agent_id,
+        type="agent",
+        name=name,
+        model={"id": "claude-sonnet-4-6"},
+        metadata=metadata,
+        description=None,
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    )
+
+
+def _list_agents_handler(agents: list[BetaManagedAgentsAgent]) -> Any:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return list_response([agent.model_dump(mode="json") for agent in agents])
+
+    return handler
+
+
+async def _seed_repo_request(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    ma_agent_id: str,
+    target: str = "github.com/o/hygiene-repo",
+    guild_id: int = _GUILD_ID,
+) -> CredentialRequestRow:
+    """Seed a `kind="repo"` request row, deliberately NOT mirroring
+    `_seed_env_request`'s random `workspace_id=f"g-{token[:8]}"` -- a repo
+    bind's gate test must land on a tenant that matches the interaction
+    builders' `guild_id`, or every gate-touching assertion below passes on
+    the wrong-guild branch instead of the one it names.
+
+    Seeds a real `accounts` row (not a bare `uuid.uuid4()`): the resolved
+    `RepoAccessProof.account_id` written by `set_binding` carries an FK to
+    `accounts.id`, so a fabricated account id would fail the write with an
+    `IntegrityError` that has nothing to do with the behaviour under test.
+    """
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(guild_id))
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+    token = mint_request_token()
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+        account = await make_account(session, tenant=tenant)
+        row = await create_credential_request(
+            session,
+            token=token,
+            kind="repo",
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            account_id=account.id,
+            target=target,
+            mcp_server_url=None,
+            requester_platform_user_id="100000000000000001",
+            channel_id="chan-1",
+            expires_at=datetime.now(UTC) + timedelta(minutes=30),
+        )
+    return row
+
+
+def _sent_message(interaction: MagicMock) -> str:
+    """Return the ephemeral text sent, on whichever half of the response fired."""
+    if interaction.response.send_message.called:
+        return str(interaction.response.send_message.call_args.args[0])
+    return str(interaction.followup.send.call_args.args[0])
+
+
+def _assert_secret_absent_from_every_reply(interaction: MagicMock, secret: str) -> None:
+    """Pin T-18-11/T-18-16: the pasted value must never reach any surface an
+    interaction mock recorded, across every response call the modal could
+    have made -- not just the first positional string of the first call."""
+    for mock_attr in (
+        interaction.response.send_message,
+        interaction.followup.send,
+        interaction.edit_original_response,
+    ):
+        for call in mock_attr.call_args_list:
+            for arg in call.args:
+                assert secret not in str(arg), (
+                    f"{mock_attr._mock_name} positional arg leaked the secret"
+                )
+            for value in call.kwargs.values():
+                assert secret not in str(value), f"{mock_attr._mock_name} kwarg leaked the secret"
 
 
 async def _seed_env_request(
@@ -438,3 +604,277 @@ async def test_mcp_modal_never_logs_the_raw_token(
 
     for entry in cap.entries:
         assert _MCP_TOKEN not in repr(entry), "no log line may contain the raw token"
+
+
+# --- RepoBindModal ------------------------------------------------------
+
+
+async def test_repo_modal_public_repo_blank_token_admin_binds_anon_against_managed_target(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Targeting a defaults-managed agent is deliberate: against a
+    non-managed, non-reachable agent this would pass without ever exercising
+    the admin branch, and would stay green even with the gate deleted."""
+    ma_agent_id = "agent_admin_managed"
+    monkeypatch.setattr(credential_repo_bind_mod, "is_public_repo", AsyncMock(return_value=True))
+    row = await _seed_repo_request(
+        db_session_factory, ma_agent_id=ma_agent_id, target="github.com/o/public-repo"
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="daimon", managed=True)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(_list_agents_handler([agent])),
+    )
+
+    modal = RepoBindModal(runtime=runtime, request_row=row)
+    await modal.on_submit(_admin_interaction())
+
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert binding is not None, "an admin binding a public repo to a shared agent must write a row"
+    assert binding.repo_url == "o/public-repo"
+    assert binding.default_branch == "main"
+    assert binding.ma_secret_ref == "anon:"
+    assert binding.proof_kind == "public"
+
+
+async def test_repo_modal_public_repo_blank_token_member_binds_anon_against_own_target(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_member_private"
+    monkeypatch.setattr(credential_repo_bind_mod, "is_public_repo", AsyncMock(return_value=True))
+    row = await _seed_repo_request(
+        db_session_factory, ma_agent_id=ma_agent_id, target="github.com/o/public-repo-2"
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="mine", managed=False)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(_list_agents_handler([agent])),
+    )
+
+    modal = RepoBindModal(runtime=runtime, request_row=row)
+    await modal.on_submit(_member_interaction())
+
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert binding is not None, (
+        "a member binding a public repo to their own, unshared agent must succeed"
+    )
+    assert binding.ma_secret_ref == "anon:"
+    assert binding.proof_kind == "public"
+
+
+async def test_repo_modal_pasted_token_that_github_accepts_binds_inline_pat(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_admin_pat_ok"
+    monkeypatch.setattr(
+        credential_repo_bind_mod, "pat_can_access_repo", AsyncMock(return_value=True)
+    )
+    row = await _seed_repo_request(
+        db_session_factory, ma_agent_id=ma_agent_id, target="github.com/o/pat-repo"
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="daimon", managed=True)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(_list_agents_handler([agent])),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    modal = RepoBindModal(runtime=runtime, request_row=row)
+    modal.pat_in._value = "ghp_accepted_token_xyz"  # pyright: ignore[reportPrivateUsage]
+    await modal.on_submit(_admin_interaction())
+
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert binding is not None
+    assert binding.ma_secret_ref == f"inline-pat:{row.agent_id}"
+    assert binding.proof_kind == "pat"
+
+
+async def test_repo_modal_pasted_token_that_github_refuses_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_admin_pat_refused"
+    monkeypatch.setattr(
+        credential_repo_bind_mod, "pat_can_access_repo", AsyncMock(return_value=False)
+    )
+    row = await _seed_repo_request(
+        db_session_factory, ma_agent_id=ma_agent_id, target="github.com/o/pat-refused-repo"
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="daimon", managed=True)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(_list_agents_handler([agent])),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    modal = RepoBindModal(runtime=runtime, request_row=row)
+    modal.pat_in._value = "ghp_refused_token_xyz"  # pyright: ignore[reportPrivateUsage]
+    interaction = _admin_interaction()
+    await modal.on_submit(interaction)
+
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert binding is None, "a GitHub-refused token must never produce a binding"
+    message = interaction.followup.send.call_args.args[0]
+    assert "can't access this repo" in message, "the panel's own refusal copy must be surfaced"
+
+
+async def test_repo_modal_double_submit_writes_exactly_one_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_admin_resubmit"
+    monkeypatch.setattr(credential_repo_bind_mod, "is_public_repo", AsyncMock(return_value=True))
+    row = await _seed_repo_request(
+        db_session_factory, ma_agent_id=ma_agent_id, target="github.com/o/resubmit-repo"
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="daimon", managed=True)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(_list_agents_handler([agent])),
+    )
+
+    first_modal = RepoBindModal(runtime=runtime, request_row=row)
+    await first_modal.on_submit(_admin_interaction())
+
+    second_modal = RepoBindModal(runtime=runtime, request_row=row)
+    second_interaction = _admin_interaction()
+    await second_modal.on_submit(second_interaction)
+
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert binding is not None, "the first submission must still have written its binding"
+
+    message = second_interaction.followup.send.call_args.args[0]
+    assert "no longer valid" in message, (
+        "a resubmission on an already-consumed token must be refused"
+    )
+
+
+async def test_repo_modal_refusal_burns_no_token_and_reports_shared_agent_message(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_member_refused"
+    row = await _seed_repo_request(
+        db_session_factory, ma_agent_id=ma_agent_id, target="github.com/o/refused-repo"
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="daimon", managed=True)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(_list_agents_handler([agent])),
+    )
+
+    modal = RepoBindModal(runtime=runtime, request_row=row)
+    interaction = _member_interaction()
+    await modal.on_submit(interaction)
+
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+        consumed = await peek_credential_request(session, token=row.token)
+    assert binding is None, "a refused member must never produce a binding"
+    assert consumed is not None and consumed.used_at is None, (
+        "a refusal must burn no token -- the gate runs before the consume"
+    )
+    assert _sent_message(interaction) == _SHARED_AGENT_MESSAGE, (
+        "the refusal must name the shared-agent message specifically, not merely refuse"
+    )
+
+
+@pytest.mark.parametrize(
+    "scenario", ["happy", "refused_by_github", "unexpected_exception", "refused_by_gate"]
+)
+async def test_repo_modal_never_leaks_the_pasted_token(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    scenario: str,
+) -> None:
+    """Parametrized secret-hygiene pin across all four submit-time outcomes,
+    not the happy path alone -- T-18-11/T-18-16's whole point is that a leak
+    on an error path ships green if only the happy path is tested."""
+    hygiene_pat = "ghp_hygiene_do_not_leak_0000000000"
+    ma_agent_id = f"agent_hygiene_{scenario}"
+    managed = scenario == "refused_by_gate"
+    row = await _seed_repo_request(
+        db_session_factory, ma_agent_id=ma_agent_id, target="github.com/o/hygiene-repo"
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="bot", managed=managed)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(_list_agents_handler([agent])),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    if scenario == "unexpected_exception":
+
+        async def _boom(http_client: httpx.AsyncClient, *, owner_repo: str, pat: str) -> bool:
+            raise httpx.ConnectError(f"upstream reset -- request envelope: token={pat}")
+
+        monkeypatch.setattr(credential_repo_bind_mod, "pat_can_access_repo", _boom)
+    elif scenario == "refused_by_github":
+        monkeypatch.setattr(
+            credential_repo_bind_mod, "pat_can_access_repo", AsyncMock(return_value=False)
+        )
+    else:
+        monkeypatch.setattr(
+            credential_repo_bind_mod, "pat_can_access_repo", AsyncMock(return_value=True)
+        )
+
+    modal = RepoBindModal(runtime=runtime, request_row=row)
+    modal.pat_in._value = hygiene_pat  # pyright: ignore[reportPrivateUsage]
+    interaction = _member_interaction() if scenario == "refused_by_gate" else _admin_interaction()
+
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        await modal.on_submit(interaction)
+    finally:
+        structlog.reset_defaults()
+
+    for entry in cap.entries:
+        assert hygiene_pat not in repr(entry), (
+            f"[{scenario}] no log record may contain the pasted token"
+        )
+        pat_masked = entry.get("pat_masked")
+        if pat_masked is not None:
+            assert pat_masked != hygiene_pat, (
+                f"[{scenario}] the mask itself must not equal the full value"
+            )
+
+    minted_custom_id = build_custom_id(row.token)
+    assert hygiene_pat not in minted_custom_id, (
+        f"[{scenario}] custom_id must never carry the pasted token"
+    )
+
+    _assert_secret_absent_from_every_reply(interaction, hygiene_pat)
+
+    if scenario == "happy":
+        async with db_session_factory() as session:
+            binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+        assert binding is not None and binding.ma_secret_ref == f"inline-pat:{row.agent_id}"
+    elif scenario == "refused_by_github":
+        message = _sent_message(interaction)
+        assert "can't access this repo" in message
+    elif scenario == "unexpected_exception":
+        message = _sent_message(interaction)
+        assert "ConnectError" in message, "only the exception class name must be surfaced"
+    elif scenario == "refused_by_gate":
+        assert _sent_message(interaction) == _SHARED_AGENT_MESSAGE
+        assert not any(
+            entry.get("event") == "credential_modal.repo.submit" for entry in cap.entries
+        ), (
+            "a gate refusal must never reach the submit log line -- the gate must run before it "
+            "(this is the mutation this test pins: moving the log line above the gate turns it red)"
+        )

--- a/packages/adapters/discord/tests/test_credential_repo_bind.py
+++ b/packages/adapters/discord/tests/test_credential_repo_bind.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -24,15 +25,19 @@ import discord
 import httpx
 import pytest
 from anthropic.types.beta import BetaManagedAgentsAgent
+from cryptography.fernet import Fernet
 from daimon.adapters.discord.agent_setup import authz as panel_authz
 from daimon.adapters.discord.agent_setup.state import RosterEntry
+from daimon.adapters.discord.agent_setup.write import load_agent_inline_pat, store_inline_pat
 from daimon.adapters.discord.credential_repo_bind import (
     _AGENT_GONE_MESSAGE,
     _SHARED_AGENT_MESSAGE,
     _WRONG_GUILD_MESSAGE,
     refuse_if_shared_and_not_admin_for_request,
+    resolve_repo_binding_credential,
 )
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.errors import DaimonError
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.notebooks._rate_limit import RateLimiter
@@ -40,7 +45,7 @@ from daimon.core.scope import DeploymentDefault, TenantScopeRef
 from daimon.core.specs import AgentSpec
 from daimon.core.stores import scoped_config_write
 from daimon.testing.factories import make_tenant
-from daimon.testing.ma import build_fake_anthropic, list_response
+from daimon.testing.ma import build_fake_anthropic, build_stub_anthropic, list_response
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 pytestmark = pytest.mark.asyncio
@@ -89,9 +94,18 @@ def _runtime(
     sessionmaker: object,
     anthropic: object,
     deployment_default: DeploymentDefault | None = None,
+    crypto_keys: tuple[str, ...] = (),
+    oauth_scopes: tuple[str, ...] = ("repo", "read:user"),
 ) -> DiscordRuntime:
+    settings = MagicMock()
+    # Defaults to no crypto configured, matching a bare MagicMock's prior
+    # behaviour of never being exercised by the gate-only tests above; the
+    # resolution tests below pass real crypto_keys so store_inline_pat /
+    # load_agent_inline_pat can round-trip through a real MultiFernet.
+    settings.crypto.keys = tuple(MagicMock(get_secret_value=lambda k=k: k) for k in crypto_keys)
+    settings.github.oauth_scopes = oauth_scopes
     return DiscordRuntime(
-        settings=MagicMock(),
+        settings=settings,
         anthropic=anthropic,  # type: ignore[arg-type]  # a real fake AsyncAnthropic, never a bare mock
         sessionmaker=sessionmaker,  # type: ignore[arg-type]  # a real async_sessionmaker or a spy MagicMock, never invoked as a client
         notebook_rate_limiter=RateLimiter(max_requests=999),
@@ -142,6 +156,30 @@ def _counting_handler(
         return list_response([agent.model_dump(mode="json") for agent in agents])
 
     return handler
+
+
+def _repo_probe_transport(
+    *,
+    calls: list[httpx.Request],
+    accepted_pats: frozenset[str] = frozenset(),
+    public: bool = False,
+) -> httpx.MockTransport:
+    """Fake `GET https://api.github.com/repos/{owner_repo}` for both
+    `pat_can_access_repo` (Authorization header present) and `is_public_repo`
+    (no header). Every request lands in `calls`, so a test can assert "zero
+    unauthenticated calls" to pin the skip-the-public-probe branches."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        auth = request.headers.get("authorization")
+        if auth is not None:
+            pat = auth.removeprefix("Bearer ")
+            if pat in accepted_pats:
+                return httpx.Response(200, json={"private": True})
+            return httpx.Response(404)
+        return httpx.Response(200, json={"private": False}) if public else httpx.Response(404)
+
+    return httpx.MockTransport(handler)
 
 
 def _sent_message(interaction: MagicMock) -> Any:  # noqa: ANN401 -- MagicMock call_args positional arg is untyped by construction
@@ -420,4 +458,211 @@ async def test_decision_table_parity_with_the_panel_gate(
     assert chat_refused == panel_refused, (
         f"decision mismatch for admin={is_admin} system={is_system} reachable={reachable}: "
         f"chat gate returned {chat_refused}, panel gate returned {panel_refused}"
+    )
+
+
+# --- resolve_repo_binding_credential -----------------------------------------
+#
+# These drive the helper directly with an httpx.AsyncClient over
+# httpx.MockTransport -- no Discord interaction is needed at all.
+
+
+async def test_pasted_pat_that_github_accepts_returns_inline_pat_ref_and_is_readable_back(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    agent_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    calls: list[httpx.Request] = []
+    transport = _repo_probe_transport(calls=calls, accepted_pats=frozenset({"ghp_good"}))
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        ref, proof = await resolve_repo_binding_credential(
+            runtime,
+            http_client,
+            agent_id=agent_id,
+            account_id=account_id,
+            repo_url="github.com/o/r",
+            pasted_pat="ghp_good",
+            now=now,
+        )
+
+    assert ref == f"inline-pat:{agent_id}", (
+        "a pasted, GitHub-accepted PAT must resolve to the inline-pat ref"
+    )
+    assert proof.kind == "pat"
+    assert proof.at == now
+    assert proof.account_id == account_id
+    stored = await load_agent_inline_pat(runtime, agent_id=agent_id)
+    assert stored == "ghp_good", (
+        "the accepted PAT must be readable back through load_agent_inline_pat"
+    )
+
+
+async def test_pasted_pat_that_github_refuses_raises_and_writes_no_credential(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    agent_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    calls: list[httpx.Request] = []
+    transport = _repo_probe_transport(calls=calls, accepted_pats=frozenset())
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        with pytest.raises(DaimonError, match="can't access this repo"):
+            await resolve_repo_binding_credential(
+                runtime,
+                http_client,
+                agent_id=agent_id,
+                account_id=account_id,
+                repo_url="github.com/o/r",
+                pasted_pat="ghp_bad",
+                now=datetime.now(UTC),
+            )
+
+    stored = await load_agent_inline_pat(runtime, agent_id=agent_id)
+    assert stored is None, "a GitHub-refused PAT must never be written"
+
+
+async def test_blank_pat_no_stored_pat_public_repo_returns_anon_ref_with_public_proof(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    agent_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    calls: list[httpx.Request] = []
+    transport = _repo_probe_transport(calls=calls, public=True)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        ref, proof = await resolve_repo_binding_credential(
+            runtime,
+            http_client,
+            agent_id=agent_id,
+            account_id=account_id,
+            repo_url="github.com/o/r",
+            pasted_pat=None,
+            now=now,
+        )
+
+    assert ref == "anon:", "a verifiably public repo with a blank token must resolve to anon:"
+    assert proof.kind == "public"
+    assert proof.at == now
+    assert proof.account_id == account_id
+
+
+async def test_blank_pat_no_stored_pat_private_repo_raises_and_writes_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    agent_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    calls: list[httpx.Request] = []
+    transport = _repo_probe_transport(calls=calls, public=False)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        with pytest.raises(DaimonError, match="isn't publicly readable"):
+            await resolve_repo_binding_credential(
+                runtime,
+                http_client,
+                agent_id=agent_id,
+                account_id=account_id,
+                repo_url="github.com/o/r",
+                pasted_pat=None,
+                now=datetime.now(UTC),
+            )
+
+    stored = await load_agent_inline_pat(runtime, agent_id=agent_id)
+    assert stored is None, "a private repo with no token must never write a credential"
+
+
+async def test_blank_pat_stored_pat_covers_repo_returns_inline_pat_ref_skipping_public_probe(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    agent_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+    await store_inline_pat(
+        runtime, account_id=account_id, agent_id=agent_id, plaintext_pat="ghp_stored_ok"
+    )
+    calls: list[httpx.Request] = []
+    transport = _repo_probe_transport(calls=calls, accepted_pats=frozenset({"ghp_stored_ok"}))
+
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        ref, proof = await resolve_repo_binding_credential(
+            runtime,
+            http_client,
+            agent_id=agent_id,
+            account_id=account_id,
+            repo_url="github.com/o/r",
+            pasted_pat=None,
+            now=now,
+        )
+
+    assert ref == f"inline-pat:{agent_id}", (
+        "an existing stored PAT that covers the repo must win over any public probe"
+    )
+    assert proof.kind == "pat"
+    assert len(calls) >= 1
+    assert all(call.headers.get("authorization") is not None for call in calls), (
+        "a stored PAT that covers the repo must skip the unauthenticated public probe entirely"
+    )
+
+
+async def test_blank_pat_stored_pat_does_not_cover_repo_raises_without_falling_through(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    agent_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+    await store_inline_pat(
+        runtime, account_id=account_id, agent_id=agent_id, plaintext_pat="ghp_stored_stale"
+    )
+    calls: list[httpx.Request] = []
+    # accepted_pats is empty AND public=True: if the code wrongly fell
+    # through to the public probe on a mismatch, this would return anon:
+    # instead of raising -- exactly what this test pins against.
+    transport = _repo_probe_transport(calls=calls, accepted_pats=frozenset(), public=True)
+
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        with pytest.raises(DaimonError, match="already has a stored GitHub token"):
+            await resolve_repo_binding_credential(
+                runtime,
+                http_client,
+                agent_id=agent_id,
+                account_id=account_id,
+                repo_url="github.com/o/r",
+                pasted_pat=None,
+                now=datetime.now(UTC),
+            )
+
+    assert len(calls) >= 1
+    assert all(call.headers.get("authorization") is not None for call in calls), (
+        "a stored PAT that fails re-verification must never fall through to the public probe"
     )

--- a/packages/adapters/discord/tests/test_credential_repo_bind.py
+++ b/packages/adapters/discord/tests/test_credential_repo_bind.py
@@ -1,0 +1,423 @@
+"""Tests for the chat-initiated repo bind's click-time authorization gate.
+
+`_admin_interaction` / `_member_interaction` are copied verbatim from
+`tests/agent_setup/test_authz.py` rather than imported: that module's package
+(`agent_setup/`, which carries an `__init__.py`) sits one level below
+`tests/`, which carries none, so pytest's `--import-mode=importlib` only
+resolves `agent_setup.test_authz` as an importable dotted name once
+`agent_setup/test_authz.py` has itself already been collected in the same
+session. Running this file alone (as the plan's own verify command does)
+raises `ModuleNotFoundError` for that import, so a copy — not an import — is
+what actually works standalone. Both builders build a `MagicMock(spec=discord.Member)`
+so `isinstance(user, discord.Member)` holds and the admin/member split is real,
+never a bare `MagicMock()`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import httpx
+import pytest
+from anthropic.types.beta import BetaManagedAgentsAgent
+from daimon.adapters.discord.agent_setup import authz as panel_authz
+from daimon.adapters.discord.agent_setup.state import RosterEntry
+from daimon.adapters.discord.credential_repo_bind import (
+    _AGENT_GONE_MESSAGE,
+    _SHARED_AGENT_MESSAGE,
+    _WRONG_GUILD_MESSAGE,
+    refuse_if_shared_and_not_admin_for_request,
+)
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault, TenantScopeRef
+from daimon.core.specs import AgentSpec
+from daimon.core.stores import scoped_config_write
+from daimon.testing.factories import make_tenant
+from daimon.testing.ma import build_fake_anthropic, list_response
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+# `make_tenant` derives the tenant id from `workspace_id` the exact same way
+# `derive_tenant_uuid(platform="discord", workspace_id=str(interaction.guild_id))`
+# does — see `daimon.testing.factories.make_tenant` and
+# `daimon.core.ma_identity.derive_tenant_uuid`. Every tenant seeded below and
+# every interaction built below must agree on this one id, or a refusal test
+# lands on the wrong-guild branch and passes for the wrong reason. The one
+# deliberate exception is the wrong-guild test itself, which seeds a distinct
+# workspace_id on purpose.
+_GUILD_ID = 111
+
+
+def _admin_interaction(*, guild_id: int = _GUILD_ID, acked: bool = False) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 1
+    interaction.user.guild_permissions.administrator = True
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.is_done.return_value = acked
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _member_interaction(*, guild_id: int = _GUILD_ID, acked: bool = False) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 2
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.guild.owner_id = 999
+    interaction.response.is_done.return_value = acked
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _runtime(
+    *,
+    sessionmaker: object,
+    anthropic: object,
+    deployment_default: DeploymentDefault | None = None,
+) -> DiscordRuntime:
+    return DiscordRuntime(
+        settings=MagicMock(),
+        anthropic=anthropic,  # type: ignore[arg-type]  # a real fake AsyncAnthropic, never a bare mock
+        sessionmaker=sessionmaker,  # type: ignore[arg-type]  # a real async_sessionmaker or a spy MagicMock, never invoked as a client
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=deployment_default or DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+    )
+
+
+def _make_agent(
+    *, ma_agent_id: str, tenant_id: uuid.UUID, name: str, managed: bool
+) -> BetaManagedAgentsAgent:
+    metadata = {"daimon_tenant": str(tenant_id)}
+    if managed:
+        metadata["daimon_managed"] = "true"
+    return BetaManagedAgentsAgent(
+        id=ma_agent_id,
+        type="agent",
+        name=name,
+        model={"id": "claude-sonnet-4-6"},
+        metadata=metadata,
+        description=None,
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    )
+
+
+def _list_agents_handler(
+    agents: list[BetaManagedAgentsAgent],
+) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return list_response([agent.model_dump(mode="json") for agent in agents])
+
+    return handler
+
+
+def _counting_handler(
+    agents: list[BetaManagedAgentsAgent], *, calls: list[httpx.Request]
+) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return list_response([agent.model_dump(mode="json") for agent in agents])
+
+    return handler
+
+
+def _sent_message(interaction: MagicMock) -> Any:  # noqa: ANN401 -- MagicMock call_args positional arg is untyped by construction
+    """Return the ephemeral message text an interaction was sent, on whichever half fired."""
+    if interaction.response.send_message.called:
+        return interaction.response.send_message.call_args.args[0]
+    return interaction.followup.send.call_args.args[0]
+
+
+async def test_defaults_managed_target_member_refuses_with_shared_agent_message(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_seeded_1"
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(_GUILD_ID))
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=ma_agent_id)
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant.id, name="daimon", managed=True)
+    client = build_fake_anthropic(_list_agents_handler([agent]))
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+    interaction = _member_interaction()
+
+    refused = await refuse_if_shared_and_not_admin_for_request(
+        interaction, runtime=runtime, tenant_id=tenant.id, agent_id=agent_id
+    )
+
+    assert refused is True, "a member must not bind a repo to a defaults-managed agent"
+    assert _sent_message(interaction) == _SHARED_AGENT_MESSAGE
+
+
+async def test_reachable_non_managed_target_flips_with_the_scope_row(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Branches (d) and (e) share one refusal message, so text alone cannot tell
+    them apart. Running the same fixture with and without the scope row that
+    makes the agent reachable, and asserting the result flips, is the only way
+    to pin branch (e) specifically — deleting it would leave this test green
+    with the scope row removed unless the flip is checked both ways."""
+    ma_agent_id = "agent_reachable_1"
+    agent_name = "bot"
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(_GUILD_ID))
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=ma_agent_id)
+    agent = _make_agent(
+        ma_agent_id=ma_agent_id, tenant_id=tenant.id, name=agent_name, managed=False
+    )
+    client = build_fake_anthropic(_list_agents_handler([agent]))
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+
+    async with db_session_factory() as session, session.begin():
+        await scoped_config_write.set_fields(
+            session,
+            scope=TenantScopeRef(tenant_id=tenant.id),
+            tenant_id=tenant.id,
+            agent_name=agent_name,
+        )
+    scoped_interaction = _member_interaction()
+    refused_when_reachable = await refuse_if_shared_and_not_admin_for_request(
+        scoped_interaction, runtime=runtime, tenant_id=tenant.id, agent_id=agent_id
+    )
+    assert refused_when_reachable is True, "the tenant-scoped default agent must refuse a member"
+    assert _sent_message(scoped_interaction) == _SHARED_AGENT_MESSAGE
+
+    async with db_session_factory() as session, session.begin():
+        await scoped_config_write.unset_fields(
+            session, scope=TenantScopeRef(tenant_id=tenant.id), fields=["agent_name"]
+        )
+    unscoped_interaction = _member_interaction()
+    refused_when_unreachable = await refuse_if_shared_and_not_admin_for_request(
+        unscoped_interaction, runtime=runtime, tenant_id=tenant.id, agent_id=agent_id
+    )
+    assert refused_when_unreachable is False, (
+        "removing the only scope row naming this agent must free it for its own member"
+    )
+    assert refused_when_reachable != refused_when_unreachable, (
+        "only branch (e), reachability, can produce this flip — a deleted branch (e) "
+        "would leave both calls returning True"
+    )
+
+
+async def test_non_managed_non_reachable_target_member_allowed_no_ephemeral(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_private_1"
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(_GUILD_ID))
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=ma_agent_id)
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant.id, name="bot", managed=False)
+    client = build_fake_anthropic(_list_agents_handler([agent]))
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+    interaction = _member_interaction()
+
+    refused = await refuse_if_shared_and_not_admin_for_request(
+        interaction, runtime=runtime, tenant_id=tenant.id, agent_id=agent_id
+    )
+
+    assert refused is False, "a private, unreachable agent is the member's own to bind a repo to"
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_admin_passes_on_defaults_managed_target_before_any_ma_request(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Ordering pin: reordering the admin branch after the defaults-managed
+    branch must turn this red. Verified empirically by temporarily swapping
+    them (see summary)."""
+    ma_agent_id = "agent_seeded_2"
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(_GUILD_ID))
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=ma_agent_id)
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant.id, name="daimon", managed=True)
+    calls: list[httpx.Request] = []
+    client = build_fake_anthropic(_counting_handler([agent], calls=calls))
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+    interaction = _admin_interaction()
+
+    refused = await refuse_if_shared_and_not_admin_for_request(
+        interaction, runtime=runtime, tenant_id=tenant.id, agent_id=agent_id
+    )
+
+    assert refused is False, "a live admin must be able to bind a repo to the seeded agent"
+    assert len(calls) == 0, "the admin branch must precede any MA request"
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_unknown_agent_uuid_refuses_with_agent_gone_message(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(_GUILD_ID))
+    client = build_fake_anthropic(_list_agents_handler([]))
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+    interaction = _member_interaction()
+
+    refused = await refuse_if_shared_and_not_admin_for_request(
+        interaction, runtime=runtime, tenant_id=tenant.id, agent_id=uuid.uuid4()
+    )
+
+    assert refused is True, "a derived agent uuid matching no MA agent must fail closed"
+    assert _sent_message(interaction) == _AGENT_GONE_MESSAGE
+
+
+async def test_wrong_guild_refuses_before_the_admin_check(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Using an admin interaction here is the point: it proves the tenant
+    re-derivation precedes even the admin short-circuit."""
+    seeded_workspace_id = "555001"
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=seeded_workspace_id)
+    calls: list[httpx.Request] = []
+    client = build_fake_anthropic(_counting_handler([], calls=calls))
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+    interaction = _admin_interaction(guild_id=_GUILD_ID)
+
+    refused = await refuse_if_shared_and_not_admin_for_request(
+        interaction, runtime=runtime, tenant_id=tenant.id, agent_id=uuid.uuid4()
+    )
+
+    assert refused is True, "a request row minted for a different guild's tenant must refuse"
+    assert _sent_message(interaction) == _WRONG_GUILD_MESSAGE
+    assert len(calls) == 0, "the tenant check must precede every MA request, admin or not"
+
+
+async def test_unacked_refusal_uses_response_send_message(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_seeded_3"
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(_GUILD_ID))
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=ma_agent_id)
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant.id, name="daimon", managed=True)
+    client = build_fake_anthropic(_list_agents_handler([agent]))
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+    interaction = _member_interaction(acked=False)
+
+    refused = await refuse_if_shared_and_not_admin_for_request(
+        interaction, runtime=runtime, tenant_id=tenant.id, agent_id=agent_id
+    )
+
+    assert refused is True
+    interaction.response.send_message.assert_called_once()
+    interaction.followup.send.assert_not_called()
+
+
+async def test_acked_refusal_uses_followup_send(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ma_agent_id = "agent_seeded_4"
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(_GUILD_ID))
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=ma_agent_id)
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant.id, name="daimon", managed=True)
+    client = build_fake_anthropic(_list_agents_handler([agent]))
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+    interaction = _member_interaction(acked=True)
+
+    refused = await refuse_if_shared_and_not_admin_for_request(
+        interaction, runtime=runtime, tenant_id=tenant.id, agent_id=agent_id
+    )
+
+    assert refused is True
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_called_once()
+
+
+async def test_shared_agent_message_matches_the_panel_gate_character_for_character() -> None:
+    assert _SHARED_AGENT_MESSAGE == panel_authz._SHARED_AGENT_MESSAGE, (
+        "the chat gate's shared-agent refusal copy must never drift from the panel's"
+    )
+
+
+@pytest.mark.parametrize(
+    ("is_admin", "is_system", "reachable"),
+    [
+        (is_admin, is_system, reachable)
+        for is_admin in (True, False)
+        for is_system in (True, False)
+        for reachable in (True, False)
+    ],
+)
+async def test_decision_table_parity_with_the_panel_gate(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    is_admin: bool,
+    is_system: bool,
+    reachable: bool,
+) -> None:
+    """Parity is between the two DECISIONS, not the two call sites: the chat
+    path additionally runs this gate as a pre-filter before a modal opens
+    (added by the next plan), and the panel's own repo-bind path gates at
+    open and at submit too — so even that shape matches — but this test's
+    scope is only the shared boolean.
+
+    Each side's own fail-closed guards (a missing roster entry on the panel
+    side; a wrong guild or an unresolvable agent on the chat side) are inputs
+    the other side does not have, and are held out of the comparison by
+    construction: the panel side always gets a real entry, and the chat side
+    always gets a matching tenant and a resolvable agent.
+    """
+    ma_agent_id = "agent_parity"
+    agent_name = "bot"
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(_GUILD_ID))
+    agent_id = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=ma_agent_id)
+    agent = _make_agent(
+        ma_agent_id=ma_agent_id, tenant_id=tenant.id, name=agent_name, managed=is_system
+    )
+    client = build_fake_anthropic(_list_agents_handler([agent]))
+    if reachable:
+        async with db_session_factory() as session, session.begin():
+            await scoped_config_write.set_fields(
+                session,
+                scope=TenantScopeRef(tenant_id=tenant.id),
+                tenant_id=tenant.id,
+                agent_name=agent_name,
+            )
+    runtime = _runtime(sessionmaker=db_session_factory, anthropic=client)
+
+    chat_interaction = _admin_interaction() if is_admin else _member_interaction()
+    chat_refused = await refuse_if_shared_and_not_admin_for_request(
+        chat_interaction, runtime=runtime, tenant_id=tenant.id, agent_id=agent_id
+    )
+
+    panel_interaction = _admin_interaction() if is_admin else _member_interaction()
+    entry = RosterEntry(
+        name=agent_name,
+        model="claude-sonnet-4-6",
+        spec=AgentSpec(name=agent_name, model="claude-sonnet-4-6"),
+        is_system=is_system,
+    )
+    panel_refused = await panel_authz.refuse_if_shared_and_not_admin(
+        panel_interaction, runtime=runtime, entry=entry
+    )
+
+    assert chat_refused == panel_refused, (
+        f"decision mismatch for admin={is_admin} system={is_system} reachable={reachable}: "
+        f"chat gate returned {chat_refused}, panel gate returned {panel_refused}"
+    )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -1,13 +1,15 @@
-"""Credential-request tools: request_env_credential, request_mcp_credential.
+"""Credential-request tools: request_env_credential, request_mcp_credential,
+request_repo_binding.
 
-These two tools replace the "go open /agent-setup" redirect for a task that
-needs an env secret or an auth-required MCP server: the agent mints a
-single-use, TTL-bounded ``credential_requests`` row and posts a
-target-naming button in the thread (``tools/discord/_credential_button.py``).
-Clicking the button opens a native Discord modal in a different process (the
-Discord bot, worker VM) — the secret itself never travels through either
-process's tool arguments, so neither tool below has a token/secret/value
-parameter, and none should ever be added.
+These three tools replace the "go open /agent-setup" redirect for a task that
+needs an env secret, an auth-required MCP server, or a repo bound to an
+agent: the agent mints a single-use, TTL-bounded ``credential_requests`` row
+and posts a target-naming button in the thread
+(``tools/discord/_credential_button.py``). Clicking the button opens a
+native Discord modal in a different process (the Discord bot, worker VM) —
+the secret itself never travels through either process's tool arguments, so
+none of the three tools below has a token/secret/value parameter, and none
+should ever be added.
 
 Deliberately NOT admin-gated — the chat-mutation admin check other tools call
 at the top of their impl is intentionally absent here. Authorization for the
@@ -39,6 +41,7 @@ from daimon.core.credential_requests import (
     mint_request_token,
 )
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
+from daimon.core.github_repo_auth import normalize_owner_repo
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.stores.credential_requests import create_credential_request
 from fastmcp import Context, FastMCP
@@ -50,6 +53,14 @@ from pydantic import BaseModel, ConfigDict
 # MCP adapter cannot import each other (import-linter's independence
 # contract), and this rule is small enough not to warrant a core lift.
 _POSIX_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# `normalize_owner_repo` does not truncate to two path segments (it only
+# strips a known prefix/suffix), so a URL like
+# "https://github.com/owner/repo/extra" normalizes to "owner/repo/extra"
+# rather than raising. This pattern is what actually enforces "exactly two
+# segments" before the row is minted, guaranteeing the modal's later
+# normalization sees the same shape this tool validated.
+_OWNER_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 
 class RequestCredentialResult(BaseModel):
@@ -191,6 +202,45 @@ async def _request_mcp_credential_impl(
     )
 
 
+# No `default_branch` parameter here: the credential_requests row has no
+# column to hold one, and none is being added, so an argument accepted here
+# would be silently discarded — the exact class of surface-that-lies this
+# tool exists not to become. The modal collects the branch instead,
+# defaulting to `main`.
+async def _request_repo_binding_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+    repo_url: str,
+    purpose: str,
+    channel_id: str,
+) -> RequestCredentialResult:
+    if auth.platform == "slack":
+        raise ToolError("request_repo_binding is not supported on Slack yet")
+    if auth.platform_user_id is None:
+        raise ToolError("credential requests require a platform-bound identity")
+    if urlparse(repo_url).scheme not in ("http", "https"):
+        raise ToolError("repo url must be http or https, e.g. https://github.com/owner/repo")
+    if not _OWNER_REPO_RE.fullmatch(normalize_owner_repo(repo_url)):
+        raise ToolError(
+            "repo url must name exactly one owner/repo, e.g. https://github.com/owner/repo"
+        )
+    agent_id = await _resolve_agent_uuid(runtime, auth, agent_name)
+    return await _mint_and_post(
+        runtime,
+        auth,
+        kind="repo",
+        target=repo_url,
+        mcp_server_url=None,
+        agent_id=agent_id,
+        requester_platform_user_id=auth.platform_user_id,
+        agent_name=agent_name,
+        purpose=purpose,
+        channel_id=channel_id,
+    )
+
+
 def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     @mcp.tool
     async def request_env_credential(  # pyright: ignore[reportUnusedFunction]
@@ -241,5 +291,31 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
             agent_name=agent_name,
             server_name=server_name,
             url=url,
+            channel_id=channel_id,
+        )
+
+    @mcp.tool
+    async def request_repo_binding(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        agent_name: str,
+        repo_url: str,
+        purpose: str,
+        channel_id: str,
+    ) -> RequestCredentialResult:
+        """Request a repo binding for an agent via a private modal.
+
+        Call this INSTEAD of ever telling the user to open ``/agent-setup``
+        to bind a repository. Posts a button in the thread naming the exact
+        repo and agent; clicking it opens a native Discord modal where the
+        user confirms the branch and, only if the repo is private and not
+        otherwise readable, pastes a GitHub token that never appears in this
+        channel or in your context.
+        """
+        return await _request_repo_binding_impl(
+            runtime,
+            await _auth(ctx),
+            agent_name=agent_name,
+            repo_url=repo_url,
+            purpose=purpose,
             channel_id=channel_id,
         )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_credential_button.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_credential_button.py
@@ -43,6 +43,7 @@ from fastmcp.exceptions import ToolError
 _KIND_NOUN: dict[CredentialRequestKind, str] = {
     "env": "an environment secret",
     "mcp": "an MCP server credential",
+    "repo": "a repo binding",
 }
 
 
@@ -54,6 +55,14 @@ def _build_message_body(
     target: str,
     purpose: str,
 ) -> str:
+    if kind == "repo":
+        return (
+            f"<@{requester_platform_user_id}> wants to bind a repo to **{agent_name}** "
+            f"(`{target}`) — {purpose}\n"
+            "Click the button below to open a private form confirming the branch, "
+            "and — only if the repo isn't publicly readable — a GitHub token that "
+            "never appears in this channel."
+        )
     return (
         f"<@{requester_platform_user_id}> **{agent_name}** needs {_KIND_NOUN[kind]} "
         f"(`{target}`) — {purpose}\n"

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2168,6 +2168,42 @@
         'type': 'object',
       }),
     }),
+    'request_repo_binding': dict({
+      'description': '''
+        Request a repo binding for an agent via a private modal.
+        
+        Call this INSTEAD of ever telling the user to open ``/agent-setup``
+        to bind a repository. Posts a button in the thread naming the exact
+        repo and agent; clicking it opens a native Discord modal where the
+        user confirms the branch and, only if the repo is private and not
+        otherwise readable, pastes a GitHub token that never appears in this
+        channel or in your context.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'agent_name': dict({
+            'type': 'string',
+          }),
+          'channel_id': dict({
+            'type': 'string',
+          }),
+          'purpose': dict({
+            'type': 'string',
+          }),
+          'repo_url': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'agent_name',
+          'repo_url',
+          'purpose',
+          'channel_id',
+        ]),
+        'type': 'object',
+      }),
+    }),
     'search_messages': dict({
       'description': '''
         Search messages with server-side filters.

--- a/packages/adapters/mcp/tests/tools/test_credential_requests.py
+++ b/packages/adapters/mcp/tests/tools/test_credential_requests.py
@@ -62,6 +62,9 @@ _request_env_credential_impl = (
 _request_mcp_credential_impl = (
     _credential_requests_mod._request_mcp_credential_impl  # pyright: ignore[reportPrivateUsage]
 )
+_request_repo_binding_impl = (
+    _credential_requests_mod._request_repo_binding_impl  # pyright: ignore[reportPrivateUsage]
+)
 register_credential_request_tools = _credential_requests_mod.register_credential_request_tools
 
 pytestmark = pytest.mark.asyncio
@@ -551,6 +554,144 @@ async def test_request_mcp_credential_rejects_non_http_url(
 # ---------------------------------------------------------------------------
 # 10. A failed button post raises a ToolError rather than silently succeeding
 # ---------------------------------------------------------------------------
+
+
+async def test_request_repo_binding_creates_row_and_posts_button(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    client = _ma_client_with_agents(
+        [_ma_agent(agent_id="ag_repo", name="daimon", tenant_id=tenant.id)]
+    )
+    runtime = _runtime(committing_sessionmaker, client=client)
+    auth = _auth_identity(tenant_id=tenant.id)
+    before = datetime.now(UTC)
+    posted: dict[str, Any] = {}
+    _patch_successful_post(monkeypatch, message_id="9204", posted=posted)
+
+    result = await _request_repo_binding_impl(
+        runtime,
+        auth,
+        agent_name="daimon",
+        repo_url="https://github.com/clsandoval/daimon-qa-scratch",
+        purpose="binding the QA scratch repo",
+        channel_id="222",
+    )
+
+    assert result.kind == "repo", "result must report the repo kind"
+    assert result.target == "https://github.com/clsandoval/daimon-qa-scratch", (
+        "result must report the exact submitted repo url"
+    )
+    assert result.message_id == "9204", "result must report the posted message id"
+    assert before + DEFAULT_TTL <= result.expires_at, "expires_at must be at least now + TTL"
+    assert await _row_count(db_session) == 1, "exactly one credential_requests row must be created"
+
+    row = await peek_credential_request(db_session, token=_token_from_posted(posted))
+    assert row is not None, "the minted token must resolve to the created row"
+    assert row.kind == "repo"
+    assert row.target == "https://github.com/clsandoval/daimon-qa-scratch"
+    assert row.mcp_server_url is None, "repo rows must not carry an mcp_server_url"
+    assert row.account_id == auth.account_id, "row must stamp the caller's account_id"
+    assert row.requester_platform_user_id == auth.platform_user_id, (
+        "row must stamp the caller's platform_user_id"
+    )
+    assert row.tenant_id == tenant.id
+
+
+async def test_request_repo_binding_rejects_unknown_agent(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    client = _ma_client_with_agents([])  # no agents in the tenant
+    runtime = _runtime(committing_sessionmaker, client=client)
+    auth = _auth_identity(tenant_id=tenant.id)
+    with pytest.raises(ToolError, match="not found in this tenant"):
+        await _request_repo_binding_impl(
+            runtime,
+            auth,
+            agent_name="ghost",
+            repo_url="https://github.com/clsandoval/daimon-qa-scratch",
+            purpose="x",
+            channel_id="222",
+        )
+    assert await _row_count(db_session) == 0, "an unknown agent must create no row"
+
+
+async def test_request_repo_binding_rejects_invalid_repo_url(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    runtime = _runtime(committing_sessionmaker)
+    auth = _auth_identity()
+    with pytest.raises(ToolError, match="owner/repo"):
+        await _request_repo_binding_impl(
+            runtime,
+            auth,
+            agent_name="daimon",
+            repo_url="https://github.com/not-a-repo-shape",
+            purpose="x",
+            channel_id="222",
+        )
+    assert await _row_count(db_session) == 0, "an invalid repo url must create no row"
+
+
+async def test_request_repo_binding_signature_has_no_secret_or_branch_parameter() -> None:
+    """Belt-and-suspenders: the repo-binding impl's own signature carries no
+    token/secret/value/pat parameter, and no default_branch parameter — the
+    row has no column to persist one."""
+    params = set(inspect.signature(_request_repo_binding_impl).parameters)
+    forbidden = {
+        p
+        for p in params
+        if any(w in p.lower() for w in ("token", "secret", "value", "pat", "default_branch"))
+    }
+    assert not forbidden, (
+        f"_request_repo_binding_impl must not accept a secret or branch parameter, "
+        f"found {forbidden}"
+    )
+
+
+async def test_request_repo_binding_posts_message_naming_agent_and_repo(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    client = _ma_client_with_agents(
+        [_ma_agent(agent_id="ag_repo_msg", name="daimon", tenant_id=tenant.id)]
+    )
+    runtime = _runtime(committing_sessionmaker, client=client)
+    auth = _auth_identity(tenant_id=tenant.id)
+    posted: dict[str, Any] = {}
+    _patch_successful_post(monkeypatch, message_id="9205", posted=posted)
+
+    await _request_repo_binding_impl(
+        runtime,
+        auth,
+        agent_name="daimon",
+        repo_url="https://github.com/clsandoval/daimon-qa-scratch",
+        purpose="binding the QA scratch repo",
+        channel_id="222",
+    )
+
+    content = posted["json"]["content"]
+    assert "daimon" in content, "message body must name the agent"
+    assert "https://github.com/clsandoval/daimon-qa-scratch" in content, (
+        "message body must name the exact repo"
+    )
+    button = posted["json"]["components"][0]["components"][0]
+    assert button["custom_id"].startswith(CUSTOM_ID_PREFIX), (
+        "the button's custom_id must carry the credential-request prefix"
+    )
+    assert button["label"].startswith("Bind repo: "), (
+        "the button's label must use the repo-kind prefix"
+    )
 
 
 async def test_request_env_credential_raises_when_button_post_fails(

--- a/packages/core/daimon/core/credential_requests.py
+++ b/packages/core/daimon/core/credential_requests.py
@@ -20,6 +20,12 @@ names the human-readable target, via `build_button_label`.
 `DynamicItem` dispatch matches incoming custom_ids with `pattern.fullmatch`,
 not a prefix search, so a template that merely starts with the right prefix
 would never dispatch (or could over-match unrelated ids).
+
+Each kind puts something different in `target`: for `env` it is the
+environment variable's key name, for `mcp` it is the MCP server name, and
+for `repo` it is the repo URL. A `repo` request's branch is collected in the
+modal at click time, not stored on the row — `credential_requests` has no
+branch column, and this module adds none.
 """
 
 from __future__ import annotations
@@ -39,7 +45,7 @@ TOKEN_BYTES: Final[int] = 16
 CUSTOM_ID_TEMPLATE: Final[str] = r"ztc:(?P<token>[A-Za-z0-9_-]{16,64})"
 CUSTOM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(CUSTOM_ID_TEMPLATE)
 
-CredentialRequestKind = Literal["env", "mcp"]
+CredentialRequestKind = Literal["env", "mcp", "repo"]
 
 # TTL bounds the replay window for a never-clicked button sitting in channel
 # scrollback; combined with the store's single-use consume, this is the full
@@ -49,7 +55,14 @@ DEFAULT_TTL: Final[dt.timedelta] = dt.timedelta(minutes=30)
 # Discord's documented Button.label limit.
 MAX_BUTTON_LABEL_CHARS: Final[int] = 80
 
-_KIND_DISPLAY: Final[dict[CredentialRequestKind, str]] = {"env": "env", "mcp": "MCP"}
+# The full label prefix for each kind. "env" and "mcp" reproduce the
+# pre-repo-kind wording byte-for-byte. "repo" cannot reuse the "Add {X}
+# credential: " interpolation — a repo binding is not a credential.
+_KIND_LABEL_PREFIX: Final[dict[CredentialRequestKind, str]] = {
+    "env": "Add env credential: ",
+    "mcp": "Add MCP credential: ",
+    "repo": "Bind repo: ",
+}
 
 
 def mint_request_token() -> str:
@@ -69,7 +82,7 @@ def build_button_label(kind: CredentialRequestKind, target: str) -> str:
     80-character button label limit — the label, not the custom_id, is what
     names the exact target, so it must fit on its own.
     """
-    prefix = f"Add {_KIND_DISPLAY[kind]} credential: "
+    prefix = _KIND_LABEL_PREFIX[kind]
     available = MAX_BUTTON_LABEL_CHARS - len(prefix)
     if len(target) <= available:
         return f"{prefix}{target}"

--- a/packages/core/tests/test_credential_requests.py
+++ b/packages/core/tests/test_credential_requests.py
@@ -69,3 +69,18 @@ def test_build_button_label_truncates_long_target_within_discord_label_limit() -
     assert label.startswith("Add MCP credential: "), (
         "truncation must not lose the human-readable prefix"
     )
+
+
+def test_build_button_label_repo() -> None:
+    assert (
+        build_button_label("repo", "clsandoval/daimon-qa-scratch")
+        == "Bind repo: clsandoval/daimon-qa-scratch"
+    )
+
+
+def test_build_button_label_truncates_long_repo_target_within_discord_label_limit() -> None:
+    label = build_button_label("repo", "https://github.com/" + "x" * 200)
+
+    assert len(label) <= MAX_BUTTON_LABEL_CHARS, "label must fit Discord's 80-char button limit"
+    assert label.startswith("Bind repo: "), "truncation must not lose the human-readable prefix"
+    assert label.endswith("…"), "truncation must append the single-character ellipsis"


### PR DESCRIPTION
Binding a repo to an agent now works from a chat turn. A member asks in the thread, gets a button naming the target repo and agent, clicks it, and the binding is written — no `/agent-setup`, no slash command.

This was the last first-run setup step that could only be done from the panel.

## Why it wasn't possible before

`middleware/mcp_identity.py` forks the toolset on the presence of an `agent_id` claim: a session either carries one and sees **only** `agent-chat` tools, or carries none and sees everything else. `set_repo_binding` lives in the `agent-chat` set and derives its target from the JWT, so it is self-bind-only. A chat turn carries no `agent_id`, so the tool is invisible to it — and simply retagging it would move the failure to `_require_agent_id`.

## What this adds

```
@daimon bind github.com/acme/repo to my-agent
  -> request_repo_binding(agent_name, repo_url)   mints a credential_requests row, kind="repo"
  -> button posted in the thread
click
  -> pre-filter: is_guild_admin (pure, no I/O)
       admin      -> send_modal immediately
       non-admin  -> full gate, bounded by wait_for(1.5s), falls through on timeout
  -> modal: branch (default main) + token (optional)
submit
  -> defer -> gate -> atomic single-use consume -> resolve -> set_binding
```

The credential-button handshake, the single-use token, the TTL, and `interaction_check` are all reused unchanged. `interaction_check`'s executable body is byte-identical; only its docstring changed, because its claim to be the sole authorization on this path is no longer true.

## Authorization

Two gates, both must pass:

1. **`interaction_check`** — are you the requester? Unchanged.
2. **New** — are you a guild admin, or is the target agent one nobody else resolves to?

The second mirrors `agent_setup/authz.refuse_if_shared_and_not_admin` exactly, re-derived from live state at click time rather than trusted from the render. It takes a `RosterEntry` this path does not have, so the decision is rebuilt from the same primitives in the same order: guild-admin first (before any API or database read), then the system-agent check, then a fresh reachability read.

Net effect is **stricter**, never looser. An admin who was not the requester is still refused.

## Credential resolution

Two tiers, matching what the panel does today:

1. Repo verifiably public → `anon:` binding with a recorded proof
2. Otherwise → verify the pasted token against the repo, then store it as the per-agent credential

There is deliberately **no GitHub App tier**. An App installation is keyed by repo, not by the tenant doing the binding, so App coverage proves nothing about whether *this* binder may read the repo — the same reasoning that removed it from the panel's bind path, and enforced at clone time by `select_clone_auth` requiring a proof. An App-covered private repo binds by pasting a token, exactly as in the panel.

## Notes

- **No migration.** `credential_requests.kind` is plain `Text` with no constraint, so admitting a third kind is a code change. The branch is a modal field, not a column.
- The seeded `workspace-setup` skill said repo binding could not be done from chat. That is now false, so it was corrected — the integration test over seeded prompt tool claims is the gate holding it true.
- The pre-filter is advisory, not authoritative: the submit-time gate runs again before the consume and is the real boundary. It is bounded by a timeout because its non-admin path lists agents, and an over-budget read would otherwise leave a button that never opens. On timeout the modal opens and the submit gate still refuses.

## Verification

`pytest` 4418 passed / 4 skipped · `pyright` strict, 0 errors project-wide · `ruff` clean · `lint-imports` 6/6 · repo test-pattern lint 9/9 · no Alembic diff.

Both branch-order guards were checked by mutation: moving the admin check below the shared-agent check turns 3 tests red, deleting the reachability read turns 2 red, and the secret-hygiene log ordering turns 1 red. Each was reverted and re-verified.

Secret hygiene is pinned across four paths — success, upstream refusal, unexpected exception, and gate refusal — with the exception case raising an error whose string embeds the pasted token, so the assertion cannot pass vacuously.

## Still outstanding

An end-to-end confirmation against a deployed environment: bind a public repo from a thread, then have the agent quote a line from its README. Discord forbids bots from invoking components, so no automated test can cover the click; this is verified by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
