### PR TITLE
fix(turn): stop showing a failure the thread is about to recover from

### DIFF
--- a/packages/core/daimon/core/turn/run.py
+++ b/packages/core/daimon/core/turn/run.py
@@ -14,14 +14,16 @@ import asyncio
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 
 import anthropic as _anthropic
 import structlog
+from anthropic.types import RawMessageStreamEvent
 from anthropic.types.beta.sessions import BetaManagedAgentsImageBlockParam
 from daimon.core.stores.thread_sessions import mark_dead
 from daimon.core.turn.deps import TurnDeps
 from daimon.core.turn.driver import run_turn
-from daimon.core.turn.lifecycle import TurnLifecycle
+from daimon.core.turn.lifecycle import InterruptSource, ReconnectReason, TurnLifecycle
 from daimon.core.turn.posture import Billed
 from daimon.core.turn.prepare import PreparedTurn, bind_recorder, create_fresh_session
 from daimon.core.turn.state import TurnState
@@ -48,6 +50,53 @@ class RunOutcome:
 # is well-formed and the session exists — it is simply closed to new events, so
 # this is a 400 rather than the 404 a deleted session gives.
 _ARCHIVED_SESSION_MARKER = "cannot send events to archived session"
+
+
+@dataclass
+class _DeferredFailureLifecycle:
+    """First-attempt wrapper that holds the terminal-failure hook until we know
+    whether recovery will run.
+
+    A dead-session 400 is recoverable and heals in about three seconds, but the
+    Discord adapter renders its red error embed from ``on_terminal_failure``
+    (despite the protocol calling that hook bookkeeping-only), so the user sees
+    a scary ``upstream: Error code: 400`` that is retracted a moment later. The
+    adopted message ref means the error does not *persist*; holding the call is
+    what stops it being *shown*. Replayed verbatim when we do not recover, so a
+    genuinely failed turn is unaffected.
+    """
+
+    inner: TurnLifecycle
+    _held: tuple[TurnState, Exception] | None = None
+
+    async def on_render(self, state: TurnState) -> None:
+        await self.inner.on_render(state)
+
+    async def on_terminal_success(self, state: TurnState) -> None:
+        await self.inner.on_terminal_success(state)
+
+    async def on_terminal_failure(self, state: TurnState, err: Exception) -> None:
+        self._held = (state, err)
+
+    async def on_sse_event(self, event: RawMessageStreamEvent) -> None:
+        await self.inner.on_sse_event(event)
+
+    async def on_reconnect(self, reason: ReconnectReason) -> None:
+        await self.inner.on_reconnect(reason)
+
+    async def on_rate_limited(self, until: datetime | None) -> None:
+        await self.inner.on_rate_limited(until)
+
+    async def on_interrupt_sent(self, source: InterruptSource) -> None:
+        await self.inner.on_interrupt_sent(source)
+
+    async def flush_held_failure(self) -> None:
+        """Replay the withheld failure. Call on every path that does not recover."""
+        if self._held is None:
+            return
+        state, err = self._held
+        self._held = None
+        await self.inner.on_terminal_failure(state, err)
 
 
 def _is_dead_session(state: TurnState) -> bool:
