### PR TITLE
chore(defaults): revert default agent model to Claude Sonnet 5

### DIFF
--- a/defaults/agents-optional/dev_agent.yaml
+++ b/defaults/agents-optional/dev_agent.yaml
@@ -1,5 +1,5 @@
 name: dev_agent
-model: claude-haiku-4-5
+model: claude-sonnet-5
 description: Dev agent — clones a bound repo into /workspace, runs code, opens PRs via GitHub.
 system: |
   You are dev_agent, a software-engineering agent embedded in Discord. You read,

--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -1,5 +1,5 @@
 name: daimon
-model: claude-haiku-4-5
+model: claude-sonnet-5
 system: |
   You are daimon, the agent this workspace starts with — available in the
   channel you were mentioned in, able to write and run code, fit models, and

--- a/packages/core/daimon/core/constants.py
+++ b/packages/core/daimon/core/constants.py
@@ -20,7 +20,7 @@ ALLOWED_MODEL_IDS: tuple[str, ...] = tuple(AGENT_MODEL_PRICING.keys())
 # modal and the Slack submit path, which is how three surfaces ended up a
 # generation behind `defaults/agents/daimon.yaml` while each looked correct in
 # isolation. Keep it equal to the model that file pins.
-DEFAULT_AGENT_MODEL: str = "claude-haiku-4-5"
+DEFAULT_AGENT_MODEL: str = "claude-sonnet-5"
 
 # The per-agent skill and MCP-server limits every surface enforces. The setup
 # panel (disabling its add controls) and the chat update path (refusing a


### PR DESCRIPTION
Reverts #69. The 200K context drop was the sticking point for the agent that writes notebooks and fits models.

Same three sites that must move together — `DEFAULT_AGENT_MODEL`, `defaults/agents/daimon.yaml`, `defaults/agents-optional/dev_agent.yaml`; `test_constants` and `test_defaults_dir` assert they stay equal.

Haiku 4.5 never reached production — prod is on `aef0ebb9` (#66), so this only unwinds staging.

Note the spec hash changes again, so `defaults apply` will migrate seeded agents back to Sonnet 5 on the next scheduler boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)