### PR TITLE
feat(skills): let chat collect a PAT for a private skill repo

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/credential_button.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_button.py
@@ -74,6 +74,7 @@ from daimon.adapters.discord.credential_modals import (
     EnvCredentialModal,
     McpCredentialModal,
     RepoBindModal,
+    SkillRepoModal,
 )
 from daimon.adapters.discord.credential_repo_bind import (
     refuse_if_shared_and_not_admin_for_request,
@@ -233,6 +234,17 @@ class CredentialRequestButton(
                 )
             elif request_row.kind == "repo":
                 await self._open_repo_modal(interaction, runtime=bot.runtime, row=request_row)
+            elif request_row.kind == "skill_repo":
+                # Explicit branch, not a fall-through: the `else` below is the
+                # MCP modal, so a kind added without a branch here silently
+                # opens the wrong modal rather than failing.
+                #
+                # No admin pre-filter, unlike the repo kind — this writes no
+                # agent_repo_binding, so the "changes what code the agent runs
+                # for every member" reasoning behind that gate does not apply.
+                await interaction.response.send_modal(
+                    SkillRepoModal(runtime=bot.runtime, request_row=request_row)
+                )
             else:
                 await interaction.response.send_modal(
                     McpCredentialModal(runtime=bot.runtime, request_row=request_row)

--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -52,16 +52,20 @@ import structlog
 from daimon.adapters.discord.agent_setup.credentials import (
     _MAX_SECRET_VALUE_BYTES,  # pyright: ignore[reportPrivateUsage]  # reusing PasteSecretModal's byte cap rather than inventing a second number
 )
-from daimon.adapters.discord.agent_setup.write import mask_tail
+from daimon.adapters.discord.agent_setup.write import mask_tail, store_inline_pat
 from daimon.adapters.discord.credential_repo_bind import (
     refuse_if_shared_and_not_admin_for_request,
     resolve_repo_binding_credential,
 )
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.credential_requests import split_skill_repo_target
 from daimon.core.defaults.ma_index import find_agent_by_derived_uuid
 from daimon.core.errors import DaimonError
+from daimon.core.github_repo_auth import normalize_owner_repo
+from daimon.core.github_visibility import pat_can_access_repo
 from daimon.core.mcp_attach import attach_mcp_server_to_agent
 from daimon.core.mcp_vault import add_external_mcp_credential
+from daimon.core.skills.pipeline import run_skill_sync
 from daimon.core.stores import credential_requests
 from daimon.core.stores.agent_files import put_agent_file
 from daimon.core.stores.agent_repo_binding import set_binding
@@ -273,6 +277,136 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
         await interaction.followup.send(
             f"MCP credential added for `{mcp_server_url}` and attached as "
             f"`{consumed_row.target}`. Anyone who talks to this agent can use it.",
+            ephemeral=True,
+        )
+
+
+class SkillRepoModal(discord.ui.Modal, title="Import skills"):
+    """Collect a GitHub token for a PRIVATE skill repo, then run the import.
+
+    Deliberately NOT a `RepoBindModal` variant, even though both collect a
+    GitHub token into the same per-agent overlay. Two differences are the
+    whole point of the separate class:
+
+    1. No `set_binding`. Importing skills from a repo must not also tell the
+       agent to check that repo out. Sharing the store is intended; sharing
+       the binding write is the bug this exists to avoid.
+    2. The token is verified against the SKILL repo (`target`), not the
+       agent's clone repo — for a skill import those are routinely different
+       repos, and validating the wrong one both refuses good tokens and
+       accepts ones that cannot read what is about to be fetched.
+
+    Because the credential lands in the same overlay `get_pat(agent_id=…)`
+    resolves, a user who already pasted a token that can read this repo is
+    never asked twice — the agent should attempt `sync_skills` first and only
+    reach for this button on an actual no-credential failure.
+
+    No admin gate. This mirrors the env/mcp kinds rather than the repo kind:
+    the repo kind is admin-gated on a shared agent because a binding changes
+    what code the agent runs for every member, and that reasoning does not
+    reach an import into the shared skill library, which `sync_skills` itself
+    already gates with `_require_admin` at request time.
+    """
+
+    def __init__(self, *, runtime: DiscordRuntime, request_row: CredentialRequestRow) -> None:
+        super().__init__()
+        self._runtime = runtime
+        self._row = request_row
+        url, _branch, _path = split_skill_repo_target(request_row.target)
+        self.pat_in: discord.ui.TextInput[SkillRepoModal] = discord.ui.TextInput(
+            label="GitHub token",
+            required=True,
+            max_length=_MAX_SECRET_VALUE_BYTES,
+            placeholder=f"Needs read access to {normalize_owner_repo(url)}",
+        )
+        self.add_item(self.pat_in)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
+        pat = str(self.pat_in.value or "").strip()
+        if not pat:
+            await interaction.followup.send("Enter a GitHub token.", ephemeral=True)
+            return
+
+        now = datetime.now(UTC)
+        async with self._runtime.sessionmaker() as session, session.begin():
+            consumed_row = await credential_requests.consume_credential_request(
+                session, token=self._row.token, now=now
+            )
+        if consumed_row is None:
+            await interaction.followup.send(_NO_LONGER_VALID, ephemeral=True)
+            return
+
+        url, branch, path = split_skill_repo_target(consumed_row.target)
+        # The token appears only as a masked tail, never in full, and never
+        # the (now-consumed) request token either.
+        _log.info(
+            "credential_modal.skill_repo.submit",
+            repo_url=url,
+            branch=branch,
+            path=path,
+            pat_masked=mask_tail(pat),
+        )
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as http_client:
+                # Verify BEFORE storing: a token that cannot read this repo is
+                # not a credential for it, and storing it would shadow a
+                # working one on the next `get_pat` (the overlay is
+                # last-write-wins, and tier 1 short-circuits the rest).
+                if not await pat_can_access_repo(
+                    http_client, owner_repo=normalize_owner_repo(url), pat=pat
+                ):
+                    await interaction.followup.send(
+                        f"That token cannot read `{normalize_owner_repo(url)}`. Nothing was "
+                        "stored, and the request was used up — ask again to retry.",
+                        ephemeral=True,
+                    )
+                    return
+                await store_inline_pat(
+                    self._runtime,
+                    account_id=consumed_row.account_id,
+                    agent_id=consumed_row.agent_id,
+                    plaintext_pat=pat,
+                )
+                outcomes = await run_skill_sync(
+                    self._runtime.anthropic,
+                    http_client,
+                    url=url,
+                    branch=branch,
+                    path=path,
+                    tenant_id=consumed_row.tenant_id,
+                    token=pat,
+                )
+        except DaimonError as err:
+            # Written for the user by the raiser — surface verbatim. The
+            # credential is already stored and still good; only the import
+            # leg failed, so say which half survived.
+            await interaction.followup.send(
+                f"Token stored, but the import failed: {err} The request was used up — "
+                "ask again to retry the import.",
+                ephemeral=True,
+            )
+            return
+        except Exception as err:
+            _log.exception(
+                "credential_modal.skill_repo_sync_failed",
+                repo_url=url,
+                err_type=type(err).__name__,
+            )
+            # Class name only — a stringified SDK/network error can carry the
+            # request envelope, which is a token-leak surface.
+            await interaction.followup.send(
+                f"Token stored, but the import failed (`{type(err).__name__}`). "
+                "Ask again to retry the import.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.followup.send(
+            f"Imported {len(outcomes)} skill(s) from `{normalize_owner_repo(url)}`. "
+            "The token is stored, so future imports from repos it can read will not ask again.",
             ephemeral=True,
         )
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -344,6 +344,15 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
             channel_id=channel_id,
         )
 
+    # The docstring below deliberately does NOT name the skill-import tool.
+    # That tool is admin-gated; this one is not (matching its sibling
+    # `request_*` tools), so naming it would disclose a gated tool's existence
+    # to every principal that can discover this one —
+    # `test_chat_session_tool_reachability` asserts against exactly that by
+    # searching the rendered tool text for the gated name. Kept as a comment
+    # rather than a docstring paragraph because the docstring IS prompt
+    # context: it is rendered into every model's tool list, where an internal
+    # rationale is noise.
     @mcp.tool
     async def request_skill_repo_credential(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
@@ -368,13 +377,6 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
         Pass the same repo url, branch, and path the failed import used —
         they are carried through the click, and the import re-runs
         automatically on submit, so there is nothing to call afterwards.
-
-        Deliberately does NOT name the import tool. That tool is admin-gated,
-        this one is not (matching its sibling ``request_*`` tools), so naming
-        it here would disclose a gated tool's existence to every principal
-        that can discover this one — which
-        ``test_chat_session_tool_reachability`` asserts against by searching
-        the rendered tool text for the gated name.
         """
         return await _request_skill_repo_credential_impl(
             runtime,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -38,6 +38,7 @@ from daimon.adapters.mcp.tools.discord import (
 from daimon.core.credential_requests import (
     DEFAULT_TTL,
     CredentialRequestKind,
+    build_skill_repo_target,
     mint_request_token,
 )
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
@@ -214,6 +215,48 @@ async def _request_mcp_credential_impl(
 # would be silently discarded — the exact class of surface-that-lies this
 # tool exists not to become. The modal collects the branch instead,
 # defaulting to `main`.
+async def _request_skill_repo_credential_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    agent_name: str,
+    repo_url: str,
+    branch: str,
+    path: str,
+    purpose: str,
+    channel_id: str,
+) -> RequestCredentialResult:
+    if auth.platform == "slack":
+        raise ToolError("request_skill_repo_credential is not supported on Slack yet")
+    if auth.platform_user_id is None:
+        raise ToolError("credential requests require a platform-bound identity")
+    if urlparse(repo_url).scheme not in ("http", "https"):
+        raise ToolError("repo url must be http or https, e.g. https://github.com/owner/repo")
+    if not _OWNER_REPO_RE.fullmatch(normalize_owner_repo(repo_url)):
+        raise ToolError(
+            "repo url must name exactly one owner/repo, e.g. https://github.com/owner/repo"
+        )
+    # "@" and "#" are the packing delimiters; a branch or path carrying one
+    # would round-trip as a different repo, so refuse rather than mangle.
+    if "@" in branch or "#" in branch:
+        raise ToolError("branch must not contain '@' or '#'")
+    if "#" in path:
+        raise ToolError("path must not contain '#'")
+    agent_id = await _resolve_agent_uuid(runtime, auth, agent_name)
+    return await _mint_and_post(
+        runtime,
+        auth,
+        kind="skill_repo",
+        target=build_skill_repo_target(repo_url, branch, path),
+        mcp_server_url=None,
+        agent_id=agent_id,
+        requester_platform_user_id=auth.platform_user_id,
+        agent_name=agent_name,
+        purpose=purpose,
+        channel_id=channel_id,
+    )
+
+
 async def _request_repo_binding_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
@@ -298,6 +341,42 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
             agent_name=agent_name,
             server_name=server_name,
             url=url,
+            channel_id=channel_id,
+        )
+
+    @mcp.tool
+    async def request_skill_repo_credential(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        agent_name: str,
+        repo_url: str,
+        purpose: str,
+        channel_id: str,
+        branch: str = "main",
+        path: str = "",
+    ) -> RequestCredentialResult:
+        """Ask for a GitHub token so ``sync_skills`` can read a PRIVATE repo.
+
+        Call this when ``sync_skills`` reports that no credential was
+        available — NOT ``request_repo_binding``. Importing skills from a repo
+        and binding a repo for the agent to check out are different things:
+        this one writes no ``agent_repo_binding`` row, so it will not make the
+        agent start cloning the skill repo. The stored token is shared between
+        the two, so a user who has already bound a repo with a token that can
+        also read this one will not be asked twice.
+
+        Pass the same ``repo_url``/``branch``/``path`` you passed to
+        ``sync_skills`` — they are carried through the click, and the import
+        re-runs automatically on submit, so you do not need to call
+        ``sync_skills`` again afterwards.
+        """
+        return await _request_skill_repo_credential_impl(
+            runtime,
+            await _auth(ctx),
+            agent_name=agent_name,
+            repo_url=repo_url,
+            branch=branch,
+            path=path,
+            purpose=purpose,
             channel_id=channel_id,
         )
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -354,20 +354,27 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
         branch: str = "main",
         path: str = "",
     ) -> RequestCredentialResult:
-        """Ask for a GitHub token so ``sync_skills`` can read a PRIVATE repo.
+        """Ask for a GitHub token so a skill import can read a PRIVATE repo.
 
-        Call this when ``sync_skills`` reports that no credential was
-        available — NOT ``request_repo_binding``. Importing skills from a repo
-        and binding a repo for the agent to check out are different things:
-        this one writes no ``agent_repo_binding`` row, so it will not make the
-        agent start cloning the skill repo. The stored token is shared between
-        the two, so a user who has already bound a repo with a token that can
-        also read this one will not be asked twice.
+        Call this when importing skills from a repo reports that no
+        credential was available — NOT ``request_repo_binding``. Importing
+        skills from a repo and binding a repo for the agent to check out are
+        different things: this one writes no ``agent_repo_binding`` row, so
+        it will not make the agent start cloning the skill repo. The stored
+        token is shared between the two, so a user who has already bound a
+        repo with a token that can also read this one will not be asked
+        twice.
 
-        Pass the same ``repo_url``/``branch``/``path`` you passed to
-        ``sync_skills`` — they are carried through the click, and the import
-        re-runs automatically on submit, so you do not need to call
-        ``sync_skills`` again afterwards.
+        Pass the same repo url, branch, and path the failed import used —
+        they are carried through the click, and the import re-runs
+        automatically on submit, so there is nothing to call afterwards.
+
+        Deliberately does NOT name the import tool. That tool is admin-gated,
+        this one is not (matching its sibling ``request_*`` tools), so naming
+        it here would disclose a gated tool's existence to every principal
+        that can discover this one — which
+        ``test_chat_session_tool_reachability`` asserts against by searching
+        the rendered tool text for the gated name.
         """
         return await _request_skill_repo_credential_impl(
             runtime,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
@@ -38,6 +38,7 @@ from daimon.core.github_app_auth import build_app_jwt, get_installation_id_for_r
 from daimon.core.github_credentials import get_pat
 from daimon.core.github_repo_auth import InstallationLookup, resolve_skill_sync_token
 from daimon.core.ma import delete_skill_and_versions, update_agent_with_version_retry
+from daimon.core.skills.fetch import GitHubFetchError
 from daimon.core.skills.pipeline import run_skill_sync
 from daimon.core.stores.agent_repo_binding import get_bindings_for_repo
 from daimon.core.stores.domain import RepoProofKind
@@ -267,6 +268,26 @@ async def _sync_impl(
                     runtime.settings.github.max_tarball_decompressed_bytes
                 ),
             )
+        except GitHubFetchError as exc:
+            # A 404 from an ANONYMOUS fetch is ambiguous: GitHub returns it for
+            # a private repo as well as a missing one, so that the caller
+            # cannot probe for existence. We know `token is None` here, which
+            # makes "private, and nothing authorized us" by far the likelier
+            # read — and it is the only one the user can act on. Left as the
+            # bare "HTTP 404" this reads as "that repo does not exist", which
+            # is why the agent used to apologize for a typo instead of asking
+            # for a credential.
+            if exc.status_code == 404 and token is None:
+                raise ToolError(
+                    f"No GitHub credential was available for {url!r}, and an "
+                    "unauthenticated fetch got HTTP 404 — which GitHub returns "
+                    "for a private repo as well as a missing one. If this repo "
+                    "is private, call `request_skill_repo_credential` with this "
+                    "url/branch/path to post a button the user can paste a "
+                    "token into; it syncs on submit. If it is public, re-check "
+                    "the url and branch."
+                ) from exc
+            raise ToolError(str(exc)) from exc
         except DaimonError as exc:
             raise ToolError(str(exc)) from exc
 

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2219,6 +2219,56 @@
         'type': 'object',
       }),
     }),
