### PR TITLE
fix(notebook-host): bound the blog-respawn disk leak and guard writes on low disk

### DIFF
--- a/apps/notebook-host/src/notebook_host/admin.py
+++ b/apps/notebook-host/src/notebook_host/admin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hmac
 import os
+import shutil
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -129,6 +130,29 @@ def _bearer_dep(settings: Settings) -> Callable[[str | None], None]:
     return require
 
 
+def _disk_headroom_dep(settings: Settings) -> Callable[[], None]:
+    """Refuse writes when the data volume lacks headroom, before any byte lands.
+
+    A full volume otherwise surfaces as an OSError 500 from deep inside the
+    first write (historically the jti burn), and on the capability route that
+    burn would waste the single-use token. Runs as a route dependency so it
+    precedes the handler body entirely. ``min_free_disk_bytes = 0`` disables.
+    """
+
+    def require() -> None:
+        if settings.min_free_disk_bytes <= 0:
+            return
+        free = shutil.disk_usage(settings.data_dir).free
+        if free < settings.min_free_disk_bytes:
+            raise HTTPException(
+                status.HTTP_507_INSUFFICIENT_STORAGE,
+                f"notebook host is out of disk space (free={free}, "
+                f"required={settings.min_free_disk_bytes})",
+            )
+
+    return require
+
+
 def _atomic_write_bytes(path: Path, content: bytes, *, owner_uid: int | None = None) -> None:
     """Write via tmp + ``os.replace`` so a concurrent reader never sees a torn file.
 
@@ -225,6 +249,7 @@ async def _spawn_tracked(
 def create_admin_router(state: AdminState) -> APIRouter:
     router = APIRouter()
     require_admin = _bearer_dep(state.settings)
+    require_disk_headroom = _disk_headroom_dep(state.settings)
 
     @router.get("/health")
     def health() -> dict[str, object]:  # pyright: ignore[reportUnusedFunction]
@@ -243,7 +268,10 @@ def create_admin_router(state: AdminState) -> APIRouter:
             "subprocess_ttl_seconds": state.settings.subprocess_ttl_seconds,
         }
 
-    @router.put("/admin/notebooks/{slug}", dependencies=[Depends(require_admin)])
+    @router.put(
+        "/admin/notebooks/{slug}",
+        dependencies=[Depends(require_admin), Depends(require_disk_headroom)],
+    )
     async def put_notebook(slug: str, body: WriteRequest) -> dict[str, object]:  # pyright: ignore[reportUnusedFunction]
         slug = safe_slug(slug)
         source_bytes = body.source.encode("utf-8")
@@ -275,7 +303,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
 
     @router.put(
         "/admin/notebooks/{slug}/data/{name}",
-        dependencies=[Depends(require_admin)],
+        dependencies=[Depends(require_admin), Depends(require_disk_headroom)],
     )
     async def put_notebook_data(  # pyright: ignore[reportUnusedFunction]
         slug: str, name: str, request: Request
@@ -362,7 +390,10 @@ def create_admin_router(state: AdminState) -> APIRouter:
             ]
         }
 
-    @router.put("/admin/blogs/{slug}", dependencies=[Depends(require_admin)])
+    @router.put(
+        "/admin/blogs/{slug}",
+        dependencies=[Depends(require_admin), Depends(require_disk_headroom)],
+    )
     async def put_blog(slug: str, body: WriteRequest) -> dict[str, object]:  # pyright: ignore[reportUnusedFunction]
         slug = safe_slug(slug)
         source_bytes = body.source.encode("utf-8")
@@ -448,7 +479,7 @@ def create_admin_router(state: AdminState) -> APIRouter:
             state.snapshot_pids()
         return {"reaped": reaped, "subprocess_ttl_seconds": state.settings.subprocess_ttl_seconds}
 
-    @router.put("/upload/{token}")
+    @router.put("/upload/{token}", dependencies=[Depends(require_disk_headroom)])
     async def upload(token: str, request: Request) -> dict[str, object]:  # pyright: ignore[reportUnusedFunction]
         # Public route — authed by the capability token, NOT the admin bearer.
         secrets_list = [s.get_secret_value() for s in state.settings.admin_secrets]

--- a/apps/notebook-host/src/notebook_host/config.py
+++ b/apps/notebook-host/src/notebook_host/config.py
@@ -98,6 +98,11 @@ class Settings(BaseSettings):
     # ``max_attachment_bytes`` cap (operator policy lives on the daimon side).
     # 100 MiB at default — well above the 10 MiB daimon cap, well below disk-fill.
     max_attachment_bytes_ceiling: int = 100 * 1024 * 1024
+    # Minimum free bytes on the data_dir volume for a write route to accept
+    # work. Below it, publishes and uploads refuse with 507 instead of dying
+    # with an OSError mid-write (a full volume once surfaced as opaque 500s
+    # on every upload). 256 MiB default; 0 disables the guard.
+    min_free_disk_bytes: int = 256 * 1024 * 1024
     # Per-subprocess RLIMIT_AS (address space) in bytes. Default 4 GiB —
     # generous enough for ML-ish notebooks, tight enough that a runaway
     # alloc kills only the offender, not the Fly Machine. Linux only;

--- a/apps/notebook-host/src/notebook_host/jail.py
+++ b/apps/notebook-host/src/notebook_host/jail.py
@@ -183,6 +183,19 @@ def remove_slug_tree(data_dir: Path, slug: str, *, uids_file: Path | None = None
         release_slug_uid(uids_file, slug)
 
 
+def clear_slug_uv_cache(data_dir: Path, slug: str) -> None:
+    """Remove a slug's ``home/.cache/uv`` without touching the rest of the tree.
+
+    Every failed sandboxed spawn leaves a fresh ephemeral uv environment in
+    the slug's cache, so a blog stuck in a spawn/kill/retry loop grows it
+    without bound until the data volume fills. Clearing on failure bounds the
+    leak at the cost of a cold install on the next attempt; a successful
+    spawn keeps its warm cache. A no-op (does not raise) if the cache doesn't
+    exist. ``slug`` must already have passed ``lifecycle.safe_slug``.
+    """
+    shutil.rmtree(get_slug_paths(data_dir, slug).home / ".cache" / "uv", ignore_errors=True)
+
+
 # ─── uid pool ────────────────────────────────────────────────────────────────
 #
 # A persisted slug -> uid registry, not a deterministic hash of the slug.

--- a/apps/notebook-host/src/notebook_host/main.py
+++ b/apps/notebook-host/src/notebook_host/main.py
@@ -27,6 +27,7 @@ from notebook_host.jail import (
     SlugPaths,
     UidPoolExhaustedError,
     can_apply_jail,
+    clear_slug_uv_cache,
     ensure_slug_jail,
     remove_slug_tree,
     resolve_jail_uid,
@@ -201,6 +202,7 @@ async def _spawn_blog_process(state: AdminState, slug: str) -> bool:
     if not ready:
         kill(np)
         state.processes.pop(slug, None)
+        clear_slug_uv_cache(state.settings.data_dir, slug)
         _log.warning("blog %r did not become ready on :%d; will retry next sweep", slug, port)
         return False
     return True

--- a/apps/notebook-host/tests/test_admin_upload.py
+++ b/apps/notebook-host/tests/test_admin_upload.py
@@ -220,3 +220,43 @@ def test_upload_rejects_body_over_host_ceiling_under_token_max(
     assert not get_slug_paths(tmp_path, "ceil").notebook.exists(), (
         "no file written when over the host ceiling"
     )
+
+
+def test_upload_returns_507_when_free_disk_below_minimum(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A host without disk headroom must refuse uploads clearly, before burning.
+
+    A full data volume used to surface as a 500 from deep inside the
+    consumed-store write. The guard runs before the jti burn, so the same
+    token stays usable once space is freed.
+    """
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MIN_FREE_DISK_BYTES", str(2**60))
+    client, _ = _make_app(tmp_path, monkeypatch)
+    tok = _mint("blog", "no-room")
+    r = client.put(f"/upload/{tok}", content=b"# nb\n")
+    assert r.status_code == 507, f"no disk headroom → 507, got {r.status_code}: {r.text}"
+    assert not get_slug_paths(tmp_path, "no-room").notebook.exists(), (
+        "no file written without disk headroom"
+    )
+
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MIN_FREE_DISK_BYTES", "0")
+    retry_client, _ = _make_app(tmp_path, monkeypatch)
+    retry = retry_client.put(f"/upload/{tok}", content=b"# nb\n")
+    assert retry.status_code == 200, (
+        "a token refused for missing headroom must not be burned — the same token "
+        f"must succeed once space is freed, got {retry.status_code}: {retry.text}"
+    )
+
+
+def test_admin_put_notebook_returns_507_when_free_disk_below_minimum(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MIN_FREE_DISK_BYTES", str(2**60))
+    client, _ = _make_app(tmp_path, monkeypatch)
+    r = client.put(
+        "/admin/notebooks/no-room",
+        json={"source": "# nb\n"},
+        headers={"Authorization": f"Bearer {_SECRET}"},
+    )
+    assert r.status_code == 507, f"no disk headroom → 507, got {r.status_code}: {r.text}"

--- a/apps/notebook-host/tests/test_main.py
+++ b/apps/notebook-host/tests/test_main.py
@@ -432,3 +432,41 @@ def _dead_proc() -> subprocess.Popen[bytes]:
     proc.poll.return_value = 0  # dead
     proc.pid = 9999
     return proc  # type: ignore[return-value]
+
+
+async def test_failed_blog_respawn_clears_slug_uv_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A respawn that never becomes ready must clear the slug's uv cache.
+
+    Every failed sandboxed spawn leaves a fresh ephemeral uv environment in
+    the slug's ``home/.cache/uv``; a blog stuck in the kill/retry loop grows
+    that cache without bound until the data volume fills and every upload
+    fails. A retry may pay a cold install; it must not leak disk.
+    """
+    import notebook_host.main as main_mod
+    from notebook_host.blogs_store import BlogRecord, register_blog
+    from notebook_host.main import _spawn_blog_process  # pyright: ignore[reportPrivateUsage]
+
+    state, _calls = _make_state(tmp_path, monkeypatch, alive=False)
+
+    async def _never_ready(port: int, slug: str, timeout_s: float) -> bool:
+        return False
+
+    monkeypatch.setattr(main_mod, "wait_for_port", _never_ready)
+    paths = get_slug_paths(tmp_path, "pre-heavy")
+    paths.notebook.parent.mkdir(parents=True, exist_ok=True)
+    paths.notebook.write_text("import marimo as mo\napp = mo.App()", encoding="utf-8")
+    register_blog(tmp_path / "blogs.json", BlogRecord(slug="pre-heavy", created_at=1.0))
+    leaked_env = paths.home / ".cache" / "uv" / "environments-v2" / "leaked"
+    leaked_env.mkdir(parents=True)
+    (leaked_env / "pyvenv.cfg").write_text("home = /nowhere", encoding="utf-8")
+
+    spawned = await _spawn_blog_process(state, "pre-heavy")
+
+    assert spawned is False, "a spawn that never binds its port must report failure"
+    assert not (paths.home / ".cache" / "uv").exists(), (
+        "a failed respawn must remove the slug's uv cache so the retry loop cannot "
+        "accumulate leaked ephemeral environments"
+    )
+    assert paths.notebook.exists(), "clearing the cache must not touch the blog source"


### PR DESCRIPTION
## What

Two defenses against a full data volume taking the notebook host down (every upload 500s once the disk fills):

1. **Failed blog respawns no longer leak disk.** A registered blog that never becomes ready within the spawn timeout is killed and retried every sweep — and each failed sandboxed attempt leaves a fresh ephemeral uv environment in the slug's `home/.cache/uv`. Left running, that loop grows the cache without bound until the data volume fills. The not-ready path now clears the slug's uv cache: a retry may pay a cold install, but it cannot leak.

2. **Write routes refuse cleanly at low disk.** The notebook/blog/attachment PUTs and the capability upload now 507 when free space on the data volume is below `min_free_disk_bytes` (default 256 MiB; `0` disables). The guard runs before the capability token's jti burn, so a token refused for headroom stays usable after space is freed — previously a full disk surfaced as an opaque 500 from inside the consumed-store write and burned the token.

## Why now

This exact sequence took down a deployment: one heavy sandboxed blog stuck in the respawn loop filled its 20G volume over ~2.5 weeks (~4,600 retries), after which every publish 500'd.

## Tests

- `test_failed_blog_respawn_clears_slug_uv_cache` — failed respawn removes the cache, leaves the source
- `test_upload_returns_507_when_free_disk_below_minimum` — 507 + token not burned (replays fine after)
- `test_admin_put_notebook_returns_507_when_free_disk_below_minimum`

All written red-first; full notebook-host suite green (223 passed), pyright strict clean, ruff clean, import contracts kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)