### PR TITLE
fix(discord): land the env-vars paste re-render on the panel itself

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import re
 import uuid
 from collections.abc import Awaitable, Callable
+from typing import Protocol
 
 import structlog
 from daimon.adapters.discord.agent_setup import authz
@@ -43,20 +44,38 @@ _SECRET_CAP = 20
 _MAX_SECRET_VALUE_BYTES = 4096
 _POSIX_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+
 # Re-render callback: invoked after a successful paste so the sub-view can
-# reload and re-render in place. Takes the modal's interaction.
-OnAdded = Callable[[discord.Interaction], Awaitable[None]]
+# reload and re-render in place. Takes the modal's interaction plus the number
+# of keys written — the count is all the collapsed render needs, and keeping it
+# a count means the modal never hands a key name or a value to the renderer.
+class OnAdded(Protocol):
+    async def __call__(self, interaction: discord.Interaction, *, key_count: int) -> None: ...
+
+
+def format_paste_result(*, key_count: int) -> str:
+    """Pure: the line that replaces the add control after a successful paste.
+
+    Takes a COUNT — never a key name, never a value. The key names surface is
+    the chips line, which the post-paste reload refreshes.
+    """
+    noun = "env var" if key_count == 1 else "env vars"
+    return f"Saved ✓ — {key_count} {noun} set"
 
 
 def build_credentials_container(
     *,
     agent_name: str,
     secret_names: list[str],
+    result_line: str | None = None,
 ) -> discord.ui.Container[discord.ui.LayoutView]:
     """Pure: render the Credentials container from key NAMES only.
 
     Never receives or renders a secret value — every value is omitted entirely
     Key names render as `KEY` chips on a single line separated by · .
+
+    `result_line` is the optional post-paste acknowledgement; it carries a
+    count only (see `format_paste_result`), so it cannot carry a value either.
 
     Env variables are per-agent daimon state (agent_files, keyed by
     tenant/agent/key) and are never part of the agent spec, so provenance
@@ -80,6 +99,9 @@ def build_credentials_container(
     else:
         # Design-language collapse: dim hint instead of "(none)" copy.
         container.add_item(discord.ui.TextDisplay("-# ＋ add your first env var"))
+
+    if result_line is not None:
+        container.add_item(discord.ui.TextDisplay(result_line))
 
     return container
 
@@ -130,7 +152,15 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
             interaction, runtime=self._runtime, entry=self._entry
         ):
             return
-        await interaction.response.defer(ephemeral=True, thinking=True)
+        # A BARE defer() on purpose: for a modal_submit discord.py maps
+        # thinking=False to `deferred_message_update`, whose `@original` is the
+        # message this interaction came from — the panel, because `_on_add`
+        # opened the modal from a component click on it. With
+        # `thinking=True` the ack is a `deferred_channel_message` instead, which
+        # repoints `@original` at a brand-new ephemeral message, so the
+        # re-render below would patch that duplicate and the panel would never
+        # change. Ephemeral followups still work after this ack.
+        await interaction.response.defer()
         raw = str(self.content_input.value or "")
 
         pairs: list[tuple[str, str]] = []
@@ -191,7 +221,9 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
         else:
             toast = f"Added {n} env vars. Takes effect on the next session."
         await interaction.followup.send(toast, ephemeral=True)
-        await self._on_added(interaction)
+        # Carries the count of keys actually WRITTEN — never a key name, never
+        # a value. It is all the collapsed render needs.
+        await self._on_added(interaction, key_count=len(pairs))
 
 
 class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
@@ -201,9 +233,10 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
     line, ✕ Remove a var… select, + Add env vars · ← Back button row.
 
     Carries key NAMES only (``secret_names``) — never values. Mutations
-    re-render this view in place via ``edit_original_response``; '← Back'
-    replaces the message with ``EditView`` (it does NOT delete it), preserving
-    the ephemeral isolation invariant.
+    re-render this view in place via ``edit_original_response``, and a
+    successful paste re-renders with the add control swapped for the result
+    line; '← Back' replaces the message with ``EditView`` (it does NOT delete
+    it), preserving the ephemeral isolation invariant.
     """
 
     def __init__(
@@ -228,12 +261,13 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
     def _agent_name(self) -> str:
         return self._state.selected.name if self._state.selected else "?"
 
-    def _build_items(self) -> None:
+    def _build_items(self, *, result_line: str | None = None) -> None:
         self.clear_items()
 
         container = build_credentials_container(
             agent_name=self._agent_name(),
             secret_names=self._secret_names,
+            result_line=result_line,
         )
 
         # ✕ Remove a var… select (cap 20, glyph in placeholder not emoji=).
@@ -244,16 +278,20 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         select_row.add_item(remove_select)
         container.add_item(select_row)
 
-        # Button row: + Add env vars · ← Back.
+        # Button row: + Add env vars · ← Back. A result line means the paste
+        # just landed, so the add control is SWAPPED OUT for it — not greyed
+        # out. Remove and ← Back stay live: the panel is still a management
+        # surface, and re-adding is one '← Back' → 'Env vars' hop away.
         btn_row: discord.ui.ActionRow[CredentialsSubView] = discord.ui.ActionRow()
 
-        add_btn: discord.ui.Button[CredentialsSubView] = discord.ui.Button(
-            label="+ Add env vars",
-            style=discord.ButtonStyle.success,
-            disabled=len(self._secret_names) >= _SECRET_CAP,
-        )
-        add_btn.callback = self._on_add  # type: ignore[method-assign]
-        btn_row.add_item(add_btn)
+        if result_line is None:
+            add_btn: discord.ui.Button[CredentialsSubView] = discord.ui.Button(
+                label="+ Add env vars",
+                style=discord.ButtonStyle.success,
+                disabled=len(self._secret_names) >= _SECRET_CAP,
+            )
+            add_btn.callback = self._on_add  # type: ignore[method-assign]
+            btn_row.add_item(add_btn)
 
         back_btn: discord.ui.Button[CredentialsSubView] = discord.ui.Button(
             label="← Back",
@@ -346,13 +384,22 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
             allowed_mentions=discord.AllowedMentions.none(),
         )
 
-    async def _reload_and_rerender(self, interaction: discord.Interaction) -> None:
+    async def _reload_and_rerender(
+        self, interaction: discord.Interaction, *, key_count: int | None = None
+    ) -> None:
+        # `key_count` is the OnAdded contract: a paste passes the number of keys
+        # it wrote and gets the collapsed render, everything else omits it and
+        # gets the normal one. It stays a per-render ARGUMENT and is never
+        # stored on the instance — a stored result line would survive into the
+        # next remove's re-render as a stale `Saved ✓`.
         async with self._runtime.sessionmaker() as session:
             rows = await list_agent_files(
                 session, tenant_id=self._tenant_id, agent_id=self._agent_id
             )
         self._secret_names = [row.key for row in rows]
-        self._build_items()
+        self._build_items(
+            result_line=None if key_count is None else format_paste_result(key_count=key_count)
+        )
         # This view is re-rendered IN PLACE (same instance across renders, not
         # reconstructed like the other four views), so the binding must be
         # refreshed here on every render — an interaction bound once at

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -337,7 +337,10 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
             return
         # key_name is the secret KEY NAME the option carried — never a value.
         _log.info("credentials.remove.click", key=key_name)
-        await interaction.response.defer(ephemeral=True, thinking=True)
+        # Bare defer() for the same reason as the paste path: a thinking ack
+        # would repoint `@original` at a fresh ephemeral message and the
+        # re-render below would never touch the panel.
+        await interaction.response.defer()
         try:
             async with self._runtime.sessionmaker() as session, session.begin():
                 await delete_agent_file(

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -21,6 +21,7 @@ from daimon.adapters.discord.agent_setup.credentials import (
     CredentialsSubView,
     PasteSecretModal,
     build_credentials_container,
+    format_paste_result,
 )
 from daimon.adapters.discord.agent_setup.edit_view import EditView
 from daimon.adapters.discord.agent_setup.state import PanelState, RosterEntry
@@ -191,6 +192,46 @@ def test_container_no_none_copy_in_empty_state() -> None:
     ]
     for d in displays:
         assert "(none)" not in d, "empty state must not say (none)"
+
+
+# --- the post-paste result line (pure) -------------------------------------
+
+
+def test_format_paste_result_is_singular_for_one_key_and_plural_above_one() -> None:
+    assert format_paste_result(key_count=1) == "Saved ✓ — 1 env var set", (
+        "one key reads as a singular env var"
+    )
+    assert format_paste_result(key_count=3) == "Saved ✓ — 3 env vars set", (
+        "more than one key pluralises"
+    )
+
+
+def test_container_appends_the_result_line_after_the_chips() -> None:
+    container = build_credentials_container(
+        agent_name="bot",
+        secret_names=["A_KEY", "B_KEY"],
+        result_line=format_paste_result(key_count=2),
+    )
+    displays = [
+        child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
+    ]
+    chips_index = next(i for i, d in enumerate(displays) if "`A_KEY`" in d)
+    result_index = next(i for i, d in enumerate(displays) if d == "Saved ✓ — 2 env vars set")
+    assert result_index > chips_index, "the result line renders after the chips, not before them"
+
+
+def test_container_result_line_never_carries_a_value() -> None:
+    """The result line is built from a count, so no value can ride along."""
+    container = build_credentials_container(
+        agent_name="bot",
+        secret_names=["XERO_API_KEY"],
+        result_line=format_paste_result(key_count=1),
+    )
+    all_text = " ".join(
+        child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
+    )
+    assert _SECRET_VALUE not in all_text, "no secret value may appear in the collapsed container"
+    assert "XERO_API_KEY" in all_text, "the key name is what the collapsed container shows"
 
 
 # --- CredentialsSubView item construction ----------------------------------
@@ -377,7 +418,9 @@ async def test_paste_modal_stores_each_pair_and_never_logs_value(
     toast = interaction.followup.send.call_args.args[0]
     assert "Added 2 env vars" in toast, "multi-key success copy"
     assert _SECRET_VALUE not in toast, "toast never echoes a value"
-    on_added.assert_awaited_once()  # re-render callback fired after a successful paste
+    # The re-render callback fires after a successful paste, carrying the COUNT
+    # the collapsed render needs — never a key name and never a value.
+    on_added.assert_awaited_once_with(interaction, key_count=2)
 
     for entry in cap.entries:
         assert _SECRET_VALUE not in repr(entry), "no log line may contain a secret value"
@@ -554,6 +597,211 @@ async def test_paste_modal_refusal_logs_no_key_names_or_values(
         assert _SECRET_VALUE not in rendered, "a refused paste must not log a secret value"
         assert "XERO_API_KEY" not in rendered, "a refused paste must not log a key name either"
         assert "TOGGL_TOKEN" not in rendered, "a refused paste must not log a key name either"
+
+
+# --- paste → panel collapse (real DB, full wiring) -------------------------
+
+
+@pytest.mark.asyncio
+async def test_paste_success_collapses_the_add_control_on_the_panel(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    account_id: uuid.UUID,
+) -> None:
+    """After a successful paste the panel stops asking for more input: the add
+    control is gone, a result line names the count, and the freshly pasted keys
+    are in the chips and the remove select. Remove and ← Back stay live."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="test-guild")
+    agent_id = uuid.uuid4()
+
+    view = CredentialsSubView(
+        runtime=_runtime(db_session_factory),
+        state=_state(_entry("bot"), account_id),
+        allowed_user_id=42,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        secret_names=[],
+    )
+
+    # Two distinct interactions, as in production: the click that opens the
+    # modal, then the modal submit.
+    click_interaction = _interaction()
+    await view._on_add(click_interaction)  # pyright: ignore[reportPrivateUsage]
+    modal = click_interaction.response.send_modal.call_args.args[0]
+    modal.content_input._value = (  # pyright: ignore[reportPrivateUsage]
+        f"XERO_API_KEY={_SECRET_VALUE}\nTOGGL_TOKEN=second-value"
+    )
+
+    submit_interaction = _interaction()
+    await modal.on_submit(submit_interaction)
+
+    submit_interaction.edit_original_response.assert_awaited_once()
+    panel = submit_interaction.edit_original_response.call_args.kwargs["view"]
+    labels = [b.label for b in _walk_buttons(panel)]
+    assert "+ Add env vars" not in labels, "the add control is swapped out, not left live"
+    assert "← Back" in labels, "← Back stays live on the collapsed panel"
+    select = _remove_select(panel)
+    assert select.disabled is False, "the remove select stays live on the collapsed panel"
+    assert sorted(o.value for o in select.options) == ["TOGGL_TOKEN", "XERO_API_KEY"], (
+        "the reload puts the freshly pasted keys into the remove select"
+    )
+    text = _container_all_text(panel)
+    assert "Saved ✓ — 2 env vars set" in text, "the result line names the count"
+    assert "XERO_API_KEY" in text and "TOGGL_TOKEN" in text, "the chips list both pasted keys"
+
+
+@pytest.mark.asyncio
+async def test_paste_success_acks_as_a_message_update_so_the_panel_is_the_edit_target(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    account_id: uuid.UUID,
+) -> None:
+    """Regression guard on the ack TYPE, which is the whole mechanism.
+
+    A `defer(ephemeral=True, thinking=True)` on a modal submit is a
+    deferred_channel_message, which repoints this interaction's `@original` at
+    a brand-new ephemeral message — so `edit_original_response` below would
+    render a duplicate panel into the ex-spinner and the real panel would never
+    change. A bare `defer()` is a deferred_message_update, whose `@original` is
+    the message the modal was opened from: the panel."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="test-guild")
+
+    view = CredentialsSubView(
+        runtime=_runtime(db_session_factory),
+        state=_state(_entry("bot"), account_id),
+        allowed_user_id=42,
+        tenant_id=tenant.id,
+        agent_id=uuid.uuid4(),
+        secret_names=[],
+    )
+
+    click_interaction = _interaction()
+    await view._on_add(click_interaction)  # pyright: ignore[reportPrivateUsage]
+    modal = click_interaction.response.send_modal.call_args.args[0]
+    modal.content_input._value = f"XERO_API_KEY={_SECRET_VALUE}"  # pyright: ignore[reportPrivateUsage]
+
+    submit_interaction = _interaction()
+    await modal.on_submit(submit_interaction)
+
+    assert submit_interaction.response.defer.call_args.args == (), (
+        "the modal submit must ack with a bare defer() — no thinking, no ephemeral"
+    )
+    assert submit_interaction.response.defer.call_args.kwargs == {}, (
+        "the modal submit must ack with a bare defer() — no thinking, no ephemeral"
+    )
+    submit_interaction.followup.send.assert_awaited()  # the toast still works after a type-6 ack
+
+
+@pytest.mark.asyncio
+async def test_paste_failure_leaves_the_panel_uncollapsed(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    account_id: uuid.UUID,
+) -> None:
+    """A rejected paste wrote nothing, so the panel must keep its add control."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="test-guild")
+
+    view = CredentialsSubView(
+        runtime=_runtime(db_session_factory),
+        state=_state(_entry("bot"), account_id),
+        allowed_user_id=42,
+        tenant_id=tenant.id,
+        agent_id=uuid.uuid4(),
+        secret_names=[],
+    )
+
+    click_interaction = _interaction()
+    await view._on_add(click_interaction)  # pyright: ignore[reportPrivateUsage]
+    modal = click_interaction.response.send_modal.call_args.args[0]
+    modal.content_input._value = "123BAD=value\nGOOD_KEY=val"  # pyright: ignore[reportPrivateUsage]
+
+    submit_interaction = _interaction()
+    await modal.on_submit(submit_interaction)
+
+    submit_interaction.edit_original_response.assert_not_awaited()
+    assert "Secret name must match" in submit_interaction.followup.send.call_args.args[0], (
+        "the invalid-key toast is the only feedback on a failed paste"
+    )
+
+
+@pytest.mark.asyncio
+async def test_collapsed_panel_renders_key_names_never_values(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    account_id: uuid.UUID,
+) -> None:
+    """The collapse path is the newest place a value could leak, so the
+    module's hygiene invariant is asserted directly on it: the key name shows,
+    the value does not — not in the container, not in the edit call."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="test-guild")
+
+    view = CredentialsSubView(
+        runtime=_runtime(db_session_factory),
+        state=_state(_entry("bot"), account_id),
+        allowed_user_id=42,
+        tenant_id=tenant.id,
+        agent_id=uuid.uuid4(),
+        secret_names=[],
+    )
+
+    click_interaction = _interaction()
+    await view._on_add(click_interaction)  # pyright: ignore[reportPrivateUsage]
+    modal = click_interaction.response.send_modal.call_args.args[0]
+    modal.content_input._value = (  # pyright: ignore[reportPrivateUsage]
+        f"XERO_API_KEY={_SECRET_VALUE}\nTOGGL_TOKEN=second-value"
+    )
+
+    submit_interaction = _interaction()
+    await modal.on_submit(submit_interaction)
+
+    all_text = _container_all_text(view)
+    assert "XERO_API_KEY" in all_text, "the collapsed panel shows the key name"
+    assert _SECRET_VALUE not in all_text, "no secret value may appear in the collapsed panel"
+    assert _SECRET_VALUE not in str(submit_interaction.edit_original_response.call_args.kwargs), (
+        "no secret value may ride along in the panel edit call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_after_a_paste_restores_the_add_control_and_drops_the_result_line(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    account_id: uuid.UUID,
+) -> None:
+    """The result line is a per-render argument, never instance state: the next
+    mutation on the same view instance must render the add control back and no
+    `Saved ✓`. Stored on the view, this test fails with a stale result line."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="test-guild")
+
+    view = CredentialsSubView(
+        runtime=_runtime(db_session_factory),
+        state=_state(_entry("bot"), account_id),
+        allowed_user_id=42,
+        tenant_id=tenant.id,
+        agent_id=uuid.uuid4(),
+        secret_names=[],
+    )
+
+    click_interaction = _interaction()
+    await view._on_add(click_interaction)  # pyright: ignore[reportPrivateUsage]
+    modal = click_interaction.response.send_modal.call_args.args[0]
+    modal.content_input._value = (  # pyright: ignore[reportPrivateUsage]
+        f"XERO_API_KEY={_SECRET_VALUE}\nTOGGL_TOKEN=second-value"
+    )
+    await modal.on_submit(_interaction())
+
+    remove_interaction = _interaction()
+    select = _remove_select(view)
+    select._values = ["XERO_API_KEY"]  # pyright: ignore[reportPrivateUsage]  # simulate a user pick
+    assert select.callback is not None
+    await select.callback(remove_interaction)
+
+    panel = remove_interaction.edit_original_response.call_args.kwargs["view"]
+    labels = [b.label for b in _walk_buttons(panel)]
+    assert "+ Add env vars" in labels, "a removal renders the add control back"
+    assert "Saved ✓" not in _container_all_text(panel), (
+        "the paste result line must not stick around into the next render"
+    )
 
 
 # --- ✕ remove (real DB) -----------------------------------------------------

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -850,6 +850,14 @@ async def test_remove_deletes_the_key_and_rerenders(
     # The re-render view must not leak the surviving value.
     rerender_kwargs = interaction.edit_original_response.call_args.kwargs
     assert _SECRET_VALUE not in str(rerender_kwargs), "no value in re-render call kwargs"
+    # Same ack mechanism as the paste path: a thinking defer would point
+    # `@original` at a fresh ephemeral message and the panel would never change.
+    assert interaction.response.defer.call_args.args == (), (
+        "the remove must ack with a bare defer() — no thinking, no ephemeral"
+    )
+    assert interaction.response.defer.call_args.kwargs == {}, (
+        "the remove must ack with a bare defer() — no thinking, no ephemeral"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Filed as UX polish — "make the buttons disappear after someone pastes". Tracing the mechanism turned up a real defect underneath: **the paste never edited the panel at all.**

## The mechanism

`PasteSecretModal.on_submit` acked with `defer(ephemeral=True, thinking=True)`. For a `modal_submit` interaction discord.py maps `thinking=True` to `deferred_channel_message` + `flags: 64`, so `edit_original_response` PATCHes the newly created ephemeral *thinking* message.

Every re-render since this panel shipped has landed on a throwaway ephemeral duplicate. The real panel was never touched — which is why the buttons stayed live — and the rebind afterwards pointed the `ExpiringView` timeout at the duplicate too.

The ack is the fix:

```python
await interaction.response.defer()   # deferred_message_update — @original IS the panel
```

valid because `_on_add` opens the modal via `response.send_modal` from a component click. Precedent already shipped in `EditView._on_back` → `rerender_root_panel` → `edit_original_response`.

## On top of that

`76fc7d0` swaps the add control for `Saved ✓ — N env vars set`; **remove and back stay live** so the panel is still a management surface. Full teardown was rejected — it would cost "add a second secret without reopening".

The result line is a **per-render argument, never instance state**; otherwise a later remove would re-render a stale `Saved ✓`. A test fails if someone stores it.

`0fdac0f` gives `_on_remove` the same one-line ack fix. Same defect in a sibling handler rather than adjacent cleanup — shipping one control fixed while its neighbour stayed broken would be worse than the slightly wider diff.

## Review notes

**Behaviour change worth a look:** both controls lose their ephemeral "thinking" spinner during the write — the panel edit is now the feedback. Deliberate, but it is a visible change on the remove path that the issue never mentioned.

**Swept for recurrences.** Every other `thinking=True` site in the adapter was checked: `credential_modals.py` (4 sites) and `feedback_modal.py` are modals that only send followups, which is the correct use of a thinking ack; slash commands can only use `deferred_channel_message`. Nothing else needed changing. Slack's env-var surface uses different primitives and was left alone.

**Secrets:** key names only ever reach the renderer — the post-paste line carries a *count*, not names or values. Covered by test.

## Verification

- `packages/adapters/discord`: **1030 passed**
- `pyright` strict: 0 errors · `ruff check`: clean · `lint-imports`: 6 contracts kept
- Discord modal AST lint and test anti-pattern lint (T1–T8): clean

Mutation-checked — restoring `thinking=True`, storing the result line on the instance, or dropping the count each fail a specific new test.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
