### PR TITLE
fix(mcp): refresh the rendered tool-schema snapshot

### DIFF
--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2730,6 +2730,17 @@
         
         Before calling, inspect the repo structure to determine the correct ``path``
         parameter (empty string = repo root). ``branch`` defaults to ``"main"``.
+        
+        IF THIS FAILS BECAUSE THE REPO IS PRIVATE AND UNREADABLE, call
+        ``request_repo_binding`` for that repo — do not report the sync as
+        blocked and do not ask the user to paste a token here. This tool
+        deliberately has no token parameter: the credential is supplied
+        out-of-band through a button and modal so it never passes through tool
+        arguments. Once the binding exists, the per-agent tier short-circuits
+        every later sync of that repo with zero GitHub I/O. Credential
+        precedence is documented on ``_resolve_skill_sync_credentials`` above,
+        which delegates to ``resolve_skill_sync_token``; a missing GitHub App
+        installation is NOT a blocker, it is just a later tier.
       ''',
       'parameters': dict({
         'additionalProperties': False,


### PR DESCRIPTION
`pytest-mcp` has been failing on `main` since the `sync_skills` docstring gained its private-repo recovery paragraph — the rendered tool-schema snapshot was never regenerated. Because the deploy job is gated on the test jobs, **staging has not deployed since**, so nothing merged after that point is on staging or promotable.

Snapshot-only change. The diff is exactly the docstring text already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)