### PR TITLE
fix: key agent defaults on the parent channel, default new agents to the current Sonnet

### DIFF
--- a/defaults/agents-optional/dev_agent.yaml
+++ b/defaults/agents-optional/dev_agent.yaml
@@ -1,5 +1,5 @@
 name: dev_agent
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Dev agent — clones a bound repo into /workspace, runs code, opens PRs via GitHub.
 system: |
   You are dev_agent, a software-engineering agent embedded in Discord. You read,

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -33,6 +33,7 @@ from daimon.adapters.discord.agent_setup.write import (
     validate_model_id,
 )
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.constants import DEFAULT_AGENT_MODEL
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.errors import DaimonError
 from daimon.core.github_visibility import (
@@ -119,7 +120,7 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
         self.model_in: discord.ui.TextInput[AgentSectionModal] = discord.ui.TextInput(
             label="Model",
             max_length=64,
-            default=current.model if current is not None else "claude-sonnet-4-6",
+            default=current.model if current is not None else DEFAULT_AGENT_MODEL,
         )
         self.add_item(self.name_in)
         self.add_item(self.prompt_in)
@@ -127,7 +128,7 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
         # name_in is intentionally ignored — rename forbidden (Pitfall 4).
-        model_value = str(self.model_in).strip() or "claude-sonnet-4-6"
+        model_value = str(self.model_in).strip() or DEFAULT_AGENT_MODEL
         submitted_system = str(self.prompt_in).strip()
         if self._system_omitted and not submitted_system:
             # Prompt was too long to show; a blank submit must KEEP it, not wipe it.

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -33,6 +33,7 @@ from daimon.adapters.discord.checks import refuse_if_not_admin
 from daimon.adapters.discord.errors import generate_request_id, render_error
 from daimon.adapters.discord.layout import hairline, header
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.constants import DEFAULT_AGENT_MODEL
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.errors import DaimonError
 from daimon.core.ma_identity import derive_agent_uuid
@@ -770,7 +771,7 @@ class NewAgentModal(discord.ui.Modal, title="New agent"):
             required=False,
         )
         self.model_in: discord.ui.TextInput[NewAgentModal] = discord.ui.TextInput(
-            label="Model", default="claude-sonnet-4-6", max_length=64
+            label="Model", default=DEFAULT_AGENT_MODEL, max_length=64
         )
         self.add_item(self.name_in)
         self.add_item(self.prompt_in)
@@ -778,7 +779,7 @@ class NewAgentModal(discord.ui.Modal, title="New agent"):
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
         new_name = str(self.name_in).strip()
