### PR TITLE
fix(defaults): raise the skills page limit — production locked itself out at 100

### DIFF
--- a/packages/core/daimon/core/defaults/ma_index.py
+++ b/packages/core/daimon/core/defaults/ma_index.py
@@ -32,7 +32,17 @@ _log = structlog.get_logger(__name__)
 # live, 2026-06-10); agents.list paginates correctly under identical
 # conditions. A full page therefore means
 # the org skill view is truncated, not simply "more pages to follow".
-_SKILLS_PAGE_LIMIT = 100
+#
+# Raised 100 -> 1000 after production crossed 100 skills and locked itself out
+# of every write path: the seeded-agent reconcile could not resolve a skill id,
+# `defaults verify` reported every tenant unverifiable, the smoke turn could not
+# resolve its agent, and a fresh install would have failed to provision at all.
+# `skills.list` honours a larger limit — 103 rows came back with has_more=False
+# at limit=200 against production, verified live 2026-08-08 — so the ceiling was
+# ours, not the API's. This buys headroom, it does not remove the ceiling: the
+# truncation guards below are still the thing that keeps a partial view from
+# driving a delete, and at 1000 skills they will fire again.
+_SKILLS_PAGE_LIMIT = 1000
 
 
 async def find_agents_by_daimon_tag(

--- a/packages/core/tests/defaults/test_ma_index.py
+++ b/packages/core/tests/defaults/test_ma_index.py
@@ -7,6 +7,7 @@ import httpx
 import structlog
 from anthropic.types.beta import BetaManagedAgentsAgent, SkillListResponse
 from daimon.core.defaults.ma_index import (
+    _SKILLS_PAGE_LIMIT,  # pyright: ignore[reportPrivateUsage]
     find_agent_by_daimon_tag,
     find_skill_by_display_title,
     list_skills_lenient,
@@ -266,23 +267,13 @@ async def test_find_skill_by_display_title() -> None:
 
 
 async def test_find_skill_by_display_title_warns_when_ceiling_hit() -> None:
-    """When `skills.list` returns a full page of 100 rows with no next_page
-    cursor, the helper must emit a ceiling-hit warning so callers know
-    adoption may be incomplete."""
-    # 100 filler skills, no target. `has_more`/`next_page` omitted so async-for
-    # stops after the first page (mirrors the MA bug shape).
-    filler = [
-        SkillListResponse(
-            id=f"sk_{i}",
-            type="custom",
-            display_title=f"unrelated-{i}",
-            latest_version="1",
-            created_at="2026-04-21T00:00:00Z",
-            updated_at="2026-04-21T00:00:00Z",
-            source="custom",
-        ).model_dump(mode="json")
-        for i in range(100)
-    ]
+    """When `skills.list` returns a FULL page with no next_page cursor, the
+    helper must emit a ceiling-hit warning so callers know adoption may be
+    incomplete. Sized off the constant so raising the limit cannot silently
+    turn this into a half-page test that proves nothing."""
+    # A full page of filler, no target. `has_more`/`next_page` omitted so
+    # async-for stops after the first page (mirrors the MA bug shape).
+    filler = _make_filler_skills(_SKILLS_PAGE_LIMIT)
     router = MARouter()
     router.add("GET", r"/v1/skills", lambda req, _m: list_response(filler))
     client = build_fake_anthropic_http(router.dispatch)
@@ -292,7 +283,8 @@ async def test_find_skill_by_display_title_warns_when_ceiling_hit() -> None:
 
     assert match is None, "target is absent; adoption must return None"
     assert any(
-        r["event"] == "ma_index.skills_list_ceiling_hit" and r["limit"] == 100 for r in logs
+        r["event"] == "ma_index.skills_list_ceiling_hit" and r["limit"] == _SKILLS_PAGE_LIMIT
+        for r in logs
     ), f"expected skills_list_ceiling_hit warning, got events: {[r['event'] for r in logs]}"
 
 
@@ -317,9 +309,11 @@ def _make_filler_skills(count: int) -> list[dict[str, object]]:
 
 
 async def test_list_skills_strict_raises_when_page_full() -> None:
-    """list_skills_strict must raise SkillsListTruncatedError on a 100-row page."""
+    """list_skills_strict must raise SkillsListTruncatedError on a full page."""
     router = MARouter()
-    router.add("GET", r"/v1/skills", lambda req, _m: list_response(_make_filler_skills(100)))
+    router.add(
+        "GET", r"/v1/skills", lambda req, _m: list_response(_make_filler_skills(_SKILLS_PAGE_LIMIT))
+    )
     client = build_fake_anthropic_http(router.dispatch)
     import pytest
 
@@ -328,12 +322,13 @@ async def test_list_skills_strict_raises_when_page_full() -> None:
 
 
 async def test_list_skills_strict_returns_rows_on_partial_page() -> None:
-    """list_skills_strict must return rows normally on a 99-row page."""
+    """list_skills_strict must return rows normally on a one-short-of-full page."""
     router = MARouter()
-    router.add("GET", r"/v1/skills", lambda req, _m: list_response(_make_filler_skills(99)))
+    partial = _SKILLS_PAGE_LIMIT - 1
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response(_make_filler_skills(partial)))
     client = build_fake_anthropic_http(router.dispatch)
     rows = await list_skills_strict(client)
-    assert len(rows) == 99, "strict list must return all 99 rows from a partial page"
+    assert len(rows) == partial, "strict list must return every row from a partial page"
 
 
 # ---------------------------------------------------------------------------
@@ -344,12 +339,14 @@ async def test_list_skills_strict_returns_rows_on_partial_page() -> None:
 async def test_list_skills_lenient_truncated_flag_is_true_on_full_page() -> None:
     """list_skills_lenient must return (rows, True) and emit a warning on a full page."""
     router = MARouter()
-    router.add("GET", r"/v1/skills", lambda req, _m: list_response(_make_filler_skills(100)))
+    router.add(
+        "GET", r"/v1/skills", lambda req, _m: list_response(_make_filler_skills(_SKILLS_PAGE_LIMIT))
+    )
     client = build_fake_anthropic_http(router.dispatch)
     with structlog.testing.capture_logs() as logs:
         rows, truncated = await list_skills_lenient(client)
     assert truncated is True, "truncated flag must be True when page is full"
-    assert len(rows) == 100, "all 100 rows must still be returned in lenient mode"
+    assert len(rows) == _SKILLS_PAGE_LIMIT, "every row must still be returned in lenient mode"
     assert any(r["event"] == "ma_index.skills_list_truncated" for r in logs), (
         f"expected skills_list_truncated warning, got: {[r['event'] for r in logs]}"
     )
@@ -381,8 +378,8 @@ async def test_find_skill_by_display_title_raises_on_full_page_even_when_match_f
         updated_at="2026-04-21T00:00:00Z",
         source="custom",
     ).model_dump(mode="json")
