### PR TITLE
chore(defaults): default agent model to Claude Haiku 4.5

### DIFF
--- a/defaults/agents-optional/dev_agent.yaml
+++ b/defaults/agents-optional/dev_agent.yaml
@@ -1,5 +1,5 @@
 name: dev_agent
-model: claude-sonnet-5
+model: claude-haiku-4-5
 description: Dev agent — clones a bound repo into /workspace, runs code, opens PRs via GitHub.
 system: |
   You are dev_agent, a software-engineering agent embedded in Discord. You read,

--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -1,5 +1,5 @@
 name: daimon
-model: claude-sonnet-5
+model: claude-haiku-4-5
 system: |
   You are daimon, the agent this workspace starts with — available in the
   channel you were mentioned in, able to write and run code, fit models, and

--- a/packages/core/daimon/core/constants.py
+++ b/packages/core/daimon/core/constants.py
@@ -20,7 +20,7 @@ ALLOWED_MODEL_IDS: tuple[str, ...] = tuple(AGENT_MODEL_PRICING.keys())
 # modal and the Slack submit path, which is how three surfaces ended up a
 # generation behind `defaults/agents/daimon.yaml` while each looked correct in
 # isolation. Keep it equal to the model that file pins.
-DEFAULT_AGENT_MODEL: str = "claude-sonnet-5"
+DEFAULT_AGENT_MODEL: str = "claude-haiku-4-5"
 
 # The per-agent skill and MCP-server limits every surface enforces. The setup
 # panel (disabling its add controls) and the chat update path (refusing a


### PR DESCRIPTION
Swaps all three sites that must move together — the shared `DEFAULT_AGENT_MODEL` constant, `defaults/agents/daimon.yaml`, and `defaults/agents-optional/dev_agent.yaml`. `test_constants` and `test_defaults_dir` assert they stay equal; that comment exists because they drifted a generation apart once before.

## The `effort` concern, checked against MA rather than assumed

`effort` is documented as unsupported on Haiku 4.5, and MA fills omitted `model` fields with its own defaults — so the worry was that seeding would 400. It doesn't:

| sent | result |
|---|---|
| bare `"claude-haiku-4-5"` (what these specs send) | **200**, stored as `{"id": "claude-haiku-4-5", "speed": "standard"}` — no `effort` key |
| `{"id": "claude-haiku-4-5", "effort": "high"}` | **400** — `` `model.effort`: "high" is not available for model "claude-haiku-4-5" `` |

MA omits `effort` for models that don't support it, so the seeded path is safe. (Prod's Sonnet 5 agent *does* store `effort: {type: high}`, confirming MA is model-aware here.)

Residual: a user who names Haiku **and** an effort level through the panel or chat tools still hits that 400. `ALLOWED_MODEL_IDS` derives from the pricing table, which already carries Haiku 4.5 rates, so the model itself passes submit-time validation.

## ⚠️ This is not new-installs-only

`model` is part of the agent spec dump, so the spec hash changes. `reconcile_agents` returns `SKIPPED` only when the stored hash matches — otherwise it UPDATEs. So **every existing seeded agent migrates to Haiku on the next `defaults apply`**, which runs on every scheduler boot. Reviewers promoting this to production should expect the whole fleet's default agent to move, not just newly-seeded ones.

## Trade-offs accepted

- context **200K**, down from 1M
- max output **64K**, down from 128K
- pricing **\$1/\$5** per MTok vs Sonnet 5's \$3/\$15 — ~2x cheaper today against Sonnet 5's introductory \$2/\$10, 3x once that ends

The context drop is the one worth weighing: this is the agent that writes notebooks and fits models.

## Verification

4270 tests passed, `pyright` 0 errors, `ruff` clean, 6/6 import contracts, 9/9 anti-pattern rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)