### PR TITLE
fix(discord): retire turns orphaned by a restart instead of freezing them forever

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -48,7 +48,12 @@ from daimon.core.stores.tenants import (
     list_tenants_by_platform,
     set_provision_status,
 )
-from daimon.core.stores.thread_sessions import update_watermark
+from daimon.core.stores.thread_sessions import (
+    clear_active_turn,
+    list_orphaned_turns,
+    mark_turn_active,
+    update_watermark,
+)
 from daimon.core.turn.admission import AdmissionDenied, MissingTurnConfigError, admit
 from daimon.core.turn.gating import should_admit_turn
 from daimon.core.turn.lifecycle import TurnLifecycle
@@ -230,6 +235,10 @@ class DaimonBot(commands.Bot):
         # Drain flag — set by _drain_and_close on SIGTERM/SIGINT.
         # While True, on_message rejects new mentions; existing turns finish.
         self.draining: bool = False
+        # One-shot guard for the orphaned-turn sweep. on_ready re-fires on every
+        # full gateway reconnect, and a second run would reap the turns THIS
+        # process is currently rendering.
+        self._orphans_retired: bool = False
 
     def _spawn(self, coro: Coroutine[Any, Any, None]) -> asyncio.Task[None]:
         """Fire-and-forget a background task, tracked so it isn't GC'd."""
@@ -486,10 +495,86 @@ class DaimonBot(commands.Bot):
             self._seed_tenant_defaults(tenant_id=result.tenant_id, guild=guild, was_ready=False)
         )
 
+    async def _retire_orphaned_turns(self) -> None:
+        """Lay to rest every embed whose turn died with the previous process.
+
+        A turn's render loop lives in the process that started it, so a deploy
+        mid-turn freezes the embed on 'thinking' forever while MA completes and
+        bills the answer server-side. The user sees a spinner that never stops
+        and has no way to tell it is dead.
+
+        Marking it failed is honest and cheap, and the alternative -- draining
+        in-flight turns before the container exits -- needs a lameduck story the
+        compose refresh does not have. This runs first in on_ready so a user
+        reading the thread sees the truth before anything else happens.
+
+        Failures to edit are swallowed per row: the message may be deleted, the
+        thread archived, or permissions changed since. One unreachable embed
+        must not stop the sweep clearing the rest, and the row is cleared either
+        way so a permanently unreachable message is not retried on every boot.
+
+        Runs at most once per process: on_ready re-fires on every full gateway
+        reconnect, and a marker set by this process is a LIVE turn, not an
+        orphan.
+        """
+        if self._orphans_retired:
+            return
+        self._orphans_retired = True
+        async with self.runtime.sessionmaker() as session:
+            orphans = await list_orphaned_turns(session, platform="discord")
+        if not orphans:
+            return
+        log.info("turn.orphans_found", count=len(orphans))
+
+        for row in orphans:
+            if row.active_turn_message_id is None:  # pragma: no cover - filtered by the query
+                continue
+            try:
+                channel = self.get_channel(int(row.thread_id)) or await self.fetch_channel(
+                    int(row.thread_id)
+                )
+                if isinstance(channel, discord.abc.Messageable):
+                    message = await channel.fetch_message(int(row.active_turn_message_id))
+                    await message.edit(
+                        embed=discord.Embed(
+                            color=theme.COLOR_RED,
+                            description=(
+                                "❌ This turn was interrupted by a restart and cannot be "
+                                "resumed. Nothing was lost on your side — mention me again "
+                                "to retry."
+                            ),
+                        ),
+                        view=None,
+                    )
+                    log.info(
+                        "turn.orphan_retired",
+                        thread_id=row.thread_id,
+                        message_id=row.active_turn_message_id,
+                        # How long the user stared at a spinner. The only place
+                        # this is visible -- the turn's own logs died with its
+                        # container.
+                        frozen_for_s=(
+                            (datetime.now(UTC) - row.active_turn_started_at).total_seconds()
+                            if row.active_turn_started_at is not None
+                            else None
+                        ),
+                    )
+            except (discord.HTTPException, discord.ClientException, ValueError) as err:
+                log.warning(
+                    "turn.orphan_retire_failed",
+                    thread_id=row.thread_id,
+                    message_id=row.active_turn_message_id,
+                    error=str(err),
+                )
+            async with self.runtime.sessionmaker() as session:
+                await clear_active_turn(session, id=row.id)
+                await session.commit()
+
     async def on_ready(self) -> None:
         """Forward-only reconcile sweep: provision-if-missing, re-seed pending/failed,
         sync the command tree. NO archive-on-absence."""
         log.info("bot_ready", user=str(self.user))
