### PR TITLE
fix: attach the MCP server the credential modal just stored a token for

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -58,7 +58,9 @@ from daimon.adapters.discord.credential_repo_bind import (
     resolve_repo_binding_credential,
 )
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.defaults.ma_index import find_agent_by_derived_uuid
 from daimon.core.errors import DaimonError
+from daimon.core.mcp_attach import attach_mcp_server_to_agent
 from daimon.core.mcp_vault import add_external_mcp_credential
 from daimon.core.stores import credential_requests
 from daimon.core.stores.agent_files import put_agent_file
@@ -221,9 +223,56 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
             )
             return
 
+        # The vault credential alone is inert: MA rejects an agent whose
+        # mcp_servers are not each referenced by an mcp_toolset, so a token
+        # stored against a server the agent never declares is unreachable.
+        # This tool is documented as the replacement for attach_mcp_server on
+        # auth-required servers, so it owes the attach too (#49) — the vault
+        # write happens first, because a declared server with no credential
+        # advertises calls that fail.
+        agent = await find_agent_by_derived_uuid(
+            self._runtime.anthropic,
+            tenant_id=consumed_row.tenant_id,
+            agent_id=consumed_row.agent_id,
+        )
+        if agent is None:
+            _log.error(
+                "credential_modal.mcp_agent_not_found",
+                agent_id=str(consumed_row.agent_id),
+            )
+            await interaction.followup.send(
+                "Auth token stored, but the agent could not be found to attach "
+                f"`{mcp_server_url}` to it. The server is not connected yet.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await attach_mcp_server_to_agent(
+                self._runtime.anthropic,
+                agent.id,
+                server_name=consumed_row.target,
+                url=mcp_server_url,
+            )
+        except Exception as err:
+            # Partial state is real and must not be reported as success: the
+            # token is stored, the server is not attached. Exception class name
+            # only, for the same token-leak reason as the vault-write branch.
+            _log.exception(
+                "credential_modal.mcp_attach_failed",
+                mcp_server_url=mcp_server_url,
+                err_type=type(err).__name__,
+            )
+            await interaction.followup.send(
+                f"Auth token stored, but attaching `{mcp_server_url}` to the agent "
+                f"failed (`{type(err).__name__}`). The server is not connected yet — "
+                "ask the agent to attach it, or request a new credential to retry.",
+                ephemeral=True,
+            )
+            return
+
         await interaction.followup.send(
-            f"MCP credential added for `{mcp_server_url}`. Anyone who talks to "
-            "this agent can use it.",
+            f"MCP credential added for `{mcp_server_url}` and attached as "
+            f"`{consumed_row.target}`. Anyone who talks to this agent can use it.",
             ephemeral=True,
         )
 

--- a/packages/adapters/discord/tests/test_credential_modals.py
+++ b/packages/adapters/discord/tests/test_credential_modals.py
@@ -260,7 +260,10 @@ async def _seed_mcp_request(
             token=token,
             kind="mcp",
             tenant_id=tenant.id,
-            agent_id=uuid.uuid4(),
+            # Derived, not random: the modal now resolves the MA agent by
+            # re-deriving this uuid5, so a random value would make every
+            # attach take the agent-not-found branch.
+            agent_id=derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=_MA_AGENT_ID),
             account_id=uuid.uuid4(),
             target="linear",
             mcp_server_url=mcp_server_url,