-        model_value = str(self.model_in).strip() or "claude-sonnet-4-6"
+        model_value = str(self.model_in).strip() or DEFAULT_AGENT_MODEL
         system_value = str(self.prompt_in).strip() or None
         log.info(
             "agent_setup.new.submit",

--- a/packages/adapters/discord/daimon/adapters/discord/context.py
+++ b/packages/adapters/discord/daimon/adapters/discord/context.py
@@ -38,12 +38,26 @@ def _render_location(thread: discord.Thread) -> list[str]:
     alongside the ids so the agent can say where it is, not just post there;
     ``thread.parent`` is None when the parent is not in the client cache, so the
     channel name is emitted only when it resolves.
+
+    The thread hint is deliberately scoped to *posting*. ``channel_id`` is
+    overloaded across the toolset: for the send and credential-request tools it
+    means "where to put this message", and the thread id is right; for the
+    scope tools (``set_agent_default``, ``clear_agent_default``,
+    ``explain_agent_resolution``) it means "which scope to key on", and only
+    the parent channel id is ever right. A hint phrased as a blanket rule for
+    every ``channel_id`` parameter taught the second case wrongly, so each
+    role carries its own hint instead.
     """
-    thread_hint = "to post in this thread, pass this id as channel_id"
+    thread_hint = "to post a message in this thread, pass this id as channel_id"
+    channel_hint = (
+        "the channel these turns belong to; agent-default and routing scopes key on this id, "
+        "never on the thread id"
+    )
     channel_name = "" if thread.parent is None else f" name={quoteattr(thread.parent.name)}"
     return [
         f"<channel platform={quoteattr('discord')} id={quoteattr(str(thread.parent_id))}"
-        f" role={quoteattr('parent_channel')}{channel_name}/>",
+        f" role={quoteattr('parent_channel')}{channel_name}"
+        f" hint={quoteattr(channel_hint)}/>",
         f"<thread platform={quoteattr('discord')} id={quoteattr(str(thread.id))}"
         f" role={quoteattr('current_thread')} hint={quoteattr(thread_hint)}"
         f" name={quoteattr(thread.name)}/>",

--- a/packages/adapters/discord/tests/test_context.py
+++ b/packages/adapters/discord/tests/test_context.py
@@ -108,13 +108,13 @@ class TestBuildContextXml:
 
         result, _ = await build_context_xml(thread, trigger)
 
-        assert '<channel platform="discord" id="800" role="parent_channel"/>' in result, (
+        assert '<channel platform="discord" id="800" role="parent_channel"' in result, (
             "should have channel element with discord platform and parent-channel id"
         )
         assert '<thread platform="discord" id="900" role="current_thread"' in result, (
             "should have thread element carrying the current thread id"
         )
-        channel_pos = result.index('<channel platform="discord" id="800" role="parent_channel"/>')
+        channel_pos = result.index('<channel platform="discord" id="800" role="parent_channel"')
         context_pos = result.index("<context>")
         history_pos = result.index("<thread_history>")
         assert context_pos < channel_pos < history_pos, (
@@ -134,7 +134,7 @@ class TestBuildContextXml:
 
         result, _ = await build_context_xml(thread, trigger)
 
-        assert '<channel platform="discord" id="42" role="parent_channel"/>' in result, (
+        assert '<channel platform="discord" id="42" role="parent_channel"' in result, (
             "channel id should be the thread's parent_id"
         )
         assert '<thread platform="discord" id="900" role="current_thread"' in result, (
@@ -500,13 +500,13 @@ class TestBuildDeltaXml:
 
         result, _ = await build_delta_xml(thread, trigger, after_message_id=50, bot_user_id=None)
 
-        assert '<channel platform="discord" id="800" role="parent_channel"/>' in result, (
+        assert '<channel platform="discord" id="800" role="parent_channel"' in result, (
             "delta should have channel element with discord platform and parent-channel id"
         )
         assert '<thread platform="discord" id="900" role="current_thread"' in result, (
             "delta should have thread element carrying the current thread id"
         )
-        channel_pos = result.index('<channel platform="discord" id="800" role="parent_channel"/>')
+        channel_pos = result.index('<channel platform="discord" id="800" role="parent_channel"')
         context_pos = result.index("<context>")
         delta_pos = result.index("<thread_delta>")
         assert context_pos < channel_pos < delta_pos, (
@@ -728,6 +728,41 @@ class TestBuildChannelContextXml:
         )
         assert 'id="42" role="parent_channel"' in result, (
             "channel-mention context must name the parent channel id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_each_location_hint_is_scoped_to_its_own_role(self) -> None:
+        """Neither hint may read as a blanket rule for every ``channel_id`` parameter.
+
+        A single hint saying "pass this id as channel_id" against the thread taught
+        the agent to hand the thread id to `set_agent_default`, whose `channel_id`
+        keys a routing scope rather than naming a place to post. The write landed on
+        a scope the turn path never reads, so scoping an agent to a channel silently
+        did nothing while reporting success.
+        """
+        trigger = _make_message(msg_id=10, content="<@999> scope this channel to me")
+        channel = _make_text_channel([trigger])
+        thread = _make_thread([trigger], thread_id=900, parent_id=42)
+
+        result, _ = await build_channel_context_xml(channel, trigger, thread=thread)
+
+        thread_el = result[result.index("<thread ") : result.index(">", result.index("<thread "))]
+        channel_el = result[
+            result.index("<channel ") : result.index(">", result.index("<channel "))
+        ]
+
+        assert "post" in thread_el, (
+            "the thread hint must confine itself to posting, not claim every channel_id"
+        )
+        assert "hint=" in channel_el, (
+            "the parent-channel element must carry its own hint, or the thread's is the "
+            "only guidance the agent sees for a channel_id argument"
+        )
+        assert "scope" in channel_el, (
+            "the parent-channel hint must say that routing scopes key on this id"
+        )
+        assert "never on the thread id" in channel_el, (
+            "the parent-channel hint must rule out the thread id explicitly"
         )
 
     @pytest.mark.asyncio

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -772,7 +772,10 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     ) -> AgentInfo:
         """Create a new agent. Pass fields directly — there is NO ``spec`` wrapper.
 
-        Required: ``name`` and ``model`` (e.g. ``"claude-sonnet-4-6"``).
+        Required: ``name`` and ``model``. Use ``"claude-sonnet-5"`` when the user
+        asks for Sonnet and ``"claude-opus-5"`` when they ask for Opus — always
+        the current generation. Only pass an older id (``claude-sonnet-4-6``,
+        ``claude-opus-4-8``, …) when the user names that version themselves.
         Optional: ``description``, ``system`` (the system prompt), ``tools``,
         ``mcp_servers``, and ``skill_repos`` — GitHub repos to sync skills from,
         e.g. ``[{"url": "https://github.com/owner/repo", "branch": "main"}]``.
@@ -805,7 +808,10 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     ) -> AgentInfo:
         """Patch-update an agent.
 
-        Scalar fields (``model``, ``description``, ``system``) replace.
+        Scalar fields (``model``, ``description``, ``system``) replace. For
+        ``model``, prefer the current generation — ``"claude-sonnet-5"`` for
+        Sonnet, ``"claude-opus-5"`` for Opus — unless the user names an older
+        version explicitly.
         List fields (``tools``, ``mcp_servers``, ``skills``) UNION with the
         agent's current state — caller's entries win on collision. To remove
         an existing entry, use the ``/agent-setup`` panel.

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/propagation.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/propagation.py
@@ -220,6 +220,13 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         omit it to set the workspace-wide default.  Any existing default at the
         chosen scope is replaced (last-write-wins; an audit stamp is recorded by
         core).  Requires Manage Server (admin).
+
+        ``channel_id`` MUST be the parent channel's id — the one your context
+        gives as ``<channel role="parent_channel" id="...">``. Never pass the
+        current thread's id here. A turn always resolves its agent from the
+        parent channel, so a default written against a thread id is a scope
+        nothing ever reads: the write succeeds, this tool reports success, and
+        the channel keeps answering with the old agent.
         """
         return await _set_agent_default_impl(runtime, await _auth(ctx), agent_name, channel_id)
 
