### PR TITLE
fix: wedged threads, aborted skill syncs, and an inert default-agent guard

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -51,6 +51,7 @@ from daimon.core.stores.tenants import (
 from daimon.core.stores.thread_sessions import (
     clear_active_turn,
     list_orphaned_turns,
+    mark_dead,
     mark_turn_active,
     update_watermark,
 )
@@ -58,7 +59,7 @@ from daimon.core.turn.admission import AdmissionDenied, MissingTurnConfigError, 
 from daimon.core.turn.gating import should_admit_turn
 from daimon.core.turn.lifecycle import TurnLifecycle
 from daimon.core.turn.prepare import bind_session
-from daimon.core.turn.run import run_prepared_turn
+from daimon.core.turn.run import RunOutcome, run_prepared_turn
 from sqlalchemy.exc import SQLAlchemyError  # noqa: TCH002
 
 import discord
@@ -76,6 +77,27 @@ _DRAIN_GRACE_S: float = 60.0
 
 # Bounded concurrency for the on_ready re-seed sweep.
 _SWEEP_CONCURRENCY = 4
+
+# Wall-clock ceiling on a single turn. Not a latency target -- legitimate
+# agentic turns run many minutes (notebooks, model fits), so this is set well
+# above the longest real turn and exists only to bound the pathological case.
+#
+# Without it a turn can hang forever: an MA session that never leaves `running`
+# (e.g. a tool call whose result never comes back) leaves the await unresolved,
+# so the clear_active_turn below it is never reached and the thread's
+# active_turn marker is held for good. _retire_orphaned_turns cannot help --
+# it runs once per process at on_ready and deliberately has no age filter,
+# because it assumes "a turn cannot outlive the process rendering it". A hung
+# await outlives the process just fine, which is how a thread ends up
+# permanently unable to accept a mention until the next deploy.
+#
+# ponytail: a flat wall-clock deadline, not a liveness deadline. A turn
+# streaming events is alive no matter how long it runs, and one silent for ten
+# minutes is wedged regardless of total duration -- keying on time-since-last-
+# event would cut the dead case loose sooner and never touch a live one. That
+# needs the render loop to expose a last-event timestamp; upgrade to it if this
+# ceiling ever fires on a real turn.
+_TURN_DEADLINE_S: float = 45.0 * 60.0
 
 
 def _resolve_bot_display_name(settings: Settings) -> str:
@@ -564,6 +586,54 @@ class DaimonBot(commands.Bot):
             async with self.runtime.sessionmaker() as session:
                 await clear_active_turn(session, id=row.id)
                 await session.commit()
+
+    async def _retire_deadlocked_turn(
+        self,
+        *,
+        mapping_id: uuid.UUID | None,
+        thread_id: str,
+        session_id: str | None,
+        message_ref: Any | None,
+    ) -> None:
+        """Lay to rest a turn that blew `_TURN_DEADLINE_S`.
+
+        The session is wedged, not merely slow: it will never reach a terminal
+        state, so the mapping is marked dead. Without that the next mention
+        binds the same dead MA session and hangs again — the thread would come
+        unstuck for exactly one message.
+
+        Clearing the active_turn marker is deliberately NOT done here; the
+        caller's `finally` owns it, so it also runs for failures that are not
+        deadline-related.
+        """
+        log.error(
+            "turn.deadline_exceeded",
+            thread_id=thread_id,
+            session_id=session_id,
+            deadline_s=_TURN_DEADLINE_S,
+        )
+        if mapping_id is not None:
+            async with self.runtime.sessionmaker() as session:
+                await mark_dead(session, id=mapping_id)
+                await session.commit()
+        if message_ref is None:
+            return
+        try:
+            await message_ref.edit(
+                embed=discord.Embed(
+                    color=theme.COLOR_RED,
+                    description=(
+                        "❌ This turn stopped responding and was abandoned. Nothing was "
+                        "lost on your side — mention me again to start fresh."
+                    ),
+                ),
+                view=None,
+            )
+        except (discord.HTTPException, discord.ClientException) as err:
+            # The spinner may be deleted or the thread archived. The marker is
+            # cleared by the caller either way, which is what actually unsticks
+            # the thread; a stale embed is cosmetic by comparison.
+            log.warning("turn.deadline_embed_failed", thread_id=thread_id, error=str(err))
 
     async def on_ready(self) -> None:
         """Forward-only reconcile sweep: provision-if-missing, re-seed pending/failed,
@@ -1373,35 +1443,56 @@ class DaimonBot(commands.Bot):
             thread_id=thread.id,
             session_id=prepared.ma_session_id,
         )
-        outcome = await run_prepared_turn(
-            self.runtime.turn_deps,
-            prepared,
-            tenant_id=tenant_id,
-            platform="discord",
-            thread_id=str(thread.id),
-            external_user_id=str(message.author.id),
-            user_message=user_message,
-            lifecycle=lifecycle,
-            cancel=cancel,
-            reseed_user_message=_reseed_user_message,
-            recovery_lifecycle=_recovery_lifecycle,
-            image_blocks=image_blocks,
-            render_interval_s=2.0,
-        )
+        outcome: RunOutcome | None = None
+        try:
+            outcome = await asyncio.wait_for(
+                run_prepared_turn(
+                    self.runtime.turn_deps,
+                    prepared,
+                    tenant_id=tenant_id,
+                    platform="discord",
+                    thread_id=str(thread.id),
+                    external_user_id=str(message.author.id),
+                    user_message=user_message,
+                    lifecycle=lifecycle,
+                    cancel=cancel,
+                    reseed_user_message=_reseed_user_message,
+                    recovery_lifecycle=_recovery_lifecycle,
+                    image_blocks=image_blocks,
+                    render_interval_s=2.0,
+                ),
+                timeout=_TURN_DEADLINE_S,
+            )
+        except TimeoutError:
+            await self._retire_deadlocked_turn(
+                mapping_id=prepared.mapping_id,
+                thread_id=str(thread.id),
+                session_id=prepared.ma_session_id,
+                message_ref=lifecycle.message_ref,
+            )
+            return
+        finally:
+            # Runs on the deadline and on any exception, not just the happy
+            # path: whatever else went wrong, the thread must not be left
+            # holding its active_turn marker. Both ids are cleared -- recovery
+            # moves the turn to a new mapping row and leaves the marker behind
+            # on the old one, which is still pointing at this same message.
+            _done_ids = {prepared.mapping_id}
+            if outcome is not None:
+                _done_ids.add(outcome.mapping_id)
+            for _done_id in _done_ids - {None}:
+                if _done_id is None:  # pragma: no cover - set difference guarantees this
+                    continue
+                async with self.runtime.sessionmaker() as _ct_session:
+                    await clear_active_turn(_ct_session, id=_done_id)
+                    await _ct_session.commit()
+
+        if outcome is None:  # pragma: no cover - the deadline branch above returns
+            return
+
         state = outcome.state
         mapping_id = outcome.mapping_id
         final_lifecycle = lifecycle_holder[0]
-
-        # The turn reached a terminal state under this process, so its embed is
-        # settled and must not be reaped by a later boot. Both ids are cleared:
-        # recovery moves the turn to a new mapping row and leaves the marker
-        # behind on the old one, which is still pointing at this same message.
-        for _done_id in {prepared.mapping_id, mapping_id} - {None}:
-            if _done_id is None:  # pragma: no cover - set comprehension guarantees this
-                continue
-            async with self.runtime.sessionmaker() as _ct_session:
-                await clear_active_turn(_ct_session, id=_done_id)
-                await _ct_session.commit()
 
         if state.error is not None:
             log.warning(

--- a/packages/adapters/discord/tests/test_orphaned_turns.py
+++ b/packages/adapters/discord/tests/test_orphaned_turns.py
@@ -23,6 +23,8 @@ from daimon.core.notebooks._rate_limit import RateLimiter
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.thread_sessions import (
     create_thread_session,
+    get_live_thread_session,
+    get_thread_session_by_id,
     list_orphaned_turns,
     mark_turn_active,
 )
@@ -142,3 +144,76 @@ async def test_sweep_runs_once_per_process_not_once_per_reconnect(
     assert [row.id for row in await list_orphaned_turns(db_session, platform="discord")] == [
         mapping_id
     ], "a reconnect must not reap the turns this process is still rendering"
+
+
+async def test_deadlocked_turn_is_marked_dead_so_the_next_mention_gets_a_fresh_session(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A turn that blows the wall-clock deadline must retire its session mapping.
+
+    The MA session is wedged, not slow — it will never reach a terminal state.
+    If the mapping stays live, the next mention binds the same dead session and
+    hangs again, so the thread would come unstuck for exactly one message.
+    """
+    mapping_id = await _make_orphan(db_session, thread_id="900", message_id="901")
+    bot = _make_bot(db_session_factory)
+    message = MagicMock(spec=discord.Message)
+    message.edit = AsyncMock()
+
+    await bot._retire_deadlocked_turn(  # pyright: ignore[reportPrivateUsage]
+        mapping_id=mapping_id,
+        thread_id="900",
+        session_id="sesn_test",
+        message_ref=message,
+    )
+
+    row = await get_thread_session_by_id(db_session, id=mapping_id)
+    assert row is not None, "the row must be retained as an audit trail, not deleted"
+    assert row.status == "dead", (
+        f"a deadlocked turn's mapping must be marked dead; got status={row.status!r}"
+    )
+    assert row.account_id is not None, "the fixture seeds an account_id"
+    assert (
+        await get_live_thread_session(
+            db_session,
+            tenant_id=row.tenant_id,
+            platform="discord",
+            thread_id="900",
+            account_id=row.account_id,
+        )
+        is None
+    ), "a dead mapping must drop out of the live lookup so the next turn binds a new session"
+
+    edited = message.edit.await_args.kwargs["embed"]  # pyright: ignore[reportAny]
+    assert edited.color.value == theme.COLOR_RED, "an abandoned turn must render as an error"
+    assert "abandoned" in edited.description, (
+        "the user must be told the turn was abandoned, not left on a frozen spinner"
+    )
+
+
+async def test_deadlocked_turn_still_marks_dead_when_the_embed_edit_fails(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A deleted spinner or archived thread must not stop the mapping being retired.
+
+    The embed is cosmetic; retiring the mapping is what stops the next mention
+    binding the wedged session.
+    """
+    mapping_id = await _make_orphan(db_session, thread_id="910", message_id="911")
+    bot = _make_bot(db_session_factory)
+    message = MagicMock(spec=discord.Message)
+    message.edit = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "gone"))
+
+    await bot._retire_deadlocked_turn(  # pyright: ignore[reportPrivateUsage]
+        mapping_id=mapping_id,
+        thread_id="910",
+        session_id="sesn_test",
+        message_ref=message,
+    )
+
+    row = await get_thread_session_by_id(db_session, id=mapping_id)
+    assert row is not None and row.status == "dead", (
+        "an unreachable embed must not prevent the mapping being retired"
+    )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -46,6 +46,7 @@ from daimon.core.defaults.mcp_merge import (
 )
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_ACCOUNT,
+    MA_METADATA_KEY_MANAGED,
     build_metadata,
     strip_tenant_prefix,
 )
@@ -244,15 +245,31 @@ def _union_tools(spec_tools: list[Tool], ma_agent: BetaManagedAgentsAgent) -> li
 
 
 def _reject_system_agent(agent: BetaManagedAgentsAgent) -> None:
-    """Reject system agents (no daimon_account stamp) from chat mutating tools.
+    """Reject defaults-owned agents from chat mutating tools.
 
     Unconditional — applies to admins too, with no bypass. A chat edit never
     stamps the seeded agent's spec hash, so the reconcile pipeline's hash
-    short-circuit would skip the drifted agent forever the next time defaults
-    are applied. Unstamped agents are the read-only seeded/system class — they
-    lack a daimon_account key — and must be forked before chat tools can edit
-    them.
+    short-circuit skips the drifted agent forever the next time defaults are
+    applied: the drift is permanent and `daimon defaults apply` cannot repair
+    it. Forking is the edit path.
+
+    Two markers, because either one on its own leaks:
+
+    - `daimon_managed="true"` is the reconciler's own provenance stamp and the
+      authoritative one. Keying on the absence of `daimon_account` alone did
+      NOT work: the guild seed path account-stamps seeded agents, so the
+      account key is present on them and this guard silently never fired. The
+      Discord panel hit the same trap and moved to this marker (#160); the MCP
+      tools did not follow until now. Panel forks stamp `managed=False` and
+      chat/CLI creates leave it unset, so both stay editable.
+    - a missing `daimon_account` still rejects, preserving cover for older
+      unstamped seeded agents that predate the account stamp.
     """
+    if agent.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
+        raise ToolError(
+            f"agent '{agent.name}' is managed by defaults; chat tools cannot modify it. "
+            "Use /agent-setup to fork it first, then edit the fork."
+        )
     owner = agent.metadata.get(MA_METADATA_KEY_ACCOUNT)
     if owner is None:
         raise ToolError(

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/wizard.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/wizard.py
@@ -119,13 +119,15 @@ def register_wizard_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     ) -> str:
         """Post a multi-step form in the channel instead of asking in prose.
 
-        Each entry in ``steps`` is single-choice, multi-select, or free-text.
-        A step may carry one finished image by passing the file-store handle
-        returned by the image-generation tool — never a URL, never a diagram
-        source. Server channels and threads are supported; direct messages
-        are not. A form that exceeds a platform ceiling (too many steps, too
-        many options, too large a label) raises an error naming the offending
-        step — split the form into a shorter follow-up and retry.
+        Each entry in ``steps`` carries ``question`` (the text shown to the
+        user), ``kind`` (``choice``, ``multi`` or ``text``), and ``options``
+        for the two choice kinds. A step may carry one finished image by
+        passing the file-store handle returned by the image-generation tool —
+        never a URL, never a diagram source. Server channels and threads are
+        supported; direct messages are not. A form that exceeds a platform
+        ceiling (too many steps, too many options, too long a question)
+        raises an error naming the offending step — split the form into a
+        shorter follow-up and retry.
 
         AFTER CALLING THIS TOOL YOU MUST END YOUR TURN IMMEDIATELY. Do not
         narrate the form, do not continue the conversation, and do not call

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -1835,13 +1835,15 @@
       'description': '''
         Post a multi-step form in the channel instead of asking in prose.
         
-        Each entry in ``steps`` is single-choice, multi-select, or free-text.
-        A step may carry one finished image by passing the file-store handle
-        returned by the image-generation tool — never a URL, never a diagram
-        source. Server channels and threads are supported; direct messages
-        are not. A form that exceeds a platform ceiling (too many steps, too
-        many options, too large a label) raises an error naming the offending
-        step — split the form into a shorter follow-up and retry.
+        Each entry in ``steps`` carries ``question`` (the text shown to the
+        user), ``kind`` (``choice``, ``multi`` or ``text``), and ``options``
+        for the two choice kinds. A step may carry one finished image by
+        passing the file-store handle returned by the image-generation tool —
+        never a URL, never a diagram source. Server channels and threads are
+        supported; direct messages are not. A form that exceeds a platform
+        ceiling (too many steps, too many options, too long a question)
+        raises an error naming the offending step — split the form into a
+        shorter follow-up and retry.
         
         AFTER CALLING THIS TOOL YOU MUST END YOUR TURN IMMEDIATELY. Do not
         narrate the form, do not continue the conversation, and do not call
@@ -1886,12 +1888,12 @@
               Accepts the shape a model actually writes as well as the canonical one.
               Authored by an LLM at a tool boundary, and the canonical field names lose
               every coin-flip against the prior set by other form APIs: `type` for
-              `kind`, `title` for `question`, plain strings for `options`, and
+              `kind`, `title`/`label` for `question`, plain strings for `options`, and
               `single_choice`/`multi_select`/`free_text` for the enum's
               `choice`/`multi`/`text`. A real session sent exactly that, collected 28
-              validation errors, retried with the same shape, and abandoned the form
-              (#51). Rejecting it was defensible per-field and useless in aggregate, so
-              the aliases and coercions below absorb the difference instead.
+              validation errors, retried with the same shape, and abandoned the form.
+              Rejecting it was defensible per-field and useless in aggregate, so the
+              aliases and coercions below absorb the difference instead.
             ''',
             'properties': dict({
               'allow_custom': dict({

--- a/packages/adapters/mcp/tests/tools/test_agents.py
+++ b/packages/adapters/mcp/tests/tools/test_agents.py
@@ -2170,6 +2170,106 @@ async def test_update_agent_impl_rejects_system_agent_no_daimon_account() -> Non
         )
 
 
+async def test_update_agent_impl_rejects_seeded_agent_that_is_also_account_stamped() -> None:
+    """The real shape of a seeded agent: daimon_managed AND daimon_account both set.
+
+    The guild seed path account-stamps seeded agents, so keying the guard on a
+    missing `daimon_account` never fired for them — 14 of 16 seeded `daimon`
+    agents in production carried an account stamp, leaving update/attach/archive
+    open to any admin. A chat edit does not restamp the spec hash, so the
+    reconcile short-circuit then skips the drifted agent forever and `defaults
+    apply` cannot repair it. The Discord panel already keys on daimon_managed
+    (#160); this asserts the MCP tools do too.
+    """
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    _, client = _list_one(
+        {
+            "id": "ag_seeded",
+            "name": "daimon",
+            "metadata": {
+                "daimon_tenant": str(tenant_id),
+                "daimon_name": "daimon",
+                "daimon_managed": "true",
+                "daimon_account": str(account_id),
+                "daimon_spec_hash": "7639a077b2b89d74",
+            },
+        }
+    )
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    with pytest.raises(ToolError, match="managed by defaults"):
+        await _update_agent_impl(
+            _runtime(client),
+            auth,
+            name="daimon",
+            model=None,
+            description="hijack",
+            system=None,
+            tools=None,
+            mcp_servers=None,
+            skills=None,
+        )
+
+
+async def test_update_agent_impl_allows_a_panel_fork_of_a_seeded_agent() -> None:
+    """Panel forks stamp managed=False, so they must stay editable.
+
+    Guards the other side of the daimon_managed check: widening protection to
+    every managed agent must not sweep up the forks that Fork-then-edit exists
+    to produce.
+    """
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    def on_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "id": "ag_fork",
+                "type": "agent",
+                "name": "daimon-fork",
+                "version": 2,
+                "model": {"id": "claude-sonnet-5", "type": "model_config"},
+                "metadata": {
+                    "daimon_tenant": str(tenant_id),
+                    "daimon_name": "daimon-fork",
+                    "daimon_account": str(account_id),
+                },
+                "created_at": "2026-08-12T00:00:00Z",
+                "updated_at": "2026-08-12T00:00:00Z",
+            },
+        )
+
+    router, client = _list_one(
+        {
+            "id": "ag_fork",
+            "name": "daimon-fork",
+            "metadata": {
+                "daimon_tenant": str(tenant_id),
+                "daimon_name": "daimon-fork",
+                "daimon_account": str(account_id),
+            },
+        }
+    )
+    router.add("POST", r"/v1/agents/ag_fork", on_update)
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    info = await _update_agent_impl(
+        _runtime(client),
+        auth,
+        name="daimon-fork",
+        model=None,
+        description="a fork is editable",
+        system=None,
+        tools=None,
+        mcp_servers=None,
+        skills=None,
+    )
+    assert info is not None, "an unmanaged fork must remain editable by chat tools"
+
+
 async def test_update_agent_impl_allows_any_stamped_agent_for_admin() -> None:
     """Admin must be able to mutate any stamped tenant agent regardless of which account owns it."""
     tenant_id = uuid.uuid4()

--- a/packages/core/daimon/core/skill_sync/__init__.py
+++ b/packages/core/daimon/core/skill_sync/__init__.py
@@ -14,7 +14,6 @@ from daimon.core.skill_sync.fetcher import (
     GitHubTarballFetcher,
     GitHubUnreachable,
     PATMissingError,
-    RepoCollisionError,
 )
 from daimon.core.skill_sync.orchestrator import (
     SyncRepoFailure,
@@ -30,7 +29,6 @@ __all__ = [
     "GitHubUnreachable",
     "PATMissingError",
     "RemoveReport",
-    "RepoCollisionError",
     "SyncReport",
     "SyncRepoFailure",
     "remove_agent_skill_repo",

--- a/packages/core/daimon/core/skill_sync/fetcher.py
+++ b/packages/core/daimon/core/skill_sync/fetcher.py
@@ -39,10 +39,6 @@ class TarballTooLarge(Exception):
     Open Question 3)."""
 
 
-class RepoCollisionError(Exception):
-    """Two repos in the same agent produced the same sanitized skill name."""
-
-
 class GitHubTarballFetcher:
     """Fetch a GitHub repo tarball authenticated with an optional bearer credential.
 

--- a/packages/core/daimon/core/skill_sync/orchestrator.py
+++ b/packages/core/daimon/core/skill_sync/orchestrator.py
@@ -75,7 +75,6 @@ from daimon.core.skill_sync.fetcher import (
     GitHubAuthError,
     GitHubTarballFetcher,
     GitHubUnreachable,
-    RepoCollisionError,
     TarballTooLarge,
 )
 from daimon.core.skill_zip import canonical_zip_bytes
@@ -620,10 +619,22 @@ async def sync_agent_skills(
                     report.failed_uploads.append((entry.name, entry.skip_reason))
                     continue
                 if entry.name in pending:
-                    raise RepoCollisionError(
-                        f"skill name {entry.name!r} appears in "
-                        f"{pending[entry.name].repo_url} and {repo.url}"
+                    # First repo in the list wins; the loser is reported like any
+                    # other per-skill failure. Aborting here would discard every
+                    # already-bundled skill from every repo, including this one's
+                    # non-colliding siblings.
+                    reason = (
+                        f"skill name {entry.name!r} already provided by "
+                        f"{pending[entry.name].repo_url}; skipped this copy from {repo.url}"
                     )
+                    _log.warning(
+                        "skill_sync.duplicate_name_across_repos",
+                        name=entry.name,
+                        kept_repo=pending[entry.name].repo_url,
+                        skipped_repo=repo.url,
+                    )
+                    report.failed_uploads.append((entry.name, reason))
+                    continue
                 pending[entry.name] = _PendingSkill(
                     name=entry.name,
                     repo_url=repo.url,

--- a/packages/core/daimon/core/wizard/spec.py
+++ b/packages/core/daimon/core/wizard/spec.py
@@ -105,12 +105,18 @@ class Step(BaseModel):
     Accepts the shape a model actually writes as well as the canonical one.
     Authored by an LLM at a tool boundary, and the canonical field names lose
     every coin-flip against the prior set by other form APIs: `type` for
-    `kind`, `title` for `question`, plain strings for `options`, and
+    `kind`, `title`/`label` for `question`, plain strings for `options`, and
     `single_choice`/`multi_select`/`free_text` for the enum's
     `choice`/`multi`/`text`. A real session sent exactly that, collected 28
-    validation errors, retried with the same shape, and abandoned the form
-    (#51). Rejecting it was defensible per-field and useless in aggregate, so
-    the aliases and coercions below absorb the difference instead.
+    validation errors, retried with the same shape, and abandoned the form.
+    Rejecting it was defensible per-field and useless in aggregate, so the
+    aliases and coercions below absorb the difference instead.
+
+    `label` joined that list after a later session lost only the `question`
+    coin-flip -- `type` and `single_choice` were both absorbed -- and had all
+    four of its steps rejected. `label` is the predictable miss: `Option.label`
+    is this schema's own word for user-facing text, so it is the name a model
+    reaches for when writing a step's text.
     """
 
     model_config = ConfigDict(frozen=True, populate_by_name=True)
@@ -123,7 +129,7 @@ class Step(BaseModel):
         ),
     )
     question: str = Field(
-        validation_alias=AliasChoices("question", "title"),
+        validation_alias=AliasChoices("question", "title", "label"),
         description="The question text shown to the user on this step.",
     )
     kind: StepKind = Field(

--- a/packages/core/daimon/core/wizard/spec.py
+++ b/packages/core/daimon/core/wizard/spec.py
@@ -111,13 +111,17 @@ class Step(BaseModel):
     validation errors, retried with the same shape, and abandoned the form.
     Rejecting it was defensible per-field and useless in aggregate, so the
     aliases and coercions below absorb the difference instead.
-
-    `label` joined that list after a later session lost only the `question`
-    coin-flip -- `type` and `single_choice` were both absorbed -- and had all
-    four of its steps rejected. `label` is the predictable miss: `Option.label`
-    is this schema's own word for user-facing text, so it is the name a model
-    reaches for when writing a step's text.
     """
+
+    # This docstring is rendered into the post_wizard tool schema, so it ships
+    # to the model on every request that carries the tool -- keep provenance in
+    # comments like this one rather than adding it above.
+    #
+    # `label` joined the alias set after a later session lost only the
+    # `question` coin-flip (`type` and `single_choice` were both absorbed) and
+    # had all four of its steps rejected. It is the predictable miss:
+    # `Option.label` is this schema's own word for user-facing text, so it is
+    # the name a model reaches for when writing a step's text.
 
     model_config = ConfigDict(frozen=True, populate_by_name=True)
 

--- a/packages/core/tests/skill_sync/test_orchestrator.py
+++ b/packages/core/tests/skill_sync/test_orchestrator.py
@@ -3475,3 +3475,117 @@ async def test_attach_refuses_union_when_legacy_registry_skill_shares_mount_name
     assert "mount" in reason and "my-skill" in reason, (
         f"reason must describe the mount collision; got {reason!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo duplicate skill name must not abort the whole sync
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_duplicate_name_across_repos_still_uploads_every_other_skill(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A skill name shared by two repos must skip that one entry, not kill the sync.
+
+    Two repos each carry a skill named 'shared' plus one unique skill. Every other
+    failure in the repo-accumulation loop is isolated (skipped_repos / failed_uploads),
+    so a duplicate name must be too: the first repo's 'shared' wins, the second repo's
+    is reported, and 'only-a' / 'only-b' still upload.
+    """
+    cli = await make_cli_principal(db_session, os_user="alice")
+    await db_session.commit()
+    fernet = _make_fernet()
+    await _seed_pat(sessionmaker=db_session_factory, fernet=fernet, principal_id=cli.id)
+
+    url_a = "https://github.com/orgA/skills"
+    url_b = "https://github.com/orgB/skills"
+
+    tarball_a = _make_tarball(
+        {
+            "skills-main/shared/SKILL.md": b"---\nname: shared\ndescription: from orgA\n---\nbody",
+            "skills-main/only-a/SKILL.md": b"---\nname: only-a\ndescription: only in A\n---\nbody",
+        }
+    )
+    tarball_b = _make_tarball(
+        {
+            "skills-main/shared/SKILL.md": b"---\nname: shared\ndescription: from orgB\n---\nbody",
+            "skills-main/only-b/SKILL.md": b"---\nname: only-b\ndescription: only in B\n---\nbody",
+        }
+    )
+
+    def tarball_router(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if "orgA" in path:
+            return httpx.Response(200, content=tarball_a)
+        if "orgB" in path:
+            return httpx.Response(200, content=tarball_b)
+        return httpx.Response(404)
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(tarball_router))
+
+    created_titles: list[str] = []
+
+    def on_create(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        raw = req.content.decode("latin-1")
+        marker = 'name="display_title"\r\n\r\n'
+        start = raw.index(marker) + len(marker)
+        title = raw[start : raw.index("\r\n", start)]
+        created_titles.append(title)
+        return httpx.Response(
+            200,
+            json=SkillListResponse(
+                id=f"sk_{len(created_titles)}",
+                type="custom",
+                display_title=title,
+                latest_version="1",
+                created_at="2026-04-21T00:00:00Z",
+                updated_at="2026-04-21T00:00:00Z",
+                source="custom",
+            ).model_dump(mode="json"),
+        )
+
+    router = MARouter()
+    router.add("GET", r"/v1/skills", lambda req, _m: list_response([]))
+    router.add("POST", r"/v1/skills", on_create)
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
+    anthropic_client = _build_anthropic(router)
+
+    monkeypatch.setattr(orch_mod, "_UPLOAD_CONCURRENCY", 1)
+
+    report = await sync_agent_skills(
+        principal_id=cli.id,
+        tenant_id=cli.tenant_id,
+        agent_name="agent",
+        repos=[
+            SkillRepo(url=url_a, branch="main", split=True),
+            SkillRepo(url=url_b, branch="main", split=True),
+        ],
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        http_client=http_client,
+        anthropic_client=anthropic_client,
+    )
+
+    async with db_session_factory() as s, s.begin():
+        rows = await list_user_skills_for_agent(
+            s, tenant_id=cli.tenant_id, principal_id=cli.id, agent_name="agent"
+        )
+    names = {r.name for r in rows}
+
+    assert names == {"shared", "only-a", "only-b"}, (
+        "a duplicate name in one repo must not discard the other skills; "
+        f"got {sorted(names)} (report.failed_uploads={report.failed_uploads})"
+    )
+
+    shared_row = next(r for r in rows if r.name == "shared")
+    assert shared_row.source_repo_url == url_a, (
+        f"first repo in the list must win the shared name; got {shared_row.source_repo_url}"
+    )
+
+    dupes = [(n, r) for n, r in report.failed_uploads if n == "shared"]
+    assert len(dupes) == 1, (
+        f"the losing duplicate must be reported once; got {report.failed_uploads}"
+    )
+    assert url_b in dupes[0][1], f"reason must name the losing repo; got {dupes[0][1]!r}"

--- a/packages/core/tests/wizard/test_spec.py
+++ b/packages/core/tests/wizard/test_spec.py
@@ -243,3 +243,33 @@ def test_choice_step_exceeding_component_ceiling_rejected() -> None:
             steps=[Step(key="k", question="q", kind=StepKind.CHOICE, options=options)],
         )
     assert "k" in str(exc_info.value), "the offending step's key must appear in the message"
+
+
+def test_step_accepts_label_as_the_question_field() -> None:
+    """`label` must alias `question`, like `title` already does.
+
+    A production session sent every step keyed on `label` with `type` +
+    `single_choice`/`free_text`/`multi_select`. The kind aliases absorbed their
+    half; `question` did not, so all four steps were rejected and the form was
+    abandoned. `label` is the predictable miss because `Option.label` is this
+    schema's own word for user-facing text.
+    """
+    step = Step.model_validate(
+        {
+            "type": "single_choice",
+            "label": "Which format do you want?",
+            "options": ["pdf", "docx"],
+        }
+    )
+    assert step.question == "Which format do you want?", (
+        "`label` must populate `question`; it is a documented alias"
+    )
+    assert step.kind is StepKind.CHOICE, "`type`/`single_choice` aliases must still apply"
+
+
+def test_step_prefers_question_over_label_when_both_are_present() -> None:
+    """AliasChoices resolves left-to-right: canonical `question` wins."""
+    step = Step.model_validate({"kind": "text", "question": "canonical", "label": "aliased"})
+    assert step.question == "canonical", (
+        "the canonical field name must win over an alias when both are supplied"
+    )


### PR DESCRIPTION
Four independent fixes, each with a test that fails without it. All four came out of tracing one wedged production thread.

## 1. A duplicate skill name aborted the whole sync

`RepoCollisionError` was raised from inside the repo-accumulation loop and caught nowhere, so it escaped `sync_agent_skills` *before* `_upload_all` ran. One skill name shared by two repos discarded every skill from every repo — including the ones already fetched and bundled — and the orphan-delete pass never ran either.

It was the only failure in that loop that wasn't isolated. Credential, fetch and bundle failures append to `skipped_repos` and continue; a per-skill `skip_reason` appends to `failed_uploads` and continues three lines above. Now a duplicate is treated the same way: first repo in the list wins, the loser is reported.

That left `RepoCollisionError` with no raise site, so it's removed rather than left as an exception that can never fire.

## 2. `post_wizard` rejected every step when the model wrote `label`

A production call had all four steps rejected with `steps.N.question Field required`. The alias machinery worked on the other coin-flips — `type` and `single_choice`/`free_text`/`multi_select` were absorbed — and only `question` fell through, because its alias set was `("question", "title")`.

`label` is the predictable miss: `Option.label` in the same schema is the word for user-facing text, and the tool docstring said *"too large a label"* about step ceilings while never naming `question` at all. The description pointed at a field that doesn't exist on a step.

`label` joins the alias set and the docstring now names the real fields. Closes #67.

The snapshot diff for this one is worth a look: `Step`'s docstring is rendered into the tool schema, so it ships to the model on every request carrying the tool. Provenance moved to comments accordingly.

## 3. A wedged session froze its thread permanently

An MA session that never leaves `running` — a tool call whose result never comes back — leaves the await on `run_prepared_turn` unresolved, so `clear_active_turn` below it is never reached and the thread keeps its `active_turn` marker for good. Every later mention is dropped as "a turn is already running".

`_retire_orphaned_turns` couldn't recover it: it runs once per process at `on_ready` and deliberately has no age filter, because `list_orphaned_turns` assumes *"a turn cannot outlive the process rendering it"*. A hung await outlives the process just fine, so the marker survived until the next deploy.

Observed in production: a thread wedged mid-tool-call with the user's follow-up message *and* their interrupt both sitting unprocessed behind it.

- `run_prepared_turn` gets a wall-clock deadline, set well above the longest legitimate turn — this bounds the pathological case, it is not a latency target.
- `clear_active_turn` moves into a `finally`, so the marker releases on the deadline and on any other exception.
- On the deadline the mapping is marked dead, so the next mention binds a fresh session. Without that the thread would come unstuck for exactly one message.

Flat wall-clock rather than liveness: a turn streaming events is alive however long it runs, and one silent for ten minutes is wedged whatever its duration. Keying on time-since-last-event would cut the dead case loose sooner and never touch a live one, but needs the render loop to expose a last-event timestamp — noted as an upgrade path at the constant.

## 4. Chat tools could mutate the seeded default agent

`_reject_system_agent` keyed on a *missing* `daimon_account` stamp, but the guild seed path account-stamps seeded agents — so the key was present and the guard silently never fired. `update_agent`, `attach_mcp_server` and `archive_agent` were all reachable on a tenant's default `daimon` agent by any admin. Measured against production: **14 of 16** seeded `daimon` agents carry an account stamp, so the guard was inert for almost every install.

The consequence is worse than a stray edit. A chat edit doesn't restamp the spec hash, so the next `defaults apply` hits the reconcile short-circuit, skips the drifted agent, and the drift becomes permanent — no path back to the spec.

The Discord panel hit this same trap and moved to the reconciler's own marker, `daimon_managed="true"` (#160), noting the account stamp "cannot discriminate seeded vs. forked agents". The MCP tools never followed. Both markers are now checked rather than one swapped for the other, so older unstamped seeded agents keep their cover. A companion test asserts panel forks (`managed=False`) stay editable — widening the guard must not sweep up the forks that Fork exists to produce.

## Verification

- 4270 passed + 14 broker (serial), `pyright` 0 errors, `ruff` clean, 6/6 import contracts, 9/9 anti-pattern rules.
- Each fix's test was confirmed to fail with the fix reverted; #2's reproduces the production Pydantic error verbatim.
- Pre-existing and unrelated: `packages/core/tests/core/broker/conftest.py` imports `factories.google_sa`, which resolves serially but not under `-n auto`. CI shards per adapter so it won't bite there — flagging rather than fixing in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
