### PR TITLE
fix(prompts): a chat reply delivers itself — stop agents posting a duplicate via send_message

### DIFF
--- a/packages/core/daimon/core/agent_guidance.py
+++ b/packages/core/daimon/core/agent_guidance.py
@@ -47,9 +47,17 @@ A request that already redacts values leaks nothing, so don't refuse it as
 "credential harvesting." The one hard rule: never emit a raw secret VALUE
 into your reply.
 
-ROUTINES RUN HEADLESS. A scheduled routine has no chat to reply into — its
-output is recorded, not auto-posted. To make a routine post to Discord it
-must explicitly call the send_message tool with a channel_id."""
+A CHAT REPLY DELIVERS ITSELF. When someone mentions you, the text you write
+IS the message — it is posted to that thread for you, automatically. Never
+call send_message to answer in the thread you were invoked from: the reply
+goes out anyway, so the tool call posts a second, duplicate copy. Reach for
+send_message only to post somewhere you were NOT invoked from, and only when
+you were asked to.
+
+ROUTINES RUN HEADLESS — the exception to the rule above. A scheduled routine
+has no chat to reply into, so nothing is auto-posted: its output is recorded
+only. To make a routine post to Discord it must explicitly call the
+send_message tool with a channel_id."""
 
 # The full sentinel-wrapped block. Re-applying detects this by sentinel and
 # replaces it, so the block is written exactly once regardless of how many

--- a/packages/core/tests/test_agent_guidance.py
+++ b/packages/core/tests/test_agent_guidance.py
@@ -49,6 +49,25 @@ def test_carves_out_redacted_self_inspection() -> None:
     assert "REDACTED" in block, "block must endorse value-redacted inspection as safe"
 
 
+def test_states_the_interactive_delivery_contract_not_only_the_headless_one() -> None:
+    # Regression for the staging trace where an agent answered one mention
+    # twice: it called send_message into the thread it was already running in,
+    # and its ordinary reply was delivered too. The block previously described
+    # only the headless-routine path ("a routine must call send_message"), so
+    # that was the sole statement about how output reaches Discord and a
+    # weakly-primed agent generalised it to interactive turns.
+    block = CREDENTIAL_GUIDANCE_BLOCK
+    assert "send_message" in block, "block must name the tool the failure mode misuses"
+    assert "ROUTINES RUN HEADLESS" in block, "the headless-routine path must still be stated"
+    assert block.index("A CHAT REPLY DELIVERS ITSELF") < block.index("ROUTINES RUN HEADLESS"), (
+        "the interactive contract must precede the routine exception, so the "
+        "default case is read first and the exception reads as an exception"
+    )
+    assert "Never" in block and "invoked from" in block, (
+        "block must forbid send_message into the thread the turn was invoked from"
+    )
+
+
 def test_replaces_stale_block_preserving_user_body() -> None:
     seeded = apply_credential_guidance("ORIGINAL BODY")
     # Simulate a user editing only their body underneath the (now stale) block.


### PR DESCRIPTION
An agent answers a single mention **twice**: once by calling the `send_message` MCP tool into its own thread, and once through the normal turn rendering.

Observed on a deployed environment. The session events show the reasoning:

```
agent.mcp_tool_use  search_tools  {"query": "send message discord"}
agent.mcp_tool_use  call_tool     {"name": "send_message",
                                   "channel_id": "<the thread it was already in>",
                                   "content": "Hey! 👋 What can I help you with?"}
agent.message                     "Hey! 👋 What can I help you with?"
```

It went looking for a way to reach Discord, found `send_message`, called it, and then also produced its ordinary reply — which the adapter delivers by editing the thinking embed into the final text.

## Why

The guidance block prepended to every agent's system prompt said exactly one thing about how output reaches Discord:

> ROUTINES RUN HEADLESS. A scheduled routine has no chat to reply into — its output is recorded, not auto-posted. To make a routine post to Discord it must explicitly call the send_message tool with a channel_id.

Correct for routines, and the only delivery model stated. Nothing said that an interactive reply is delivered automatically, so an agent with little other context generalises the one rule it has.

## Why it looked intermittent

It tracks how strongly primed the agent is, not which agent it is. Compared side by side, same deployment, same minute:

| Agent | system prompt | skills | doubles? |
|---|---|---|---|
| seeded default | 6271 chars | 5 | no |
| created via `create_agent` | 1865 chars | 0 | **yes** |

Both carry the identical block. The seeded agent has enough surrounding context to infer the interactive case; a bare one has only the routines paragraph.

That makes this a first-run problem: every agent created through `create_agent` starts at the low-priming end, so a freshly created agent double-posts on its first reply.

## The change

States the interactive contract first, and demotes the routine rule to the exception it actually is. No behaviour change beyond the prompt text.

The `v1` sentinel is deliberately unchanged: `_strip_existing_block` matches on it and its comment notes the body may evolve across versions. Bumping to `v2` would fail to match existing `v1` blocks and stack a second one instead of replacing.

## Verification

`pytest` 4419 passed / 4 skipped · `pyright` strict 0 errors project-wide · `ruff` clean · `lint-imports` 6/6.

New regression test asserts the interactive contract is present, that it precedes the routine exception so the default case is read first, and that the routine path is still stated.

## Follow-up worth considering separately

Prompt guidance is what failed here, so prose alone is a weak fix. A `send_message` call targeting the thread the current turn was invoked from is almost always a mistake, and could be rejected at the tool boundary with an error explaining that the reply is delivered automatically. That would close the failure mode for weakly-primed and adversarial cases alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
