### PR TITLE
fix(prompts): stop the agent reporting a file as sent when nothing was sent

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -152,10 +152,17 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     ) -> MessageRow:
         """Post a message to a Discord channel.
 
-        Only call this when the user explicitly asks you to send or post something
-        to Discord. Do NOT call it to share results, summaries, or outputs unless
-        the user specifically requested a Discord post. Deliver output in your reply
-        instead.
+        For TEXT: only call this when the user explicitly asks you to send or
+        post something to Discord. Do NOT call it to share results, summaries,
+        or outputs unless the user specifically requested a Discord post.
+        Deliver text output in your reply instead.
+
+        For FILES that rule does not apply, because a reply cannot carry an
+        attachment. Posting a file in the thread you were invoked from is
+        delivery, not a duplicate — asking you to "attach it here" is a
+        request to call this tool with ``file_handles``. Read the two
+        paragraphs above together or you will conclude, wrongly, that you
+        should hand a file back "in your reply" and silently deliver nothing.
 
         ``attachments=[{url, filename}]`` fetches over https, restricted to
         Discord's own CDN hosts — an arbitrary external URL will be refused

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/media.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/media.py
@@ -166,8 +166,16 @@ def register_upload_tool(mcp: FastMCP, *, runtime: McpRuntime) -> None:
         title: str,
         mime_type: str,
     ) -> str:
-        """Get a one-time URL for uploading a file you produced — a chart, a
-        table, a data file — so it can be posted as a Discord attachment.
+        """Attach, post, send, or share a file in Discord — step 1 of 2.
+
+        This is the ONLY way to put a file you produced (a chart, a table, an
+        image, a data file) into Discord as an attachment. Your reply text
+        delivers itself; a file never does. Reading a file, or copying it to
+        /mnt/session/outputs/, does not send it anywhere.
+
+        The intent words are in this first line on purpose: an agent looking
+        for "attach an image" or "post a file" has to find this tool by
+        search, and the name alone does not carry any of them.
 
         Call this FIRST, then send the bytes from your sandbox with curl:
 

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -1003,8 +1003,16 @@
     }),
     'create_file_upload_url': dict({
       'description': '''
-        Get a one-time URL for uploading a file you produced — a chart, a
-        table, a data file — so it can be posted as a Discord attachment.
+        Attach, post, send, or share a file in Discord — step 1 of 2.
+        
+        This is the ONLY way to put a file you produced (a chart, a table, an
+        image, a data file) into Discord as an attachment. Your reply text
+        delivers itself; a file never does. Reading a file, or copying it to
+        /mnt/session/outputs/, does not send it anywhere.
+        
+        The intent words are in this first line on purpose: an agent looking
+        for "attach an image" or "post a file" has to find this tool by
+        search, and the name alone does not carry any of them.
         
         Call this FIRST, then send the bytes from your sandbox with curl:
         
@@ -2455,10 +2463,17 @@
       'description': '''
         Post a message to a Discord channel.
         
-        Only call this when the user explicitly asks you to send or post something
-        to Discord. Do NOT call it to share results, summaries, or outputs unless
-        the user specifically requested a Discord post. Deliver output in your reply
-        instead.
+        For TEXT: only call this when the user explicitly asks you to send or
+        post something to Discord. Do NOT call it to share results, summaries,
+        or outputs unless the user specifically requested a Discord post.
+        Deliver text output in your reply instead.
+        
+        For FILES that rule does not apply, because a reply cannot carry an
+        attachment. Posting a file in the thread you were invoked from is
+        delivery, not a duplicate — asking you to "attach it here" is a
+        request to call this tool with ``file_handles``. Read the two
+        paragraphs above together or you will conclude, wrongly, that you
+        should hand a file back "in your reply" and silently deliver nothing.
         
         ``attachments=[{url, filename}]`` fetches over https, restricted to
         Discord's own CDN hosts — an arbitrary external URL will be refused

--- a/packages/core/daimon/core/agent_guidance.py
+++ b/packages/core/daimon/core/agent_guidance.py
@@ -54,6 +54,22 @@ goes out anyway, so the tool call posts a second, duplicate copy. Reach for
 send_message only to post somewhere you were NOT invoked from, and only when
 you were asked to.
 
+FILES ARE THE OTHER EXCEPTION. Your reply text delivers itself; a FILE never
+does. There is no way to attach a file to your reply, so "deliver it in your
+reply instead" cannot apply to one — for a file, send_message IS the delivery
+path, not a duplicate of it. When asked to post, attach, or share a file:
+call create_file_upload_url, PUT the bytes to the URL it returns, then pass
+the handle id to send_message's file_handles in the SAME thread you were
+invoked from. That is the only sequence that reaches Discord.
+
+Two things that feel like delivery and are not. Calling `read` on an image
+renders it into YOUR OWN transcript so you can see it — the user sees
+nothing, and seeing it yourself is not evidence it was sent. Copying a file
+into /mnt/session/outputs/ stores it where nothing collects it; daimon does
+not sweep that directory. Both succeed, which is exactly why they mislead.
+A file is delivered only when send_message returns a Discord message
+carrying the attachment. Do not report a file as sent on any weaker signal.
+
 ROUTINES RUN HEADLESS — the exception to the rule above. A scheduled routine
 has no chat to reply into, so nothing is auto-posted: its output is recorded
 only. To make a routine post to Discord it must explicitly call the


### PR DESCRIPTION
Closes the prompt half of #54.

## What happened

Asked to attach an image in a thread, the agent took three attempts. The first two delivered nothing and it reported both as done (staging, MA session `sesn_012nGKT7x5uMw97w1zJAi3SP`):

1. `read` on the PNG — renders the image into the agent's **own** transcript. Never touches Discord.
2. Copied it into `/mnt/session/outputs/` — nothing sweeps that directory (confirmed: no reference to `session/outputs` anywhere under `packages/`).
3. `create_file_upload_url` → PUT → `send_message(file_handles=[...])` — worked.

## Why a careful agent still loses

**Both wrong paths return success, and one of them shows the agent the image.** There is no stronger false confirmation available than "I can see it."

And the tool docs actively steered toward them. `send_message` opened with:

> Do NOT call it to share results, summaries, or outputs unless the user specifically requested a Discord post. **Deliver output in your reply instead.**

That is correct for text and *impossible* for a file — a reply cannot carry an attachment. The user said "attach it here", which is ambiguous against "specifically requested a Discord post", so the agent obeyed the louder instruction and tried to deliver in its reply.

Note the irony: that paragraph exists to fix the double-reply duplicate (#45). Fixing that bug made this one more likely. The two rules were in direct conflict and nothing said which won.

## Changes

- **`agent_guidance.py`** — files named as the second exception to "a chat reply delivers itself", with both false positives called out explicitly. This is the file we verified propagates to live agents, unlike seeded skills (#41), so it lands on installs without waiting on that.
- **`send_message`** — rule split by text vs file, so the steer-away no longer covers the one case where this tool *is* the delivery path.
- **`create_file_upload_url`** — first line now leads with attach/post/send/share. It is reachable only via BM25 tool search and its name contains none of the words an agent would search for.

No behaviour change; docstrings and prompt text only. Tool schema snapshot updated.

## Not in scope

A one-call `send_file` was considered and rejected for now: the MCP server has no access to the agent's sandbox filesystem, so the bytes must be pushed out by the agent — a `send_file(path=...)` cannot work. The achievable version collapses three steps to two by having the PUT itself trigger the post, which needs the pending post target on the upload row, i.e. a migration. Deferred deliberately; #54 keeps it.

2475 tests pass across core + mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)