### PR TITLE
fix(skills): refuse to create a skill whose mount name is already taken

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -63,7 +63,7 @@ from daimon.adapters.discord.credential_repo_bind import (
 )
 from daimon.adapters.discord.runtime import DiscordRuntime
 from daimon.core.credential_requests import split_skill_repo_target
-from daimon.core.defaults.ma_index import find_agent_by_derived_uuid
+from daimon.core.defaults.ma_index import find_agent_by_derived_uuid, find_attach_mount_collision
 from daimon.core.defaults.report import Action, ResourceOutcome
 from daimon.core.defaults.spec_merge import merge_skills_with_ma
 from daimon.core.errors import DaimonError
@@ -487,8 +487,14 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
         ]
 
         async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
+            merged = merge_skills_with_ma(new_skills, fresh)
+            collision = await find_attach_mount_collision(
+                self._runtime.anthropic, tenant_id=tenant_id, skills=merged
+            )
+            if collision is not None:
+                raise DaimonError(f"cannot attach: {collision}")
             return await self._runtime.anthropic.beta.agents.update(
-                fresh.id, version=fresh.version, skills=merge_skills_with_ma(new_skills, fresh)
+                fresh.id, version=fresh.version, skills=merged
             )
 
         try:

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
@@ -26,6 +26,7 @@ from daimon.adapters.mcp.tools._ctx import (
 from daimon.core.constants import AGENT_SKILL_CAP
 from daimon.core.defaults.ma_index import (
     find_agent_by_daimon_tag,
+    find_attach_mount_collision,
     find_skill_by_display_title,
     list_agents_by_tenant,
     list_skills_lenient,
@@ -232,13 +233,18 @@ async def _attach_synced_skills(
                 f"Cannot attach: the merged skill set ({len(merged)}) exceeds this "
                 f"organization's per-agent skill limit ({AGENT_SKILL_CAP})."
             )
+        collision = await find_attach_mount_collision(
+            runtime.client, tenant_id=auth.tenant_id, skills=merged
+        )
+        if collision is not None:
+            raise ToolError(f"Cannot attach: {collision}")
         return await runtime.client.beta.agents.update(
             fresh.id, version=fresh.version, skills=merged
         )
 
     try:
         await update_agent_with_version_retry(runtime.client, agent.id, _apply)
-    except (ToolError, anthropic.APIStatusError) as exc:
+    except (ToolError, DaimonError, anthropic.APIStatusError) as exc:
         return f"Uploaded to the registry, but attaching to '{agent_name}' failed: {exc}"
     return f"Attached to '{agent_name}'."
 

--- a/packages/adapters/mcp/tests/tools/test_agents_sync.py
+++ b/packages/adapters/mcp/tests/tools/test_agents_sync.py
@@ -270,6 +270,7 @@ async def test_create_agent_impl_syncs_skill_repos(
     router = MARouter()
     router.add("POST", r"/v1/agents$", on_agents_create)
     router.add("POST", r"/v1/skills$", on_skills_create)
+    router.add("GET", r"/v1/skills$", lambda req, _m: list_response([]))
     router.add("GET", r"/v1/agents$", on_agents_list)
     router.add("GET", r"/v1/agents/([^/]+)$", on_agents_retrieve)
     router.add("POST", r"/v1/agents/([^/]+)$", on_agents_update)

--- a/packages/adapters/mcp/tests/tools/test_skills.py
+++ b/packages/adapters/mcp/tests/tools/test_skills.py
@@ -765,6 +765,7 @@ async def test_sync_impl_attaches_to_the_named_agent_and_preserves_its_existing_
             )
 
         router = MARouter()
+        router.add("GET", r"/v1/skills", lambda _req, _m: list_response([]))
         router.add("GET", r"/v1/agents$", on_agents_list)
         router.add("GET", r"/v1/agents/ag_1$", on_agent_get)
         router.add("POST", r"/v1/agents/ag_1$", on_agent_update)
@@ -850,4 +851,109 @@ async def test_sync_impl_404_with_a_token_does_not_blame_credentials() -> None:
 
     assert "request_skill_repo_credential" not in str(excinfo.value), (
         "a 404 on an authenticated fetch is a bad url/branch, not a missing credential"
+    )
+
+
+async def test_sync_impl_refuses_attach_when_registry_skill_collides_with_scoped_mount(
+    tmp_path: Path,
+) -> None:
+    """Attaching a registry skill to an agent owning a same-named scoped skill is refused.
+
+    The create guards stop new colliding skills, but a legacy pair can still be
+    joined at attach time — MA would accept the update and then fail every
+    session create for the agent. The tool must refuse the attach and say why,
+    while the upload half still lands in the registry.
+    """
+    from daimon.core.defaults.metadata import tenant_scoped_display_title
+
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    outcomes = [
+        ResourceOutcome(
+            kind="skill", name="last30days", action=Action.UPDATED, anthropic_id="sk_reg"
+        ),
+    ]
+
+    with (
+        patch("daimon.core.skills.pipeline.fetch_repo") as mock_fetch,
+        patch("daimon.core.skills.pipeline.discover_skills"),
+        patch("daimon.core.skills.pipeline.sync_skills") as mock_sync,
+    ):
+        from daimon.core.skills.fetch import FetchResult
+
+        cleanup_dir = tmp_path / "cleanup"
+        cleanup_dir.mkdir()
+        mock_fetch.return_value = FetchResult(path=tmp_path, cleanup_dir=cleanup_dir)
+        mock_sync.return_value = outcomes
+
+        def on_skills_list(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+            return list_response(
+                [
+                    SkillListResponse(
+                        id="sk_reg",
+                        type="custom",
+                        display_title=tenant_scoped_display_title(
+                            tenant_id=tenant_id, name="last30days"
+                        ),
+                        latest_version="1",
+                        created_at="2026-04-21T00:00:00Z",
+                        updated_at="2026-04-21T00:00:00Z",
+                        source="custom",
+                    ).model_dump(mode="json"),
+                    SkillListResponse(
+                        id="sk_scoped",
+                        type="custom",
+                        display_title=tenant_scoped_display_title(
+                            tenant_id=tenant_id, name="last30days", agent_name="agent"
+                        ),
+                        latest_version="1",
+                        created_at="2026-04-21T00:00:00Z",
+                        updated_at="2026-04-21T00:00:00Z",
+                        source="custom",
+                    ).model_dump(mode="json"),
+                ]
+            )
+
+        updates: list[dict[str, Any]] = []
+
+        def on_agent_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+            updates.append(json.loads(req.content))
+            return httpx.Response(500, json={"error": "must not be called"})
+
+        router = MARouter()
+        router.add("GET", r"/v1/skills", on_skills_list)
+        router.add(
+            "GET",
+            r"/v1/agents$",
+            lambda _req, _m: list_response(
+                [_agent_json(agent_id="ag_1", tenant_id=tenant_id, skill_ids=["sk_scoped"])]
+            ),
+        )
+        router.add(
+            "GET",
+            r"/v1/agents/ag_1$",
+            lambda _req, _m: httpx.Response(
+                200, json=_agent_json(agent_id="ag_1", tenant_id=tenant_id, skill_ids=["sk_scoped"])
+            ),
+        )
+        router.add("POST", r"/v1/agents/ag_1$", on_agent_update)
+        client = build_fake_anthropic(router.dispatch)
+
+        auth = AuthIdentity(
+            account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True
+        )
+        result = await _sync_impl(
+            _runtime(client),
+            auth,
+            url="https://github.com/org/repo",
+            branch="main",
+            path="",
+            agent_name="agent",
+        )
+
+    assert updates == [], "agents.update must not run when the merged list has a mount collision"
+    assert result.attached_count == 0, "nothing may count as attached when the attach was refused"
+    assert "mount" in result.summary, (
+        f"the summary must explain the mount collision so the caller can rename; got {result.summary!r}"
     )

--- a/packages/core/daimon/core/defaults/ma_index.py
+++ b/packages/core/daimon/core/defaults/ma_index.py
@@ -16,12 +16,18 @@ from typing import Literal
 import sentry_sdk
 import structlog
 from anthropic import AsyncAnthropic
-from anthropic.types.beta import BetaEnvironment, BetaManagedAgentsAgent, SkillListResponse
+from anthropic.types.beta import (
+    BetaEnvironment,
+    BetaManagedAgentsAgent,
+    BetaManagedAgentsSkillParams,
+    SkillListResponse,
+)
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_ACCOUNT,
     MA_METADATA_KEY_NAME,
     MA_METADATA_KEY_TENANT,
     find_conflicting_skill_body,
+    find_mount_collision,
     strip_tenant_prefix,
 )
 from daimon.core.errors import SkillsListTruncatedError
@@ -303,6 +309,42 @@ async def find_conflicting_skill_mount(
         existing_bodies=list(bodies_by_title), name=name, agent_name=agent_name
     )
     return bodies_by_title[conflict] if conflict is not None else None
+
+
+async def find_attach_mount_collision(
+    client: AsyncAnthropic,
+    *,
+    tenant_id: uuid.UUID,
+    skills: list[BetaManagedAgentsSkillParams],
+) -> str | None:
+    """Return a human-readable description of a mount-name collision in a
+    proposed agent skill list, else None.
+
+    Attach-side companion to :func:`find_conflicting_skill_mount`: the create
+    guards stop NEW colliding skills, but attaching an EXISTING registry skill
+    to an agent that owns a same-named agent-scoped skill would still brick
+    session creation. Call this on the merged list before ``agents.update``.
+
+    Truncation raises SkillsListTruncatedError — a truncated view can hide the
+    collider, and attaching blind bricks the agent.
+    """
+    rows = await list_skills_strict(client)
+    body_by_skill_id: dict[str, str] = {}
+    for sk in rows:
+        if sk.source != "custom":
+            continue
+        body = strip_tenant_prefix(tenant_id=tenant_id, display_title=sk.display_title or "")
+        if body is not None:
+            body_by_skill_id[sk.id] = body
+    skill_ids = [s["skill_id"] for s in skills]
+    collision = find_mount_collision(skill_ids=skill_ids, body_by_skill_id=body_by_skill_id)
+    if collision is None:
+        return None
+    mount_name, bodies = collision
+    return (
+        f"skills {bodies!r} would all mount at {mount_name!r} on this agent — "
+        f"rename one (e.g. {mount_name}-2) and re-sync before attaching"
+    )
 
 
 async def find_skill_by_display_title(

--- a/packages/core/daimon/core/defaults/ma_index.py
+++ b/packages/core/daimon/core/defaults/ma_index.py
@@ -21,6 +21,8 @@ from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_ACCOUNT,
     MA_METADATA_KEY_NAME,
     MA_METADATA_KEY_TENANT,
+    find_conflicting_skill_body,
+    strip_tenant_prefix,
 )
 from daimon.core.errors import SkillsListTruncatedError
 from daimon.core.ma_identity import derive_agent_uuid
@@ -267,6 +269,40 @@ async def find_skills_by_display_title(
         _log.warning("ma_index.multi_match", kind="skills", count=len(matches))
     matches.sort(key=lambda m: m.created_at, reverse=True)
     return matches
+
+
+async def find_conflicting_skill_mount(
+    client: AsyncAnthropic,
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    agent_name: str | None,
+) -> SkillListResponse | None:
+    """Return a tenant skill whose MA mount name would collide with creating
+    ``name`` under the given shape (registry when ``agent_name`` is None,
+    agent-scoped otherwise), else None.
+
+    MA mounts by the skill's internal name at SESSION create, not at skill
+    create — so a registry skill and an agent-scoped skill sharing a terminal
+    name are both accepted on upload and only fail once attached to the same
+    agent. Call this before ``skills.create`` in write contexts; collision
+    rules live in :func:`~daimon.core.defaults.metadata.find_conflicting_skill_body`.
+
+    Truncation always raises SkillsListTruncatedError — this is a create-guard,
+    and a truncated view can hide the collider.
+    """
+    rows = await list_skills_strict(client)
+    bodies_by_title: dict[str, SkillListResponse] = {}
+    for sk in rows:
+        if sk.source != "custom":
+            continue
+        body = strip_tenant_prefix(tenant_id=tenant_id, display_title=sk.display_title or "")
+        if body is not None:
+            bodies_by_title[body] = sk
+    conflict = find_conflicting_skill_body(
+        existing_bodies=list(bodies_by_title), name=name, agent_name=agent_name
+    )
+    return bodies_by_title[conflict] if conflict is not None else None
 
 
 async def find_skill_by_display_title(

--- a/packages/core/daimon/core/defaults/metadata.py
+++ b/packages/core/daimon/core/defaults/metadata.py
@@ -137,6 +137,29 @@ def find_conflicting_skill_body(
     return None
 
 
+def find_mount_collision(
+    *, skill_ids: list[str], body_by_skill_id: dict[str, str]
+) -> tuple[str, list[str]] | None:
+    """Return ``(mount_name, bodies)`` for the first mount path that two or
+    more of ``skill_ids`` would share, else None.
+
+    ``body_by_skill_id`` maps a tenant's custom skill ids to their
+    tenant-stripped display_title bodies; ids absent from the map (anthropic
+    built-ins, foreign tenants) are skipped — their mounts cannot collide with
+    tenant-owned names. The mount name is the body's terminal path segment.
+    """
+    bodies_by_mount: dict[str, list[str]] = {}
+    for skill_id in skill_ids:
+        body = body_by_skill_id.get(skill_id)
+        if body is None:
+            continue
+        bodies_by_mount.setdefault(body.rsplit("/", 1)[-1], []).append(body)
+    for mount_name, bodies in bodies_by_mount.items():
+        if len(bodies) > 1:
+            return mount_name, bodies
+    return None
+
+
 def strip_tenant_prefix(*, tenant_id: uuid.UUID, display_title: str) -> str | None:
     """Strip the tenant id-8 prefix from a display_title and return the body.
 

--- a/packages/core/daimon/core/defaults/metadata.py
+++ b/packages/core/daimon/core/defaults/metadata.py
@@ -105,6 +105,38 @@ def tenant_scoped_display_title(
     return f"{prefix}{body[:keep]}~{digest}"
 
 
+def find_conflicting_skill_body(
+    *, existing_bodies: list[str], name: str, agent_name: str | None
+) -> str | None:
+    """Return the first existing skill body whose MA mount name would collide
+    with creating a skill called ``name`` under the given shape, else None.
+
+    MA mounts skills by their internal name (the terminal segment of the
+    display_title body), not the full display_title — two distinct skill
+    resources with the same terminal name attached to one agent make session
+    creation fail with a mount collision. Bodies are tenant-stripped
+    display_title bodies (see :func:`strip_tenant_prefix`).
+
+    Rules:
+    - Creating a registry skill (``agent_name is None``): any agent-scoped body
+      (``"agent/name"``) with the same terminal name conflicts — registry skills
+      are attachable to any agent, including that one. An exact registry-shape
+      match is NOT a conflict; that is the update-in-place path.
+    - Creating an agent-scoped skill: only an exact registry-shape body
+      conflicts. Other agents' scoped skills never mount alongside this one.
+    """
+    for body in existing_bodies:
+        is_scoped = "/" in body
+        terminal_name = body.rsplit("/", 1)[-1]
+        if terminal_name != name:
+            continue
+        if agent_name is None and is_scoped:
+            return body
+        if agent_name is not None and not is_scoped:
+            return body
+    return None
+
+
 def strip_tenant_prefix(*, tenant_id: uuid.UUID, display_title: str) -> str | None:
     """Strip the tenant id-8 prefix from a display_title and return the body.
 

--- a/packages/core/daimon/core/skill_sync/orchestrator.py
+++ b/packages/core/daimon/core/skill_sync/orchestrator.py
@@ -52,6 +52,7 @@ from anthropic.types.beta import (
 from cryptography.fernet import MultiFernet
 from daimon.core.defaults.ma_index import (
     find_agent_by_daimon_tag,
+    find_attach_mount_collision,
     find_conflicting_skill_mount,
     find_skill_by_display_title,
 )
@@ -744,6 +745,15 @@ async def sync_agent_skills(
             # unchanged (version bump already happened; no update needed).
             return fresh
 
+        # Mount-name guard, attach side: the union dedupes by skill_id, but MA
+        # mounts by internal name at session create — a legacy registry skill
+        # already on the agent plus a same-named scoped row would brick it.
+        collision = await find_attach_mount_collision(
+            anthropic_client, tenant_id=tenant_id, skills=union_list
+        )
+        if collision is not None:
+            raise DefaultsError(collision)
+
         # #141 guard: if the agent lacks a base agent_toolset, attach it now so
         # skills remain usable. MA rejects session creation on an agent with skills
         # but no agent_toolset_20260401 entry providing the read tool.
@@ -769,6 +779,19 @@ async def sync_agent_skills(
 
     try:
         updated = await update_agent_with_version_retry(anthropic_client, agent.id, _apply)
+    except DefaultsError as err:
+        # Mount-name collision (or truncated skills view) — uploads landed;
+        # only the attach binding is refused. Same partial-failure surface as
+        # the skill-cap branch below.
+        _log.warning(
+            "skill_sync.attach_mount_collision",
+            agent_name=agent_name,
+            agent_id=agent.id,
+            error=str(err),
+        )
+        async with report_lock:
+            report.attach_failures.append((agent_name, str(err)))
+        return report
     except anthropic.APIStatusError as err:
         if not _looks_like_skill_cap(err):
             raise

--- a/packages/core/daimon/core/skill_sync/orchestrator.py
+++ b/packages/core/daimon/core/skill_sync/orchestrator.py
@@ -52,6 +52,7 @@ from anthropic.types.beta import (
 from cryptography.fernet import MultiFernet
 from daimon.core.defaults.ma_index import (
     find_agent_by_daimon_tag,
+    find_conflicting_skill_mount,
     find_skill_by_display_title,
 )
 from daimon.core.defaults.metadata import (
@@ -279,6 +280,18 @@ async def _process_one(
     anthropic_id: str
     latest_version: str | None
     if existing is None or existing.anthropic_id is None:
+        # Mount-name guard: MA accepts two skills with the same internal name
+        # and only fails at SESSION create when both are attached to one agent.
+        # Refuse to create the collider here instead.
+        conflict = await find_conflicting_skill_mount(
+            anthropic_client, tenant_id=tenant_id, name=pending.name, agent_name=agent_name
+        )
+        if conflict is not None:
+            raise DefaultsError(
+                f"skill name {pending.name!r} is already taken by "
+                f"{conflict.display_title!r} — the two would mount at the same path "
+                f"on this agent. Rename the skill (e.g. {pending.name}-2) and re-sync."
+            )
         try:
             created = await anthropic_client.beta.skills.create(
                 display_title=display_title,

--- a/packages/core/daimon/core/skills/sync.py
+++ b/packages/core/daimon/core/skills/sync.py
@@ -22,9 +22,10 @@ import uuid
 
 import structlog
 from anthropic import AsyncAnthropic
-from daimon.core.defaults.ma_index import find_skill_by_display_title
+from daimon.core.defaults.ma_index import find_conflicting_skill_mount, find_skill_by_display_title
 from daimon.core.defaults.metadata import tenant_scoped_display_title
 from daimon.core.defaults.report import Action, ResourceOutcome
+from daimon.core.errors import DaimonError
 from daimon.core.skill_zip import build_skill_zip
 from daimon.core.skills.discover import DiscoveredSkill
 
@@ -89,6 +90,16 @@ async def sync_skills(
                         )
                     )
                 else:
+                    conflict = await find_conflicting_skill_mount(
+                        client, tenant_id=tenant_id, name=skill.spec.name, agent_name=None
+                    )
+                    if conflict is not None:
+                        raise DaimonError(
+                            f"skill name {skill.spec.name!r} is already taken by "
+                            f"{conflict.display_title!r} — the two would mount at the same "
+                            f"path on an agent. Rename the skill (e.g. "
+                            f"{skill.spec.name}-2) and re-sync."
+                        )
                     with pkg.path.open("rb") as fh:
                         created = await client.beta.skills.create(
                             display_title=canonical,

--- a/packages/core/tests/defaults/test_metadata.py
+++ b/packages/core/tests/defaults/test_metadata.py
@@ -8,6 +8,7 @@ from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_NAME,
     MA_METADATA_KEY_TENANT,
     build_metadata,
+    find_conflicting_skill_body,
     strip_tenant_prefix,
     tenant_scoped_display_title,
 )
@@ -161,3 +162,57 @@ def test_strip_tenant_prefix_mangle_stability() -> None:
     assert re_prefixed == title, (
         "re-prefixing a stripped mangled title must reproduce the same 64-char string — no re-mangle"
     )
+
+
+def test_find_conflicting_skill_body_registry_create_hits_agent_scoped_same_name() -> None:
+    result = find_conflicting_skill_body(
+        existing_bodies=["research daimon/last30days", "cli-auth"],
+        name="last30days",
+        agent_name=None,
+    )
+    assert result == "research daimon/last30days", (
+        "creating a registry skill must conflict with an agent-scoped skill of the same "
+        "mount name — both would mount at the same path on a shared agent"
+    )
+
+
+def test_find_conflicting_skill_body_scoped_create_hits_registry_same_name() -> None:
+    result = find_conflicting_skill_body(
+        existing_bodies=["last30days"],
+        name="last30days",
+        agent_name="research daimon",
+    )
+    assert result == "last30days", (
+        "creating an agent-scoped skill must conflict with a registry skill of the same name"
+    )
+
+
+def test_find_conflicting_skill_body_scoped_create_ignores_other_agents_scoped() -> None:
+    result = find_conflicting_skill_body(
+        existing_bodies=["other agent/last30days"],
+        name="last30days",
+        agent_name="research daimon",
+    )
+    assert result is None, (
+        "two agents may each own a scoped skill with the same name — they never mount together"
+    )
+
+
+def test_find_conflicting_skill_body_registry_create_ignores_exact_registry_match() -> None:
+    result = find_conflicting_skill_body(
+        existing_bodies=["last30days"],
+        name="last30days",
+        agent_name=None,
+    )
+    assert result is None, (
+        "an exact registry-shape match is the update-in-place path, not a conflict"
+    )
+
+
+def test_find_conflicting_skill_body_no_match_returns_none() -> None:
+    result = find_conflicting_skill_body(
+        existing_bodies=["research daimon/weekly", "cli-auth"],
+        name="last30days",
+        agent_name=None,
+    )
+    assert result is None, "unrelated names must not conflict"

--- a/packages/core/tests/defaults/test_metadata.py
+++ b/packages/core/tests/defaults/test_metadata.py
@@ -9,6 +9,7 @@ from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_TENANT,
     build_metadata,
     find_conflicting_skill_body,
+    find_mount_collision,
     strip_tenant_prefix,
     tenant_scoped_display_title,
 )
@@ -216,3 +217,29 @@ def test_find_conflicting_skill_body_no_match_returns_none() -> None:
         agent_name=None,
     )
     assert result is None, "unrelated names must not conflict"
+
+
+def test_find_mount_collision_registry_and_scoped_same_name() -> None:
+    result = find_mount_collision(
+        skill_ids=["sk_registry", "sk_scoped"],
+        body_by_skill_id={
+            "sk_registry": "last30days",
+            "sk_scoped": "research daimon/last30days",
+        },
+    )
+    assert result is not None, "registry + scoped same-name must collide"
+    mount_name, bodies = result
+    assert mount_name == "last30days", "collision must name the shared mount"
+    assert sorted(bodies) == ["last30days", "research daimon/last30days"], (
+        "collision must list both colliding bodies"
+    )
+
+
+def test_find_mount_collision_unique_names_return_none() -> None:
+    result = find_mount_collision(
+        skill_ids=["sk_a", "sk_b", "sk_builtin"],
+        body_by_skill_id={"sk_a": "last30days", "sk_b": "agent/weekly"},
+    )
+    assert result is None, (
+        "unique mounts must not collide; ids missing from the map (built-ins) are skipped"
+    )

--- a/packages/core/tests/skill_sync/test_orchestrator.py
+++ b/packages/core/tests/skill_sync/test_orchestrator.py
@@ -620,6 +620,7 @@ async def test_first_sync_creates_new_skill(
         )
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("POST", r"/v1/skills", on_create)
     # Attach step lookup — empty list = no agent on MA → attach skipped.
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
@@ -856,6 +857,7 @@ async def test_re_run_no_changes_yields_zero_synced_zero_updated(
         )
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("POST", r"/v1/skills", on_create)
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
     anthropic_client = _build_anthropic(router)
@@ -1320,8 +1322,9 @@ async def test_non_duplicate_api_status_error_re_raises_to_failed_uploads(
     assert len(report.failed_uploads) == 1, (
         f"non-duplicate error must be recorded as failed upload, got {report.failed_uploads}"
     )
-    assert list_calls == [], (
-        "recovery MUST NOT trigger find_skill_by_display_title for non-duplicate errors"
+    assert len(list_calls) == 1, (
+        "only the pre-create mount-name guard may list skills — recovery MUST NOT "
+        "trigger find_skill_by_display_title for non-duplicate errors"
     )
 
 
@@ -1387,7 +1390,10 @@ async def test_400_with_display_title_substring_does_not_trigger_recovery(
     assert len(report.failed_uploads) == 1, (
         "length-rejection must be recorded as failed_upload, not silently recovered"
     )
-    assert list_calls == [], "recovery MUST NOT trigger for 400s that aren't the dup-title phrase"
+    assert len(list_calls) == 1, (
+        "only the pre-create mount-name guard may list skills — recovery MUST NOT "
+        "trigger for 400s that aren't the dup-title phrase"
+    )
 
 
 async def test_orphan_delete_only_fires_for_successfully_fetched_repos(
@@ -2147,6 +2153,7 @@ async def test_sync_agent_skills_attaches_uploaded_skills_to_ma_agent(
         return httpx.Response(200, json=agent_payload)
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("POST", r"/v1/skills", on_create)
     router.add("GET", r"/v1/agents", on_list_agents)
     router.add("GET", r"/v1/agents/ag_target", on_retrieve_agent)
@@ -2335,6 +2342,7 @@ async def test_sync_agent_skills_skips_attach_when_agent_not_found(
         return httpx.Response(500, json={"error": "must not be called"})
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("POST", r"/v1/skills", on_create)
     router.add("GET", r"/v1/agents", on_list_agents)
     router.add("POST", r"/v1/agents/.*", on_update_agent)
@@ -2454,6 +2462,7 @@ async def test_bundled_sync_two_repos_same_trailing_segment_keeps_both_skills(
         return httpx.Response(204)
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("POST", r"/v1/skills", on_create)
     router.add("DELETE", r"/v1/skills/.*", on_delete)
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
@@ -2606,6 +2615,7 @@ async def test_sync_creates_two_distinct_skills_when_two_tenants_sync_same_named
         return httpx.Response(500, json={"error": "must not be called in SC-4 test"})
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("POST", r"/v1/skills", on_create)
     router.add("POST", r"/v1/skills/.*/versions", on_version)
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
@@ -2756,6 +2766,7 @@ async def test_recovery_refuses_to_push_version_onto_foreign_tenant_skill(
         return httpx.Response(500, json={"error": "must not be called"})
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("POST", r"/v1/skills", on_create)
     router.add("POST", r"/v1/skills/sk_foreign/versions", on_version)
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
@@ -3288,3 +3299,68 @@ async def test_attach_over_cap_records_failure_instead_of_raising(
     failed_agent, reason = report.attach_failures[0]
     assert failed_agent == "agent", "attach_failures must carry the agent name"
     assert "exceeds maximum of 20" in reason, "the MA cap message must be preserved for the user"
+
+
+async def test_first_sync_refuses_create_when_registry_skill_takes_the_mount_name(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A registry skill with the same mount name → failed upload, no skills.create.
+
+    MA mounts by internal skill name at session create, not at skill create —
+    a registry skill and this agent-scoped skill would collide once both are
+    attached to the agent, so the create must be refused up front.
+    """
+    cli = await make_cli_principal(db_session, os_user="alice")
+    await db_session.commit()
+    fernet = _make_fernet()
+    await _seed_pat(sessionmaker=db_session_factory, fernet=fernet, principal_id=cli.id)
+
+    tarball = _make_tarball({"r-main/SKILL.md": b"---\nname: r\ndescription: d\n---\nbody"})
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda req: httpx.Response(200, content=tarball))
+    )
+
+    registry_title = tenant_scoped_display_title(tenant_id=cli.tenant_id, name="o-r")
+    registry_skill = SkillListResponse(
+        id="sk_registry",
+        type="custom",
+        display_title=registry_title,
+        latest_version="1",
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        source="custom",
+    )
+
+    create_calls: list[httpx.Request] = []
+
+    def on_create(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        create_calls.append(req)
+        return httpx.Response(500, json={"error": "must not be called"})
+
+    router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: _list_envelope([registry_skill]))
+    router.add("POST", r"/v1/skills", on_create)
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
+    anthropic_client = _build_anthropic(router)
+
+    report = await sync_agent_skills(
+        principal_id=cli.id,
+        tenant_id=cli.tenant_id,
+        agent_name="agent",
+        repos=[SkillRepo(url="https://github.com/o/r", branch="main", split=False)],
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        http_client=http_client,
+        anthropic_client=anthropic_client,
+    )
+
+    assert create_calls == [], "skills.create must not run for a colliding mount name"
+    assert len(report.failed_uploads) == 1, (
+        f"mount-name refusal must land in failed_uploads; got {report.failed_uploads}"
+    )
+    failed_name, failed_msg = report.failed_uploads[0]
+    assert failed_name == "o-r", f"failed skill must be 'o-r', got {failed_name!r}"
+    assert "already taken" in failed_msg, (
+        f"failure message must say the name is taken so the caller can rename; got {failed_msg!r}"
+    )

--- a/packages/core/tests/skill_sync/test_orchestrator.py
+++ b/packages/core/tests/skill_sync/test_orchestrator.py
@@ -1928,6 +1928,7 @@ async def test_orphan_delete_transient_failure_retains_row_without_poisoning_att
         )
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add(
         "DELETE",
         r"/v1/skills/sk_transient",
@@ -2883,6 +2884,7 @@ async def test_attach_adds_base_toolset_when_agent_lacks_it(
         )
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([agent_payload]))
     router.add(
         "GET", r"/v1/agents/ag_toolless", lambda req, _m: httpx.Response(200, json=agent_payload)
@@ -3011,6 +3013,7 @@ async def test_attach_sends_skills_only_when_agent_has_base_toolset(
         )
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([agent_payload]))
     router.add(
         "GET",
@@ -3162,6 +3165,7 @@ async def test_attach_retries_once_on_version_conflict(
 
     # max_retries=0: disable SDK auto-retry so helper retry logic fires in isolation.
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([initial_agent]))
     router.add("GET", r"/v1/agents/ag_conflict", on_retrieve)
     router.add("POST", r"/v1/agents/ag_conflict", on_update)
@@ -3268,6 +3272,7 @@ async def test_attach_over_cap_records_failure_instead_of_raising(
         )
 
     router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
     router.add("GET", r"/v1/agents", lambda req, _m: list_response([agent_payload]))
     router.add("GET", r"/v1/agents/ag_cap", lambda req, _m: httpx.Response(200, json=agent_payload))
     router.add("POST", r"/v1/agents/ag_cap", on_update)
@@ -3363,4 +3368,110 @@ async def test_first_sync_refuses_create_when_registry_skill_takes_the_mount_nam
     assert failed_name == "o-r", f"failed skill must be 'o-r', got {failed_name!r}"
     assert "already taken" in failed_msg, (
         f"failure message must say the name is taken so the caller can rename; got {failed_msg!r}"
+    )
+
+
+async def test_attach_refuses_union_when_legacy_registry_skill_shares_mount_name(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A registry skill already on the agent + a same-named scoped row → attach refused.
+
+    The create guards stop new colliding skills, but a legacy registry skill
+    attached before the guard existed can still collide with a scoped row at
+    union time. The attach must be refused and recorded in attach_failures —
+    attaching blind would brick every session create for the agent.
+    """
+    cli = await make_cli_principal(db_session, os_user="alice")
+    await db_session.commit()
+    fernet = _make_fernet()
+
+    ledger_key = derive_agent_uuid(tenant_id=cli.tenant_id, ma_agent_id="ag_coll")
+    async with db_session_factory() as s, s.begin():
+        await upsert_user_skill(
+            s,
+            tenant_id=cli.tenant_id,
+            principal_id=ledger_key,
+            agent_name="agent",
+            name="my-skill",
+            source_repo_url="https://github.com/o/r",
+            source_repo_branch="main",
+            source_path="",
+            content_hash="hash_1",
+            anthropic_id="sk_scoped",
+            anthropic_latest_version="1",
+        )
+
+    agent_payload = BetaManagedAgentsAgent(
+        id="ag_coll",
+        type="agent",
+        name="agent",
+        model={"id": "claude-opus-4-7"},
+        metadata={"daimon_tenant": str(cli.tenant_id), "daimon_name": "agent"},
+        description=None,
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        version=10,
+        mcp_servers=[],
+        skills=[{"type": "custom", "skill_id": "sk_registry", "version": "1"}],
+        tools=[],
+        system=None,
+    ).model_dump(mode="json")
+
+    registry_skill = SkillListResponse(
+        id="sk_registry",
+        type="custom",
+        display_title=tenant_scoped_display_title(tenant_id=cli.tenant_id, name="my-skill"),
+        latest_version="1",
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        source="custom",
+    )
+    scoped_skill = SkillListResponse(
+        id="sk_scoped",
+        type="custom",
+        display_title=tenant_scoped_display_title(
+            tenant_id=cli.tenant_id, name="my-skill", agent_name="agent"
+        ),
+        latest_version="1",
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        source="custom",
+    )
+
+    update_calls: list[httpx.Request] = []
+
+    def on_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        update_calls.append(req)
+        return httpx.Response(500, json={"error": "must not be called"})
+
+    router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: _list_envelope([registry_skill, scoped_skill]))
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([agent_payload]))
+    router.add(
+        "GET", r"/v1/agents/ag_coll", lambda req, _m: httpx.Response(200, json=agent_payload)
+    )
+    router.add("POST", r"/v1/agents/ag_coll", on_update)
+    anthropic_client = _build_anthropic(router)
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(_unreachable_handler))
+
+    report = await sync_agent_skills(
+        principal_id=cli.id,
+        tenant_id=cli.tenant_id,
+        agent_name="agent",
+        repos=[],
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        http_client=http_client,
+        anthropic_client=anthropic_client,
+    )
+
+    assert update_calls == [], "agents.update must not run when the union has a mount collision"
+    assert len(report.attach_failures) == 1, (
+        f"mount collision must be recorded as one attach failure, got {report.attach_failures}"
+    )
+    failed_agent, reason = report.attach_failures[0]
+    assert failed_agent == "agent", "attach_failures must carry the agent name"
+    assert "mount" in reason and "my-skill" in reason, (
+        f"reason must describe the mount collision; got {reason!r}"
     )

--- a/packages/core/tests/skill_sync/test_resync.py
+++ b/packages/core/tests/skill_sync/test_resync.py
@@ -1025,6 +1025,10 @@ def _make_skills_handler() -> Callable[[httpx.Request], httpx.Response]:
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         method = request.method
+        if method == "GET" and path == "/v1/skills":
+            # Mount-name guard listing before create; the in-memory store's
+            # titles are unprefixed, so an empty view is equivalent.
+            return httpx.Response(200, json={"data": [], "next_page": None})
         if method == "POST" and path == "/v1/skills":
             counter["n"] += 1
             skill_id = f"sk_{counter['n']}"

--- a/packages/core/tests/skills/test_sync.py
+++ b/packages/core/tests/skills/test_sync.py
@@ -321,3 +321,38 @@ async def test_sync_records_failed_outcome_when_list_is_truncated(tmp_path: Path
         "truncated list on lookup should produce FAILED outcome"
     )
     assert outcomes[0].error is not None, "FAILED outcome should carry error text"
+
+
+async def test_sync_fails_when_agent_scoped_skill_takes_the_mount_name(tmp_path: Path) -> None:
+    """An agent-scoped skill with the same terminal name → FAILED, no skills.create.
+
+    A registry skill and an agent-scoped skill sharing a mount name are both
+    accepted by MA at upload and only collide at session create once attached
+    to the same agent — so the create must be refused up front.
+    """
+    skill = _skill(tmp_path, name="last30days")
+    scoped_title = tenant_scoped_display_title(
+        tenant_id=_TENANT_A, name="last30days", agent_name="research daimon"
+    )
+    router = MARouter()
+    router.add(
+        "GET", r"/v1/skills", lambda req, _m: list_response([_skill_row("sk_scoped", scoped_title)])
+    )
+    create_called = False
+
+    def on_create(req: httpx.Request, _m: object) -> httpx.Response:
+        nonlocal create_called
+        create_called = True
+        return httpx.Response(500, json={"error": "should never be reached"})
+
+    router.add("POST", r"/v1/skills", on_create)
+    client = build_fake_anthropic_http(router.dispatch)
+
+    outcomes = await sync_skills(client, [skill], tenant_id=_TENANT_A)
+
+    assert len(outcomes) == 1, "should return one outcome"
+    assert outcomes[0].action is Action.FAILED, "colliding mount name must fail the sync"
+    assert outcomes[0].error is not None and "already taken" in outcomes[0].error, (
+        "error should tell the caller the name is taken so it can rename"
+    )
+    assert not create_called, "skills.create must not run for a colliding name"

--- a/packages/testing/daimon/testing/ma.py
+++ b/packages/testing/daimon/testing/ma.py
@@ -360,6 +360,11 @@ def make_fake_ma_handler() -> Callable[[httpx.Request], httpx.Response]:
         if method == "GET" and path == "/v1/agents":
             return httpx.Response(200, json={"data": list(store.values()), "has_more": False})
 
+        # GET /v1/skills — empty list (the mount-name guards list skills before
+        # create/attach; tests that need real rows layer their own handler on top)
+        if method == "GET" and path == "/v1/skills":
+            return httpx.Response(200, json={"data": [], "next_page": None})
+
         # POST /v1/agents — create
         if method == "POST" and path == "/v1/agents":
             body: dict[str, Any] = json.loads(request.content)


### PR DESCRIPTION
## Problem

Session creation for an agent 400s with:

> Skill name collision: two skills cannot share the same name (both mount at "last30days")

MA accepts two skill resources with the same internal name and only fails at **session create**, when both are attached to one agent and expand to the same mount path. The registry sync (tenant title shape) and the per-agent repo sync (agent-scoped title shape) use different display_title shapes, so each path's existence lookup missed the other's skill and created the collider — bricking every turn for that agent.

## Fix

Guard both `skills.create` paths with a mount-name check (`find_conflicting_skill_mount`):

- Registry create conflicts with any agent-scoped skill of the same terminal name (registry skills are attachable to any agent).
- Agent-scoped create conflicts only with a registry skill of that name — two agents may each own a same-named scoped skill.
- Exact same-shape matches keep updating in place, unchanged.

On conflict the sync fails with a message telling the caller the name is taken and to rename (e.g. `last30days-2`) — surfaced through the existing FAILED-outcome / failed_uploads reporting, so the calling agent can react.

## Tests

- Pure collision rules: 5 cases in `test_metadata.py`
- Registry path refusal (no `skills.create` issued): `test_sync.py`
- Agent-scoped path refusal into `failed_uploads`: `test_orchestrator.py`
- Existing fakes updated for the guard's pre-create `GET /v1/skills` call

All shards pass locally; pyright/ruff/lint-imports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)