### PR TITLE
docs(mcp): point sync_skills at request_repo_binding on auth failure

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
@@ -411,7 +411,18 @@ def register_skill_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         states both what was imported and what was attached.
 
         Before calling, inspect the repo structure to determine the correct ``path``
-        parameter (empty string = repo root). ``branch`` defaults to ``"main"``."""
+        parameter (empty string = repo root). ``branch`` defaults to ``"main"``.
+
+        IF THIS FAILS BECAUSE THE REPO IS PRIVATE AND UNREADABLE, call
+        ``request_repo_binding`` for that repo — do not report the sync as
+        blocked and do not ask the user to paste a token here. This tool
+        deliberately has no token parameter: the credential is supplied
+        out-of-band through a button and modal so it never passes through tool
+        arguments. Once the binding exists, the per-agent tier short-circuits
+        every later sync of that repo with zero GitHub I/O. Credential
+        precedence is documented on ``_resolve_skill_sync_credentials`` above,
+        which delegates to ``resolve_skill_sync_token``; a missing GitHub App
+        installation is NOT a blocker, it is just a later tier."""
         return await _sync_impl(runtime, await _auth(ctx), url, branch, path, agent_name)
 
     @mcp.tool


### PR DESCRIPTION
`sync_skills` has no token parameter by design — the credential arrives out-of-band via button + modal so it never passes through tool arguments. But the tool's own docstring never said so, and `skills.py` never referenced `request_repo_binding` anywhere.

Consequence, hit for real: a reader lands on `sync_skills`, sees no token param, sees the GitHub App has no installation, and concludes the sync is blocked and the operator must supply a PAT some other way. It isn't blocked — the App is just a later tier, and the button flow is the designed recovery.

Adds that to the docstring the agent actually reads at runtime, and points back at `_resolve_skill_sync_credentials` for precedence rather than restating the four tiers a third time.

Docstring only, no behavior change.