### PR TITLE
fix(discord): stop dead-session recovery from replaying the image that killed it

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -1231,13 +1231,27 @@ class DaimonBot(commands.Bot):
         lifecycle_holder: list[DiscordTurnLifecycle] = [lifecycle]
 
         async def _reseed_user_message() -> str:
-            """Full history re-seed for the recreated session (dead-session recovery)."""
+            """Full history re-seed for the recreated session (dead-session recovery).
+
+            ``omit_oversized_image_urls=True`` is what stops recovery from
+            recreating the failure it is recovering from. An oversized image in
+            the history is the most likely reason the previous session died:
+            the agent curls the URL, ``read``s it at full size, and MA
+            terminates the session. Reseeding that same URL into the fresh
+            session just repeats it, so the thread recovers, dies, recovers,
+            dies -- each cycle billing a full agentic run. Observed on staging
+            thread 1535185295245582356: two consecutive recoveries burned 243k
+            then 62k input tokens and both ended terminated. Withholding the
+            URL (rather than only warning about it, which the model may ignore)
+            is what actually breaks the loop.
+            """
             full_message, _ = await build_context_xml(
                 thread,
                 trigger=message,
                 limit=100,
                 bot_user_id=self.user.id if self.user else None,
                 bot_display_name=discord_settings.bot_display_name,
+                omit_oversized_image_urls=True,
             )
             if synthetic_prefix:
                 full_message = synthetic_prefix + "\n" + full_message
@@ -1250,6 +1264,10 @@ class DaimonBot(commands.Bot):
                 agent_name=agent.name,
                 model_id=agent.model.id,
                 cancel_view=CancelView(allowed_user_id=message.author.id, cancel=cancel_event),
+                # Take over the failed attempt's message so its upstream-error
+                # embed is edited into this turn's answer rather than left
+                # standing next to a second, successful message.
+                adopt_message_ref=lifecycle.message_ref,
             )
             lifecycle_holder[0] = new_lifecycle
             return new_lifecycle

--- a/packages/adapters/discord/daimon/adapters/discord/context.py
+++ b/packages/adapters/discord/daimon/adapters/discord/context.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import re
 from xml.sax.saxutils import escape, quoteattr
 
-from daimon.adapters.discord.vision import is_vision_image_attachment
+from daimon.adapters.discord.vision import (
+    MAX_VISION_IMAGE_DIMENSION,
+    is_oversized_image,
+    is_vision_image_attachment,
+)
 
 import discord
 
@@ -65,9 +69,25 @@ def _render_location(thread: discord.Thread) -> list[str]:
 
 
 def _render_message(
-    msg: discord.Message, bot_user_id: int | None, *, bot_display_name: str = "daimon"
+    msg: discord.Message,
+    bot_user_id: int | None,
+    *,
+    bot_display_name: str = "daimon",
+    omit_oversized_image_urls: bool = False,
 ) -> list[str]:
-    """Render a single message as XML lines."""
+    """Render a single message as XML lines.
+
+    Image attachments over the API's pixel cap are marked ``oversized="true"``
+    and carry a warning, because the agent otherwise sees a plain URL, curls it,
+    ``read``s it at full size, and the resulting rejection is terminal — it
+    kills the session and (before recovery existed) the whole thread.
+
+    ``omit_oversized_image_urls`` drops those URLs entirely rather than merely
+    warning. Set only on a dead-session recovery reseed: there the previous
+    session provably died, so a prompt-level warning the model may ignore is
+    not good enough — withholding the URL is what actually breaks the
+    recover-replay-die loop.
+    """
     attrs = (
         f" author_name={quoteattr(msg.author.display_name)}"
         f" user_id={quoteattr(str(msg.author.id))}"
@@ -83,12 +103,29 @@ def _render_message(
 
     lines = [f"<message{attrs}>", content, "<attachments>"]
     for att in msg.attachments:
-        att_attrs = (
-            f" filename={quoteattr(att.filename)}"
-            f" url={quoteattr(att.url)}"
+        oversized = is_oversized_image(att)
+        att_attrs = f" filename={quoteattr(att.filename)}"
+        if not (oversized and omit_oversized_image_urls):
+            att_attrs += f" url={quoteattr(att.url)}"
+        att_attrs += (
             f" content_type={quoteattr(att.content_type or 'unknown')}"
             f" size={quoteattr(str(att.size))}"
         )
+        if att.width is not None and att.height is not None:
+            att_attrs += f" width={quoteattr(str(att.width))} height={quoteattr(str(att.height))}"
+        if oversized:
+            att_attrs += ' oversized="true"'
+            att_attrs += " note=" + quoteattr(
+                "Larger than "
+                f"{MAX_VISION_IMAGE_DIMENSION}px on an edge. Do NOT read this at full "
+                "size — that inlines it at its original dimensions and the request is "
+                "rejected terminally, which kills this conversation. Downscale a copy "
+                "first, then read the copy."
+                if not omit_oversized_image_urls
+                else "Larger than "
+                f"{MAX_VISION_IMAGE_DIMENSION}px on an edge. Its URL is withheld: "
+                "reading it at full size already terminated a session in this thread."
+            )
         lines.append(f"<attachment{att_attrs}/>")
     lines.append("</attachments>")
     lines.append("</message>")
@@ -102,8 +139,12 @@ async def build_context_xml(
     limit: int = 100,
     bot_user_id: int | None = None,
     bot_display_name: str = "daimon",
+    omit_oversized_image_urls: bool = False,
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context from thread history for the turn driver.
+
+    Pass ``omit_oversized_image_urls=True`` on a dead-session recovery reseed
+    so an image that already terminated a session cannot be fetched again.
 
     Returns ``(xml, image_attachments)`` where ``xml`` has
     ``<context>/<thread_history>`` wrapping prior messages and a
@@ -146,7 +187,14 @@ async def build_context_xml(
         "<thread_history>",
     ]
     for msg in messages:
-        lines.extend(_render_message(msg, bot_user_id, bot_display_name=bot_display_name))
+        lines.extend(
+            _render_message(
+                msg,
+                bot_user_id,
+                bot_display_name=bot_display_name,
+                omit_oversized_image_urls=omit_oversized_image_urls,
+            )
+        )
     lines.append("</thread_history>")
     lines.append("</context>")
 
@@ -172,6 +220,7 @@ async def build_delta_xml(
     after_message_id: int | None,
     bot_user_id: int | None = None,
     bot_display_name: str = "daimon",
+    omit_oversized_image_urls: bool = False,
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context for a continuation turn (delta since watermark).
 
@@ -222,7 +271,14 @@ async def build_delta_xml(
         "<thread_delta>",
     ]
     for msg in messages:
-        lines.extend(_render_message(msg, bot_user_id, bot_display_name=bot_display_name))
+        lines.extend(
+            _render_message(
+                msg,
+                bot_user_id,
+                bot_display_name=bot_display_name,
+                omit_oversized_image_urls=omit_oversized_image_urls,
+            )
+        )
     lines.append("</thread_delta>")
     lines.append("</context>")
 
@@ -248,6 +304,7 @@ async def build_channel_context_xml(
     limit: int = CHANNEL_BACKFILL_LIMIT,
     bot_user_id: int | None = None,
     bot_display_name: str = "daimon",
+    omit_oversized_image_urls: bool = False,
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context from parent channel history for a channel-mention turn.
 
@@ -276,7 +333,14 @@ async def build_channel_context_xml(
 
     lines: list[str] = [*_render_location(thread), f'<channel_context count="{len(messages)}">']
     for msg in messages:
-        lines.extend(_render_message(msg, bot_user_id, bot_display_name=bot_display_name))
+        lines.extend(
+            _render_message(
+                msg,
+                bot_user_id,
+                bot_display_name=bot_display_name,
+                omit_oversized_image_urls=omit_oversized_image_urls,
+            )
+        )
     lines.append("</channel_context>")
 
     trigger_attrs = (

--- a/packages/adapters/discord/daimon/adapters/discord/lifecycle.py
+++ b/packages/adapters/discord/daimon/adapters/discord/lifecycle.py
@@ -107,6 +107,7 @@ class DiscordTurnLifecycle:
         model_id: str,
         cancel_view: discord.ui.View | None = None,
         clock: Callable[[], float] = time.monotonic,
+        adopt_message_ref: Any | None = None,
     ) -> None:
         self._send = send
         self._edit = edit
@@ -119,12 +120,28 @@ class DiscordTurnLifecycle:
             agent_name=agent_name,
             started_at=self._clock(),
         )
-        self._message_ref: Any | None = None
+        # Seeded only by dead-session recovery, which hands over the message the
+        # failed attempt already posted. Without this the recovery lifecycle
+        # sends a SECOND message and the first attempt's ❌ embed stays in the
+        # thread forever — the user sees a scary upstream error immediately
+        # followed by a working answer, and cannot tell that the error was
+        # retracted. Adopting the ref means the recovered turn edits that embed
+        # into the real answer, so a recovered turn looks like a normal one.
+        self._message_ref: Any | None = adopt_message_ref
         self._last_flush: float = 0.0
         self._terminal: bool = False
         self._cancel_view = cancel_view
         self._persisted_sealed_indices: set[int] = set()
         self._was_answered: bool = False
+
+    @property
+    def message_ref(self) -> Any | None:
+        """The message this lifecycle is rendering into, if it has posted one.
+
+        Public so dead-session recovery can hand it to the replacement
+        lifecycle via ``adopt_message_ref``; nothing else should need it.
+        """
+        return self._message_ref
 
     async def post_initial(self) -> None:
         """Post the initial thinking embed immediately, before the turn starts.

--- a/packages/adapters/discord/daimon/adapters/discord/vision.py
+++ b/packages/adapters/discord/daimon/adapters/discord/vision.py
@@ -87,6 +87,19 @@ def _exceeds_dimension_cap(attachment: discord.Attachment) -> bool:
     return width > MAX_VISION_IMAGE_DIMENSION or height > MAX_VISION_IMAGE_DIMENSION
 
 
+def is_oversized_image(attachment: discord.Attachment) -> bool:
+    """True for an image attachment whose pixels exceed the API cap.
+
+    Distinct from ``not is_vision_image_attachment``, which is also True for a
+    perfectly small PDF. Callers rendering history need to single out the
+    images that will terminate a session if the agent curls and ``read``s them
+    at full size.
+    """
+    return (attachment.content_type or "").startswith("image/") and _exceeds_dimension_cap(
+        attachment
+    )
+
+
 def is_vision_image_attachment(attachment: discord.Attachment) -> bool:
     """True when the attachment can be sent as an API vision content block."""
     return (

--- a/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
@@ -489,6 +489,10 @@ async def run_wizard_submit_turn(
                 agent_name=agent.name,
                 model_id=agent.model.id,
                 cancel_view=CancelView(allowed_user_id=interaction.user.id, cancel=cancel_event),
+                # Take over the failed attempt's message so its upstream-error
+                # embed is edited into this turn's answer rather than left
+                # standing next to a second, successful message.
+                adopt_message_ref=lifecycle.message_ref,
             )
             lifecycle_holder[0] = new_lifecycle
             return new_lifecycle

--- a/packages/adapters/discord/tests/test_context.py
+++ b/packages/adapters/discord/tests/test_context.py
@@ -934,3 +934,59 @@ class TestBuildChannelContextXml:
     async def test_channel_backfill_limit_constant_is_twenty_five(self) -> None:
         """CHANNEL_BACKFILL_LIMIT module constant must be 25."""
         assert CHANNEL_BACKFILL_LIMIT == 25, "CHANNEL_BACKFILL_LIMIT must equal 25"
+
+
+async def test_oversized_history_image_is_marked_and_warned() -> None:
+    """A history image over the pixel cap must not look like a safe URL.
+
+    The agent otherwise curls it, ``read``s it at full size, and MA terminates
+    the session — which is how staging thread 1535185295245582356 died.
+    """
+    huge = _make_attachment(
+        filename="huge.jpg", content_type="image/jpeg", width=12000, height=4000
+    )
+    history = _make_message(msg_id=1, content="here", attachments=[huge])
+    trigger = _make_message(msg_id=2, content="look")
+    thread = _make_thread([history, trigger])
+
+    xml, _ = await build_context_xml(thread, trigger=trigger)
+
+    assert 'oversized="true"' in xml
+    assert "Do NOT read this at full size" in xml
+    assert 'width="12000"' in xml, "dimensions must be visible so the agent can reason about them"
+    assert huge.url in xml, "normal history still exposes the URL — downscaling needs it"
+
+
+async def test_recovery_reseed_withholds_the_oversized_image_url() -> None:
+    """The reseed must not hand back the URL that just killed a session.
+
+    A warning is a prompt-level hint the model may ignore; on a recovery we
+    KNOW the previous session died, so the URL is withheld outright. Without
+    this the thread recovers, replays the image, dies, and repeats — two such
+    cycles on staging burned 243k then 62k input tokens.
+    """
+    huge = _make_attachment(
+        filename="huge.jpg", content_type="image/jpeg", width=12000, height=4000
+    )
+    history = _make_message(msg_id=1, content="here", attachments=[huge])
+    trigger = _make_message(msg_id=2, content="hello?")
+    thread = _make_thread([history, trigger])
+
+    xml, _ = await build_context_xml(thread, trigger=trigger, omit_oversized_image_urls=True)
+
+    assert huge.url not in xml, "the URL that terminated the last session must be withheld"
+    assert 'oversized="true"' in xml, "the agent must still know the image exists"
+    assert "already terminated a session" in xml
+
+
+async def test_reseed_still_exposes_normal_image_urls() -> None:
+    """Only oversized images are withheld — ordinary attachments are untouched."""
+    ok = _make_attachment(filename="fine.png", width=800, height=600)
+    history = _make_message(msg_id=1, content="here", attachments=[ok])
+    trigger = _make_message(msg_id=2, content="hello?")
+    thread = _make_thread([history, trigger])
+
+    xml, _ = await build_context_xml(thread, trigger=trigger, omit_oversized_image_urls=True)
+
+    assert ok.url in xml
+    assert "oversized" not in xml

--- a/packages/adapters/discord/tests/test_lifecycle.py
+++ b/packages/adapters/discord/tests/test_lifecycle.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import discord
+import pytest
 from anthropic.types.beta.sessions.beta_managed_agents_span_model_request_end_event import (
     BetaManagedAgentsSpanModelRequestEndEvent,
 )
@@ -803,3 +804,42 @@ class TestTurnSummaryFooter:
         assert expected in footer, (
             f"footer cost must equal the billing-ledger cost {expected} to the cent"
         )
+
+
+@pytest.mark.asyncio
+async def test_adopted_message_ref_edits_instead_of_posting_a_second_message() -> None:
+    """Dead-session recovery must reuse the failed attempt's message.
+
+    Without this the recovery lifecycle posts a SECOND message and the first
+    attempt's upstream-error embed is left standing in the thread — the user
+    sees a red failure immediately followed by a working answer, with no way to
+    tell the failure was retracted. Observed on staging after the recovery fix
+    landed: the turn ran fine but the 400 embed stayed above it.
+    """
+    sent: list[object] = []
+    edited: list[object] = []
+
+    async def _send(**kwargs: object) -> object:
+        sent.append(kwargs)
+        return "new-message"
+
+    async def _edit(ref: object, **kwargs: object) -> None:
+        edited.append((ref, kwargs))
+
+    lifecycle = DiscordTurnLifecycle(
+        send=_send,
+        edit=_edit,
+        agent_name="content-daimon",
+        model_id="claude-sonnet-5",
+        adopt_message_ref="failed-attempt-message",
+    )
+
+    assert lifecycle.message_ref == "failed-attempt-message"
+
+    await lifecycle.on_terminal_success(_make_success_state())
+
+    assert sent == [], "must not post a second message when one was adopted"
+    assert edited, "the recovered answer must be written somewhere"
+    assert {ref for ref, _ in edited} == {"failed-attempt-message"}, (
+        "every write must target the failed attempt's message, overwriting its error embed"
+    )


### PR DESCRIPTION
## The loop

A Discord thread is bound to one MA session. When that session dies, recovery recreates it and re-seeds the full thread history. That history rendered image attachments as a **bare URL with no dimensions** — so the agent curled it, `read` it at full size, and MA terminated the new session too. Recover, replay, die. Each cycle bills a full agentic run; one observed thread burned 243k then 62k input tokens across two recoveries, both terminated.

The previously-shipped image clamp only covered images on the *inbound* message. It never covered images rendered from *history*, which is the exact path recovery takes.

## The fix

- `vision.is_oversized_image()` — distinct from `not is_vision_image_attachment`, which is also true for a perfectly small PDF.
- History attachments now carry `width`/`height`, an `oversized="true"` marker, and a note telling the agent to downscale a copy before reading.
- New `omit_oversized_image_urls` flag threads through all four context builders. The dead-session reseed sets it, which **withholds the URL** rather than only warning about it — the previous session provably died, so a prompt-level warning the model may ignore is not good enough.

## Second defect, same path

The recovery lifecycle sent a *second* message, so the failed attempt's red upstream-error embed stayed in the thread forever: the user saw a scary error immediately followed by a working answer, with no way to tell the error had been retracted. `DiscordTurnLifecycle` now accepts `adopt_message_ref` and the recovery paths in `bot.py` / `wizard_submit.py` hand over the message ref, so the recovered turn edits that embed into the real answer. A recovered turn now looks like a normal one.

## Tests

4 new: oversized history image is marked and warned; recovery reseed withholds the URL; reseed still exposes normal image URLs; an adopted message ref edits instead of posting a second message.

Full discord suite green, ruff + pyright clean.

## Verification

QA scenarios for both cases (deliberate session kill → revival, and an image past the 8000px cap in a thread that already died) have been added to the QA runbook in the companion infra repo, and will be run against staging after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)