### PR TITLE
chore(billing): raise the default signup credit to $10

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,7 +118,7 @@ DAIMON_ANTHROPIC__API_KEY=
 # Multiplier applied to raw Anthropic usage cost before billing the tenant. 1.0 = pass-through.
 # DAIMON_BILLING__MARKUP=1.0
 # USD credit automatically seeded when a guild/workspace is provisioned, so a freshly-installed tenant can chat immediately on trial credit before paying. Set to 0 to require payment before use.
-# DAIMON_BILLING__SIGNUP_CREDIT=5.00
+# DAIMON_BILLING__SIGNUP_CREDIT=10.00
 
 # === Scheduler (optional) ===
 # Seconds between scheduler ticks (loop sleep).

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -505,7 +505,7 @@ class BillingSettings(BaseModel):
         ),
     )
     signup_credit: Decimal = Field(
-        default=Decimal("5.00"),
+        default=Decimal("10.00"),
         description=(
             "USD credit automatically seeded when a guild/workspace is "
             "provisioned, so a freshly-installed tenant can chat immediately "

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -198,8 +198,8 @@ def test_billing_defaults_when_no_env_set(monkeypatch: pytest.MonkeyPatch) -> No
     assert settings.billing.markup == Decimal("1.0"), (
         "default markup must be Decimal('1.0') (pass-through)"
     )
-    assert settings.billing.signup_credit == Decimal("5.00"), (
-        "default signup_credit must be >0 (Decimal('5.00')) so one-click works on trial "
+    assert settings.billing.signup_credit == Decimal("10.00"), (
+        "default signup_credit must be >0 (Decimal('10.00')) so one-click works on trial "
         "credit before payment; operators set 0 for pay-first"
     )
 


### PR DESCRIPTION
Bumps `BillingSettings.signup_credit` from `5.00` to `10.00` — the trial credit seeded when a guild/workspace is provisioned, so a fresh install can chat before paying.

Nothing else hardcodes the amount: the user-facing copy is formatted from the setting (`oauth_slack.py`), and `.env.example` is regenerated from the Settings model. Operators who want a different amount — or pay-first — still set `DAIMON_BILLING__SIGNUP_CREDIT`.

Production currently has no override for this var, so it runs the code default; this PR is what moves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)