@@ -233,6 +240,11 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         When ``channel_id`` is provided only that channel's default is cleared;
         omit it to clear the workspace-wide default.  If the scope had no
         default the call is a no-op (idempotent).  Requires Manage Server (admin).
+
+        ``channel_id`` MUST be the parent channel's id
+        (``<channel role="parent_channel" id="...">``), never the current
+        thread's id — clearing a thread id is a silent no-op that leaves the
+        channel's real default in place.
         """
         return await _clear_agent_default_impl(runtime, await _auth(ctx), channel_id)
 
@@ -254,5 +266,12 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
         Not admin-gated: this is a read of routing any member can already infer
         from a reply's footer.
+
+        ``channel_id`` MUST be the parent channel's id
+        (``<channel role="parent_channel" id="...">``), never the current
+        thread's id. Asking about a thread id reports that thread's own
+        (almost always empty) scope, which reads as a confident answer about
+        the channel and is not one — and if the same wrong id was just passed
+        to ``set_agent_default``, this tool will agree with it.
         """
         return await _explain_agent_resolution_impl(runtime, await _auth(ctx), channel_id)

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -85,6 +85,11 @@
         When ``channel_id`` is provided only that channel's default is cleared;
         omit it to clear the workspace-wide default.  If the scope had no
         default the call is a no-op (idempotent).  Requires Manage Server (admin).
