### PR TITLE
fix(defaults): deliver seeded skill content edits to already-provisioned installs

### DIFF
--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -69,9 +69,9 @@ admin-managed — changing its prompt, model, skills, or MCP servers needs a
 workspace admin, because people are already relying on that configuration.
 And the agent this deployment ships with can't be edited at all, by anyone,
 admin included — fork it (`fork_agent`) to get an editable copy, and
-configure that instead. Deleting an agent (**archive_agent**) is never
-available from chat either way — that always goes through `/agent-setup` or
-the `daimon agents archive` CLI command.
+configure that instead. Deleting an agent (**archive_agent**) is admin-only
+in the same way — a workspace admin can archive from chat; for anyone else
+it goes through `/agent-setup` or the `daimon agents archive` CLI command.
 
 ## Credentials never travel through chat
 

--- a/packages/adapters/cli/daimon/adapters/cli/commands/defaults.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/defaults.py
@@ -217,7 +217,7 @@ async def defaults_verify(
         # with rate limits, and the ready-tenant count here is small enough that
         # parallelizing would only add provider-side contention risk for no gain.
         report = await verify_tenant_defaults(
-            rt.anthropic, defaults_root, tenant_id=tenant.id, public_url=public_url
+            rt.anthropic, rt.sessionmaker, defaults_root, tenant_id=tenant.id, public_url=public_url
         )
         outcome = classify_verification(report)
         results.append(

--- a/packages/adapters/cli/daimon/adapters/cli/sessions_bootstrap.py
+++ b/packages/adapters/cli/daimon/adapters/cli/sessions_bootstrap.py
@@ -121,7 +121,7 @@ async def resolve_agent_and_environment(
             daimon_tag=agent_name,
             cached_id=None,
             apply_callable=lambda: reconcile_tenant_defaults(
-                anthropic, defaults_root, tenant_id=tenant_id, public_url=None
+                anthropic, session_factory, defaults_root, tenant_id=tenant_id, public_url=None
             ),
             cache=cache,
         )
@@ -137,7 +137,7 @@ async def resolve_agent_and_environment(
             daimon_tag=env_name,
             cached_id=None,
             apply_callable=lambda: reconcile_tenant_defaults(
-                anthropic, defaults_root, tenant_id=tenant_id, public_url=None
+                anthropic, session_factory, defaults_root, tenant_id=tenant_id, public_url=None
             ),
             cache=cache,
         )

--- a/packages/adapters/cli/tests/commands/test_defaults.py
+++ b/packages/adapters/cli/tests/commands/test_defaults.py
@@ -132,6 +132,7 @@ def _install_verify_tenant_defaults(
 
     async def fake_verify_tenant_defaults(
         client: Any,
+        session_factory: Any,
         defaults_root: Path,
         *,
         tenant_id: uuid.UUID,

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -396,6 +396,7 @@ class DaimonBot(commands.Bot):
         try:
             report = await reconcile_tenant_defaults(
                 self.runtime.anthropic,
+                self.runtime.sessionmaker,
                 self.runtime.settings.defaults_root,
                 tenant_id=tenant_id,
                 public_url=public_url,

--- a/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
+++ b/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
@@ -218,7 +218,7 @@ async def _build_fire(
             daimon_tag=agent_tag,
             cached_id=row.agent_id,
             apply_callable=lambda: reconcile_tenant_defaults(
-                client, settings.defaults_root, tenant_id=row.tenant_id, public_url=_public_url
+                client, sm, settings.defaults_root, tenant_id=row.tenant_id, public_url=_public_url
             ),
             cache=resolver_cache,
         )
@@ -228,7 +228,7 @@ async def _build_fire(
             daimon_tag=deployment_default.environment_name or "default",
             cached_id=None,
             apply_callable=lambda: reconcile_tenant_defaults(
-                client, settings.defaults_root, tenant_id=row.tenant_id, public_url=_public_url
+                client, sm, settings.defaults_root, tenant_id=row.tenant_id, public_url=_public_url
             ),
             cache=resolver_cache,
         )

--- a/packages/adapters/scheduler/tests/test_main.py
+++ b/packages/adapters/scheduler/tests/test_main.py
@@ -697,6 +697,7 @@ async def test_fire_closure_threads_public_url_from_settings(
 
     async def fake_reconcile(
         client: object,
+        session_factory: object,
         defaults_root: object,
         *,
         tenant_id: uuid.UUID,

--- a/packages/core/alembic/versions/0009_seeded_skills.py
+++ b/packages/core/alembic/versions/0009_seeded_skills.py
@@ -1,0 +1,45 @@
+"""Content fingerprint per seeded skill, so an edit can reach a live install.
+
+Revision ID: 0009_seeded_skills
+Revises: 0008_active_turn_marker
+Create Date: 2026-08-07
+
+downgrade: safe
+
+No backfill. An absent row reads as "MA holds unknown content", which drives
+exactly one version upload per seeded skill on the first reconcile after this
+lands — the intended behaviour, since every existing install is carrying
+whatever content it was seeded with and nothing knows what that was.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009_seeded_skills"
+down_revision: str | None = "0008_active_turn_marker"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "seeded_skills",
+        sa.Column("tenant_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("content_hash", sa.Text(), nullable=False),
+        sa.Column("anthropic_id", sa.Text(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("tenant_id", "name", name="pk_seeded_skills"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("seeded_skills")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -421,6 +421,42 @@ class UserSkill(Base):
     )
 
 
+class SeededSkill(Base):
+    """Content fingerprint for one seeded (`defaults/skills/**`) skill per tenant.
+
+    Exists because MA gives skills no idempotence carrier of its own: they hold
+    no metadata field, `latest_version` is an opaque counter rather than a
+    content hash, and the API rejects any zip whose top-level directory differs
+    from the SKILL.md `name:` — so the folder name cannot carry a digest either.
+    Without a local fingerprint, `defaults apply` had no way to tell an edited
+    skill from an unchanged one and adopted every MA match as-is, which left
+    every `defaults/skills/**` edit undeliverable to an already-provisioned
+    install.
+
+    Distinct from `user_skills`, which fingerprints repo-synced skills per
+    principal and per agent. Seeded skills have neither: they are one row per
+    (tenant, skill name).
+    """
+
+    __tablename__ = "seeded_skills"
+    __table_args__ = (PrimaryKeyConstraint("tenant_id", "name", name="pk_seeded_skills"),)
+
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    content_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    anthropic_id: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class AgentGithubBinding(Base):
     """Per-agent GitHub credential overlay. Day-1 always empty; populated by
     Discord agent-setup panel. Single credential per principal day-1,

--- a/packages/core/daimon/core/defaults/_reconcile.py
+++ b/packages/core/daimon/core/defaults/_reconcile.py
@@ -33,6 +33,7 @@ from daimon.core.defaults.sweep import (
     sweep_removed_skills,
 )
 from daimon.core.errors import DaimonError, DefaultsError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 _log = structlog.get_logger(__name__)
 
@@ -96,6 +97,7 @@ async def _run_per_resource(
 
 async def _reconcile_core(
     client: AsyncAnthropic,
+    session_factory: async_sessionmaker[AsyncSession],
     defaults_root: Path,
     *,
     tenant_id: uuid.UUID,
@@ -109,6 +111,9 @@ async def _reconcile_core(
     Called by both `apply_defaults` (account_id=None, dry_run/run_preflight from caller)
     and `reconcile_tenant_defaults` (account_id=_derive_account_uuid(tenant_id),
     dry_run=False, run_preflight=True).
+
+    `session_factory` is here for the skill pass alone: MA has no carrier for
+    skill content idempotence, so the fingerprint lives in `seeded_skills`.
     """
     report = ApplyReport()
 
@@ -147,7 +152,7 @@ async def _reconcile_core(
         await _run_per_resource(
             report,
             lambda skill_dir=skill_dir: reconcile_skill(
-                client, skill_dir, tenant_id=tenant_id, dry_run=dry_run
+                client, session_factory, skill_dir, tenant_id=tenant_id, dry_run=dry_run
             ),
             kind="skill",
             name=skill_dir.name,

--- a/packages/core/daimon/core/defaults/apply.py
+++ b/packages/core/daimon/core/defaults/apply.py
@@ -43,6 +43,7 @@ async def apply_defaults(
     # 2-7. Delegate the shared reconcile spine.
     return await _reconcile_core(
         client,
+        session_factory,
         defaults_root,
         tenant_id=tenant_id,
         account_id=None,

--- a/packages/core/daimon/core/defaults/provisioning.py
+++ b/packages/core/daimon/core/defaults/provisioning.py
@@ -136,6 +136,7 @@ async def provision_tenant(
 
 async def reconcile_tenant_defaults(
     client: AsyncAnthropic,
+    session_factory: async_sessionmaker[AsyncSession],
     defaults_root: Path,
     *,
     tenant_id: uuid.UUID,
@@ -154,6 +155,7 @@ async def reconcile_tenant_defaults(
     """
     return await _reconcile_core(
         client,
+        session_factory,
         defaults_root,
         tenant_id=tenant_id,
         account_id=_derive_account_uuid(tenant_id),
@@ -165,6 +167,7 @@ async def reconcile_tenant_defaults(
 
 async def verify_tenant_defaults(
     client: AsyncAnthropic,
+    session_factory: async_sessionmaker[AsyncSession],
     defaults_root: Path,
     *,
     tenant_id: uuid.UUID,
@@ -193,6 +196,7 @@ async def verify_tenant_defaults(
     """
     return await _reconcile_core(
         client,
+        session_factory,
         defaults_root,
         tenant_id=tenant_id,
         account_id=_derive_account_uuid(tenant_id),

--- a/packages/core/daimon/core/defaults/reconcile_skills.py
+++ b/packages/core/daimon/core/defaults/reconcile_skills.py
@@ -1,12 +1,20 @@
 """Per-resource reconciliation for skills.
 
-Two-state decision tree: find on MA by display_title → skip (found) or create
-(not found). Skills are org-wide on MA, have no metadata field, and the
-`latest_version` column is an opaque monotonic counter rather than a content
-hash, so there is no carrier to drive idempotent updates from. `defaults apply`
-treats skills as immutable: when an MA match exists, it is adopted as-is and no
-new version is uploaded. Content updates flow through `daimon skills sync`
-explicitly. See L13 smoke-matrix finding + skills_idempotency_carrier probe.
+Three-state decision tree: find on MA by display_title → create (no match),
+skip (match, content unchanged), or upload a new version (match, content
+changed).
+
+MA offers nothing to compare content against. Skills carry no metadata field,
+`latest_version` is an opaque monotonic counter rather than a content hash, no
+endpoint returns a version's file bytes, and the API rejects any zip whose
+top-level directory differs from the SKILL.md `name:` — so the folder name
+cannot smuggle a digest either. The fingerprint therefore lives in our own
+`seeded_skills` table.
+
+Updates go to a new VERSION of the existing skill rather than a
+delete-and-recreate. Agents pin `version="latest"`, so they pick the new
+content up with no re-attach, and the skill id never changes — deleting a
+skill an agent references 400s every one of that agent's turns.
 
 Duplicate skills sharing a display_title (a race-prone artifact, observed in
 production with two cli-auth skills created 54ms apart) are deleted inline,
@@ -28,12 +36,15 @@ from daimon.core.defaults.report import Action, ResourceOutcome
 from daimon.core.errors import DefaultsError
 from daimon.core.ma import delete_skill_and_versions
 from daimon.core.skill_zip import build_skill_zip
+from daimon.core.stores.seeded_skills import load_seeded_skill, record_seeded_skill
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 _log = structlog.get_logger(__name__)
 
 
 async def reconcile_skill(
     client: AsyncAnthropic,
+    session_factory: async_sessionmaker[AsyncSession],
     skill_dir: Path,
     *,
     tenant_id: uuid.UUID,
@@ -68,22 +79,64 @@ async def reconcile_skill(
             )
             await delete_skill_and_versions(client, dup.id)
 
-    if ma_match is not None:
-        return ResourceOutcome(
-            kind="skill",
-            name=spec.name,
-            action=Action.SKIPPED,
-            anthropic_id=None if dry_run else ma_match.id,
-        )
-
-    if dry_run:
-        return ResourceOutcome(kind="skill", name=spec.name, action=Action.CREATED)
     pkg = build_skill_zip(skill_dir)
     try:
+        if ma_match is not None:
+            async with session_factory() as session:
+                recorded = await load_seeded_skill(session, tenant_id=tenant_id, name=spec.name)
+            # A recorded hash for a DIFFERENT skill id describes content we can
+            # no longer vouch for on this one, so it does not count as a match.
+            if (
+                recorded is not None
+                and recorded.anthropic_id == ma_match.id
+                and recorded.content_hash == pkg.content_hash
+            ):
+                return ResourceOutcome(
+                    kind="skill",
+                    name=spec.name,
+                    action=Action.SKIPPED,
+                    anthropic_id=None if dry_run else ma_match.id,
+                )
+            if dry_run:
+                return ResourceOutcome(kind="skill", name=spec.name, action=Action.UPDATED)
+            _log.info(
+                "reconcile.skill_content_changed",
+                name=spec.name,
+                skill_id=ma_match.id,
+                had_fingerprint=recorded is not None,
+            )
+            with pkg.path.open("rb") as fh:
+                await client.beta.skills.versions.create(
+                    ma_match.id, files=[("SKILL.zip", fh, "application/zip")]
+                )
+            async with session_factory() as session:
+                await record_seeded_skill(
+                    session,
+                    tenant_id=tenant_id,
+                    name=spec.name,
+                    content_hash=pkg.content_hash,
+                    anthropic_id=ma_match.id,
+                )
+                await session.commit()
+            return ResourceOutcome(
+                kind="skill", name=spec.name, action=Action.UPDATED, anthropic_id=ma_match.id
+            )
+
+        if dry_run:
+            return ResourceOutcome(kind="skill", name=spec.name, action=Action.CREATED)
         with pkg.path.open("rb") as fh:
             created = await client.beta.skills.create(
                 display_title=display_title, files=[("SKILL.zip", fh, "application/zip")]
             )
+        async with session_factory() as session:
+            await record_seeded_skill(
+                session,
+                tenant_id=tenant_id,
+                name=spec.name,
+                content_hash=pkg.content_hash,
+                anthropic_id=created.id,
+            )
+            await session.commit()
     finally:
         pkg.path.unlink(missing_ok=True)
     return ResourceOutcome(

--- a/packages/core/daimon/core/skill_zip.py
+++ b/packages/core/daimon/core/skill_zip.py
@@ -19,6 +19,7 @@ idempotent across re-syncs.
 
 from __future__ import annotations
 
+import hashlib
 import io
 import os
 import re
@@ -42,6 +43,7 @@ class SkillPackage:
 
     path: Path
     included_paths: list[str]
+    content_hash: str
     dropped_paths: list[str] = field(default_factory=list[str])
     uncompressed_bytes: int = 0
 
@@ -89,6 +91,17 @@ def build_skill_zip(skill_dir: Path, *, name: str | None = None) -> SkillPackage
         if len(included) > MAX_FILES:
             raise DefaultsError(f"{skill_dir}: too many files (> {MAX_FILES})")
 
+    # Hashed off the same (arc_name, bytes) pairs that are about to be written,
+    # so the digest can never describe something other than what was uploaded.
+    # The zip file itself is not hashable for this — it carries real mtimes, so
+    # two builds of identical content differ byte-for-byte.
+    digest = hashlib.sha256()
+    for arc_name, file in included:
+        digest.update(arc_name.encode())
+        digest.update(b"\0")
+        digest.update(file.read_bytes())
+        digest.update(b"\0")
+
     fd, tmp_path = tempfile.mkstemp(prefix=f"skill-{top}-", suffix=".zip")
     os.close(fd)
     tmp = Path(tmp_path)
@@ -99,6 +112,7 @@ def build_skill_zip(skill_dir: Path, *, name: str | None = None) -> SkillPackage
     return SkillPackage(
         path=tmp,
         included_paths=[arc for arc, _ in included],
+        content_hash=digest.hexdigest(),
         dropped_paths=dropped,
         uncompressed_bytes=total_bytes,
     )

--- a/packages/core/daimon/core/smoke.py
+++ b/packages/core/daimon/core/smoke.py
@@ -138,6 +138,7 @@ async def run_smoke_check(
             # daimon-mcp server — a bare turn binds no vault credential, and
             # MA fails session init for an agent whose MCP server has none.
             anthropic,
+            session_factory,
             defaults_root,
             tenant_id=tenant_id,
             public_url=None,

--- a/packages/core/daimon/core/stores/domain.py
+++ b/packages/core/daimon/core/stores/domain.py
@@ -319,6 +319,16 @@ class TenantLedgerRow(BaseModel):
     occurred_at: datetime
 
 
+class SeededSkillRow(BaseModel):
+    model_config = ConfigDict(from_attributes=True, frozen=True)
+
+    tenant_id: uuid.UUID
+    name: str
+    content_hash: str
+    anthropic_id: str
+    updated_at: datetime
+
+
 class UserSkillRow(BaseModel):
     model_config = ConfigDict(from_attributes=True, frozen=True)
 

--- a/packages/core/daimon/core/stores/seeded_skills.py
+++ b/packages/core/daimon/core/stores/seeded_skills.py
@@ -1,0 +1,59 @@
+"""Free-function store for seeded_skills.
+
+Content fingerprint per (tenant_id, name) for skills shipped in
+`defaults/skills/**`. This is the idempotence carrier MA does not provide —
+see the `SeededSkill` model for why nothing on the provider side can hold it.
+
+No try/except — exceptions propagate. None from `load_seeded_skill` means
+'never seeded here', NEVER 'something broke'.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from daimon.core._models import SeededSkill
+from daimon.core.stores.domain import SeededSkillRow
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def load_seeded_skill(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+) -> SeededSkillRow | None:
+    orm = await session.get(SeededSkill, (tenant_id, name))
+    if orm is None:
+        return None
+    return SeededSkillRow.model_validate(orm)
+
+
+async def record_seeded_skill(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    content_hash: str,
+    anthropic_id: str,
+) -> None:
+    """Record the content just uploaded to MA under `anthropic_id`.
+
+    Written AFTER the upload succeeds. The reverse order would let a failed
+    upload leave a fingerprint claiming MA holds content it does not, and the
+    skill would then never be retried.
+    """
+    stmt = pg_insert(SeededSkill).values(
+        tenant_id=tenant_id,
+        name=name,
+        content_hash=content_hash,
+        anthropic_id=anthropic_id,
+    )
+    await session.execute(
+        stmt.on_conflict_do_update(
+            index_elements=[SeededSkill.tenant_id, SeededSkill.name],
+            set_={"content_hash": content_hash, "anthropic_id": anthropic_id},
+        )
+    )
+    await session.flush()

--- a/packages/core/daimon/core/turn/admission.py
+++ b/packages/core/daimon/core/turn/admission.py
@@ -94,6 +94,7 @@ async def admit(
     async def _apply() -> object:
         return await reconcile_tenant_defaults(
             deps.anthropic,
+            deps.sessionmaker,
             deps.defaults_root,
             tenant_id=tenant_id,
             public_url=deps.public_url,

--- a/packages/core/tests/defaults/test_provisioning.py
+++ b/packages/core/tests/defaults/test_provisioning.py
@@ -346,6 +346,7 @@ async def test_reconcile_tenant_defaults_idempotent_on_rerun(
 
     first = await reconcile_tenant_defaults(
         build_fake_anthropic_http(_create_serving_router().dispatch),
+        db_session_factory,
         tmp_path,
         tenant_id=result.tenant_id,
     )
@@ -355,6 +356,7 @@ async def test_reconcile_tenant_defaults_idempotent_on_rerun(
 
     second = await reconcile_tenant_defaults(
         build_fake_anthropic_http(_existing_resources_router(tenant_id=result.tenant_id).dispatch),
+        db_session_factory,
         tmp_path,
         tenant_id=result.tenant_id,
     )
@@ -411,6 +413,7 @@ async def test_reconcile_tenant_defaults_uses_passed_tenant_not_bootstrap(
     router = _create_serving_router(agent_create_handler=on_agent_create)
     await reconcile_tenant_defaults(
         build_fake_anthropic_http(router.dispatch),
+        db_session_factory,
         tmp_path,
         tenant_id=result.tenant_id,
     )
@@ -452,6 +455,7 @@ async def test_reconcile_tenant_defaults_applies_tenant_prefix_to_skill_title(
     router = _create_serving_router(skill_create_handler=on_skill_create)
     await reconcile_tenant_defaults(
         build_fake_anthropic_http(router.dispatch),
+        db_session_factory,
         tmp_path,
         tenant_id=result.tenant_id,
     )
@@ -526,6 +530,7 @@ async def test_reconcile_tenant_defaults_stamps_guild_account_on_agents(
     )
     await reconcile_tenant_defaults(
         build_fake_anthropic_http(router.dispatch),
+        db_session_factory,
         tmp_path,
         tenant_id=result.tenant_id,
     )
@@ -683,6 +688,7 @@ async def test_reconcile_tenant_defaults_seed_tree_with_skill_ref_pins_tenant_sk
 
     report = await reconcile_tenant_defaults(
         build_fake_anthropic_http(router.dispatch),
+        db_session_factory,
         tmp_path,
         tenant_id=result.tenant_id,
     )
@@ -846,6 +852,7 @@ async def test_reconcile_tenant_defaults_flips_status_failed_when_skills_list_pa
     # Assertion 1: run completes without raising (boundary catches SkillsListTruncatedError).
     report = await reconcile_tenant_defaults(
         build_fake_anthropic_http(router.dispatch),
+        db_session_factory,
         tmp_path,
         tenant_id=result.tenant_id,
     )
@@ -1102,11 +1109,15 @@ async def test_verify_tenant_defaults_in_sync_report_makes_zero_write_requests(
     client = build_fake_anthropic_http(router.dispatch)
 
     # Build real state once: a genuine reconcile creates the skill/env/agent.
-    first = await reconcile_tenant_defaults(client, tmp_path, tenant_id=result.tenant_id)
+    first = await reconcile_tenant_defaults(
+        client, db_session_factory, tmp_path, tenant_id=result.tenant_id
+    )
     assert not first.is_failure(), "seeding reconcile must succeed before verifying"
 
     writes_before_verify = write_count[0]
-    report = await verify_tenant_defaults(client, tmp_path, tenant_id=result.tenant_id)
+    report = await verify_tenant_defaults(
+        client, db_session_factory, tmp_path, tenant_id=result.tenant_id
+    )
 
     assert write_count[0] == writes_before_verify, (
         "verify_tenant_defaults must make zero write requests: "
@@ -1136,7 +1147,9 @@ async def test_verify_tenant_defaults_classifies_missing_agent_as_diverged(
     client = build_fake_anthropic_http(router.dispatch)
 
     # Build real state for env/skill only, never for the agent.
-    first = await reconcile_tenant_defaults(client, tmp_path, tenant_id=result.tenant_id)
+    first = await reconcile_tenant_defaults(
+        client, db_session_factory, tmp_path, tenant_id=result.tenant_id
+    )
     assert not first.is_failure()
 
     # A second router with an empty agent list (env/skill state carried over via a
@@ -1184,6 +1197,7 @@ async def test_verify_tenant_defaults_classifies_missing_agent_as_diverged(
     )
     report = await verify_tenant_defaults(
         build_fake_anthropic_http(missing_agent_router.dispatch),
+        db_session_factory,
         tmp_path,
         tenant_id=result.tenant_id,
     )
@@ -1207,14 +1221,18 @@ async def test_verify_tenant_defaults_classifies_fingerprint_mismatch_as_diverge
     router, _write_count = _build_stateful_router(tenant_id=result.tenant_id)
     client = build_fake_anthropic_http(router.dispatch)
 
-    first = await reconcile_tenant_defaults(client, tmp_path, tenant_id=result.tenant_id)
+    first = await reconcile_tenant_defaults(
+        client, db_session_factory, tmp_path, tenant_id=result.tenant_id
+    )
     assert not first.is_failure()
 
     # The spec changed since that reconcile ran (model bumped) — MA still carries
     # the OLD spec_hash, so a fresh fingerprint no longer matches it.
     (tmp_path / "agents" / "daimon.yaml").write_text("name: daimon\nmodel: claude-opus-4-7\n")
 
-    report = await verify_tenant_defaults(client, tmp_path, tenant_id=result.tenant_id)
+    report = await verify_tenant_defaults(
+        client, db_session_factory, tmp_path, tenant_id=result.tenant_id
+    )
     outcome = classify_verification(report)
     assert outcome.status == "diverged", f"expected diverged, got {outcome.status!r}"
     assert ("agent", "daimon") in [(c.kind, c.name) for c in outcome.changed], (
@@ -1248,7 +1266,10 @@ async def test_verify_tenant_defaults_classifies_provider_read_failure_as_unveri
         ),
     )
     report = await verify_tenant_defaults(
-        build_fake_anthropic_http(router.dispatch), tmp_path, tenant_id=result.tenant_id
+        build_fake_anthropic_http(router.dispatch),
+        db_session_factory,
+        tmp_path,
+        tenant_id=result.tenant_id,
     )
     outcome = classify_verification(report)
     assert outcome.status == "unverifiable", (

--- a/packages/core/tests/defaults/test_reconcile_skills.py
+++ b/packages/core/tests/defaults/test_reconcile_skills.py
@@ -5,18 +5,29 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import pytest_asyncio
 from anthropic.types.beta import SkillListResponse
+from anthropic.types.beta.skills import VersionCreateResponse
 from daimon.core.defaults.reconcile_skills import reconcile_skill
 from daimon.core.defaults.report import Action
+from daimon.core.stores.seeded_skills import load_seeded_skill
+from daimon.testing.factories import make_tenant
 from daimon.testing.ma import MARouter, list_response
 from daimon.testing.ma import build_fake_anthropic as build_fake_anthropic_http
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-TENANT_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+@pytest_asyncio.fixture
+async def tenant_id(db_session: AsyncSession) -> uuid.UUID:
+    """A real tenants row — `seeded_skills.tenant_id` is a FK onto it."""
+    tenant = await make_tenant(db_session)
+    await db_session.commit()
+    return tenant.id
 
 
 def _write_skill(tmp_path: Path, name: str = "brainstorming", body: str = "body\n") -> Path:
     skill_dir = tmp_path / name
-    skill_dir.mkdir()
+    skill_dir.mkdir(exist_ok=True)
     (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\ndescription: d\n---\n{body}")
     return skill_dir
 
@@ -39,7 +50,12 @@ def _router_with_skills(skills: list[dict[str, Any]]) -> MARouter:
     return router
 
 
-async def test_reconcile_skill_creates_when_not_on_ma(tmp_path: Path) -> None:
+async def test_reconcile_skill_creates_when_not_on_ma(
+    tmp_path: Path,
+    tenant_id: uuid.UUID,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
     """No MA match → CREATE path; skills.create called with display_title and zip."""
     skill_dir = _write_skill(tmp_path)
     router = _router_with_skills([])
@@ -64,36 +80,131 @@ async def test_reconcile_skill_creates_when_not_on_ma(tmp_path: Path) -> None:
     router.add("POST", r"/v1/skills", on_create)
     client = build_fake_anthropic_http(router.dispatch)
 
-    outcome = await reconcile_skill(client, skill_dir, tenant_id=TENANT_ID, dry_run=False)
+    outcome = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=False
+    )
     assert outcome.action is Action.CREATED
     assert outcome.anthropic_id == "sk_new"
     assert create_called, "skills.create must have been called"
 
+    recorded = await load_seeded_skill(db_session, tenant_id=tenant_id, name="brainstorming")
+    assert recorded is not None, "a create must leave a fingerprint, or the next boot re-uploads"
+    assert recorded.anthropic_id == "sk_new"
 
-async def test_reconcile_skill_skips_when_on_ma(tmp_path: Path) -> None:
-    """MA match found → SKIPPED; defaults apply never pushes a new version.
 
-    Per L13 fix: skills are immutable from defaults apply's perspective. Content
-    updates flow through `daimon skills sync` explicitly. There is no
-    content-addressed carrier on MA to drive idempotency from, and constant
-    re-upload churn (33 versions/day in production) is worse than stale content.
+async def test_reconcile_skill_skips_when_content_matches_the_fingerprint(
+    tmp_path: Path,
+    tenant_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Unchanged content → SKIPPED, and no version is pushed.
+
+    The steady state. The boot sweep runs this for every tenant on every deploy,
+    so an unchanged skill must cost reads only.
     """
     skill_dir = _write_skill(tmp_path)
-    router = _router_with_skills(
-        [_existing_skill_row("sk_1", f"{str(TENANT_ID)[:8]}-brainstorming")]
+    ma_row = _existing_skill_row("sk_1", f"{str(tenant_id)[:8]}-brainstorming")
+    router = _router_with_skills([ma_row])
+    router.add(
+        "POST",
+        r"/v1/skills/[^/]+/versions",
+        lambda req, _m: httpx.Response(
+            200,
+            json=VersionCreateResponse(
+                id="skv_1",
+                created_at="2026-04-21T00:00:00Z",
+                description="d",
+                directory="brainstorming",
+                name="brainstorming",
+                skill_id="sk_1",
+                type="skill_version",
+                version="1",
+            ).model_dump(mode="json"),
+        ),
     )
-    # No POST handler registered for versions — router raises if reconcile
-    # tries to push a new version.
     client = build_fake_anthropic_http(router.dispatch)
 
-    outcome = await reconcile_skill(client, skill_dir, tenant_id=TENANT_ID, dry_run=False)
-    assert outcome.action is Action.SKIPPED, (
-        "reconcile must not push a new version when MA match exists"
+    # First pass records the fingerprint (no local row yet → one upload).
+    first = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=False
     )
-    assert outcome.anthropic_id == "sk_1"
+    assert first.action is Action.UPDATED, (
+        "an install with no fingerprint holds unknown content and must be refreshed once"
+    )
+
+    # Second pass, same bytes.
+    second = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=False
+    )
+    assert second.action is Action.SKIPPED, "identical content must not push another version"
+    assert second.anthropic_id == "sk_1"
 
 
-async def test_reconcile_skill_deletes_duplicates_keeping_newest(tmp_path: Path) -> None:
+async def test_reconcile_skill_pushes_a_new_version_when_the_content_changed(
+    tmp_path: Path,
+    tenant_id: uuid.UUID,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The defect this exists for: an edit to a seeded SKILL.md must reach a live install.
+
+    A new VERSION of the same skill, not a delete-and-recreate: agents pin
+    `version="latest"`, and deleting a referenced skill 400s every one of that
+    agent's turns.
+    """
+    skill_dir = _write_skill(tmp_path, body="original guidance\n")
+    ma_row = _existing_skill_row("sk_1", f"{str(tenant_id)[:8]}-brainstorming")
+    router = _router_with_skills([ma_row])
+    version_posts: list[str] = []
+
+    def on_version_create(req: httpx.Request, _m: object) -> httpx.Response:
+        version_posts.append(req.url.path)
+        return httpx.Response(
+            200,
+            json=VersionCreateResponse(
+                id="skv_2",
+                created_at="2026-04-22T00:00:00Z",
+                description="d",
+                directory="brainstorming",
+                name="brainstorming",
+                skill_id="sk_1",
+                type="skill_version",
+                version="2",
+            ).model_dump(mode="json"),
+        )
+
+    router.add("POST", r"/v1/skills/[^/]+/versions", on_version_create)
+    router.add(
+        "DELETE",
+        r"/v1/skills/[^/]+",
+        lambda req, _m: httpx.Response(500, json={"never": "delete a referenced skill"}),
+    )
+    client = build_fake_anthropic_http(router.dispatch)
+
+    await reconcile_skill(client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=False)
+    async with db_session_factory() as read:
+        before = await load_seeded_skill(read, tenant_id=tenant_id, name="brainstorming")
+    assert before is not None
+
+    _write_skill(tmp_path, body="corrected guidance\n")
+    outcome = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=False
+    )
+
+    assert outcome.action is Action.UPDATED, "an edited SKILL.md must be delivered, not skipped"
+    assert outcome.anthropic_id == "sk_1", "the skill id must not change — agents pin it"
+    assert len(version_posts) == 2, f"one version push per content change, got {version_posts}"
+    async with db_session_factory() as read:
+        after = await load_seeded_skill(read, tenant_id=tenant_id, name="brainstorming")
+    assert after is not None
+    assert after.content_hash != before.content_hash, "the fingerprint must track the new content"
+
+
+async def test_reconcile_skill_deletes_duplicates_keeping_newest(
+    tmp_path: Path,
+    tenant_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
     """Multiple skills with same display_title → keep newest, delete older(s).
 
     Mirrors the agent/env dedup pattern. cli-auth duplicated in production with
@@ -101,11 +212,10 @@ async def test_reconcile_skill_deletes_duplicates_keeping_newest(tmp_path: Path)
     on next apply.
     """
     skill_dir = _write_skill(tmp_path)
-    # Two skills, same display_title. Newest = sk_new (later created_at).
     older = SkillListResponse(
         id="sk_old",
         type="custom",
-        display_title=f"{str(TENANT_ID)[:8]}-brainstorming",
+        display_title=f"{str(tenant_id)[:8]}-brainstorming",
         latest_version="1",
         created_at="2026-04-20T00:00:00Z",
         updated_at="2026-04-20T00:00:00Z",
@@ -114,7 +224,7 @@ async def test_reconcile_skill_deletes_duplicates_keeping_newest(tmp_path: Path)
     newer = SkillListResponse(
         id="sk_new",
         type="custom",
-        display_title=f"{str(TENANT_ID)[:8]}-brainstorming",
+        display_title=f"{str(tenant_id)[:8]}-brainstorming",
         latest_version="1",
         created_at="2026-04-21T00:00:00Z",
         updated_at="2026-04-21T00:00:00Z",
@@ -124,79 +234,113 @@ async def test_reconcile_skill_deletes_duplicates_keeping_newest(tmp_path: Path)
 
     deleted_skill_ids: list[str] = []
 
-    # delete_skill_and_versions does: list versions, delete each, then delete skill.
-    def on_versions_list(req: httpx.Request, _m: object) -> httpx.Response:
-        return list_response([])
-
     def on_skill_delete(req: httpx.Request, m: object) -> httpx.Response:
-        # extract the {skill_id} from the URL — path is /v1/skills/{id}
         sk_id = req.url.path.rstrip("/").rsplit("/", 1)[-1]
         deleted_skill_ids.append(sk_id)
         return httpx.Response(200, json={"id": sk_id, "deleted": True})
 
-    router.add("GET", r"/v1/skills/[^/]+/versions", on_versions_list)
+    # delete_skill_and_versions does: list versions, delete each, then delete skill.
+    router.add("GET", r"/v1/skills/[^/]+/versions", lambda req, _m: list_response([]))
     router.add("DELETE", r"/v1/skills/[^/]+", on_skill_delete)
+    router.add(
+        "POST",
+        r"/v1/skills/[^/]+/versions",
+        lambda req, _m: httpx.Response(
+            200,
+            json=VersionCreateResponse(
+                id="skv_1",
+                created_at="2026-04-21T00:00:00Z",
+                description="d",
+                directory="brainstorming",
+                name="brainstorming",
+                skill_id="sk_new",
+                type="skill_version",
+                version="2",
+            ).model_dump(mode="json"),
+        ),
+    )
     client = build_fake_anthropic_http(router.dispatch)
 
-    outcome = await reconcile_skill(client, skill_dir, tenant_id=TENANT_ID, dry_run=False)
-    assert outcome.action is Action.SKIPPED, "canonical match still skips version push"
+    outcome = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=False
+    )
     assert outcome.anthropic_id == "sk_new", "newest must be adopted as canonical"
     assert deleted_skill_ids == ["sk_old"], (
         f"only the older duplicate must be deleted, got {deleted_skill_ids}"
     )
 
 
-async def test_reconcile_skill_dry_run_create(tmp_path: Path) -> None:
+async def test_reconcile_skill_dry_run_create(
+    tmp_path: Path,
+    tenant_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
     """dry_run=True with no MA match → CREATED action, no write calls, no anthropic_id."""
     skill_dir = _write_skill(tmp_path)
     # No POST handler — router raises if reconcile tries to write.
     router = _router_with_skills([])
     client = build_fake_anthropic_http(router.dispatch)
 
-    outcome = await reconcile_skill(client, skill_dir, tenant_id=TENANT_ID, dry_run=True)
+    outcome = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=True
+    )
     assert outcome.action is Action.CREATED
     assert outcome.anthropic_id is None
 
 
-async def test_reconcile_skill_dry_run_skip(tmp_path: Path) -> None:
-    """dry_run=True with MA match → SKIPPED action (no version push planned), no anthropic_id."""
+async def test_reconcile_skill_dry_run_reports_a_content_change_without_writing(
+    tmp_path: Path,
+    tenant_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """`defaults verify` must call an edited skill diverged, and must stay read-only.
+
+    No POST handler is registered, so any write attempt trips the router.
+    """
     skill_dir = _write_skill(tmp_path)
-    # No POST handler for versions — router raises if reconcile tries to write.
     router = _router_with_skills(
-        [_existing_skill_row("sk_1", f"{str(TENANT_ID)[:8]}-brainstorming")]
+        [_existing_skill_row("sk_1", f"{str(tenant_id)[:8]}-brainstorming")]
     )
     client = build_fake_anthropic_http(router.dispatch)
 
-    outcome = await reconcile_skill(client, skill_dir, tenant_id=TENANT_ID, dry_run=True)
-    assert outcome.action is Action.SKIPPED
+    outcome = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=True
+    )
+    assert outcome.action is Action.UPDATED, "unfingerprinted content on MA is not verified in-sync"
     assert outcome.anthropic_id is None
 
 
-async def test_reconcile_skill_looks_up_prefixed_display_title(tmp_path: Path) -> None:
+async def test_reconcile_skill_looks_up_prefixed_display_title(
+    tmp_path: Path,
+    tenant_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
     """reconcile_skill uses the prefixed title for the MA lookup, not the bare spec name.
 
-    The MA skills list returns one skill with the PREFIXED display_title
-    (str(TENANT_ID)[:8] + "-brainstorming"). If reconcile looked up the bare
-    "brainstorming" it would not match and would call skills.create instead.
-    The test registers no POST /v1/skills handler so any create attempt trips the
-    router's AssertionError — confirming the lookup used the prefixed form.
+    The MA skills list returns one skill with the PREFIXED display_title. If
+    reconcile looked up the bare "brainstorming" it would miss and call
+    skills.create — which the absent POST /v1/skills handler turns into a
+    router AssertionError.
     """
     skill_dir = _write_skill(tmp_path)
-    prefixed = f"{str(TENANT_ID)[:8]}-brainstorming"
-    # Only the prefixed title is on MA. If reconcile queries by bare name it misses
-    # and tries to CREATE, tripping the no-POST-handler assertion.
+    prefixed = f"{str(tenant_id)[:8]}-brainstorming"
     router = _router_with_skills([_existing_skill_row("sk_1", prefixed)])
     client = build_fake_anthropic_http(router.dispatch)
 
-    outcome = await reconcile_skill(client, skill_dir, tenant_id=TENANT_ID, dry_run=False)
-    assert outcome.action is Action.SKIPPED, (
+    outcome = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=True
+    )
+    assert outcome.action is Action.UPDATED, (
         f"reconcile must match the prefixed display_title '{prefixed}' on MA; "
         "CREATED means it queried the unprefixed 'brainstorming' and missed"
     )
-    assert outcome.anthropic_id == "sk_1", "adopted skill id must be sk_1 (the prefixed-title row)"
 
 
-async def test_reconcile_skill_creates_with_same_prefixed_title(tmp_path: Path) -> None:
+async def test_reconcile_skill_creates_with_same_prefixed_title(
+    tmp_path: Path,
+    tenant_id: uuid.UUID,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
     """skills.create is called with the same prefixed title used for the lookup.
 
     No MA match exists. The POST /v1/skills handler captures the display_title
@@ -205,30 +349,17 @@ async def test_reconcile_skill_creates_with_same_prefixed_title(tmp_path: Path) 
     a title mismatch between find and create).
     """
     skill_dir = _write_skill(tmp_path)
-    prefixed = f"{str(TENANT_ID)[:8]}-brainstorming"
+    prefixed = f"{str(tenant_id)[:8]}-brainstorming"
     router = _router_with_skills([])
 
     captured_display_title: list[str] = []
 
     def on_create(req: httpx.Request, _m: object) -> httpx.Response:
         # The SDK sends display_title as a multipart field; search the raw body bytes.
-        body_bytes = req.content
-        for part in body_bytes.split(b"\r\n"):
-            if part.startswith(b"{"):
-                # JSON part — not the display_title field
-                continue
-        # Decode and find the display_title value in the multipart payload
-        body_text = body_bytes.decode("latin-1")
+        body_text = req.content.decode("latin-1")
         for segment in body_text.split("\r\n"):
-            segment = segment.strip()
-            # Candidate value segment that matches our prefixed display_title
-            if (
-                segment
-                and not segment.startswith("--")
-                and not segment.startswith("Content-")
-                and segment == prefixed
-            ):
-                captured_display_title.append(segment)
+            if segment.strip() == prefixed:
+                captured_display_title.append(prefixed)
         return httpx.Response(
             200,
             json=SkillListResponse(
@@ -245,7 +376,9 @@ async def test_reconcile_skill_creates_with_same_prefixed_title(tmp_path: Path) 
     router.add("POST", r"/v1/skills", on_create)
     client = build_fake_anthropic_http(router.dispatch)
 
-    outcome = await reconcile_skill(client, skill_dir, tenant_id=TENANT_ID, dry_run=False)
+    outcome = await reconcile_skill(
+        client, db_session_factory, skill_dir, tenant_id=tenant_id, dry_run=False
+    )
     assert outcome.action is Action.CREATED, "no MA match → CREATE path"
     assert outcome.anthropic_id == "sk_created"
     assert captured_display_title == [prefixed], (

--- a/packages/core/tests/stores/test_seeded_skills.py
+++ b/packages/core/tests/stores/test_seeded_skills.py
@@ -1,0 +1,63 @@
+"""The content fingerprint for seeded skills.
+
+MA offers no carrier for skill-content idempotence, so this table is the only
+thing standing between "a `defaults/skills/**` edit reaches every install" and
+"it reaches none of them".
+"""
+
+from __future__ import annotations
+
+from daimon.core.stores.seeded_skills import load_seeded_skill, record_seeded_skill
+from daimon.testing.factories import make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def test_absent_row_reads_as_never_seeded(db_session: AsyncSession) -> None:
+    """An install predating this table has no row, which must drive one refresh."""
+    tenant = await make_tenant(db_session)
+
+    assert await load_seeded_skill(db_session, tenant_id=tenant.id, name="brainstorming") is None
+
+
+async def test_record_round_trips_and_overwrites_on_conflict(db_session: AsyncSession) -> None:
+    tenant = await make_tenant(db_session)
+    await record_seeded_skill(
+        db_session,
+        tenant_id=tenant.id,
+        name="brainstorming",
+        content_hash="hash-v1",
+        anthropic_id="sk_1",
+    )
+
+    row = await load_seeded_skill(db_session, tenant_id=tenant.id, name="brainstorming")
+    assert row is not None
+    assert row.content_hash == "hash-v1"
+
+    await record_seeded_skill(
+        db_session,
+        tenant_id=tenant.id,
+        name="brainstorming",
+        content_hash="hash-v2",
+        anthropic_id="sk_1",
+    )
+
+    row = await load_seeded_skill(db_session, tenant_id=tenant.id, name="brainstorming")
+    assert row is not None
+    assert row.content_hash == "hash-v2", (
+        "a second upload must replace the fingerprint, not accumulate rows"
+    )
+
+
+async def test_fingerprints_do_not_leak_across_tenants(db_session: AsyncSession) -> None:
+    """Skills are per-tenant on MA; a neighbour's upload must not make us skip ours."""
+    one = await make_tenant(db_session, workspace_id="guild-1")
+    two = await make_tenant(db_session, workspace_id="guild-2")
+    await record_seeded_skill(
+        db_session,
+        tenant_id=one.id,
+        name="brainstorming",
+        content_hash="hash-v1",
+        anthropic_id="sk_1",
+    )
+
+    assert await load_seeded_skill(db_session, tenant_id=two.id, name="brainstorming") is None

--- a/tests/integration/test_seeded_prompt_tool_claims.py
+++ b/tests/integration/test_seeded_prompt_tool_claims.py
@@ -79,8 +79,9 @@ _TOKEN_RE = re.compile(r"\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b")
 _INTENTIONAL_NON_CHAT_MENTIONS: dict[str, str] = {
     # named only to distinguish it from remove_skill, its chat-reachable sibling
     "delete_skill": "tenant-wide destructive skill delete; admin-only, panel-only",
-    # named only to say it is NOT available from chat, unlike most roster ops
-    "archive_agent": "destructive agent delete; admin-only, panel/CLI-only",
+    # admin-only, so an ADMIN chat turn does reach it — this test's chat
+    # session is deliberately non-admin, which is the only reason it is here
+    "archive_agent": "destructive agent delete; admin-gated, so absent from a non-admin chat turn",
 }
 
 


### PR DESCRIPTION
Two defects in the seeded-defaults path, both of which make an already-installed
tenant behave differently from a fresh one.

## Seeded skill content edits never reached a live install

Editing `defaults/skills/<name>/SKILL.md` had no path to an existing install.
`reconcile_skill` matched on `display_title` and, on a hit, adopted the MA skill
as-is and reported `SKIPPED` — content was never compared and no new version was
ever uploaded. The documented escape hatch, `daimon skills sync`, takes a git
repo URL and is the agent-repo path; nothing pushed `defaults/skills/**`
anywhere.

That is worse than a stale doc. An agent resolving a conflict between its skill
and its own observable toolset sides with the skill, so a stale seeded skill can
switch off a shipped feature — observed live, with the same prompt producing a
redirect and a working button seven minutes apart.

### Why a local fingerprint

MA offers no carrier to drive idempotence from:

- skills hold no metadata field
- `latest_version` is an opaque monotonic counter, not a content hash
- no endpoint returns a version's file bytes
- the zip's top-level directory looked promising (it comes back on every
  version) but the API rejects a mismatch, verified against the live API:
  `The folder name 'x-aaaa1111' must match the skill name 'x' in SKILL.md.`

So the fingerprint lives in a new `seeded_skills` table, one row per
(tenant, skill name), and `build_skill_zip` now hashes the same
`(arcname, bytes)` pairs it is about to upload — the digest can never describe
something other than what was sent.

### Why a new version, not a recreate

A content change uploads a new **version** of the existing skill. Agents pin
`version="latest"`, so they pick it up with no re-attach, and the skill id never
moves — deleting a skill an agent references 400s every one of that agent's
turns.

### Migration behaviour

No backfill. An install with no row reads as "MA holds unknown content", which
drives exactly one version upload per seeded skill on the first reconcile after
this lands. That is intended: nothing knows what those installs were seeded
with. `defaults verify` reports those tenants diverged until that first
reconcile runs, which is an honest answer rather than a false pass.

`session_factory` is threaded through `_reconcile_core` for the skill pass alone;
every caller already had one.

## The seeded skill stated a falsehood about `archive_agent`

`workspace-setup` said archiving an agent "is never available from chat either
way". `archive_agent` carries `tags={"admin"}` and the MCP identity middleware
enables admin components whenever `is_admin` resolves true, so an admin's chat
session does hold the tool. Asked to use it, the agent quoted the skill, and
when told the text was wrong it held the line anyway — a capability claim reads
as policy.

Reworded to describe the admin gate the way the surrounding paragraph already
describes the others. The tool-claims drift gate keeps `archive_agent` on its
exclusion list, but now for the honest reason: that test's chat session is
deliberately non-admin.

## Verification

- `uv run pytest` — 4459 passed, 4 skipped
- `uv run pyright` — 0 errors
- `uv run lint-imports` — 6 kept, 0 broken
- New coverage: the store's fingerprint semantics and cross-tenant isolation;
  reconcile creating, skipping on a hash match, and pushing a version on a
  content change without touching the skill id; dry-run reporting a change
  while making zero writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)