### PR TITLE
fix(turn): unbrick a thread whose MA session was terminated

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/vision.py
+++ b/packages/adapters/discord/daimon/adapters/discord/vision.py
@@ -113,6 +113,16 @@ def build_image_url_prefix(attachments: list[discord.Attachment]) -> str:
     )
 
 
+def _skipped_for_dimensions(reason: str) -> bool:
+    """Was this skip the pixel cap (rather than bytes/count/type/fetch)?
+
+    Matches the reason string `download_as_image_blocks` writes for the
+    dimension gate. Keyed on the shared `MAX_VISION_IMAGE_DIMENSION` constant
+    rather than a copied literal, so the two cannot drift apart silently.
+    """
+    return f"{MAX_VISION_IMAGE_DIMENSION}px" in reason
+
+
 def build_skipped_image_prefix(skipped: list[tuple[discord.Attachment, str]]) -> str:
     """One ``*system: ...*`` line per image that was NOT inlined as a vision block.
 
@@ -122,11 +132,38 @@ def build_skipped_image_prefix(skipped: list[tuple[discord.Attachment, str]]) ->
     downloaded to disk — so surfacing the URL keeps the image usable (curl it to
     disk then ``read`` it to view, or hand the URL to an external API) instead of
     silently dropping it.
+
+    **A dimension-skipped image gets a different line, and must.** For every
+    other skip reason "curl it and `read` it" is sound advice. For this one it
+    is the exact sequence that kills the session: `read` inlines the image at
+    full size, the next model request is rejected with "image dimensions exceed
+    max allowed size: 8000 pixels", and that rejection is terminal — MA
+    terminates the session and every later message in the thread 400s with
+    "Cannot send events to archived session".
+
+    That is not hypothetical. Staging session sesn_01TBcsjhyD4KMEc6wasC3vyg
+    (2026-08-07) died exactly this way: four images refused inline here, the
+    agent curled them to /tmp and `read` all four, and the thread was
+    permanently unusable. This gate rejecting the image and then handing over a
+    URL with instructions to reintroduce it through an unguarded path made the
+    cap self-defeating. So the line below tells the agent to downscale FIRST.
     """
     return "\n".join(
-        f"*system: image `{attachment.filename}` was NOT inlined as a vision block "
-        f"({reason}); fetch it yourself — signed CDN URL (curl to disk then use your "
-        f"`read` tool to view it, or pass to an external API; expires ~24h): {attachment.url}*"
+        (
+            f"*system: image `{attachment.filename}` was NOT inlined as a vision block "
+            f"({reason}). Do NOT `read` it at full size — that inlines it at its "
+            f"original dimensions and the request is rejected terminally, which kills "
+            f"this whole conversation. Downscale it first so its longest edge is under "
+            f'{MAX_VISION_IMAGE_DIMENSION}px (e.g. python -c "from PIL import Image; '
+            f"im=Image.open('in.jpg'); im.thumbnail(({MAX_VISION_IMAGE_DIMENSION - 1000},"
+            f"{MAX_VISION_IMAGE_DIMENSION - 1000})); im.save('small.jpg')\"), then `read` "
+            f"the downscaled copy. Signed CDN URL (expires ~24h): {attachment.url}*"
+            if _skipped_for_dimensions(reason)
+            else f"*system: image `{attachment.filename}` was NOT inlined as a vision block "
+            f"({reason}); fetch it yourself — signed CDN URL (curl to disk then use your "
+            f"`read` tool to view it, or pass to an external API; expires ~24h): "
+            f"{attachment.url}*"
+        )
         for attachment, reason in skipped
     )
 

--- a/packages/adapters/discord/tests/test_vision.py
+++ b/packages/adapters/discord/tests/test_vision.py
@@ -447,3 +447,49 @@ class TestBuildSkippedImagePrefix:
         lines = prefix.split("\n")
         assert len(lines) == 2, "each skipped image should contribute exactly one line"
         assert "a.png" in lines[0] and "b.png" in lines[1], "lines should preserve order"
+
+
+def test_dimension_skipped_image_is_warned_not_told_to_read_it() -> None:
+    """The pixel cap must not hand the agent a URL and say "curl it then read it".
+
+    Regression: staging session sesn_01TBcsjhyD4KMEc6wasC3vyg. Four images were
+    refused inline here for exceeding 8000px, the note told the agent to fetch
+    and ``read`` them, ``read`` inlined them at full size, and the resulting
+    terminal rejection killed the session and bricked the whole thread.
+    """
+    att = FakeAttachment(
+        filename="huge.jpg",
+        content_type="image/jpeg",
+        size=1024,
+        width=12000,
+        height=4000,
+        url="https://cdn.discordapp.com/attachments/1/2/huge.jpg?ex=a",
+    )
+
+    text = build_skipped_image_prefix(
+        [(att, f"image dimensions unknown or exceed {MAX_VISION_IMAGE_DIMENSION}px")]
+    )
+
+    assert "Do NOT `read` it at full size" in text
+    assert "Downscale it first" in text
+    assert "kills" in text, "the consequence must be stated, not just the instruction"
+    assert att.url in text, "the URL is still surfaced — downscaling needs the bytes"
+
+
+def test_non_dimension_skip_keeps_the_plain_fetch_and_read_instruction() -> None:
+    """Only the pixel cap is dangerous to ``read``; other skips keep the old advice."""
+    att = FakeAttachment(
+        filename="big.png",
+        content_type="image/png",
+        size=9_000_000,
+        width=800,
+        height=600,
+        url="https://cdn.discordapp.com/attachments/1/2/big.png?ex=a",
+    )
+
+    text = build_skipped_image_prefix(
+        [(att, f"exceeds vision size cap (9000000 > {MAX_VISION_IMAGE_BYTES})")]
+    )
+
+    assert "`read` tool to view it" in text
+    assert "Do NOT `read`" not in text