+        await self._retire_orphaned_turns()
         tenants = await list_tenants_by_platform(self.runtime.sessionmaker, platform="discord")
         known_guild_ids = {tr.external_id for tr in tenants}
         sem = asyncio.Semaphore(_SWEEP_CONCURRENCY)
@@ -1127,6 +1212,20 @@ class DaimonBot(commands.Bot):
             reused=prepared.reused,
         )
 
+        # Flag the turn as in flight. The render loop lives in THIS process, so
+        # if the container is recreated mid-turn the embed freezes forever while
+        # MA completes and bills the answer server-side. Recording the embed's
+        # id is what lets the next boot find it and say so.
+        if prepared.mapping_id is not None and lifecycle.final_message_id is not None:
+            async with self.runtime.sessionmaker() as _at_session:
+                await mark_turn_active(
+                    _at_session,
+                    id=prepared.mapping_id,
+                    active_turn_message_id=lifecycle.final_message_id,
+                    now=datetime.now(UTC),
+                )
+                await _at_session.commit()
+
         # Split trigger-message attachments: API-consumable images → vision
         # blocks; everything else (data files, unsupported/oversized images)
         # → signed CDN URL surfaced to the agent (it has bash + network egress
@@ -1297,6 +1396,17 @@ class DaimonBot(commands.Bot):
         state = outcome.state
         mapping_id = outcome.mapping_id
         final_lifecycle = lifecycle_holder[0]