+        
+        ``channel_id`` MUST be the parent channel's id
+        (``<channel role="parent_channel" id="...">``), never the current
+        thread's id — clearing a thread id is a silent no-op that leaves the
+        channel's real default in place.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -173,7 +178,10 @@
       'description': '''
         Create a new agent. Pass fields directly — there is NO ``spec`` wrapper.
         
-        Required: ``name`` and ``model`` (e.g. ``"claude-sonnet-4-6"``).
+        Required: ``name`` and ``model``. Use ``"claude-sonnet-5"`` when the user
+        asks for Sonnet and ``"claude-opus-5"`` when they ask for Opus — always
+        the current generation. Only pass an older id (``claude-sonnet-4-6``,
+        ``claude-opus-4-8``, …) when the user names that version themselves.
         Optional: ``description``, ``system`` (the system prompt), ``tools``,
         ``mcp_servers``, and ``skill_repos`` — GitHub repos to sync skills from,
         e.g. ``[{"url": "https://github.com/owner/repo", "branch": "main"}]``.
@@ -1231,6 +1239,13 @@
         
         Not admin-gated: this is a read of routing any member can already infer
         from a reply's footer.
+        
+        ``channel_id`` MUST be the parent channel's id
+        (``<channel role="parent_channel" id="...">``), never the current
+        thread's id. Asking about a thread id reports that thread's own
+        (almost always empty) scope, which reads as a confident answer about
+        the channel and is not one — and if the same wrong id was just passed
+        to ``set_agent_default``, this tool will agree with it.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2451,6 +2466,13 @@
         omit it to set the workspace-wide default.  Any existing default at the
         chosen scope is replaced (last-write-wins; an audit stamp is recorded by
         core).  Requires Manage Server (admin).
+        
+        ``channel_id`` MUST be the parent channel's id — the one your context
+        gives as ``<channel role="parent_channel" id="...">``. Never pass the
+        current thread's id here. A turn always resolves its agent from the
+        parent channel, so a default written against a thread id is a scope
+        nothing ever reads: the write succeeds, this tool reports success, and
+        the channel keeps answering with the old agent.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2636,7 +2658,10 @@
       'description': '''
         Patch-update an agent.
         
-        Scalar fields (``model``, ``description``, ``system``) replace.
+        Scalar fields (``model``, ``description``, ``system``) replace. For
+        ``model``, prefer the current generation — ``"claude-sonnet-5"`` for
+        Sonnet, ``"claude-opus-5"`` for Opus — unless the user names an older
+        version explicitly.
         List fields (``tools``, ``mcp_servers``, ``skills``) UNION with the
         agent's current state — caller's entries win on collision. To remove
         an existing entry, use the ``/agent-setup`` panel.

--- a/packages/adapters/mcp/tests/test_rbac.py
+++ b/packages/adapters/mcp/tests/test_rbac.py
@@ -429,7 +429,16 @@ async def test_non_admin_search_excludes_remaining_admin_tool(
     sessionmaker: async_sessionmaker[AsyncSession],
     tool_name: str,
 ) -> None:
-    """Each tenant-wide tool stays invisible to a non-admin session's search_tools."""
+    """Each tenant-wide tool stays invisible to a non-admin session's search_tools.
+
+    Asserted against the ``### <name>`` heading the renderer gives every returned
+    tool, not against the bare name anywhere in the output. Docstrings cross-
+    reference each other by tool name — ``explain_agent_resolution`` warns about
+    ``set_agent_default``, ``remove_skill`` contrasts itself with ``delete_skill``
+    — so a substring search cannot tell "this tool is exposed" from "some visible
+    tool mentions it in prose". The heading only appears for a tool the filter
+    actually returned, which is the property being protected.
+    """
     _, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