-    # 99 filler + 1 target = 100 total (full page)
-    skills = _make_filler_skills(99) + [target]
+    # one short of the limit, plus the target = exactly a full page
+    skills = _make_filler_skills(_SKILLS_PAGE_LIMIT - 1) + [target]
     router = MARouter()
     router.add("GET", r"/v1/skills", lambda req, _m: list_response(skills))
     client = build_fake_anthropic_http(router.dispatch)

--- a/packages/core/tests/defaults/test_provisioning.py
+++ b/packages/core/tests/defaults/test_provisioning.py
@@ -22,6 +22,9 @@ from anthropic.types.beta import (
     SkillListResponse,
 )
 from daimon.core._models import Account, Tenant
+from daimon.core.defaults.ma_index import (
+    _SKILLS_PAGE_LIMIT,  # pyright: ignore[reportPrivateUsage]
+)
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_ACCOUNT,
     MA_METADATA_KEY_NAME,
@@ -746,7 +749,7 @@ async def test_reconcile_tenant_defaults_flips_status_failed_when_skills_list_pa
     tmp_path: Path,
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """SC-5 end-to-end proof: skills list at 100 rows (full page) -> SkillsListTruncatedError
+    """SC-5 end-to-end proof: skills list at a FULL page -> SkillsListTruncatedError
     is caught by _run_per_resource -> FAILED skill outcome -> provision_status 'failed'.
 
     Assertions:
@@ -779,7 +782,7 @@ async def test_reconcile_tenant_defaults_flips_status_failed_when_skills_list_pa
             updated_at="2026-04-21T00:00:00Z",
             source="custom",
         ).model_dump(mode="json")
-        for i in range(100)
+        for i in range(_SKILLS_PAGE_LIMIT)
     ]
 
     router = MARouter()

--- a/packages/core/tests/skill_sync/test_orchestrator.py
+++ b/packages/core/tests/skill_sync/test_orchestrator.py
@@ -32,6 +32,9 @@ from anthropic.types.beta.skills import VersionCreateResponse
 from cryptography.fernet import Fernet, MultiFernet
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from daimon.core.defaults.ma_index import (
+    _SKILLS_PAGE_LIMIT,  # pyright: ignore[reportPrivateUsage]
+)
 from daimon.core.defaults.metadata import tenant_scoped_display_title
 from daimon.core.github_credentials import encrypt_token
 from daimon.core.ma_identity import derive_agent_uuid
@@ -1211,7 +1214,8 @@ async def test_recovery_raises_skills_list_truncated_error_on_full_page(
         transport=httpx.MockTransport(lambda req: httpx.Response(200, content=tarball))
     )
 
-    # 100 rows (a full page) — triggers SkillsListTruncatedError in strict mode.
+    # A full page — triggers SkillsListTruncatedError in strict mode. Sized off
+    # the constant so raising the limit cannot turn this into a partial page.
     full_page = [
         SkillListResponse(
             id=f"sk_{i:03d}",
@@ -1222,7 +1226,7 @@ async def test_recovery_raises_skills_list_truncated_error_on_full_page(
             updated_at="2026-04-21T00:00:00Z",
             source="custom",
         )
-        for i in range(100)
+        for i in range(_SKILLS_PAGE_LIMIT)
     ]
 
     def on_create(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:


### PR DESCRIPTION
Production crossed 100 org-wide skills and every defaults write path stopped working.

`skills.list` returned a full page, the truncation guard correctly refused to decide
on a view it could not confirm was complete, and that cascaded:

- the seeded-agent reconcile could not resolve a skill id, so seeded agents kept their old config
- `defaults verify` reported every tenant `unverifiable`, `ok: false`
- the post-deploy smoke turn could not resolve its agent
- **a fresh install would have failed to provision** — the one-click install path

Turns themselves were unaffected: existing agents resolve from their own records, so
live installs kept working throughout.

## The ceiling was ours, not the API's

```
limit=  200 -> returned  103  has_more=False
limit=  500 -> returned  103  has_more=False
limit= 1000 -> returned  103  has_more=False
```

Verified live. `100` was a self-imposed constant; the API returns everything.

## What this does and does not fix

Raises the limit to 1000. It buys headroom — it does not remove the ceiling. The
truncation guards remain the thing that stops a partial view from driving a delete,
and at 1000 skills they fire again with the same symptoms.

Tests now size their fillers off `_SKILLS_PAGE_LIMIT` rather than a hardcoded `100`,
so raising the limit again cannot silently turn a full-page test into a half-page
test that proves nothing.

## Verification

- `uv run pytest` — 4459 passed, 4 skipped
- `uv run pyright` — 0 errors
- `uv run lint-imports` — 6 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)