+
+        # The turn reached a terminal state under this process, so its embed is
+        # settled and must not be reaped by a later boot. Both ids are cleared:
+        # recovery moves the turn to a new mapping row and leaves the marker
+        # behind on the old one, which is still pointing at this same message.
+        for _done_id in {prepared.mapping_id, mapping_id} - {None}:
+            if _done_id is None:  # pragma: no cover - set comprehension guarantees this
+                continue
+            async with self.runtime.sessionmaker() as _ct_session:
+                await clear_active_turn(_ct_session, id=_done_id)
+                await _ct_session.commit()
 
         if state.error is not None:
             log.warning(

--- a/packages/adapters/discord/tests/test_orphaned_turns.py
+++ b/packages/adapters/discord/tests/test_orphaned_turns.py
@@ -1,0 +1,144 @@
+"""The boot sweep that lays to rest turns whose process died mid-flight.
+
+A turn's render loop lives in the process that started it, so a container
+recreate freezes its embed on 'thinking' forever while MA completes the answer
+server-side. These cover the sweep itself — an embed it can edit, one it
+cannot, and the reconnect that must not trigger it. The marker's own semantics
+live in the store tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+from daimon.adapters.discord import theme
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.config import McpSettings
+from daimon.core.ma_resolver import new_resolver_cache
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.thread_sessions import (
+    create_thread_session,
+    list_orphaned_turns,
+    mark_turn_active,
+)
+from daimon.testing.factories import make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+def _make_bot(sessionmaker: async_sessionmaker[AsyncSession]) -> DaimonBot:
+    settings = MagicMock()
+    settings.mcp = McpSettings()
+    discord_settings = MagicMock()
+    discord_settings.max_concurrent_turns_per_tenant = 3
+    settings.discord = discord_settings
+    runtime = DiscordRuntime(
+        settings=settings,
+        anthropic=AsyncMock(),
+        sessionmaker=sessionmaker,
+        notebook_rate_limiter=RateLimiter(max_requests=999),
+        billing_config=None,
+        deployment_default=DeploymentDefault(),
+        resolver_cache=new_resolver_cache(),
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # the sweep never runs a turn
+    )
+    intents = discord.Intents.default()
+    intents.message_content = True
+    return DaimonBot(runtime=runtime, intents=intents)
+
+
+async def _make_orphan(
+    session: AsyncSession,
+    *,
+    thread_id: str = "555",
+    message_id: str = "777",
+) -> uuid.UUID:
+    tenant = await make_tenant(session)
+    row = await create_thread_session(
+        session,
+        tenant_id=tenant.id,
+        platform="discord",
+        thread_id=thread_id,
+        account_id=uuid.uuid4(),
+        ma_session_id="sesn_test",
+    )
+    await mark_turn_active(
+        session,
+        id=row.id,
+        active_turn_message_id=message_id,
+        now=datetime.now(UTC),
+    )
+    await session.commit()
+    return row.id
+
+
+async def test_sweep_marks_the_embed_failed_and_clears_the_row(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    await _make_orphan(db_session)
+    bot = _make_bot(db_session_factory)
+    message = MagicMock(spec=discord.Message)
+    message.edit = AsyncMock()
+    thread = MagicMock(spec=discord.Thread)
+    thread.fetch_message = AsyncMock(return_value=message)
+    bot.get_channel = MagicMock(return_value=thread)  # pyright: ignore[reportAttributeAccessIssue]
+
+    await bot._retire_orphaned_turns()  # pyright: ignore[reportPrivateUsage]
+
+    thread.fetch_message.assert_awaited_once_with(777)
+    edited = message.edit.await_args.kwargs["embed"]  # pyright: ignore[reportAny]
+    assert edited.color.value == theme.COLOR_RED, "an interrupted turn must render as an error"
+    assert "interrupted" in edited.description, (
+        "the user must be told the turn is dead, not left on a frozen spinner"
+    )
+    assert await list_orphaned_turns(db_session, platform="discord") == [], (
+        "a retired turn must not be retired again on the next boot"
+    )
+
+
+async def test_sweep_clears_the_row_even_when_the_embed_is_unreachable(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A deleted message or lost permission must not make the sweep retry forever."""
+    await _make_orphan(db_session)
+    bot = _make_bot(db_session_factory)
+    thread = MagicMock(spec=discord.Thread)
+    thread.fetch_message = AsyncMock(
+        side_effect=discord.NotFound(MagicMock(status=404), "Unknown Message")
+    )
+    bot.get_channel = MagicMock(return_value=thread)  # pyright: ignore[reportAttributeAccessIssue]
+
+    await bot._retire_orphaned_turns()  # pyright: ignore[reportPrivateUsage]
+
+    assert await list_orphaned_turns(db_session, platform="discord") == [], (
+        "an unreachable embed must still clear its marker"
+    )
+
+
+async def test_sweep_runs_once_per_process_not_once_per_reconnect(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """on_ready re-fires on a full gateway reconnect; a live turn is not an orphan."""
+    await _make_orphan(db_session)
+    bot = _make_bot(db_session_factory)
+    message = MagicMock(spec=discord.Message)
+    message.edit = AsyncMock()
+    thread = MagicMock(spec=discord.Thread)
+    thread.fetch_message = AsyncMock(return_value=message)
+    bot.get_channel = MagicMock(return_value=thread)  # pyright: ignore[reportAttributeAccessIssue]
+
+    await bot._retire_orphaned_turns()  # pyright: ignore[reportPrivateUsage]
+    # A turn started after the sweep — its marker belongs to THIS process.
+    mapping_id = await _make_orphan(db_session, thread_id="556", message_id="778")
+    await bot._retire_orphaned_turns()  # pyright: ignore[reportPrivateUsage]
+
+    assert [row.id for row in await list_orphaned_turns(db_session, platform="discord")] == [
+        mapping_id
+    ], "a reconnect must not reap the turns this process is still rendering"

--- a/packages/core/alembic/versions/0008_active_turn_marker.py
+++ b/packages/core/alembic/versions/0008_active_turn_marker.py
@@ -1,0 +1,44 @@
+"""Record the in-flight turn's embed so a restart can lay it to rest.
+
+Revision ID: 0008_active_turn_marker
+Revises: 14d362cce079
+Create Date: 2026-08-07
+
+downgrade: safe
+
+Both columns are nullable with no backfill: a row with a NULL marker is a
+thread with no turn in flight, which is the correct reading for every row that
+exists when this lands.
+
+The marker cannot be inferred from `status`. That column tracks whether the
+SESSION MAPPING is usable ('live'/'dead'), not whether a turn is running --
+every healthy thread carries a live row forever. Sweeping on `status` would
+mark every working thread failed, so the in-flight turn needs a carrier of its
+own.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008_active_turn_marker"
+down_revision: str | None = "14d362cce079"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "thread_sessions",
+        sa.Column("active_turn_message_id", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "thread_sessions",
+        sa.Column("active_turn_started_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("thread_sessions", "active_turn_started_at")
+    op.drop_column("thread_sessions", "active_turn_message_id")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -313,6 +313,13 @@ class ThreadSession(Base):
     ma_session_id: Mapped[str] = mapped_column(Text, nullable=False)
     watermark_message_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'live'"))
+    # Set while a turn is running, cleared when it reaches a terminal state.
+    # Distinct from `status`, which is about the session mapping and stays
+    # 'live' on every healthy thread forever.
+    active_turn_message_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    active_turn_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/packages/core/daimon/core/stores/domain.py
+++ b/packages/core/daimon/core/stores/domain.py
@@ -176,6 +176,8 @@ class ThreadSessionRow(BaseModel):
     status: str
     created_at: datetime
     updated_at: datetime
+    active_turn_message_id: str | None = None
+    active_turn_started_at: datetime | None = None
 
 
 class GitHubOauthStateRow(BaseModel):

--- a/packages/core/daimon/core/stores/thread_sessions.py
+++ b/packages/core/daimon/core/stores/thread_sessions.py
@@ -151,6 +151,66 @@ async def update_watermark(
     await session.flush()
 
 
+async def mark_turn_active(
+    session: AsyncSession,
+    *,
+    id: _uuid.UUID,
+    active_turn_message_id: str,
+    now: datetime,
+) -> None:
+    """Record that a turn is running and which message is rendering it.
+
+    Written once the embed exists and the mapping row is known. The pair is
+    what lets a restarted process find embeds it can never finish -- the
+    process holding them is gone, and nothing else knows they were mid-flight.
+    """
+    await session.execute(
+        update(ThreadSession)
+        .where(ThreadSession.id == id)
+        .values(active_turn_message_id=active_turn_message_id, active_turn_started_at=now)
+    )
+    await session.flush()
+
+
+async def clear_active_turn(
+    session: AsyncSession,
+    *,
+    id: _uuid.UUID,
+) -> None:
+    """Clear the in-flight marker. Call on every terminal path, including failure."""
+    await session.execute(
+        update(ThreadSession)
+        .where(ThreadSession.id == id)
+        .values(active_turn_message_id=None, active_turn_started_at=None)
+    )
+    await session.flush()
+
+
+async def list_orphaned_turns(
+    session: AsyncSession,
+    *,
+    platform: str,
+) -> list[ThreadSessionRow]:
+    """Rows still flagged as mid-turn, i.e. turns no live process owns.
+
+    Only meaningful at process start: a turn cannot outlive the process
+    rendering it, so any marker still set when we boot belongs to a turn that
+    died with the previous container.
+
+    ponytail: assumes one adapter process per platform. With two, this would
+    reap the other's in-flight turns -- gate on an owner id before scaling out.
+    """
+    rows = (
+        await session.execute(
+            select(ThreadSession).where(
+                ThreadSession.platform == platform,
+                ThreadSession.active_turn_message_id.is_not(None),
+            )
+        )
+    ).scalars()
+    return [ThreadSessionRow.model_validate(row) for row in rows]
+
+
 async def mark_dead(
     session: AsyncSession,
     *,

--- a/packages/core/tests/stores/test_thread_sessions.py
+++ b/packages/core/tests/stores/test_thread_sessions.py
@@ -16,10 +16,13 @@ import pytest_asyncio
 from daimon.core._models import ThreadSession
 from daimon.core.stores.domain import ThreadSessionRow
 from daimon.core.stores.thread_sessions import (
+    clear_active_turn,
     create_thread_session,
     get_latest_thread_session,
     get_live_thread_session,
+    list_orphaned_turns,
     mark_dead,
+    mark_turn_active,
     update_watermark,
 )
 from daimon.testing.factories import make_tenant
@@ -420,3 +423,77 @@ async def test_get_latest_thread_session_returns_none_for_unknown_thread(
     )
 
     assert fetched is None
+
+
+async def test_healthy_threads_are_never_reported_as_orphans(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    """The load-bearing safety property of the whole sweep.
+
+    `status` stays 'live' on every healthy thread forever, so a sweep keyed on
+    it would mark every working thread failed. Only an explicit in-flight
+    marker may qualify a row.
+    """
+    await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="healthy-1",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_healthy",
+    )
+
+    orphans = await list_orphaned_turns(db_session, platform="discord")
+
+    assert orphans == [], "a live row with no in-flight marker is not an orphaned turn"
+
+
+async def test_marked_turn_is_listed_then_cleared(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="inflight-1",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_inflight",
+    )
+    started = datetime.now(UTC)
+
+    await mark_turn_active(db_session, id=row.id, active_turn_message_id="msg-42", now=started)
+    orphans = await list_orphaned_turns(db_session, platform="discord")
+    assert [o.id for o in orphans] == [row.id], "a marked row must be reapable after a restart"
+    assert orphans[0].active_turn_message_id == "msg-42", (
+        "the embed id must survive, since it is the only handle on the frozen message"
+    )
+
+    await clear_active_turn(db_session, id=row.id)
+    assert await list_orphaned_turns(db_session, platform="discord") == [], (
+        "a turn that reached a terminal state must not be reaped later"
+    )
+
+
+async def test_orphan_listing_is_scoped_to_one_platform(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    """A Discord boot must not retire Slack's in-flight turns."""
+    slack_row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id="slack-1",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_slack",
+    )
+    await mark_turn_active(
+        db_session, id=slack_row.id, active_turn_message_id="slack-msg", now=datetime.now(UTC)
+    )
+
+    assert await list_orphaned_turns(db_session, platform="discord") == [], (
+        "each adapter reaps only its own platform's turns"
+    )
+    assert len(await list_orphaned_turns(db_session, platform="slack")) == 1


### PR DESCRIPTION
Closes #50.

## The defect

A turn's render loop lives in the process that started it. Recreating the container mid-turn (i.e. every deploy) freezes the embed on `🧠 thinking` **permanently** — no error, no notice — while MA completes the turn server-side and bills it, with nobody left to post the answer.

```
05:49:59  bot posts the thinking embed   <- never resolves
05:50:44  daimon-discord-1 recreated, 46s into the turn
```

It also destroys the evidence: `docker logs` only retains output since the new container started, so the dead turn's `mention_received` is gone and its absence reads as *"the message never triggered a turn"* — the opposite of what happened. I lost time to exactly this while debugging something else today.

## The filed fix would have been a disaster

#50 proposed sweeping `thread_sessions` rows still marked `live`. That column tracks whether the **session mapping** is usable, not whether a turn is running — it stays `live` on every healthy thread forever. Sweeping on it would have marked every working thread in the deployment failed.

The in-flight turn needs a carrier of its own, so this adds one.

## Changes

- **Migration `0008`** — `active_turn_message_id` + `active_turn_started_at` on `thread_sessions`, both nullable, no backfill. A NULL marker means "no turn in flight", which is correct for every row that exists when this lands.
- **Store** — `mark_turn_active` / `clear_active_turn` / `list_orphaned_turns`, the last scoped by platform so a Discord boot never reaps Slack's turns.
- **Adapter** — marks once the embed exists and the mapping is known; clears on every terminal path (both the pre- and post-recovery mapping id, since recovery moves the turn to a new row while the old marker still points at the same message).
- **`_retire_orphaned_turns`** — runs first in `on_ready`, edits each frozen embed to say it was interrupted and can be retried, then clears the row.

## Two traps worth naming

**`on_ready` is not once-per-process.** It re-fires on every full gateway reconnect, so an unguarded sweep would reap the turns *this* process is currently rendering — turning a transient network blip into cancelled work. Guarded with a one-shot flag and covered by a test.

**Unreachable embeds must not be retried forever.** A deleted message, an archived thread, or a permission change makes the edit fail. Failures are swallowed per row and the row is cleared regardless, so one dead message neither stalls the sweep nor comes back on every boot.

## Not done

Draining in-flight turns before the container exits is the better fix and needs a readiness/lameduck story the compose refresh does not have. This makes the lie honest in the meantime.

## Tests

Store: healthy rows are never reported as orphans (the load-bearing safety property), mark→list→clear round trip, platform scoping. Sweep: edits and clears, clears even when the embed is unreachable, and does not reap live turns on a reconnect.

2815 pass across core + discord + integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)