### PR TITLE
feat: let sync_skills attach to an agent, and reject unmetered models

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -32,7 +32,7 @@ from daimon.adapters.mcp.tools._ctx import (
 )
 from daimon.core import agent_lifecycle
 from daimon.core.agent_guidance import apply_credential_guidance
-from daimon.core.constants import AGENT_MCP_CAP, AGENT_SKILL_CAP
+from daimon.core.constants import AGENT_MCP_CAP, AGENT_SKILL_CAP, ALLOWED_MODEL_IDS
 from daimon.core.defaults.ma_index import (
     find_agent_by_daimon_tag,
     find_agents_by_daimon_tag,
@@ -301,6 +301,21 @@ async def _get_agent_impl(
     return await _build_agent_info(runtime.client, agent, tenant_id=auth.tenant_id)
 
 
+def _reject_unknown_model(model: str) -> None:
+    """Raise unless ``model`` is one this deployment meters and allows.
+
+    The panel paths have validated free-text model input against
+    ALLOWED_MODEL_IDS since UX-25-03; the chat paths never did, so a typo or a
+    hallucinated id was accepted here and only surfaced later as a session that
+    would not start. An unpriced id is also invisible to cost accounting —
+    ``pricing.cost_of`` returns None for a model it has no rates for, so the
+    turn is billed by Anthropic and recorded as free by us.
+    """
+    if model not in ALLOWED_MODEL_IDS:
+        allowed = ", ".join(ALLOWED_MODEL_IDS)
+        raise ToolError(f"Model '{model}' is not available. Choose one of: {allowed}")
+
+
 def _build_create_spec(
     *,
     name: str,
@@ -321,6 +336,7 @@ def _build_create_spec(
     ``mcp_toolset``) is reshaped into a readable ``ToolError`` rather than leaking
     raw validator output.
     """
+    _reject_unknown_model(model)
     try:
         return AgentSpec(
             name=name,
@@ -446,6 +462,8 @@ async def _update_agent_impl(
     mcp_servers: list[BetaManagedAgentsURLMCPServerParams] | None,
     skills: list[str | BetaManagedAgentsSkillParams] | None,
 ) -> AgentInfo:
+    if model is not None:
+        _reject_unknown_model(model)
     scalars: dict[str, Any] = {"model": model, "description": description, "system": system}
     list_fields = (tools, mcp_servers, skills)
     if all(v is None for v in scalars.values()) and all(v is None for v in list_fields):

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -187,6 +187,13 @@ async def _request_mcp_credential_impl(
         raise ToolError("credential requests require a platform-bound identity")
     if urlparse(url).scheme not in ("http", "https"):
         raise ToolError("mcp server url must be http or https")
+    # Normalise the trailing slash once, here, before the URL is persisted.
+    # The vault stores it as the credential's `auth.mcp_server_url` and
+    # mcp_vault's idempotent replace matches on that string exactly, so
+    # `…/mcp/` and `…/mcp` are two credentials for one server — a re-paste
+    # would stack rather than replace. Observed live: request row held the
+    # slashed form while the vault held the bare one.
+    url = url.rstrip("/")
     agent_id = await _resolve_agent_uuid(runtime, auth, agent_name)
     return await _mint_and_post(
         runtime,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
@@ -10,26 +10,34 @@ from __future__ import annotations
 import datetime
 import time
 
+import anthropic
 import httpx
-from anthropic.types.beta import SkillListResponse
+from anthropic.types.beta import (
+    BetaManagedAgentsAgent,
+    BetaManagedAgentsSkillParams,
+    SkillListResponse,
+)
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools._ctx import (
     _auth,  # pyright: ignore[reportPrivateUsage]
     _require_admin,  # pyright: ignore[reportPrivateUsage]
 )
+from daimon.core.constants import AGENT_SKILL_CAP
 from daimon.core.defaults.ma_index import (
+    find_agent_by_daimon_tag,
     find_skill_by_display_title,
     list_agents_by_tenant,
     list_skills_lenient,
 )
 from daimon.core.defaults.metadata import strip_tenant_prefix, tenant_scoped_display_title
 from daimon.core.defaults.report import Action, ResourceOutcome
+from daimon.core.defaults.spec_merge import merge_skills_with_ma
 from daimon.core.errors import DaimonError
 from daimon.core.github_app_auth import build_app_jwt, get_installation_id_for_repo
 from daimon.core.github_credentials import get_pat
 from daimon.core.github_repo_auth import InstallationLookup, resolve_skill_sync_token
-from daimon.core.ma import delete_skill_and_versions
+from daimon.core.ma import delete_skill_and_versions, update_agent_with_version_retry
 from daimon.core.skills.pipeline import run_skill_sync
 from daimon.core.stores.agent_repo_binding import get_bindings_for_repo
 from daimon.core.stores.domain import RepoProofKind
@@ -67,12 +75,15 @@ class SkillSyncResult(BaseModel):
     should report that back to the user rather than presenting an opaque list of
     skills with no origin.
 
-    Landing in the registry is not the same as being usable by any agent —
-    synced skills are attached to nothing until a separate attach step runs.
-    This model reports that distinction (``registry_count`` /
-    ``attached_count`` / ``summary``) rather than the caller inferring it from
-    ``outcomes``' ``action`` values, which read as "available now" but say
-    nothing about attachment.
+    Landing in the library is not the same as being usable by any agent — an
+    import with no ``agent_name`` attaches to nothing. This model reports that
+    distinction (``registry_count`` / ``attached_count`` / ``summary``) rather
+    than the caller inferring it from ``outcomes``' ``action`` values, which
+    read as "available now" but say nothing about attachment.
+
+    The counts stayed permanently lopsided while the tool had no way to
+    attach: ``attached_count`` was structurally 0 and the summary could only
+    describe the gap it could not close. ``agent_name`` closes it.
     """
 
     source_url: str
@@ -84,11 +95,11 @@ class SkillSyncResult(BaseModel):
     attached_count: int
     """Of ``registry_count``, how many are attached to at least one agent in
     the tenant right now — computed from the tenant's agents at report time,
-    not asserted."""
+    not asserted. Recounted after this call's own attach, when one ran."""
     summary: str
-    """One-line plain-language statement of both counts, naming the registry
-    and that attachment is a separate step (e.g. "3 skill(s) added to the
-    tenant's shared registry; 0 attached to an agent yet.")."""
+    """One-line plain-language statement of both counts, and either what was
+    attached or how to attach (e.g. "3 skill(s) imported into the workspace's
+    shared skill library; 3 attached to an agent. Attached to 'analyst'.")."""
 
 
 async def _resolve_sync_token(
@@ -189,12 +200,55 @@ async def _resolve_sync_token(
     )
 
 
+async def _attach_synced_skills(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+    skill_ids: set[str],
+) -> str:
+    """Attach ``skill_ids`` to ``agent_name``, returning a one-line outcome.
+
+    Returns prose rather than raising, because the upload has already
+    succeeded by the time this runs: a failure here is partial, not total,
+    and the caller must report both halves truthfully rather than lose the
+    successful import behind an exception.
+    """
+    agent = await find_agent_by_daimon_tag(
+        runtime.client, tenant_id=auth.tenant_id, name=agent_name
+    )
+    if agent is None:
+        return f"Could not attach: agent '{agent_name}' not found. The skills are in the registry."
+
+    new_skills: list[BetaManagedAgentsSkillParams] = [
+        {"type": "custom", "skill_id": skill_id} for skill_id in sorted(skill_ids)
+    ]
+
+    async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
+        merged = merge_skills_with_ma(new_skills, fresh)
+        if len(merged) > AGENT_SKILL_CAP:
+            raise ToolError(
+                f"Cannot attach: the merged skill set ({len(merged)}) exceeds this "
+                f"organization's per-agent skill limit ({AGENT_SKILL_CAP})."
+            )
+        return await runtime.client.beta.agents.update(
+            fresh.id, version=fresh.version, skills=merged
+        )
+
+    try:
+        await update_agent_with_version_retry(runtime.client, agent.id, _apply)
+    except (ToolError, anthropic.APIStatusError) as exc:
+        return f"Uploaded to the registry, but attaching to '{agent_name}' failed: {exc}"
+    return f"Attached to '{agent_name}'."
+
+
 async def _sync_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
     url: str,
     branch: str,
     path: str,
+    agent_name: str | None = None,
 ) -> SkillSyncResult:
     _require_admin(auth)
     async with httpx.AsyncClient(timeout=30.0) as http:
@@ -221,14 +275,25 @@ async def _sync_impl(
         for outcome in outcomes
         if outcome.anthropic_id is not None and outcome.action in (Action.CREATED, Action.UPDATED)
     }
+    attach_note = ""
+    if agent_name is not None and registry_ids:
+        attach_note = " " + await _attach_synced_skills(
+            runtime, auth, agent_name=agent_name, skill_ids=registry_ids
+        )
+
+    # Recounted AFTER any attach, so attached_count reflects this call's own
+    # effect rather than the state it observed on the way in.
     agents = await list_agents_by_tenant(runtime.client, tenant_id=auth.tenant_id)
     attached_ids = {skill.skill_id for agent in agents for skill in agent.skills}
     attached = registry_ids & attached_ids
 
     summary = (
-        f"{len(registry_ids)} skill(s) added to the tenant's shared registry; "
-        f"{len(attached)} attached to an agent so far (registry membership and "
-        "agent attachment are separate steps)."
+        f"{len(registry_ids)} skill(s) imported into the workspace's shared skill "
+        f"library; {len(attached)} attached to an agent."
+        + (
+            attach_note
+            or " Importing and attaching are separate steps — pass agent_name to do both."
+        )
     )
     return SkillSyncResult(
         source_url=url,
@@ -303,20 +368,30 @@ def register_skill_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         url: str,
         branch: str = "main",
         path: str = "",
+        agent_name: str | None = None,
     ) -> SkillSyncResult:
-        """Sync skills from a GitHub repository. Discovers SKILL.md and creates or updates them.
+        """Import skills from a GitHub repo into this workspace's shared skill library.
 
-        LOCAL-FIRST: before syncing an external repo, call ``list_skills`` to see
-        what is already installed and prefer an existing skill over pulling a
-        near-duplicate. Only sync an external repo the user explicitly asked for.
+        Discovers SKILL.md files and creates or updates them. This is an IMPORT,
+        not a per-agent change: the library is visible to every agent in the
+        workspace, and importing alone attaches nothing.
 
-        Synced skills are added to this tenant's shared skill registry (visible to
-        every agent in the tenant), so name where they came from when you report
-        back — the returned ``source_url``/``branch``/``path`` echo that provenance.
+        Pass ``agent_name`` to also attach everything imported to that agent —
+        which is almost always what someone means by "add this skill to my
+        agent". Omit it only to stock the library without touching any agent.
+        Existing skills on the agent are preserved; the attach is a union.
+
+        LOCAL-FIRST: before importing an external repo, call ``list_skills`` to
+        see what is already in the library and prefer an existing skill over
+        pulling a near-duplicate. Only import a repo the user explicitly asked for.
+
+        Report where the skills came from — the returned
+        ``source_url``/``branch``/``path`` echo that provenance, and ``summary``
+        states both what was imported and what was attached.
 
         Before calling, inspect the repo structure to determine the correct ``path``
         parameter (empty string = repo root). ``branch`` defaults to ``"main"``."""
-        return await _sync_impl(runtime, await _auth(ctx), url, branch, path)
+        return await _sync_impl(runtime, await _auth(ctx), url, branch, path, agent_name)
 
     @mcp.tool
     async def list_skills(ctx: Context) -> list[SkillInfo]:  # pyright: ignore[reportUnusedFunction]
@@ -342,11 +417,13 @@ def register_skill_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         url: str,
         branch: str = "main",
         path: str = "",
+        agent_name: str | None = None,
     ) -> SkillSyncResult:
-        """Sync skills from a GitHub repository (alias of ``sync_skills``).
+        """Import skills from a GitHub repo into the shared library (alias of ``sync_skills``).
 
-        Discovers SKILL.md and creates or updates them."""
-        return await _sync_impl(runtime, await _auth(ctx), url, branch, path)
+        Discovers SKILL.md and creates or updates them. Pass ``agent_name`` to
+        also attach them to that agent; importing alone attaches nothing."""
+        return await _sync_impl(runtime, await _auth(ctx), url, branch, path, agent_name)
 
     @mcp.tool
     async def skills_list(ctx: Context) -> list[SkillInfo]:  # pyright: ignore[reportUnusedFunction]

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2572,13 +2572,25 @@
     }),
     'skills_sync': dict({
       'description': '''
-        Sync skills from a GitHub repository (alias of ``sync_skills``).
+        Import skills from a GitHub repo into the shared library (alias of ``sync_skills``).
         
-        Discovers SKILL.md and creates or updates them.
+        Discovers SKILL.md and creates or updates them. Pass ``agent_name`` to
+        also attach them to that agent; importing alone attaches nothing.
       ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
+          'agent_name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
           'branch': dict({
             'default': 'main',
             'type': 'string',
@@ -2620,15 +2632,24 @@
     }),
     'sync_skills': dict({
       'description': '''
-        Sync skills from a GitHub repository. Discovers SKILL.md and creates or updates them.
+        Import skills from a GitHub repo into this workspace's shared skill library.
         
-        LOCAL-FIRST: before syncing an external repo, call ``list_skills`` to see
-        what is already installed and prefer an existing skill over pulling a
-        near-duplicate. Only sync an external repo the user explicitly asked for.
+        Discovers SKILL.md files and creates or updates them. This is an IMPORT,
+        not a per-agent change: the library is visible to every agent in the
+        workspace, and importing alone attaches nothing.
         
-        Synced skills are added to this tenant's shared skill registry (visible to
-        every agent in the tenant), so name where they came from when you report
-        back — the returned ``source_url``/``branch``/``path`` echo that provenance.
+        Pass ``agent_name`` to also attach everything imported to that agent —
+        which is almost always what someone means by "add this skill to my
+        agent". Omit it only to stock the library without touching any agent.
+        Existing skills on the agent are preserved; the attach is a union.
+        
+        LOCAL-FIRST: before importing an external repo, call ``list_skills`` to
+        see what is already in the library and prefer an existing skill over
+        pulling a near-duplicate. Only import a repo the user explicitly asked for.
+        
+        Report where the skills came from — the returned
+        ``source_url``/``branch``/``path`` echo that provenance, and ``summary``
+        states both what was imported and what was attached.
         
         Before calling, inspect the repo structure to determine the correct ``path``
         parameter (empty string = repo root). ``branch`` defaults to ``"main"``.
@@ -2636,6 +2657,17 @@
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
+          'agent_name': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
           'branch': dict({
             'default': 'main',
             'type': 'string',

--- a/packages/adapters/mcp/tests/test_tool_e2e.py
+++ b/packages/adapters/mcp/tests/test_tool_e2e.py
@@ -139,7 +139,7 @@ async def test_create_agent_end_to_end_validates_ma_response(
     async with Client(mcp) as client:
         result = await client.call_tool(
             "create_agent",
-            {"name": "newagent", "model": "claude-opus-4-5"},
+            {"name": "newagent", "model": "claude-opus-5"},
         )
         row = json.loads(result.content[0].text)  # type: ignore[union-attr]
         assert row["name"] == "newagent", "should persist created agent name"

--- a/packages/adapters/mcp/tests/tools/test_agents.py
+++ b/packages/adapters/mcp/tests/tools/test_agents.py
@@ -4651,3 +4651,49 @@ async def test_update_agent_allows_an_mcp_merge_exactly_at_the_cap() -> None:
     assert len(update_calls[0]["mcp_servers"]) == AGENT_MCP_CAP, (
         "the merged patch must carry exactly AGENT_MCP_CAP mcp servers"
     )
+
+
+def test_create_spec_rejects_a_model_this_deployment_does_not_meter() -> None:
+    """The chat path validates model ids the way the panel always has.
+
+    An unmetered id is worse than a wrong one: the agent is created, fails only
+    when a session tries to start, and every turn it does run is billed by
+    Anthropic while `pricing.cost_of` returns None for it — spend that never
+    reaches the ledger. `claude-opus-4-5` is real and in the SDK's Literal, but
+    absent from AGENT_MODEL_PRICING, which is exactly the gap.
+    """
+    from daimon.adapters.mcp.tools.agents import (
+        _build_create_spec,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        _build_create_spec(
+            name="a",
+            model="claude-opus-4-5",
+            description=None,
+            system=None,
+            tools=None,
+            mcp_servers=None,
+            skill_repos=None,
+        )
+    assert "claude-opus-5" in str(excinfo.value), (
+        "the refusal must list what IS available, or the caller has to guess"
+    )
+
+
+def test_create_spec_accepts_the_current_generation_models() -> None:
+    from daimon.adapters.mcp.tools.agents import (
+        _build_create_spec,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    for model in ("claude-sonnet-5", "claude-opus-5"):
+        spec = _build_create_spec(
+            name="a",
+            model=model,
+            description=None,
+            system=None,
+            tools=None,
+            mcp_servers=None,
+            skill_repos=None,
+        )
+        assert spec.model == model, f"{model} must be accepted"

--- a/packages/adapters/mcp/tests/tools/test_skills.py
+++ b/packages/adapters/mcp/tests/tools/test_skills.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import uuid
 from pathlib import Path
@@ -422,7 +423,9 @@ def _agent_json(*, agent_id: str, tenant_id: uuid.UUID, skill_ids: list[str]) ->
         type="agent",
         name="agent",
         model={"id": "claude-opus-4-7"},
-        metadata={"daimon_tenant": str(tenant_id)},
+        # daimon_name too: name lookups go through the metadata tag, not the
+        # MA `name` field, so an agent without it is invisible to them.
+        metadata={"daimon_tenant": str(tenant_id), "daimon_name": "agent"},
         description=None,
         created_at="2026-04-21T00:00:00Z",
         updated_at="2026-04-21T00:00:00Z",
@@ -489,7 +492,11 @@ async def test_sync_impl_reports_zero_attached_when_no_agent_attaches_synced_ski
     assert "3" in result.summary and "0" in result.summary, (
         "summary must name both the registry and attached counts"
     )
-    assert "registry" in result.summary, "summary must name the registry explicitly"
+    assert "librar" in result.summary, "summary must name where the skills landed"
+    assert "agent_name" in result.summary, (
+        "with no agent named, the summary must say how to attach — describing the gap "
+        "without naming the next call is what left skills stranded in the library"
+    )
     assert len(agent_list_calls) == 1, "exactly one agent-listing request per sync, not per skill"
 
 
@@ -702,3 +709,86 @@ async def test_get_skill_and_alias_dispatch_identically() -> None:
     assert canonical.structured_content == alias.structured_content, (
         "get_skill and its skills_get alias must dispatch to identical behavior"
     )
+
+
+async def test_sync_impl_attaches_to_the_named_agent_and_preserves_its_existing_skills(
+    tmp_path: Path,
+) -> None:
+    """``agent_name`` closes the import/attach gap in one call.
+
+    Without it, an import left ``attached_count`` structurally 0 — the skill sat
+    in the shared library and reached no agent, and nothing in the tool or the
+    prompt told the model to make the second call. The union matters as much as
+    the attach: an agent that loses its existing skills to gain a new one has
+    traded one broken state for another.
+    """
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    outcomes = [
+        ResourceOutcome(kind="skill", name="skill-a", action=Action.CREATED, anthropic_id="sk_a"),
+    ]
+
+    with (
+        patch("daimon.core.skills.pipeline.fetch_repo") as mock_fetch,
+        patch("daimon.core.skills.pipeline.discover_skills"),
+        patch("daimon.core.skills.pipeline.sync_skills") as mock_sync,
+    ):
+        from daimon.core.skills.fetch import FetchResult
+
+        cleanup_dir = tmp_path / "cleanup"
+        cleanup_dir.mkdir()
+        mock_fetch.return_value = FetchResult(path=tmp_path, cleanup_dir=cleanup_dir)
+        mock_sync.return_value = outcomes
+
+        updates: list[dict[str, Any]] = []
+        attached_after_update = ["sk_existing"]
+
+        def on_agents_list(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+            return list_response(
+                [_agent_json(agent_id="ag_1", tenant_id=tenant_id, skill_ids=attached_after_update)]
+            )
+
+        def on_agent_get(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json=_agent_json(agent_id="ag_1", tenant_id=tenant_id, skill_ids=["sk_existing"]),
+            )
+
+        def on_agent_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+            body = json.loads(req.content)
+            updates.append(body)
+            ids = [s["skill_id"] for s in body["skills"]]
+            attached_after_update[:] = ids
+            return httpx.Response(
+                200, json=_agent_json(agent_id="ag_1", tenant_id=tenant_id, skill_ids=ids)
+            )
+
+        router = MARouter()
+        router.add("GET", r"/v1/agents$", on_agents_list)
+        router.add("GET", r"/v1/agents/ag_1$", on_agent_get)
+        router.add("POST", r"/v1/agents/ag_1$", on_agent_update)
+        client = build_fake_anthropic(router.dispatch)
+
+        auth = AuthIdentity(
+            account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True
+        )
+        result = await _sync_impl(
+            _runtime(client),
+            auth,
+            url="https://github.com/org/repo",
+            branch="main",
+            path="",
+            agent_name="agent",
+        )
+
+    assert len(updates) == 1, "the named agent must actually be updated, not just counted"
+    attached_ids = {s["skill_id"] for s in updates[0]["skills"]}
+    assert "sk_a" in attached_ids, "the freshly imported skill must be attached"
+    assert "sk_existing" in attached_ids, (
+        "attaching is a union — the agent's existing skills must survive"
+    )
+    assert result.attached_count == 1, (
+        "attached_count must reflect this call's own attach, not the state it saw on the way in"
+    )
+    assert "agent" in result.summary, "the summary must name the agent it attached to"


### PR DESCRIPTION
Three chat-surface gaps of the same shape: the tool accepts the request, reports
success, and leaves the user with something that does not work. Follow-on to the
MCP credential fix, found by pulling on the same thread.

## `sync_skills` could not do what its name promises

It is an **import**: fetch a repo, discover `SKILL.md` files, upload them to the
workspace-wide library. Nothing attached them to anything — and the tool took no
`agent_name`, so it *could not*. `attached_count` was therefore structurally 0 and
the summary could only describe a gap it had no way to close.

Nothing named the follow-up call either — not the tool docstring, not the result,
not the seeded prompt. The summary said *"registry membership and agent attachment
are separate steps"*, which states a fact and no action. Observed behaviour is that
the model does not make the second call: the skill lands in the library and reaches
no agent.

Meanwhile `sync_agent_skills` — used by `create_agent(skill_repos=…)` and the push
webhook resync — has always synced **and** attached, via `agents.update(agent_id,
skills=…)`, with `attach_failures` tracking. The chat surface was the odd one out.

`agent_name` closes it:

- **Omitted** — behaviour unchanged, library only. The summary now names the
  parameter instead of merely stating the two are separate.
- **Given** — imported skills are attached as a **union** with whatever the agent
  already has, under the same per-agent cap the panel enforces, and
  `attached_count` is recounted *after* the attach so it reports this call's own
  effect rather than the state it observed on the way in.
- A failed attach after a successful upload is reported as exactly that rather
  than raising, which would throw away the successful import.

The docstrings also led with "sync", which reads as "make these skills present on
the agent I'm talking to" — the same reading a user has, and the reason the
mismatch went unnoticed. They now lead with import-into-a-shared-library and name
attachment as the other half.

## MCP server url normalisation

The request row held `…/mcp/` while the vault stored `…/mcp`, and `mcp_vault`'s
idempotent replace matches that string exactly — so a re-paste stacked a second
credential for one server instead of replacing the first. Normalised once, before
the value is persisted. (Noted as secondary in the previous fix and deliberately
left out of it.)

## Model validation on the chat path

`create_agent` / `update_agent` now validate against `ALLOWED_MODEL_IDS`, as both
panel paths have since UX-25-03. An unmetered id was accepted and surfaced only
when a session failed to start — and any turn that did run was billed by Anthropic
while `pricing.cost_of` returned `None` for it, so the spend never reached the
ledger.

**Behaviour change worth flagging:** this rejects `claude-opus-4-5`, which is a
real model in the SDK's `Literal` but absent from `AGENT_MODEL_PRICING`. One e2e
test used it and moves to `claude-opus-5`. If an unpriced model should be
selectable, the fix is to price it, not to drop the check.

## Tests

The new attach test asserts the union, not just the attach — an agent that loses
its existing skills to gain a new one has traded one broken state for another. The
zero-attached test now asserts the summary names `agent_name`, since describing the
gap without naming the next call is precisely what stranded skills in the library.

Verified locally: 4159 passed across core / mcp / discord / slack / cli /
integration, pyright clean, import-linter 6 contracts kept, anti-pattern lint clean.

Unrelated, pre-existing: passing `packages/adapters/mcp` and `packages/core` to a
single `pytest -n auto` produces 6 collection errors under
`packages/core/tests/core/broker`. Identical on clean `main` (2446 passed there,
2449 here — the difference is this PR's new tests). CI shards those packages
separately, so it does not surface there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)