### PR TITLE
fix(discord): bind the repo and attach the skills when a skill-repo PAT is pasted

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -45,14 +45,18 @@ opened.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 
+import anthropic
 import httpx
 import structlog
+from anthropic.types.beta import BetaManagedAgentsAgent
+from anthropic.types.beta.beta_managed_agents_skill_params import BetaManagedAgentsSkillParams
 from daimon.adapters.discord.agent_setup.credentials import (
     _MAX_SECRET_VALUE_BYTES,  # pyright: ignore[reportPrivateUsage]  # reusing PasteSecretModal's byte cap rather than inventing a second number
 )
-from daimon.adapters.discord.agent_setup.write import mask_tail, store_inline_pat
+from daimon.adapters.discord.agent_setup.write import mask_tail
 from daimon.adapters.discord.credential_repo_bind import (
     refuse_if_shared_and_not_admin_for_request,
     resolve_repo_binding_credential,
@@ -60,9 +64,12 @@ from daimon.adapters.discord.credential_repo_bind import (
 from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.credential_requests import split_skill_repo_target
 from daimon.core.defaults.ma_index import find_agent_by_derived_uuid
+from daimon.core.defaults.report import Action, ResourceOutcome
+from daimon.core.defaults.spec_merge import merge_skills_with_ma
 from daimon.core.errors import DaimonError
 from daimon.core.github_repo_auth import normalize_owner_repo
 from daimon.core.github_visibility import pat_can_access_repo
+from daimon.core.ma import update_agent_with_version_retry
 from daimon.core.mcp_attach import attach_mcp_server_to_agent
 from daimon.core.mcp_vault import add_external_mcp_credential
 from daimon.core.skills.pipeline import run_skill_sync
@@ -368,12 +375,36 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
                         ephemeral=True,
                     )
                     return
-                await store_inline_pat(
+                # Reuse the repo kind's resolver rather than calling
+                # `store_inline_pat` directly: it returns the `ma_secret_ref`
+                # AND the access proof that `set_binding` requires, so the two
+                # writes cannot disagree about what was established.
+                ma_secret_ref, proof = await resolve_repo_binding_credential(
                     self._runtime,
-                    account_id=consumed_row.account_id,
+                    http_client,
                     agent_id=consumed_row.agent_id,
-                    plaintext_pat=pat,
+                    account_id=consumed_row.account_id,
+                    repo_url=url,
+                    pasted_pat=pat,
+                    now=now,
                 )
+                # Without this row the stored PAT is unreachable: the skill-sync
+                # resolver finds a per-agent token by walking this tenant's
+                # `agent_repo_binding` rows FOR THIS REPO, not by agent alone
+                # (the session JWT carries no agent_id claim). Storing the
+                # credential without binding the repo is what made a pasted
+                # token look ignored — every later sync resolved `token=None`,
+                # got GitHub's 404, and asked for the credential again.
+                async with self._runtime.sessionmaker.begin() as session:
+                    await set_binding(
+                        session,
+                        tenant_id=consumed_row.tenant_id,
+                        agent_id=consumed_row.agent_id,
+                        repo_url=url,
+                        default_branch=branch,
+                        ma_secret_ref=ma_secret_ref,
+                        proof=proof,
+                    )
                 outcomes = await run_skill_sync(
                     self._runtime.anthropic,
                     http_client,
@@ -408,11 +439,68 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
             )
             return
 
+        attach_note = await self._attach_to_requested_agent(
+            tenant_id=consumed_row.tenant_id,
+            agent_id=consumed_row.agent_id,
+            outcomes=outcomes,
+        )
         await interaction.followup.send(
             f"Imported {len(outcomes)} skill(s) from `{normalize_owner_repo(url)}`. "
-            "The token is stored, so future imports from repos it can read will not ask again.",
+            f"{attach_note} The token is stored and the repo is bound, so future "
+            "imports from it will not ask again.",
             ephemeral=True,
         )
+
+    async def _attach_to_requested_agent(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        outcomes: list[ResourceOutcome],
+    ) -> str:
+        """Attach the just-imported skills to the agent this request named.
+
+        Importing puts skills in the tenant's shared library; it does not put
+        them on an agent. The request row already names the agent, so doing
+        only the import leaves the user staring at an agent with no skills and
+        no way to tell that anything worked.
+
+        Returns prose rather than raising: the import has already succeeded by
+        the time this runs, so a failure here is partial and both halves must
+        be reported truthfully.
+        """
+        skill_ids = sorted(
+            outcome.anthropic_id
+            for outcome in outcomes
+            if outcome.anthropic_id is not None
+            and outcome.action in (Action.CREATED, Action.UPDATED)
+        )
+        if not skill_ids:
+            return "Nothing new to attach."
+        agent = await find_agent_by_derived_uuid(
+            self._runtime.anthropic, tenant_id=tenant_id, agent_id=agent_id
+        )
+        if agent is None:
+            return "Could not attach: that agent no longer exists. The skills are in the library."
+        new_skills: list[BetaManagedAgentsSkillParams] = [
+            {"type": "custom", "skill_id": skill_id} for skill_id in skill_ids
+        ]
+
+        async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
+            return await self._runtime.anthropic.beta.agents.update(
+                fresh.id, version=fresh.version, skills=merge_skills_with_ma(new_skills, fresh)
+            )
+
+        try:
+            await update_agent_with_version_retry(self._runtime.anthropic, agent.id, _apply)
+        except (DaimonError, anthropic.APIStatusError) as err:
+            _log.warning(
+                "credential_modal.skill_repo_attach_failed",
+                agent_id=str(agent_id),
+                err_type=type(err).__name__,
+            )
+            return f"Imported, but attaching to `{agent.name}` failed ({type(err).__name__})."
+        return f"Attached {len(skill_ids)} to `{agent.name}`."
 
 
 class RepoBindModal(discord.ui.Modal, title="Bind repo"):

--- a/packages/adapters/discord/tests/test_credential_modals.py
+++ b/packages/adapters/discord/tests/test_credential_modals.py
@@ -24,16 +24,23 @@ import pytest
 import structlog
 from anthropic.types.beta import BetaManagedAgentsAgent
 from cryptography.fernet import Fernet
+from daimon.adapters.discord import credential_modals as credential_modals_mod
 from daimon.adapters.discord import credential_repo_bind as credential_repo_bind_mod
 from daimon.adapters.discord.credential_modals import (
     EnvCredentialModal,
     McpCredentialModal,
     RepoBindModal,
+    SkillRepoModal,
 )
 from daimon.adapters.discord.credential_repo_bind import _SHARED_AGENT_MESSAGE
 from daimon.adapters.discord.runtime import DiscordRuntime
-from daimon.core.credential_requests import build_custom_id, mint_request_token
+from daimon.core.credential_requests import (
+    build_custom_id,
+    build_skill_repo_target,
+    mint_request_token,
+)
 from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
+from daimon.core.defaults.report import Action, ResourceOutcome
 from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.notebooks._rate_limit import RateLimiter
@@ -185,6 +192,38 @@ async def _seed_repo_request(
             session,
             token=token,
             kind="repo",
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            account_id=account.id,
+            target=target,
+            mcp_server_url=None,
+            requester_platform_user_id="100000000000000001",
+            channel_id="chan-1",
+            expires_at=datetime.now(UTC) + timedelta(minutes=30),
+        )
+    return row
+
+
+async def _seed_skill_repo_request(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    ma_agent_id: str,
+    target: str,
+    guild_id: int = _GUILD_ID,
+) -> CredentialRequestRow:
+    """Seed a `kind="skill_repo"` request row. Same real-tenant/real-account
+    reasoning as `_seed_repo_request`: `set_binding` writes a proof carrying an
+    FK to `accounts.id`."""
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(guild_id))
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+    token = mint_request_token()
+    async with db_session_factory() as session, session.begin():
+        tenant = await make_tenant(session, platform="discord", workspace_id=str(guild_id))
+        account = await make_account(session, tenant=tenant)
+        row = await create_credential_request(
+            session,
+            token=token,
+            kind="skill_repo",
             tenant_id=tenant_id,
             agent_id=agent_id,
             account_id=account.id,
@@ -951,3 +990,112 @@ async def test_repo_modal_never_leaks_the_pasted_token(
             "a gate refusal must never reach the submit log line -- the gate must run before it "
             "(this is the mutation this test pins: moving the log line above the gate turns it red)"
         )
+
+
+# --- SkillRepoModal -----------------------------------------------------
+
+
+async def test_skill_repo_modal_binds_the_repo_so_a_later_sync_can_resolve_the_pat(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The pasted token must produce an agent_repo_binding row, not just a
+    credential. The skill-sync resolver walks this tenant's bindings FOR THIS
+    REPO to find a per-agent PAT, so without the row the stored token is
+    unreachable and every later sync falls back to an anonymous 404."""
+    ma_agent_id = "agent_skill_repo_bind"
+    monkeypatch.setattr(
+        credential_repo_bind_mod, "pat_can_access_repo", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(credential_modals_mod, "pat_can_access_repo", AsyncMock(return_value=True))
+    monkeypatch.setattr(credential_modals_mod, "run_skill_sync", AsyncMock(return_value=[]))
+
+    row = await _seed_skill_repo_request(
+        db_session_factory,
+        ma_agent_id=ma_agent_id,
+        target=build_skill_repo_target("https://github.com/o/skills-repo", "main", ""),
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="daimon", managed=True)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(_list_agents_handler([agent])),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    modal = SkillRepoModal(runtime=runtime, request_row=row)
+    modal.pat_in._value = "ghp_skill_repo_token"  # pyright: ignore[reportPrivateUsage]
+    await modal.on_submit(_admin_interaction())
+
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert binding is not None, (
+        "a pasted skill-repo token must bind the repo -- without the binding the "
+        "credential is stored but unreachable, which is the loop this pins"
+    )
+    assert binding.ma_secret_ref == f"inline-pat:{row.agent_id}"
+    assert binding.proof_kind == "pat"
+
+
+async def test_skill_repo_modal_attaches_the_imported_skills_to_the_requested_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Importing puts skills in the tenant library; the request names an agent,
+    so the modal must also attach them. Import-without-attach leaves the user
+    with an agent that has no skills and a success message saying otherwise."""
+    ma_agent_id = "agent_skill_repo_attach"
+    monkeypatch.setattr(
+        credential_repo_bind_mod, "pat_can_access_repo", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(credential_modals_mod, "pat_can_access_repo", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        credential_modals_mod,
+        "run_skill_sync",
+        AsyncMock(
+            return_value=[
+                ResourceOutcome(
+                    kind="skill",
+                    name="imported-skill",
+                    action=Action.CREATED,
+                    anthropic_id="skill_01imported",
+                )
+            ]
+        ),
+    )
+
+    row = await _seed_skill_repo_request(
+        db_session_factory,
+        ma_agent_id=ma_agent_id,
+        target=build_skill_repo_target("https://github.com/o/attach-repo", "main", ""),
+    )
+    tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(_GUILD_ID))
+    agent = _make_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="daimon", managed=True)
+
+    updates: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith(agent.id):
+            # Both the version-retry re-fetch and the update itself address the
+            # agent directly and must parse as ONE agent; only the list route
+            # gets the list envelope.
+            if request.method in ("POST", "PATCH"):
+                updates.append(json.loads(request.content))
+            return httpx.Response(200, json=agent.model_dump(mode="json"))
+        return list_response([agent.model_dump(mode="json")])
+
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_fake_anthropic(handler),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+
+    modal = SkillRepoModal(runtime=runtime, request_row=row)
+    modal.pat_in._value = "ghp_attach_token"  # pyright: ignore[reportPrivateUsage]
+    await modal.on_submit(_admin_interaction())
+
+    assert updates, "the modal must call agents.update to attach the imported skills"
+    attached_ids = {entry["skill_id"] for entry in updates[-1]["skills"]}
+    assert "skill_01imported" in attached_ids, (
+        "the newly imported skill must be attached to the agent the request named"
+    )


### PR DESCRIPTION
Pasting a token into the skill-repo modal stored a credential and imported skills, and that was all. Two things were missing; together they made a successful paste look like it had been ignored.

## 1. The binding was never written — this is the loop

`_resolve_sync_token` finds a per-agent PAT by walking the tenant's `agent_repo_binding` rows **for this repo**. The session JWT carries no `agent_id` claim, so the repo URL is the only way back to the credential.

`SkillRepoModal.on_submit` called `store_inline_pat` (which writes `agent_github_binding(agent_id → agent_id)`) and never `set_binding`. So the pasted token was stored and permanently unreachable: every later `sync_skills` resolved `token=None`, got GitHub's 404-for-private-or-missing, and asked for a credential again. Paste, import, still nothing, new button.

`RepoBindModal` never had this bug — it calls `set_binding`. The skill-repo kind now goes through the same `resolve_repo_binding_credential`, which returns both the `ma_secret_ref` and the access proof, so the credential write and the binding write cannot disagree about what was established.

## 2. Nothing was attached to the agent

Importing puts skills in the tenant's shared library; it does not put them on an agent. The consumed request row already names the agent it was minted for. The modal now attaches what it imported and reports the count, instead of announcing a successful import against an agent that still has zero skills.

Attach reuses core (`ma.update_agent_with_version_retry`, `defaults.spec_merge.merge_skills_with_ma`) — no adapter cross-import. It returns prose rather than raising, matching `_attach_synced_skills` in the MCP tool: the import has already succeeded by then, so a partial failure must report both halves.

## Tests

Two new, both fail without the fix:
- the pasted token produces an `agent_repo_binding` with `proof_kind="pat"`
- the imported skill id reaches `agents.update`

Full discord suite: 1022 passed.