+    'request_skill_repo_credential': dict({
+      'description': '''
+        Ask for a GitHub token so a skill import can read a PRIVATE repo.
+        
+        Call this when importing skills from a repo reports that no
+        credential was available — NOT ``request_repo_binding``. Importing
+        skills from a repo and binding a repo for the agent to check out are
+        different things: this one writes no ``agent_repo_binding`` row, so
+        it will not make the agent start cloning the skill repo. The stored
+        token is shared between the two, so a user who has already bound a
+        repo with a token that can also read this one will not be asked
+        twice.
+        
+        Pass the same repo url, branch, and path the failed import used —
+        they are carried through the click, and the import re-runs
+        automatically on submit, so there is nothing to call afterwards.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'agent_name': dict({
+            'type': 'string',
+          }),
+          'branch': dict({
+            'default': 'main',
+            'type': 'string',
+          }),
+          'channel_id': dict({
+            'type': 'string',
+          }),
+          'path': dict({
+            'default': '',
+            'type': 'string',
+          }),
+          'purpose': dict({
+            'type': 'string',
+          }),
+          'repo_url': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'agent_name',
+          'repo_url',
+          'purpose',
+          'channel_id',
+        ]),
+        'type': 'object',
+      }),
+    }),
     'search_messages': dict({
       'description': '''
         Search messages with server-side filters.

--- a/packages/adapters/mcp/tests/tools/test_skills.py
+++ b/packages/adapters/mcp/tests/tools/test_skills.py
@@ -792,3 +792,62 @@ async def test_sync_impl_attaches_to_the_named_agent_and_preserves_its_existing_
         "attached_count must reflect this call's own attach, not the state it saw on the way in"
     )
     assert "agent" in result.summary, "the summary must name the agent it attached to"
+
+
+async def test_sync_impl_anonymous_404_names_the_credential_remedy() -> None:
+    """An anonymous 404 must read as "no credential", not "no such repo".
+
+    GitHub 404s a private repo rather than 403ing it, so the bare status is
+    ambiguous. `_sync_impl` knows it sent no token, which makes the private
+    case both the likelier read and the only actionable one — and naming the
+    remedy is what makes the agent reach for the button instead of
+    apologizing for a typo.
+    """
+    from daimon.core.skills.fetch import GitHubFetchError
+
+    with (
+        patch("daimon.adapters.mcp.tools.skills._resolve_sync_token", return_value=None),
+        patch("daimon.core.skills.pipeline.fetch_repo") as mock_fetch,
+    ):
+        mock_fetch.side_effect = GitHubFetchError("HTTP 404", status_code=404)
+
+        auth = AuthIdentity(
+            account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.ADMIN, is_admin=True
+        )
+        with pytest.raises(ToolError, match="request_skill_repo_credential") as excinfo:
+            await _sync_impl(
+                _runtime(build_fake_anthropic(MARouter().dispatch)),
+                auth,
+                url="https://github.com/org/private-repo",
+                branch="main",
+                path="",
+            )
+
+    assert "no github credential was available" in str(excinfo.value).lower()
+
+
+async def test_sync_impl_404_with_a_token_does_not_blame_credentials() -> None:
+    """With a token that GitHub accepted, a 404 really is a bad url/branch."""
+    from daimon.core.skills.fetch import GitHubFetchError
+
+    with (
+        patch("daimon.adapters.mcp.tools.skills._resolve_sync_token", return_value="ghp_x"),
+        patch("daimon.core.skills.pipeline.fetch_repo") as mock_fetch,
+    ):
+        mock_fetch.side_effect = GitHubFetchError("HTTP 404", status_code=404)
+
+        auth = AuthIdentity(
+            account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.ADMIN, is_admin=True
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await _sync_impl(
+                _runtime(build_fake_anthropic(MARouter().dispatch)),
+                auth,
+                url="https://github.com/org/repo",
+                branch="typo",
+                path="",
+            )
+
+    assert "request_skill_repo_credential" not in str(excinfo.value), (
+        "a 404 on an authenticated fetch is a bad url/branch, not a missing credential"
+    )

--- a/packages/core/daimon/core/credential_requests.py
+++ b/packages/core/daimon/core/credential_requests.py
@@ -45,7 +45,7 @@ TOKEN_BYTES: Final[int] = 16
 CUSTOM_ID_TEMPLATE: Final[str] = r"ztc:(?P<token>[A-Za-z0-9_-]{16,64})"
 CUSTOM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(CUSTOM_ID_TEMPLATE)
 
-CredentialRequestKind = Literal["env", "mcp", "repo"]
+CredentialRequestKind = Literal["env", "mcp", "repo", "skill_repo"]
 
 # TTL bounds the replay window for a never-clicked button sitting in channel
 # scrollback; combined with the store's single-use consume, this is the full
@@ -58,11 +58,44 @@ MAX_BUTTON_LABEL_CHARS: Final[int] = 80
 # The full label prefix for each kind. "env" and "mcp" reproduce the
 # pre-repo-kind wording byte-for-byte. "repo" cannot reuse the "Add {X}
 # credential: " interpolation — a repo binding is not a credential.
+# "skill_repo" is deliberately worded as an import, not a binding: it shares
+# "repo"'s PAT store but writes NO agent_repo_binding row, so a label saying
+# "bind" would promise a checkout the user never asked for.
 _KIND_LABEL_PREFIX: Final[dict[CredentialRequestKind, str]] = {
     "env": "Add env credential: ",
     "mcp": "Add MCP credential: ",
     "repo": "Bind repo: ",
+    "skill_repo": "Import skills from: ",
 }
+
+
+def build_skill_repo_target(url: str, branch: str, path: str) -> str:
+    """Pack a skill-sync target into one `target` column value.
+
+    `URL[@branch][#path]` — the same grammar the CLI's `--repo` argument
+    already accepts, reused so the round trip needs no schema change and no
+    second parser. `branch`/`path` have to survive the button click because
+    the modal re-runs the sync on submit, and a click carries nothing but
+    the request row.
+    """
+    packed = url
+    if branch:
+        packed = f"{packed}@{branch}"
+    if path:
+        packed = f"{packed}#{path}"
+    return packed
+
+
+def split_skill_repo_target(target: str) -> tuple[str, str, str]:
+    """Inverse of `build_skill_repo_target`. Returns `(url, branch, path)`.
+
+    Defaults match `sync_skills`' own defaults: branch "main", path "".
+    Split on "#" first — a branch name cannot contain "#", but a path can
+    contain "@", so splitting on "@" first would mangle it.
+    """
+    rest, _, path = target.partition("#")
+    url, _, branch = rest.partition("@")
+    return url, branch or "main", path
 
 
 def mint_request_token() -> str:

--- a/packages/core/daimon/core/skills/fetch.py
+++ b/packages/core/daimon/core/skills/fetch.py
@@ -15,6 +15,25 @@ from daimon.core.errors import DaimonError
 _log = structlog.get_logger(__name__)
 
 
+class GitHubFetchError(DaimonError):
+    """A non-2xx response from GitHub, carrying the status for the caller.
+
+    A ``DaimonError`` subclass so every existing ``except DaimonError``
+    handler keeps catching it unchanged — this adds a discriminator, it does
+    not reroute anything.
+
+    The status matters because 404 is ambiguous on an *anonymous* fetch:
+    GitHub 404s a private repo rather than 403ing it, specifically so an
+    unauthenticated caller cannot probe for existence. Callers that know
+    whether they sent a credential can resolve that ambiguity; this layer
+    cannot, so it reports the status instead of guessing at a message.
+    """
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
 @dataclass(frozen=True)
 class FetchResult:
     """Result of fetch_repo: ``path`` is the repo root, ``cleanup_dir`` is what to rmtree."""
@@ -91,8 +110,9 @@ async def fetch_repo(
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            raise DaimonError(
-                f"failed to fetch {url!r} (branch {branch!r}): HTTP {exc.response.status_code}"
+            raise GitHubFetchError(
+                f"failed to fetch {url!r} (branch {branch!r}): HTTP {exc.response.status_code}",
+                status_code=exc.response.status_code,
             ) from exc
 
         if max_tarball_bytes > 0:

--- a/packages/core/tests/test_credential_requests.py
+++ b/packages/core/tests/test_credential_requests.py
@@ -7,7 +7,9 @@ from daimon.core.credential_requests import (
     MAX_BUTTON_LABEL_CHARS,
     build_button_label,
     build_custom_id,
+    build_skill_repo_target,
     mint_request_token,
+    split_skill_repo_target,
 )
 
 
@@ -84,3 +86,40 @@ def test_build_button_label_truncates_long_repo_target_within_discord_label_limi
     assert len(label) <= MAX_BUTTON_LABEL_CHARS, "label must fit Discord's 80-char button limit"
     assert label.startswith("Bind repo: "), "truncation must not lose the human-readable prefix"
     assert label.endswith("…"), "truncation must append the single-character ellipsis"
+
+
+def test_build_button_label_skill_repo_does_not_say_bind() -> None:
+    label = build_button_label("skill_repo", "clsandoval/seedance-2.0")
+
+    assert label == "Import skills from: clsandoval/seedance-2.0"
+    assert "Bind" not in label, (
+        "a skill import writes no agent_repo_binding, so the label must not "
+        "promise the user a checkout they did not ask for"
+    )
+
+
+def test_skill_repo_target_round_trips_url_branch_and_path() -> None:
+    for url, branch, path in [
+        ("https://github.com/o/r", "main", ""),
+        ("https://github.com/o/r", "dev", "skills"),
+        ("https://github.com/o/r", "release/1.x", "nested/skills"),
+    ]:
+        packed = build_skill_repo_target(url, branch, path)
+
+        assert split_skill_repo_target(packed) == (url, branch, path)
+
+
+def test_skill_repo_target_splits_path_before_branch() -> None:
+    """A path may contain '@'; splitting on '@' first would mangle it."""
+    packed = build_skill_repo_target("https://github.com/o/r", "main", "a@b/c")
+
+    assert split_skill_repo_target(packed) == ("https://github.com/o/r", "main", "a@b/c")
+
+
+def test_split_skill_repo_target_defaults_match_sync_skills_defaults() -> None:
+    """A bare url must resolve to sync_skills' own defaults, not to empties."""
+    assert split_skill_repo_target("https://github.com/o/r") == (
+        "https://github.com/o/r",
+        "main",
+        "",
+    )


### PR DESCRIPTION
## The problem

Syncing skills from a **private** repo was a dead end, and the error actively misled.

`resolve_skill_sync_token` returns `None` when nothing authorizes. `None` is a legal value meaning *anonymous fetch* — and GitHub 404s a private repo rather than 403ing it, specifically so an unauthenticated caller cannot probe for existence. So the agent saw:

```
failed to fetch 'https://github.com/owner/repo' (branch 'main'): HTTP 404
```

…and apologized for a typo instead of asking for a credential.

Nothing could collect one for this path either. `request_repo_binding` is for the agent's **checkout** repo — a different feature that happens to share the PAT store. Pointing it at a skill repo would also `set_binding`, telling the agent to clone a repo the user only wanted skills from.

## The fix

A fourth credential-request kind, `skill_repo`. **No migration** — `kind` is a Python `Literal` over a free-text column with no CHECK constraint.

```
sync_skills → no credential → anonymous 404
  ↓
"No GitHub credential was available … call request_skill_repo_credential"
  ↓
agent posts button → user pastes PAT → verified against the SKILL repo
  ↓
stored in the per-agent overlay get_pat reads → import runs → "Imported N skill(s)"
```

| File | Change |
|---|---|
| `core/skills/fetch.py` | `GitHubFetchError(DaimonError)` carrying `status_code` — a subclass, so every existing `except DaimonError` keeps catching it. Only the caller knows whether it sent a credential, so only the caller can resolve the 404 ambiguity. |
| `mcp/tools/skills.py` | `_sync_impl` turns an anonymous 404 into a message naming the remedy. **This is the actual blocker** — without it the agent never reaches for the button. |
| `core/credential_requests.py` | `skill_repo` kind + `URL[@branch][#path]` pack/unpack (the grammar the CLI's `--repo` already accepts) |
| `mcp/tools/credential_requests.py` | `request_skill_repo_credential` |
| `discord/credential_modals.py` | `SkillRepoModal` — verify, store, **run the import**, report the count |
| `discord/credential_button.py` | explicit dispatch branch |

`RepoBindModal` ended with *"Takes effect on the next session."* `SkillRepoModal` ends with *"Imported N skill(s)"* — the loop closes without needing an agent-resume primitive the adapter doesn't have.

## Three judgment calls worth reviewing

1. **The PAT is deliberately shared with the `repo` kind.** Same per-agent overlay, so a user who already pasted a token that can read this repo is never asked twice. But this writes **no** `agent_repo_binding` — sharing the store is intended, sharing the binding write was the bug.
2. **Verify before store.** The overlay is last-write-wins and tier 1 short-circuits the rest, so storing an unverified token would shadow a working one. Checked against the **skill** repo, not the clone target — for a skill import those are routinely different repos, and validating the wrong one both refuses good tokens and accepts ones that cannot read what is about to be fetched.
3. **No admin gate**, matching the `env`/`mcp` kinds rather than the `repo` kind. That gate exists because a binding changes what code the agent runs for every member; an import into the shared library does not, and `sync_skills` already `_require_admin`s at request time. Easy to add if you disagree.

Scope note: the webhook resync path (`resync.py::_select_credential`) already raises `DaimonError` and records `last_sync_error` correctly. Untouched — this is the interactive path only.

## Verification

- **+6 tests**: `URL[@branch][#path]` round-trip including the `@`-in-path case (path must split before branch), label wording (`skill_repo` must not say "Bind"), and both 404 branches — with a token it must **not** blame credentials.
- Full suite **2670 passed** vs **2664** on baseline. The 3 failures and 1755 errors are pre-existing, all need a live Postgres, and are identical on a clean tree.
- `ruff`, `ruff-format`, `pyright` (0 errors), `lint-imports` (**6/6 contracts kept**), and all 14 pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)