### PR TITLE
fix: pre-ping pooled DB connections and stop render_error leaking SQL

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/errors.py
+++ b/packages/adapters/discord/daimon/adapters/discord/errors.py
@@ -12,6 +12,7 @@ from daimon.core.errors import (
     SpecError,
     StoreError,
 )
+from sqlalchemy.exc import SQLAlchemyError
 from ulid import ULID
 
 import discord
@@ -42,6 +43,13 @@ def render_error(exc: Exception, *, request_id: str) -> str:
         return f"❌ **API Error**: {exc.message}\n`rid: {request_id}`"
     if isinstance(exc, discord.HTTPException):
         return f"❌ **Discord Error ({exc.status})**: {exc.text}\n`rid: {request_id}`"
+    if isinstance(exc, SQLAlchemyError):
+        # Never `{exc}` here: DBAPIError stringifies to the failing statement
+        # plus its bound parameters, which would publish both to the channel.
+        # The rid is the handle for the real detail, which stays in the logs.
+        return (
+            f"❌ **Database error** ({type(exc).__name__}). Please try again.\n`rid: {request_id}`"
+        )
     if isinstance(exc, ValueError):
         return f"⚠️ **Invalid input**: {exc}\n`rid: {request_id}`"
     return f"❌ **Unexpected error**: {exc}\n`rid: {request_id}`"

--- a/packages/adapters/discord/tests/test_errors_render.py
+++ b/packages/adapters/discord/tests/test_errors_render.py
@@ -9,6 +9,7 @@ import discord
 import httpx
 from daimon.adapters.discord.errors import generate_request_id, render_error
 from daimon.core.errors import DaimonError, SpecError, StoreError
+from sqlalchemy.exc import DBAPIError, OperationalError
 
 TEST_RID = "01JTZXTEST000000000000000"
 
@@ -89,6 +90,21 @@ class TestRenderError:
         assert result.startswith("⚠️"), "should start with warning emoji"
         assert "**Invalid input**" in result, "should have bold label"
         assert "bad input" in result, "should include error detail"
+        assert TEST_RID in result, "should include request ID"
+
+    def test_database_error_omits_statement_and_parameters(self) -> None:
+        # str() on a DBAPIError embeds the failing statement and its bound
+        # parameters, so rendering it verbatim publishes both to the channel.
+        exc = DBAPIError(
+            "SELECT tenants.id FROM tenants WHERE tenants.id = $1::UUID",
+            {"id": "8014123e-f113-5516-a71e-3ba7401d3808"},
+            OperationalError("SELECT 1", None, Exception("connection was closed in the middle")),
+        )
+        result = render_error(exc, request_id=TEST_RID)
+        assert "SELECT" not in result, "must not leak the failing SQL statement"
+        assert "tenants" not in result, "must not leak table or column names"
+        assert "8014123e" not in result, "must not leak bound parameter values"
+        assert "DBAPIError" in result, "should name the exception class"
         assert TEST_RID in result, "should include request ID"
 
     def test_discord_http_exception(self) -> None:

--- a/packages/core/daimon/core/db.py
+++ b/packages/core/daimon/core/db.py
@@ -19,8 +19,19 @@ def build_engine(url: str, *, echo: bool = False) -> AsyncEngine:
     """Build an `AsyncEngine` for the given DSN.
 
     The caller owns lifecycle and must `await engine.dispose()` on shutdown.
+
+    Adapters hold one engine for the whole process lifetime, so pooled
+    connections outlive any single turn and go idle for hours between them. A
+    managed Postgres reached over a private network path drops such connections
+    without a FIN, and the pool cannot tell: it hands the dead socket back and
+    the next query fails with `ConnectionDoesNotExistError`. `pool_pre_ping`
+    validates on checkout and transparently substitutes a fresh connection;
+    `pool_recycle` retires connections before they reach that idle window.
+
+    Pre-ping only covers checkout, so a connection that dies mid-statement
+    (a failover, say) still raises — that needs retry at the adapter boundary.
     """
-    return create_async_engine(url, echo=echo)
+    return create_async_engine(url, echo=echo, pool_pre_ping=True, pool_recycle=1800)
 
 
 def build_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:

--- a/packages/core/tests/test_db.py
+++ b/packages/core/tests/test_db.py
@@ -22,6 +22,43 @@ async def test_build_engine_returns_live_async_engine_when_pointed_at_test_db() 
 
 
 @pytest.mark.asyncio