@@ -435,10 +438,53 @@ async def test_env_modal_never_logs_the_secret_value(
 # --- McpCredentialModal ------------------------------------------------------
 
 
+_MA_AGENT_ID = "agent_01CredModal"
+
+
+def _ma_agent_json(tenant_id: str, *, mcp_servers: list[dict[str, str]] | None = None) -> Any:
+    """One MA agent payload, shaped as the SDK parses it."""
+    return {
+        "id": _MA_AGENT_ID,
+        "type": "agent",
+        "name": "test-agent",
+        "description": None,
+        "system": None,
+        "model": {"id": "claude-sonnet-5"},
+        "mcp_servers": mcp_servers if mcp_servers is not None else [],
+        "skills": [],
+        "tools": [],
+        "metadata": {"daimon_tenant": tenant_id},
+        "archived_at": None,
+        "created_at": "2026-04-01T00:00:00Z",
+        "updated_at": "2026-04-01T00:00:00Z",
+        "version": 1,
+    }
+
+
 def _vault_handler(
-    vault_id: str, per_agent_display: str, creds_created: list[dict[str, Any]]
+    vault_id: str,
+    per_agent_display: str,
+    creds_created: list[dict[str, Any]],
+    *,
+    tenant_id: str = "",
+    agent_updates: list[dict[str, Any]] | None = None,
 ) -> Any:
     def _handler(req: httpx.Request) -> httpx.Response:
+        # Agent routes back the attach half of the flow (#49): the modal must
+        # add the server to the agent it just stored a credential for.
+        if req.method == "GET" and req.url.path == "/v1/agents":
+            return httpx.Response(
+                200, json={"data": [_ma_agent_json(tenant_id)], "has_more": False}
+            )
+        if req.method == "GET" and req.url.path == f"/v1/agents/{_MA_AGENT_ID}":
+            return httpx.Response(200, json=_ma_agent_json(tenant_id))
+        if req.method == "POST" and req.url.path == f"/v1/agents/{_MA_AGENT_ID}":
+            body = json.loads(req.content)
+            if agent_updates is not None:
+                agent_updates.append(body)
+            return httpx.Response(
+                200, json=_ma_agent_json(tenant_id, mcp_servers=body.get("mcp_servers") or [])
+            )
         if req.method == "GET" and req.url.path == "/v1/vaults":
             return httpx.Response(
                 200,
@@ -486,10 +532,19 @@ async def test_mcp_modal_submit_consumes_token_and_writes_vault_credential(
     vault_id = "vlt_credmodal"
     per_agent_display = f"daimon-mcp:{row.account_id}:{row.agent_id}"
     creds_created: list[dict[str, Any]] = []
+    agent_updates: list[dict[str, Any]] = []
 
     runtime = _runtime(
         sessionmaker=db_session_factory,
-        anthropic=build_stub_anthropic(_vault_handler(vault_id, per_agent_display, creds_created)),
+        anthropic=build_stub_anthropic(
+            _vault_handler(
+                vault_id,
+                per_agent_display,
+                creds_created,
+                tenant_id=str(row.tenant_id),
+                agent_updates=agent_updates,
+            )
+        ),
         public_url=HttpUrl("https://mcp.example.com/mcp"),
         jwt_secret="x" * 32,
     )
@@ -504,6 +559,19 @@ async def test_mcp_modal_submit_consumes_token_and_writes_vault_credential(
         "the mcp_server_url must come from the consumed row, never user input"
     )
     assert creds_created[0]["auth"]["token"] == _MCP_TOKEN
+
+    assert len(agent_updates) == 1, (
+        "the server must also be attached to the agent — a vault credential for a "
+        "server the agent never declares is unreachable (#49)"
+    )
+    attached = agent_updates[0]
+    assert {"name": "linear", "type": "url", "url": "https://ext.example.com/mcp"} in (
+        attached["mcp_servers"]
+    ), "the attached server takes its name from the consumed row and its url from the request"
+    assert any(
+        t.get("type") == "mcp_toolset" and t.get("mcp_server_name") == "linear"
+        for t in attached["tools"]
+    ), "MA rejects an mcp_servers entry with no matching mcp_toolset, so both must be written"
 
     toast = interaction.followup.send.call_args.args[0]
     assert "anyone who talks to this agent" in toast.lower(), (
@@ -538,7 +606,12 @@ async def test_mcp_modal_unconfigured_mcp_reports_misconfiguration_no_consume_no
     retry_runtime = _runtime(
         sessionmaker=db_session_factory,
         anthropic=build_stub_anthropic(
-            _vault_handler("vlt_retry", f"daimon-mcp:{row.account_id}:{row.agent_id}", [])
+            _vault_handler(
+                "vlt_retry",
+                f"daimon-mcp:{row.account_id}:{row.agent_id}",
+                [],
+                tenant_id=str(row.tenant_id),
+            )
         ),
         public_url=HttpUrl("https://mcp.example.com/mcp"),
         jwt_secret="x" * 32,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -58,6 +58,7 @@ from daimon.core.github_app_auth import build_app_jwt, get_installation_id_for_r
 from daimon.core.github_repo_auth import InstallationLookup
 from daimon.core.ma import update_agent_with_version_retry
 from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.mcp_attach import attach_mcp_server_to_agent
 from daimon.core.memory_resource import archive_memory_store_for_agent
 from daimon.core.skill_sync import SyncRepoFailure, sync_agent_skills, sync_report_failures
 from daimon.core.specs import (
@@ -584,49 +585,15 @@ async def _attach_mcp_server_impl(
         if s.name == server_name and s.url == url:
             return await _build_agent_info(runtime.client, agent, tenant_id=auth.tenant_id)
 
-    # #144-2: version-retry closure. new_mcp_servers and new_tools are recomputed
-    # from `fresh` on each retry attempt. The reserved-server guard above is not
-    # repeated here — it depends only on caller inputs.
-    async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
-        # Replace any entry with the same server_name (last-write-wins); keep the rest.
-        fresh_existing = list(fresh.mcp_servers or [])
-        new_mcp_servers: list[BetaManagedAgentsURLMCPServerParams] = [
-            {"name": s.name, "type": "url", "url": s.url}
-            for s in fresh_existing
-            if s.name != server_name
-        ]
-        new_mcp_servers.append({"name": server_name, "type": "url", "url": url})
-
-        # MA rejects an agent whose mcp_servers names are not each referenced by
-        # a matching mcp_toolset entry in tools. Mirror the panel's
-        # apply_mcp_modal (state.py): append the missing toolset entry atomically
-        # — bug 3 of issue #56. Preserve every existing tool (caller win on
-        # mcp_toolset same-name collision is implicit since we keep the existing
-        # entry below).
-        new_tools: list[Tool] = [_ma_tool_to_param(t) for t in fresh.tools]
-        if not any(
-            t.get("type") == "mcp_toolset" and t.get("mcp_server_name") == server_name
-            for t in new_tools
-        ):
-            new_tools.append(
-                cast(
-                    Tool,
-                    {
-                        "type": "mcp_toolset",
-                        "mcp_server_name": server_name,
-                        "default_config": _DEFAULT_MCP_TOOLSET_CONFIG,
-                    },
-                )
-            )
-        return await runtime.client.beta.agents.update(
-            fresh.id,
-            version=fresh.version,
-            mcp_servers=new_mcp_servers,
-            tools=new_tools,
-        )
-
+    # #144-2: the spec recompute lives in core.mcp_attach so the Discord
+    # credential modal performs the identical write — it must attach the server
+    # it just stored a vault credential for, and cannot import this module.
+    # The reserved-server guard above is not repeated there: it depends only on
+    # caller inputs, so each entry point applies its own policy.
     try:
-        updated = await update_agent_with_version_retry(runtime.client, agent.id, _apply)
+        updated = await attach_mcp_server_to_agent(
+            runtime.client, agent.id, server_name=server_name, url=url
+        )
     except anthropic.ConflictError as exc:
         # Residual conflict after the one retry — surface as a clean ToolError.
         raise ToolError("the agent was modified concurrently — please retry the operation") from exc

--- a/packages/core/daimon/core/defaults/ma_index.py
+++ b/packages/core/daimon/core/defaults/ma_index.py
@@ -23,6 +23,7 @@ from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_TENANT,
 )
 from daimon.core.errors import SkillsListTruncatedError
+from daimon.core.ma_identity import derive_agent_uuid
 
 _log = structlog.get_logger(__name__)
 
@@ -127,6 +128,22 @@ async def list_agents_by_tenant(
         if ag.metadata.get(MA_METADATA_KEY_TENANT) == str(tenant_id):
             results.append(ag)
     return results
+
+
+async def find_agent_by_derived_uuid(
+    client: AsyncAnthropic, *, tenant_id: uuid.UUID, agent_id: uuid.UUID
+) -> BetaManagedAgentsAgent | None:
+    """Return the tenant's MA agent whose derived uuid5 is ``agent_id``, or None.
+
+    The inverse of ``derive_agent_uuid``, which is one-way — so this scans the
+    tenant's agents and re-derives. Needed by callers that hold only daimon's
+    derived id (rows in ``credential_requests`` and other daimon-side tables
+    key on it, never on the MA id) but must act on the MA agent itself.
+    """
+    for agent in await list_agents_by_tenant(client, tenant_id=tenant_id):
+        if derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(agent.id)) == agent_id:
+            return agent
+    return None
 
 
 async def list_referenced_skill_ids(client: AsyncAnthropic) -> set[str]:

--- a/packages/core/daimon/core/mcp_attach.py
+++ b/packages/core/daimon/core/mcp_attach.py
@@ -1,0 +1,95 @@
+"""Attach an external MCP server to an MA agent's spec.
+
+Two adapters need this and neither may import the other: the MCP tool
+``attach_mcp_server`` and the Discord credential modal, which must attach the
+server it has just written a vault credential for. Before this module existed
+only the MCP tool could do it, so the credential flow stored a token for a
+server the agent was never told about and reported success anyway.
+
+MA rejects an agent whose ``mcp_servers`` entries are not each referenced by a
+matching ``mcp_toolset`` in ``tools``, so the two lists must move together —
+which is the whole reason this is one function rather than a caller-assembled
+pair of updates.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, cast
+
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import BetaManagedAgentsAgent
+from anthropic.types.beta.agent_create_params import Tool
+from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
+    BetaManagedAgentsURLMCPServerParams,
+)
+from daimon.core.ma import update_agent_with_version_retry
+
+DEFAULT_MCP_TOOLSET_CONFIG: Final[dict[str, Any]] = {
+    "permission_policy": {"type": "always_allow"},
+}
+
+
+def _ma_tool_to_param(tool: Any) -> Tool:  # pyright: ignore[reportExplicitAny]
+    """Dump an MA response Tool to a Params dict suitable for the SDK update body."""
+    return cast(Tool, tool.model_dump(mode="json", exclude_none=True))
+
+
+def build_attached_spec(
+    agent: BetaManagedAgentsAgent, *, server_name: str, url: str
+) -> tuple[list[BetaManagedAgentsURLMCPServerParams], list[Tool]]:
+    """Return ``(mcp_servers, tools)`` with ``server_name`` attached at ``url``.
+
+    Pure. An entry with the same ``server_name`` is replaced (last-write-wins)
+    and every other server, toolset, and tool is preserved. The matching
+    ``mcp_toolset`` is appended only when absent, so re-attaching an existing
+    server does not accumulate duplicate toolsets.
+
+    Takes the agent it should compute against as an argument rather than
+    reading one, so a version-retry can recompute from the freshly-retrieved
+    agent instead of a stale read.
+    """
+    servers: list[BetaManagedAgentsURLMCPServerParams] = [
+        {"name": s.name, "type": "url", "url": s.url}
+        for s in (agent.mcp_servers or [])
+        if s.name != server_name
+    ]
+    servers.append({"name": server_name, "type": "url", "url": url})
+
+    tools: list[Tool] = [_ma_tool_to_param(t) for t in agent.tools]
+    if not any(
+        t.get("type") == "mcp_toolset" and t.get("mcp_server_name") == server_name for t in tools
+    ):
+        tools.append(
+            cast(
+                Tool,
+                {
+                    "type": "mcp_toolset",
+                    "mcp_server_name": server_name,
+                    "default_config": DEFAULT_MCP_TOOLSET_CONFIG,
+                },
+            )
+        )
+    return servers, tools
+
+
+async def attach_mcp_server_to_agent(
+    client: AsyncAnthropic, agent_id: str, *, server_name: str, url: str
+) -> BetaManagedAgentsAgent:
+    """Attach ``server_name`` at ``url`` to ``agent_id``, preserving the rest.
+
+    Retrieves the agent, recomputes both lists from that fresh read, and
+    updates. ``anthropic.ConflictError`` propagates after the single retry
+    ``update_agent_with_version_retry`` performs — callers at an adapter
+    boundary decide how to surface it.
+
+    Callers are responsible for any policy gate (reserved-server rejection,
+    admin checks). This function performs the write and nothing else.
+    """
+
+    async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
+        servers, tools = build_attached_spec(fresh, server_name=server_name, url=url)
+        return await client.beta.agents.update(
+            fresh.id, version=fresh.version, mcp_servers=servers, tools=tools
+        )
+
+    return await update_agent_with_version_retry(client, agent_id, _apply)

--- a/packages/core/tests/test_mcp_attach.py
+++ b/packages/core/tests/test_mcp_attach.py
@@ -1,0 +1,149 @@
+"""Tests for the MCP-server attach spec computation.
+
+The defect these exist for (#49) was a missing step, not a wrong one: the
+credential modal stored an auth token for a server it never added to the
+agent, so the agent held a credential for something it could not reach. The
+assertions below are therefore about what the attach must PRESERVE and what it
+must ALWAYS produce — a returned server list is worthless if its matching
+``mcp_toolset`` is absent, because MA rejects that spec outright.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from anthropic.types.beta import BetaManagedAgentsAgent
+from anthropic.types.beta.beta_managed_agents_agent_toolset20260401 import (
+    BetaManagedAgentsAgentToolset20260401,
+)
+from anthropic.types.beta.beta_managed_agents_agent_toolset_default_config import (
+    BetaManagedAgentsAgentToolsetDefaultConfig,
+)
+from anthropic.types.beta.beta_managed_agents_always_allow_policy import (
+    BetaManagedAgentsAlwaysAllowPolicy,
+)
+from anthropic.types.beta.beta_managed_agents_custom_tool import BetaManagedAgentsCustomTool
+from anthropic.types.beta.beta_managed_agents_mcp_toolset import BetaManagedAgentsMCPToolset
+from anthropic.types.beta.beta_managed_agents_mcp_toolset_default_config import (
+    BetaManagedAgentsMCPToolsetDefaultConfig,
+)
+from anthropic.types.beta.beta_managed_agents_model_config import BetaManagedAgentsModelConfig
+from daimon.core.mcp_attach import build_attached_spec
+
+
+def _agent_toolset() -> BetaManagedAgentsAgentToolset20260401:
+    return BetaManagedAgentsAgentToolset20260401(
+        type="agent_toolset_20260401",
+        configs=[],
+        default_config=BetaManagedAgentsAgentToolsetDefaultConfig(
+            enabled=True,
+            permission_policy=BetaManagedAgentsAlwaysAllowPolicy(type="always_allow"),
+        ),
+    )
+
+
+def _mcp_toolset(server_name: str) -> BetaManagedAgentsMCPToolset:
+    return BetaManagedAgentsMCPToolset(
+        type="mcp_toolset",
+        mcp_server_name=server_name,
+        configs=[],
+        default_config=BetaManagedAgentsMCPToolsetDefaultConfig(
+            enabled=True,
+            permission_policy=BetaManagedAgentsAlwaysAllowPolicy(type="always_allow"),
+        ),
+    )
+
+
+def _agent(
+    *,
+    mcp_servers: list[dict[str, str]],
+    tools: list[object],
+) -> BetaManagedAgentsAgent:
+    now = datetime(2026, 8, 7, tzinfo=UTC)
+    return BetaManagedAgentsAgent(
+        id="agent_01Test",
+        archived_at=None,
+        created_at=now,
+        description=None,
+        mcp_servers=[{"name": s["name"], "type": "url", "url": s["url"]} for s in mcp_servers],  # pyright: ignore[reportArgumentType]
+        metadata={},
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-5"),
+        name="test-agent",
+        skills=[],
+        system=None,
+        tools=tools,  # pyright: ignore[reportArgumentType]
+        type="agent",
+        updated_at=now,
+        version=1,
+    )
+
+
+def test_attach_adds_the_server_and_its_matching_toolset() -> None:
+    agent = _agent(mcp_servers=[], tools=[_agent_toolset()])
+
+    servers, tools = build_attached_spec(agent, server_name="acme", url="https://acme.test/mcp")
+
+    assert {"name": "acme", "type": "url", "url": "https://acme.test/mcp"} in servers, (
+        "the server must be added to mcp_servers"
+    )
+    assert any(
+        t.get("type") == "mcp_toolset" and t.get("mcp_server_name") == "acme" for t in tools
+    ), "MA rejects an mcp_servers entry with no matching mcp_toolset, so both must be written"
+
+
+def test_attach_preserves_the_builtin_daimon_mcp_server_and_toolset() -> None:
+    """The reserved daimon-mcp entry must survive — losing it cuts the agent off."""
+    agent = _agent(
+        mcp_servers=[{"name": "daimon-mcp", "url": "https://daimon.test/mcp"}],
+        tools=[_agent_toolset(), _mcp_toolset("daimon-mcp")],
+    )
+
+    servers, tools = build_attached_spec(agent, server_name="acme", url="https://acme.test/mcp")
+
+    assert [s["name"] for s in servers] == ["daimon-mcp", "acme"], (
+        "the existing server must be preserved alongside the new one"
+    )
+    assert any(t.get("type") == "agent_toolset_20260401" for t in tools), (
+        "the builtin agent toolset must survive"
+    )
+    assert sum(1 for t in tools if t.get("type") == "mcp_toolset") == 2, (
+        "each server keeps its own toolset"
+    )
+
+
+def test_attach_replaces_same_name_server_without_duplicating_its_toolset() -> None:
+    """Re-attaching under one name is a URL change, not a second entry."""
+    agent = _agent(
+        mcp_servers=[{"name": "acme", "url": "https://old.test/mcp"}],
+        tools=[_mcp_toolset("acme")],
+    )
+
+    servers, tools = build_attached_spec(agent, server_name="acme", url="https://new.test/mcp")
+
+    assert servers == [{"name": "acme", "type": "url", "url": "https://new.test/mcp"}], (
+        "same-name attach is last-write-wins on the URL, not an append"
+    )
+    assert sum(1 for t in tools if t.get("mcp_server_name") == "acme") == 1, (
+        "the existing toolset is reused, never duplicated"
+    )
+
+
+def test_attach_preserves_unrelated_custom_tools() -> None:
+    agent = _agent(
+        mcp_servers=[],
+        tools=[
+            BetaManagedAgentsCustomTool(
+                type="custom",
+                name="my_tool",
+                description="a tool the agent already had",
+                input_schema={"type": "object"},
+            ),
+            _agent_toolset(),
+        ],
+    )
+
+    _servers, tools = build_attached_spec(agent, server_name="acme", url="https://acme.test/mcp")
+
+    assert any(t.get("type") == "custom" and t.get("name") == "my_tool" for t in tools), (
+        "attaching a server must not drop the agent's other tools"
+    )


### PR DESCRIPTION
Pasting an auth token through the private modal stored a vault credential and
reported *"MCP credential added … Anyone who talks to this agent can use it."*
It was not usable. Nothing wrote `mcp_servers` or the matching `mcp_toolset`, so
the agent held a valid token for a server it had never been told existed.

Found by running the credential gate end to end for the first time.

## Why it survived

Every surface reported success. The request was consumed, the vault write landed
one second later, and no error was logged anywhere — because nothing failed. The
step simply did not exist. The only visible symptom was an agent that could not
call a server it appeared to be configured for, and the obvious diagnostic
(`list_env_credential_keys`) reads `agent_files`, a table this flow never writes.

## The fix

`request_mcp_credential` is documented as the replacement for `attach_mcp_server`
on auth-required servers, so it owes the attach as well as the credential.

The attach lived in `_attach_mcp_server_impl` in the MCP adapter, which the
Discord adapter cannot import (`import-linter`'s adapter-independence contract,
correctly). So the spec computation moves to `daimon.core.mcp_attach` and both
entry points share it — `_attach_mcp_server_impl` now delegates rather than
keeping a second copy that could drift from the one the modal uses.

Policy stays with each caller: the reserved-server guard and the admin
reachability check remain the MCP tool's, since they depend on caller inputs
rather than on the write.

Two ordering decisions worth stating:

- **Vault write first, then attach.** A declared server with no credential
  advertises tool calls that fail; the reverse is inert. Attaching at
  `request_mcp_credential` time instead was considered and rejected for the same
  reason — it leaves the gap open for as long as the user takes to click.
- **Partial failure is reported, not swallowed.** Token-stored-but-not-attached
  is a real state, so the modal says exactly that instead of claiming success,
  matching the care the existing `mcp_write_failed` branch already takes.

`find_agent_by_derived_uuid` inverts `derive_agent_uuid` by re-deriving over the
tenant's agents. daimon-side rows key on the derived uuid and never on the MA id,
so a caller holding only a `credential_requests` row previously had no way to
reach the agent that row refers to.

## Tests

The bug was a missing step, so the tests assert what the attach must **preserve**,
not only what it adds: the reserved `daimon-mcp` entry, the builtin agent toolset,
unrelated custom tools, and that re-attaching one name replaces its url without
duplicating its toolset.

The modal test now asserts the agent update happens at all — that assertion fails
against the previous behaviour, which is the point.

Verified locally: 3911 passed across core / mcp / discord / slack / integration,
pyright clean, import-linter 6 contracts kept, anti-pattern lint 9 rules clean.

## Not covered here

The request row stores the server URL with a trailing slash while the vault stores
it without, and `mcp_vault.py`'s idempotent replace matches on the exact string —
so a re-paste can leave two credentials for one server. Real but separate;
tracked in the companion planning repo rather than widened into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)