### PR TITLE
fix(turn): reconnect when the SSE body drops mid-stream

### DIFF
--- a/packages/core/daimon/core/turn/driver.py
+++ b/packages/core/daimon/core/turn/driver.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, cast
 
 import anthropic as _anthropic
+import httpx
 import structlog
 from anthropic import AsyncAnthropic
 from anthropic.types.beta.sessions import (
@@ -36,6 +37,14 @@ from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt
 log = structlog.get_logger(__name__)
 
 InterruptPhase = Literal["pre-stream", "replay", "reattach"]
+
+# The SDK only wraps httpx failures raised while *opening* a request into
+# `APIConnectionError`. Once an SSE stream is open, a mid-body drop surfaces
+# raw from httpx while iterating the response — `RemoteProtocolError` for the
+# common "peer closed connection without sending complete message body"
+# case. Both mean the same thing to us (stream died, session still alive
+# server-side), so both take the reconnect-and-replay path.
+_CONNECTION_LOST = (_anthropic.APIConnectionError, httpx.RemoteProtocolError)
 
 # Guarded single-render: no-op if `diff(prev, state)` is empty; else calls
 # `lifecycle.on_render(state)` and advances the render anchor. Finalizers
@@ -161,7 +170,7 @@ async def _pump(
         try:
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(2),
-                retry=retry_if_exception_type(_anthropic.APIConnectionError),
+                retry=retry_if_exception_type(_CONNECTION_LOST),
                 reraise=True,
             ):
                 with attempt:
@@ -195,7 +204,7 @@ async def _pump(
                 render_once=_render_once,
                 interrupt_timeout_s=interrupt_timeout_s,
             )
-        except _anthropic.APIConnectionError as err:
+        except _CONNECTION_LOST as err:
             # tenacity exhausted with reraise=True.
             await _cancel_render()
             return await _finalize_connection_lost(

--- a/packages/core/tests/turn/fakes.py
+++ b/packages/core/tests/turn/fakes.py
@@ -40,6 +40,19 @@ class RaiseConnection:
 
 
 @dataclass
+class RaiseStreamDrop:
+    """Stream step: raise the raw httpx error a mid-body SSE drop produces.
+
+    The SDK does not wrap this one — it escapes while iterating the already
+    open response, not while opening it.
+    """
+
+    message: str = (
+        "peer closed connection without sending complete message body (incomplete chunked read)"
+    )
+
+
+@dataclass
 class RaiseStatus:
     """Stream step: raise APIStatusError (non-429) mid-iteration."""
 
@@ -68,7 +81,9 @@ class BlockForever:
     """
 
 
-StreamAction = YieldEvent | RaiseConnection | RaiseStatus | RaiseRateLimit | BlockForever
+StreamAction = (
+    YieldEvent | RaiseConnection | RaiseStreamDrop | RaiseStatus | RaiseRateLimit | BlockForever
+)
 
 
 @dataclass
@@ -118,6 +133,8 @@ class _FakeEventStream:
                 yield step.event
             elif isinstance(step, RaiseConnection):
                 raise anthropic.APIConnectionError(request=_make_request())  # type: ignore[call-arg]
+            elif isinstance(step, RaiseStreamDrop):
+                raise httpx.RemoteProtocolError(step.message, request=_make_request())
             elif isinstance(step, RaiseStatus):
                 raise _make_status_error(step.status_code, step.message)
             elif isinstance(step, BlockForever):

--- a/packages/core/tests/turn/test_driver_hooks.py
+++ b/packages/core/tests/turn/test_driver_hooks.py
@@ -18,6 +18,7 @@ from .fakes import (
     FakeAnthropic,
     RaiseConnection,
     RaiseRateLimit,
+    RaiseStreamDrop,
     RecordingLifecycle,
     YieldEvent,
 )
@@ -104,6 +105,43 @@ async def test_driver_calls_on_reconnect_on_connection_drop() -> None:
         "driver must call on_reconnect with 'connection_dropped' after APIConnectionError"
     )
     assert len(lc.terminal_success) == 1, "turn must complete successfully after reconnect"
+
+
+@pytest.mark.asyncio
+async def test_driver_reconnects_when_sse_body_drops_mid_stream() -> None:
+    """A mid-body SSE drop arrives as a raw httpx error, not APIConnectionError.
+
+    It must still take the reconnect-and-replay path rather than escaping the
+    driver as an unhandled exception.
+    """
+    fa = FakeAnthropic()
+    pre = make_agent_message(event_id="sevt_1", text="hello ")
+    mid = make_agent_message(event_id="sevt_2", text="world")
+    done = make_status_idle(event_id="sevt_3", stop_reason=make_end_turn())
+
+    fa.beta.sessions.events.stream_scripts = [
+        [YieldEvent(pre), RaiseStreamDrop()],
+        [YieldEvent(mid), YieldEvent(done)],
+    ]
+    fa.beta.sessions.events.replay_events = [pre, mid]
+    lc = RecordingLifecycle()
+
+    await run_turn(
+        anthropic=_cast(fa),
+        session_id="sess_1",
+        user_message="hi",
+        lifecycle=lc,
+        cancel=asyncio.Event(),
+        render_interval_s=0.001,
+        now=_now,
+        billing=_EXEMPT,
+    )
+
+    assert lc.reconnects == ["connection_dropped"], (
+        "driver must reconnect after a raw httpx.RemoteProtocolError mid-stream"
+    )
+    assert len(lc.terminal_success) == 1, "turn must complete successfully after reconnect"
+    assert not lc.terminal_failures, "a recovered stream drop must not surface as a failure"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A live turn surfaced `❌ **Unexpected error**: peer closed connection without sending complete message body (incomplete chunked read)` in the thread — on a turn that actually **succeeded**. The session kept running server-side, finished its work, uploaded its artifact, and went idle cleanly. Only the adapter's view of it died.

That string comes from `h11`, via `httpx.RemoteProtocolError`.

## Cause

The SDK wraps httpx failures into `APIConnectionError` only around `self._client.send(...)` — connect and headers. Once `events.stream()` has returned, the body is read lazily while iterating, so a mid-stream drop escapes **raw**.

All three of the driver's recovery gates were keyed on `APIConnectionError`, so none of them fired:

- the tenacity retry predicate → no reconnect + replay
- the terminal `except` arm → no `_finalize_connection_lost`
- `on_reconnect("connection_dropped")` → never called

The raw httpx error propagated past the driver to the adapter's outermost `except Exception`, which renders the generic branch.

## Fix

Treat `httpx.RemoteProtocolError` as connection-lost alongside `APIConnectionError`, via one `_CONNECTION_LOST` tuple used by both gates. The reconnect path already replays from the event log, which is exactly the right recovery here — the session was alive the whole time.

## Test

`test_driver_reconnects_when_sse_body_drops_mid_stream` scripts a raw `RemoteProtocolError` mid-body and asserts the turn reconnects, replays, and completes. Verified it fails on `main` and passes with the fix.

Scoped deliberately to `RemoteProtocolError` rather than all of `httpx.TransportError` — widen it if other httpx types show up in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)