--- a/packages/core/daimon/core/turn/run.py
+++ b/packages/core/daimon/core/turn/run.py
@@ -44,19 +44,53 @@ class RunOutcome:
     recovered: bool
 
 
-def _is_dead_session(state: TurnState) -> bool:
-    """Return True if state.error signals a gone/expired MA session (HTTP 404).
+# MA's rejection when events.send targets a session it has terminated. The id
+# is well-formed and the session exists — it is simply closed to new events, so
+# this is a 400 rather than the 404 a deleted session gives.
+_ARCHIVED_SESSION_MARKER = "cannot send events to archived session"
 
-    A 404 not_found_error from events.send means the session existed but is now
-    gone (deleted / expired / GC'd). The turn recreates silently.
-    A 400 means a malformed session id -- not reachable with well-formed stored ids
-    and must surface as a normal turn error (do NOT recreate on it).
+
+def _is_dead_session(state: TurnState) -> bool:
+    """Return True if state.error signals a gone or closed MA session.
+
+    Two distinct signatures, both meaning "this session can never accept
+    another event, so recreate rather than surfacing a dead end":
+
+    - **404** from events.send: the session existed but is gone (deleted /
+      expired / GC'd).
+    - **400 whose message is `Cannot send events to archived session`**: MA
+      terminated the session (e.g. a turn hit a terminal model error) and
+      closed it to further events.
+
+    Every OTHER 400 still surfaces as a normal turn error. That distinction is
+    the point: a bare 400 means a malformed session id, which is not reachable
+    with well-formed stored ids and must not trigger a recreate. Matching on
+    the message rather than the status alone keeps that case excluded.
+
+    The 400 limb is why this function exists in its current shape. Without it a
+    single terminal error bricked the thread PERMANENTLY: MA terminated the
+    session, the mapping row still pointed at it, and every later message in
+    that thread 400'd here forever with zero tokens billed and no path back.
+    Observed on staging thread 1535185295245582356 / session
+    sesn_01TBcsjhyD4KMEc6wasC3vyg (2026-08-07), where an oversized image ended
+    the session and the next "hello" — and every message after it — failed.
+
+    Note this deliberately does NOT fire on the terminating turn itself (whose
+    error is `session terminated by MA`, carrying no APIStatusError cause).
+    That turn really did fail, and re-running it against a fresh session would
+    just replay whatever killed it. Recovery instead happens on the NEXT
+    message, which is the first to see the archived-session 400 — so the thread
+    heals on its own without retrying poison.
     """
     err = state.error
     if err is None or err.kind != "upstream":
         return False
     cause = err.cause
-    return isinstance(cause, _anthropic.APIStatusError) and cause.status_code == 404
+    if not isinstance(cause, _anthropic.APIStatusError):
+        return False
+    if cause.status_code == 404:
+        return True
+    return cause.status_code == 400 and _ARCHIVED_SESSION_MARKER in str(cause).lower()
 
 
 async def run_prepared_turn(

--- a/packages/core/tests/turn/test_run_prepared_turn.py
+++ b/packages/core/tests/turn/test_run_prepared_turn.py
@@ -14,11 +14,13 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
 
+import anthropic
 import httpx
 from anthropic.types.beta import BetaEnvironment, BetaManagedAgentsAgent
 from anthropic.types.beta.beta_managed_agents_model_config import BetaManagedAgentsModelConfig
 from daimon.core.config import McpSettings
 from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
+from daimon.core.errors import TurnError
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.scope import DeploymentDefault, ResolvedConfig
 from daimon.core.stores import usage_events
@@ -26,7 +28,8 @@ from daimon.core.stores.thread_sessions import get_live_thread_session
 from daimon.core.turn.admission import Admission
 from daimon.core.turn.deps import TurnDeps
 from daimon.core.turn.prepare import PreparedTurn, bind_recorder
-from daimon.core.turn.run import run_prepared_turn
+from daimon.core.turn.run import _is_dead_session, run_prepared_turn
+from daimon.core.turn.state import TurnState
 from daimon.testing.ma import (
     EMPTY_CLOUD_CONFIG,
     MARouter,
@@ -715,3 +718,49 @@ async def test_second_consecutive_dead_session_does_not_loop(
         "exactly one recovery create_session call -- no second recovery"
     )
     assert len(stream_calls) == 2, "exactly two run_turn attempts total -- no further retry loop"
+
+
+def _api_status_error(status_code: int, message: str) -> anthropic.APIStatusError:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/sessions/sess_1/events")
+    response = httpx.Response(status_code, request=request, json={"error": {"message": message}})
+    return anthropic.APIStatusError(message, response=response, body=None)
+
+
+def _state_with_upstream_cause(cause: Exception) -> TurnState:
+    return TurnState(error=TurnError(kind="upstream", message=str(cause), cause=cause))
+
+
+def test_dead_session_detects_archived_400_so_a_thread_can_heal() -> None:
+    """A terminated session 400s rather than 404ing, and must still recover.
+
+    Regression: staging session sesn_01TBcsjhyD4KMEc6wasC3vyg. MA terminated
+    it, the mapping row kept pointing at it, and because only 404 counted as
+    dead, every later message in that thread failed forever.
+    """
+    cause = _api_status_error(
+        400, "Cannot send events to archived session: sesn_01TBcsjhyD4KMEc6wasC3vyg"
+    )
+
+    assert _is_dead_session(_state_with_upstream_cause(cause)) is True
+
+
+def test_dead_session_still_detects_404() -> None:
+    assert _is_dead_session(_state_with_upstream_cause(_api_status_error(404, "not found"))) is True
+
+
+def test_dead_session_ignores_other_400s() -> None:
+    """A malformed-id 400 must surface as a turn error, not trigger a recreate."""
+    cause = _api_status_error(400, "session_id: invalid format")
+
+    assert _is_dead_session(_state_with_upstream_cause(cause)) is False
+
+
+def test_dead_session_ignores_a_terminating_turn_with_no_api_cause() -> None:
+    """The turn that KILLS the session must not recover — it would replay the poison.
+
+    Its error carries no APIStatusError; recovery happens on the next message,
+    which is the first to see the archived-session 400.
+    """
+    state = TurnState(error=TurnError(kind="upstream", message="session terminated by MA"))
+
+    assert _is_dead_session(state) is False


### PR DESCRIPTION
Both halves of one incident: staging thread `1535185295245582356`, session `sesn_01TBcsjhyD4KMEc6wasC3vyg`, 2026-08-07.

## What happened

```
07:18:19  session starts, runs fine (145s active)
          agent curls 4 reference images to /tmp, `read`s all four
07:22:12  span.model_request_end is_error
            "messages.3.content.17.image.source.base64.data:
             At least one of the image dimensions exceed max allowed size: 8000 pixels"
            retry_status: terminal
07:22:14  session.error -> session.status_terminated
07:24:18  user: "hello @daimon-staging"
07:24:20  400 "Cannot send events to archived session"   <- and forever after
```

The thread was permanently unusable. Not the deploy, not skills.

## Fix 1 — recovery (`core/turn/run.py`)

Recovery already existed in `run_prepared_turn`; **`_is_dead_session` just never matched.** It tested `status_code == 404` only, and its docstring explicitly excluded 400 as "a malformed session id — must surface as a normal turn error (do NOT recreate on it)".

That was correct when written. But MA answers a *terminated yet well-formed* session with **400**, so the blanket exclusion is exactly what made the thread unrecoverable.

Now 400 also counts — but **only** when the message is `Cannot send events to archived session`. Every other 400 still surfaces as a normal turn error, so the malformed-id reasoning the docstring protected is untouched.

Deliberately does **not** fire on the terminating turn itself (error `session terminated by MA`, no `APIStatusError` cause). That turn genuinely failed, and re-running it against a fresh session would replay whatever killed it. Recovery happens on the *next* message — the first to see the archived 400 — so the thread heals without retrying poison.

## Fix 2 — the cap was self-defeating (`discord/vision.py`)

`vision.py` already caps inlining at 8000px, correctly. It then handed the agent the CDN URLs with instructions to *"curl to disk then use your `read` tool to view it"* — reintroducing the exact images the cap had just rejected, through a path with no cap. `read` inlined them at full size and the session died.

Dimension-skipped images now get a different line: don't `read` at full size, why (it kills the conversation), and how to downscale first. Every other skip reason keeps the original wording — "curl it and read it" is fine for a byte-cap or count-cap skip.

## Verification

- **+6 tests.** Four on the predicate (404 still recovers; archived-400 now recovers; other 400s don't; the terminating turn doesn't), two on the skip-note split.
- Full suite **4437 passed, 0 failed** against a real Postgres.
- `ruff`, `pyright`, `import-linter` (6/6 contracts), all 14 pre-commit hooks pass.

## Note for the reviewer

There's an uncommitted `packages/core/daimon/core/wizard/spec.py` on the author's machine that drifts `test_tool_schema_snapshot`. It is **not** part of this PR and this branch does not touch it; the 4437-pass run above is with it set aside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)