@@ -442,7 +451,7 @@ async def test_non_admin_search_excludes_remaining_admin_tool(
     call_result = result.get("result", result)
     content = call_result.get("content", [])  # type: ignore[union-attr]
     output_text = " ".join(item.get("text", "") for item in content if isinstance(item, dict))
-    assert tool_name not in output_text, (
+    assert f"### {tool_name}" not in output_text, (
         f"{tool_name} must NOT be discoverable by a non-admin session; got: {output_text!r}"
     )
 

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
@@ -62,6 +62,7 @@ from daimon.adapters.slack.agent_setup.write import (
     store_inline_pat,
 )
 from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.constants import DEFAULT_AGENT_MODEL
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.defaults.mcp_merge import get_reserved_mcp_rejection
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
@@ -247,7 +248,7 @@ def evaluate_new_agent_submission(payload: dict[str, Any]) -> SubmitDecision:
         payload=payload,
         extra={
             "name": name,
-            "model": model or "claude-sonnet-4-6",
+            "model": model or DEFAULT_AGENT_MODEL,
             "system": system or None,
         },
     )
@@ -605,7 +606,7 @@ async def run_new_agent_submission(
             tenant_id=tenant_id,
             name=str(extra.get("name") or ""),
             system=str(extra["system"]) if extra.get("system") else None,
-            model=str(extra.get("model") or "claude-sonnet-4-6"),
+            model=str(extra.get("model") or DEFAULT_AGENT_MODEL),
             account_id=account_id,
         )
 

--- a/packages/core/daimon/core/constants.py
+++ b/packages/core/daimon/core/constants.py
@@ -14,6 +14,14 @@ from daimon.core.pricing import AGENT_MODEL_PRICING
 # tuple.
 ALLOWED_MODEL_IDS: tuple[str, ...] = tuple(AGENT_MODEL_PRICING.keys())
 
+# What a new agent gets when the creator does not name a model: every panel
+# prefill and every "no model supplied" fallback reads this one value. It used
+# to be a bare literal repeated across the Discord panel, the Discord section
+# modal and the Slack submit path, which is how three surfaces ended up a
+# generation behind `defaults/agents/daimon.yaml` while each looked correct in
+# isolation. Keep it equal to the model that file pins.
+DEFAULT_AGENT_MODEL: str = "claude-sonnet-5"
+
 # The per-agent skill and MCP-server limits every surface enforces. The setup
 # panel (disabling its add controls) and the chat update path (refusing a
 # merge that would exceed the cap) both read these two values, so the two

--- a/packages/core/tests/defaults/test_defaults_dir.py
+++ b/packages/core/tests/defaults/test_defaults_dir.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from daimon.core.constants import DEFAULT_AGENT_MODEL
 from daimon.core.defaults.loader import (
     load_agent_specs,
     load_environment_specs,
@@ -23,13 +24,22 @@ def test_defaults_agents_parse() -> None:
 
 def test_defaults_ships_dev_agent_with_copilot_mcp() -> None:
     """The dev_agent seed must declare the GitHub Copilot MCP server + a matching
-    mcp_toolset (or MA 400s) and run on claude-opus-4-8 (proven in spikes 033/034).
+    mcp_toolset (or MA 400s) and run on the current-generation Sonnet.
     Moved out of auto-seeded defaults/agents/ into defaults/agents-optional/ so it
-    stops appearing in every customer guild."""
+    stops appearing in every customer guild.
+
+    The model is asserted against DEFAULT_AGENT_MODEL rather than a literal: this
+    seed sat on claude-sonnet-4-6 for a generation after the shipped agent moved
+    on, and a hardcoded expectation is what let that pass. The Sonnet family
+    itself is deliberate — an earlier revision ran claude-opus-4-8 and was moved
+    off it.
+    """
     specs = load_agent_specs(DEFAULTS / "agents-optional")
     dev = next((s for s in specs if s.name == "dev_agent"), None)
     assert dev is not None, "defaults/agents-optional/dev_agent.yaml must exist"
-    assert dev.model == "claude-sonnet-4-6"
+    assert dev.model == DEFAULT_AGENT_MODEL, (
+        f"dev_agent pins {dev.model}; expected the shared default {DEFAULT_AGENT_MODEL}"
+    )
 
     servers = dev.mcp_servers or []
     github = next((s for s in servers if s.get("name") == "github"), None)

--- a/packages/core/tests/test_constants.py
+++ b/packages/core/tests/test_constants.py
@@ -3,10 +3,20 @@
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 
-from daimon.adapters.discord.agent_setup import edit_view
+import yaml
+from daimon.adapters.discord.agent_setup import edit_view, modals, panel
 from daimon.adapters.mcp.tools import agents as mcp_agents_tool
-from daimon.core.constants import AGENT_MCP_CAP, AGENT_SKILL_CAP
+from daimon.adapters.slack.agent_setup import submit as slack_submit
+from daimon.core.constants import (
+    AGENT_MCP_CAP,
+    AGENT_SKILL_CAP,
+    ALLOWED_MODEL_IDS,
+    DEFAULT_AGENT_MODEL,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_agent_caps_are_positive_ints() -> None:
@@ -35,4 +45,51 @@ def test_adapter_modules_declare_no_private_cap_literal_of_their_own() -> None:
         )
         assert "_MCP_CAP =" not in source, (
             f"{module.__name__} must not declare a private _MCP_CAP literal"
+        )
+
+
+def test_default_agent_model_is_selectable() -> None:
+    assert DEFAULT_AGENT_MODEL in ALLOWED_MODEL_IDS, (
+        "the model new agents get by default must itself pass the panel's submit-time "
+        f"validation; {DEFAULT_AGENT_MODEL} is not in ALLOWED_MODEL_IDS"
+    )
+
+
+def test_current_generation_opus_and_sonnet_are_both_selectable() -> None:
+    """The two models a user asks for by word must both resolve to something allowed.
+
+    Someone saying "use Opus" gets `claude-opus-5`; the panel validates free-text
+    input against ALLOWED_MODEL_IDS, so an id missing from the pricing table is
+    refused at submit with no hint that the model exists.
+    """
+    for model in ("claude-opus-5", "claude-sonnet-5"):
+        assert model in ALLOWED_MODEL_IDS, f"{model} must be selectable as an agent model"
+
+
+def test_default_agent_model_matches_the_seeded_agent() -> None:
+    """The default new agents get must equal the model `defaults/` ships.
+
+    These drifted apart once: the seeded agent moved to claude-sonnet-5 while three
+    adapter surfaces kept a private "claude-sonnet-4-6" literal, so creating an
+    agent through chat or the panel produced one a generation behind the bot the
+    same install already ran, with nothing surfacing the difference.
+    """
+    seeded = yaml.safe_load((REPO_ROOT / "defaults" / "agents" / "daimon.yaml").read_text())
+    assert seeded["model"] == DEFAULT_AGENT_MODEL, (
+        f"defaults/agents/daimon.yaml pins {seeded['model']} but new agents default to "
+        f"{DEFAULT_AGENT_MODEL} — the two must move together"
+    )
+
+
+def test_agent_surfaces_declare_no_private_model_literal_of_their_own() -> None:
+    """Same reasoning as the cap test: catch a reintroduced literal, not a divergence.
+
+    Asserting equality against today's model id would keep passing if an edit
+    reintroduced a hardcoded "claude-..." default that happens to match, and would
+    only fail later once the two drifted — which is exactly how this bug shipped.
+    """
+    for module in (panel, modals, slack_submit):
+        source = inspect.getsource(module)
+        assert '"claude-' not in source, (
+            f"{module.__name__} must read DEFAULT_AGENT_MODEL, not hardcode a model id"
         )


### PR DESCRIPTION
Two defects found while exercising the chat-only setup flow against a deployed
environment. Both are chat-path bugs that report success while doing the wrong
thing, which is what makes them worth fixing together.

## Channel scoping silently wrote to the thread

Asked in chat to scope an agent to a channel, the agent handed the current
thread's id to `set_agent_default`. A turn always resolves its agent from the
parent channel, so the default landed on a scope nothing reads: the write
succeeded, the tool reported success, and the channel kept answering with the
old agent.

`explain_agent_resolution` then confirmed the change, because it takes the same
caller-supplied `channel_id` and was asked about the same wrong id. The
verification step and the broken write shared the mistake, so the flow looked
correct end to end.

Observed, then reproduced from the other side — a plain mention in the parent
channel afterwards reported `channel_default: null` and answered as the
deployment default, with none of the skills or MCP servers configured in the
preceding steps.

The plumbing was already correct; only the id the model chose was wrong. Both
ids were already in the agent's context, differentiated by `role`, but the one
hint read *"to post in this thread, pass this id as channel_id"* — which
generalises to every `channel_id` parameter. There are two meanings:

- **where to put a message** — the send and credential-request tools; the thread
  id is correct
- **which scope to key on** — `set_agent_default`, `clear_agent_default`,
  `explain_agent_resolution`; only the parent channel id is ever correct

So each role now carries its own hint, and the three scope tools state in their
own docstrings that a thread id produces a write nothing reads.

I did not add a hard guard rejecting thread ids. The MCP server cannot tell a
thread snowflake from a channel one without a Discord round-trip, so the guard
would cost an API call on every scope write to catch what the hints now address.

## New agents defaulted a generation behind

`create_agent`'s docstring offered `"claude-sonnet-4-6"` as its only example, so
asking for Sonnet in chat produced an agent a generation behind the `daimon` the
same install already ran on `claude-sonnet-5`, with nothing surfacing the
difference. The docstrings now name the current generation for both Sonnet and
Opus and reserve older ids for when the user asks by version.

The same literal was repeated across six sites in three surfaces — Discord
panel, Discord section modal, Slack submit — which is how each stayed plausible
in isolation while all three drifted. They now read one `DEFAULT_AGENT_MODEL`,
asserted equal to what `defaults/agents/daimon.yaml` pins. `dev_agent` moves with
it: its test claimed opus-4-8 while asserting sonnet-4-6, so the Sonnet family
was deliberate and only the generation was stale.

Current-generation Opus was already selectable — `ALLOWED_MODEL_IDS` derives from
the pricing table, which carries `claude-opus-5`. It was invisible rather than
blocked, since the chat path had no model list in context at all.

## Two existing tests corrected rather than accommodated

- **`test_rbac`** asserted an admin tool's name appeared nowhere in a non-admin's
  `search_tools` output. That cannot distinguish an exposed tool from a visible
  tool mentioning it in prose — already latently true of `remove_skill` naming
  `delete_skill`. It now asserts the `### <name>` heading the renderer emits only
  for tools the filter actually returned, which is the property being protected.
- **`test_context`** pinned the self-closing form of the channel element. It now
  matches on attributes, as the thread assertions beside it already did.

## Tests

New coverage for the four properties that would have caught the model drift —
the default is itself selectable, current-generation Opus and Sonnet both are,
the default equals what `defaults/` ships, and no surface re-declares a private
model literal — plus one asserting each location hint stays scoped to its own
role.

Verified locally: 3907 passed across core / mcp / discord / slack / integration,
pyright clean, import-linter 6 contracts kept, anti-pattern lint 9 rules clean.

Tracked in the companion planning repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