@@ -124,11 +173,12 @@ async def run_prepared_turn(
     ma_session_id = prepared.ma_session_id
     mapping_id = prepared.mapping_id
 
+    first_attempt = _DeferredFailureLifecycle(inner=lifecycle)
     state = await run_turn(
         anthropic=deps.anthropic,
         session_id=ma_session_id,
         user_message=user_message,
-        lifecycle=lifecycle,
+        lifecycle=first_attempt,
         cancel=cancel,
         render_interval_s=render_interval_s,
         billing=Billed(record=prepared._record),  # pyright: ignore[reportPrivateUsage]
@@ -136,6 +186,7 @@ async def run_prepared_turn(
     )
 
     if not (_is_dead_session(state) and mapping_id is not None):
+        await first_attempt.flush_held_failure()
         return RunOutcome(
             state=state,
             ma_session_id=ma_session_id,
@@ -143,50 +194,58 @@ async def run_prepared_turn(
             recovered=False,
         )
 
-    async with deps.sessionmaker() as session:
-        await mark_dead(session, id=mapping_id)
-        await session.commit()
+    # If recovery itself blows up, the withheld failure is the only thing the
+    # user would ever see -- without this the embed sits on "thinking" forever,
+    # which is the exact failure mode this module exists to prevent. Re-raise:
+    # the caller still needs to know recovery broke.
+    try:
+        async with deps.sessionmaker() as session:
+            await mark_dead(session, id=mapping_id)
+            await session.commit()
 
-    new_session_id, new_mapping_id = await create_fresh_session(
-        deps,
-        prepared.admission,
-        tenant_id=tenant_id,
-        platform=platform,
-        thread_id=thread_id,
-        session_account_id=prepared.session_account_id,
-    )
+        new_session_id, new_mapping_id = await create_fresh_session(
+            deps,
+            prepared.admission,
+            tenant_id=tenant_id,
+            platform=platform,
+            thread_id=thread_id,
+            session_account_id=prepared.session_account_id,
+        )
 
-    new_record = bind_recorder(
-        deps,
-        prepared.admission,
-        tenant_id=tenant_id,
-        external_user_id=external_user_id,
-        ma_session_id=new_session_id,
-    )
+        new_record = bind_recorder(
+            deps,
+            prepared.admission,
+            tenant_id=tenant_id,
+            external_user_id=external_user_id,
+            ma_session_id=new_session_id,
+        )
 
-    log.info(
-        "turn.session_recovered",
-        old_session_id=ma_session_id,
-        new_session_id=new_session_id,
-        old_mapping_id=str(mapping_id),
-        new_mapping_id=str(new_mapping_id),
-        thread_id=thread_id,
-    )
+        log.info(
+            "turn.session_recovered",
+            old_session_id=ma_session_id,
+            new_session_id=new_session_id,
+            old_mapping_id=str(mapping_id),
+            new_mapping_id=str(new_mapping_id),
+            thread_id=thread_id,
+        )
 
-    reseeded_message = await reseed_user_message()
-    fresh_cancel = asyncio.Event()
-    new_lifecycle = recovery_lifecycle(fresh_cancel)
+        reseeded_message = await reseed_user_message()
+        fresh_cancel = asyncio.Event()
+        new_lifecycle = recovery_lifecycle(fresh_cancel)
 
-    recovered_state = await run_turn(
-        anthropic=deps.anthropic,
-        session_id=new_session_id,
-        user_message=reseeded_message,
-        lifecycle=new_lifecycle,
-        cancel=fresh_cancel,
-        render_interval_s=render_interval_s,
-        billing=Billed(record=new_record),
-        image_blocks=image_blocks,
-    )
+        recovered_state = await run_turn(
+            anthropic=deps.anthropic,
+            session_id=new_session_id,
+            user_message=reseeded_message,
+            lifecycle=new_lifecycle,
+            cancel=fresh_cancel,
+            render_interval_s=render_interval_s,
+            billing=Billed(record=new_record),
+            image_blocks=image_blocks,
+        )
+    except Exception:
+        await first_attempt.flush_held_failure()
+        raise
 
     return RunOutcome(
         state=recovered_state,

--- a/packages/core/tests/turn/test_run_prepared_turn.py
+++ b/packages/core/tests/turn/test_run_prepared_turn.py
@@ -764,3 +764,126 @@ def test_dead_session_ignores_a_terminating_turn_with_no_api_cause() -> None:
     state = TurnState(error=TurnError(kind="upstream", message="session terminated by MA"))
 
     assert _is_dead_session(state) is False
+
+
+async def test_recovered_turn_never_shows_the_user_a_failure(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A recoverable dead session must not paint a terminal failure.
+
+    The adapter renders its red error embed from ``on_terminal_failure``, so
+    delivering that hook for an error we heal three seconds later shows the
+    user a scary upstream 400 that is then retracted.
+    """
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    row = await make_thread_session(
+        db_session,
+        tenant=tenant,
+        account=account,
+        platform="discord",
+        thread_id="thread-quiet-recovery",
+        ma_session_id="sess_old",
+    )
+    await db_session.commit()
+
+    router = _router(session_bodies=[], dead_session_ids={"sess_old"})
+    deps = _deps(sessionmaker=db_session_factory, router=router)
+    agent = _agent(agent_id="ag_1", tenant_id=tenant.id)
+    env = _env(env_id="env_1", tenant_id=tenant.id)
+    admission = _admission(account_id=account.id, agent=agent, env=env)
+    prepared = _prepared_turn(
+        deps=deps,
+        admission=admission,
+        tenant_id=tenant.id,
+        external_user_id="user-1",
+        ma_session_id="sess_old",
+        mapping_id=row.id,
+        session_account_id=account.id,
+    )
+
+    caller_lifecycle = RecordingLifecycle()
+    outcome = await run_prepared_turn(
+        deps,
+        prepared,
+        tenant_id=tenant.id,
+        platform="discord",
+        thread_id="thread-quiet-recovery",
+        external_user_id="user-1",
+        user_message="hello",
+        lifecycle=caller_lifecycle,
+        cancel=asyncio.Event(),
+        reseed_user_message=_reseed,
+        recovery_lifecycle=_recovery_lifecycle,
+        render_interval_s=0.001,
+    )
+
+    assert outcome.recovered is True, "the dead session must still recover"
+    assert caller_lifecycle.terminal_failures == [], (
+        "a recovered turn must never deliver on_terminal_failure -- that hook is "
+        "what paints the error embed the user sees retracted"
+    )
+
+
+async def test_unrecovered_failure_is_still_delivered_to_the_caller(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Withholding is only for the recovery path; a real failure must surface."""
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    row = await make_thread_session(
+        db_session,
+        tenant=tenant,
+        account=account,
+        platform="discord",
+        thread_id="thread-real-failure",
+        ma_session_id="sess_bad",
+    )
+    await db_session.commit()
+
+    router = MARouter()
+
+    def _400(_request: httpx.Request, _match: object) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={"type": "error", "error": {"type": "invalid_request_error", "message": "bad id"}},
+        )
+
+    router.add("GET", r"/v1/sessions/(?P<sid>[^/]+)/events/stream", _400)
+
+    deps = _deps(sessionmaker=db_session_factory, router=router)
+    agent = _agent(agent_id="ag_1", tenant_id=tenant.id)
+    env = _env(env_id="env_1", tenant_id=tenant.id)
+    admission = _admission(account_id=account.id, agent=agent, env=env)
+    prepared = _prepared_turn(
+        deps=deps,
+        admission=admission,
+        tenant_id=tenant.id,
+        external_user_id="user-1",
+        ma_session_id="sess_bad",
+        mapping_id=row.id,
+        session_account_id=account.id,
+    )
+
+    caller_lifecycle = RecordingLifecycle()
+    outcome = await run_prepared_turn(
+        deps,
+        prepared,
+        tenant_id=tenant.id,
+        platform="discord",
+        thread_id="thread-real-failure",
+        external_user_id="user-1",
+        user_message="hello",
+        lifecycle=caller_lifecycle,
+        cancel=asyncio.Event(),
+        reseed_user_message=_reseed,
+        recovery_lifecycle=_recovery_lifecycle,
+        render_interval_s=0.001,
+    )
+
+    assert outcome.recovered is False, "a plain 400 must not recover"
+    assert len(caller_lifecycle.terminal_failures) == 1, (
+        "a turn that is not recovered must still deliver its failure exactly once"
+    )


### PR DESCRIPTION
## What you see today

Send a message into a thread whose MA session was archived and you get a red embed:

```
❌ upstream: Error code: 400 - {'type': 'error', 'error': {'type':
'invalid_request_error', 'message': ... · 0s · 0 in / 0 out · <$0.001
```

Three seconds later the thread heals and answers normally. Observed live on staging:

```
09:39:27  session.ready (reused, archived)
09:39:27  turn.failed              <- the red embed
09:39:28  turn.terminal_failure
09:39:30  turn.session_recovered   old=sesn_01MQ513C... new=sesn_012nGKT7...
09:39:30  turn.started (new session)
```

Recovery works. The problem is that the user is shown a scary failure for a condition the system already knows how to fix.

## Why it leaks

`TurnLifecycle` documents `on_terminal_failure` as *"bookkeeping only. Must NOT render content"*, with `on_render` as the sole display path. `DiscordTurnLifecycle.on_terminal_failure` does not honour that — it applies an `EmbedEvent(kind="error", ...)` and calls `_flush_terminal()`. So the embed is painted the instant the 400 lands, before `_is_dead_session` is even consulted.

The recently-added `adopt_message_ref` means the recovered turn edits that message rather than posting a second one, so the error does not **persist**. Nothing stopped it being **shown**.

## The fix

The first attempt runs behind `_DeferredFailureLifecycle`, which delegates every hook except `on_terminal_failure` — that one is held. It is replayed verbatim on every path that does not recover, so a genuinely failed turn behaves exactly as before, and a recovered turn shows an uninterrupted thinking embed.

Fixing the adapter's protocol violation instead was the other option. It is the more correct fix and a much wider blast radius — every adapter renders failures from that hook today. Worth doing separately; this change is scoped to the symptom.

## The trap this closes

Withholding the failure introduces a new way to hang: if recovery itself throws, the held error is the *only* thing the user would ever see, and dropping it leaves the embed on "thinking" forever. The turn runs in a bare `asyncio.create_task` with no enclosing boundary, so nothing else would catch it. Recovery is wrapped to flush the withheld failure before re-raising — the old behaviour covered this case by accident, and this keeps it covered on purpose.

## Tests

- `test_recovered_turn_never_shows_the_user_a_failure` — verified to fail without the fix (`terminal_failures` gets one entry) and pass with it
- `test_unrecovered_failure_is_still_delivered_to_the_caller` — the withholding must not swallow real failures

Core turn + discord suites: 1145 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)