+async def test_build_engine_replaces_pooled_connection_when_killed_while_idle() -> None:
+    """A connection reaped while it sits in the pool must not fail the next query.
+
+    Long-lived adapters hold one engine for the process lifetime, so a quiet
+    thread leaves a pooled connection idle long enough for the network path to
+    drop it without a FIN. Without pool_pre_ping the pool hands that dead socket
+    straight back and the caller sees ConnectionDoesNotExistError.
+    """
+    url = os.environ["DAIMON_DATABASE__TEST_URL"]
+    engine = build_engine(url)
+    factory = build_session_factory(engine)
+    try:
+        async with factory() as session:
+            first_pid = (await session.execute(text("SELECT pg_backend_pid()"))).scalar_one()
+
+        # `terminate()` drops the transport without a clean shutdown, which is
+        # what the client is left holding after a network-side idle reap: a
+        # socket that is gone with no FIN to announce it. Killing the backend
+        # server-side instead would not reproduce this — Postgres would send a
+        # FATAL and asyncpg would abort the protocol, a different failure.
+        pooled = await engine.raw_connection()
+        driver = pooled.driver_connection
+        assert driver is not None, "pooled connection should expose its asyncpg connection"
+        driver.terminate()
+        pooled.close()
+
+        async with factory() as session:
+            second_pid = (await session.execute(text("SELECT pg_backend_pid()"))).scalar_one()
+
+        assert second_pid != first_pid, (
+            "pool should have opened a replacement backend, not reused the dead one"
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_build_session_factory_produces_usable_sessions_when_called() -> None:
     url = os.environ["DAIMON_DATABASE__TEST_URL"]
     engine = build_engine(url)


### PR DESCRIPTION
Two independent production defects, surfaced by one Discord error report and fixed in one commit each.

The report carried a rid whose ULID decodes to 2026-08-12 05:33:39 UTC — **39.5h after the most recent deployment to either environment**. That ruled out the initial "post-deploy" reading and pointed at connection age instead.

## `d65646f` — pre-ping and recycle pooled DB connections (closes #63)

`build_engine` passed neither `pool_pre_ping` nor `pool_recycle`, so SQLAlchemy's default `QueuePool` held connections for the life of the process and never validated them on checkout.

Adapters build one engine at startup and keep it — discord, slack, mcp and scheduler all do — so a pooled connection outlives any single turn and sits idle between them. A managed Postgres reached over a private network path drops those connections without a FIN, and the pool cannot tell: it returns the dead socket and the next query fails with `ConnectionDoesNotExistError`.

```python
create_async_engine(url, echo=echo, pool_pre_ping=True, pool_recycle=1800)
```

### The test is the interesting part

The obvious test — `pg_terminate_backend` from a second engine — **does not reproduce this bug**. Postgres sends a FATAL, asyncpg aborts the protocol, and you get `InternalClientError: cannot switch to state 15`, which pre-ping neither can nor should rescue. That test fails identically before and after the fix.

The production shape is a socket that vanishes with nothing announcing it. `asyncpg.Connection.terminate()` (public API — drops the transport with no clean shutdown) reproduces it exactly. Verified red/green: `InterfaceError` without the fix, passing with it.

### Known ceiling, deliberately not addressed

Pre-ping validates on checkout only, so a connection dying *mid-statement* (a failover) still raises. That needs retry at the adapter boundary — different change, different risk profile. Documented in the docstring.

## `d8c29f6` — stop `render_error` leaking SQL and bound parameters (closes #64)

`str()` on a SQLAlchemy `DBAPIError` embeds the failing statement **and its bound parameters**, and `render_error`'s catch-all interpolated `{exc}` — so a routine connection error published the SQL and a tenant UUID into the channel where the turn was running.

`render_error` already branched on `DaimonError`, the anthropic types, `discord.HTTPException` and `ValueError`; there was simply no `SQLAlchemyError` branch, so every DB failure fell through to the stringifying fallback. Added one that renders the exception class name plus the rid, never `str(exc)`.

The generic fallback still stringifies unknown exceptions — narrowing that changes behaviour for every non-DB error and is left for its own commit.

## Verification

- Full suite: **4489 passed, 4 skipped**
- `pyright` strict: 0 errors · `ruff check`: clean · `lint-imports`: 6 contracts kept
- All pre-commit gates green on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
