### PR TITLE
fix(discord): confirm a consumed credential request on the button itself

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -31,6 +31,15 @@ only ever produce one write no matter how many times its modal is
 (re)submitted — the loser of a race, or any resubmission, gets `None` back
 and writes nothing.
 
+Every `on_submit` acks with a bare `defer()`, never `thinking=True`. On a
+modal opened from a component click that is a `deferred_message_update`,
+whose `@original` is the message the button lives on — which is what lets
+`_mark_button_consumed` disable the button in place once the row is spent.
+`thinking=True` would point `@original` at a fresh ephemeral instead and the
+edit would land there, the defect `agent_setup/credentials.py` already fixed
+on the setup panel. Ephemeral followups still work after this ack, so every
+validation, error and success toast below is unchanged.
+
 `RepoBindModal`'s write is additionally admin-gated on a shared agent: token
 consumption alone is sufficient authorization for an env secret or an MCP
 token (the requester supplies a value only they hold, scoped to one key on
@@ -84,6 +93,41 @@ _log = structlog.get_logger()
 
 _NO_LONGER_VALID = "This request is no longer valid — ask again."
 
+_CONSUMED_BUTTON_LABEL = "✓ Received"
+"""Replaces the request's own label once the row is consumed. Deliberately
+kind-agnostic and about the SUBMISSION rather than the write: this runs the
+moment the consume commits, before the vault/binding/import below it is known
+to have worked, and one of those failing still leaves the button dead."""
+
+
+async def _mark_button_consumed(interaction: discord.Interaction, *, kind: str) -> None:
+    """Swap the request's button for a disabled confirmation, in place.
+
+    The bare `defer()` every `on_submit` opens with makes this interaction's
+    `@original` the message the button lives on (`deferred_message_update`),
+    so this edit lands on the button itself rather than on a fresh ephemeral —
+    the same ack shape `agent_setup/credentials.py` uses to land its paste
+    re-render on the panel.
+
+    Called once the row is durably consumed. From that point the button can
+    only ever be refused by `interaction_check`, so leaving it looking live
+    invites a click that cannot succeed, and leaves a thread with no durable
+    record that the credential was ever supplied — the ephemeral reply is
+    gone on refresh and was never visible to anyone else.
+    """
+    view = discord.ui.View(timeout=None)
+    view.add_item(discord.ui.Button[discord.ui.View](label=_CONSUMED_BUTTON_LABEL, disabled=True))
+    try:
+        await interaction.edit_original_response(view=view)
+    except discord.HTTPException as err:
+        # The consume already committed. A confirmation edit that fails
+        # (message deleted, thread archived, permissions lost) must not read
+        # as a failed submission — the ephemeral reply still carries the
+        # outcome, so this is a downgrade in feedback, not in correctness.
+        _log.warning(
+            "credential_modal.consumed_edit_failed", kind=kind, err_type=type(err).__name__
+        )
+
 
 class EnvCredentialModal(discord.ui.Modal, title="Add secret"):
     """Add secrets modal: one value, atomic consume, existing agent_files write."""
@@ -102,7 +146,7 @@ class EnvCredentialModal(discord.ui.Modal, title="Add secret"):
         self.add_item(self.value_input)
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.response.defer()
         raw_value = str(self.value_input.value or "")
 
         if not raw_value.strip():
@@ -142,6 +186,10 @@ class EnvCredentialModal(discord.ui.Modal, title="Add secret"):
 
         # Log the key NAME only — never the value.
         _log.info("credential_modal.env.submit", key=consumed_row.target)
+        # After the transaction, not inside it: the consume and the file write
+        # commit together here, so this is the first point the row is durably
+        # spent, and it keeps a Discord round trip out of an open transaction.
+        await _mark_button_consumed(interaction, kind="env")
         await interaction.followup.send(
             f"Added `{consumed_row.target}`. Takes effect on the next session — "
             "anyone who talks to this agent can use it.",
@@ -165,7 +213,7 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
         self.add_item(self.token_input)
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.response.defer()
         token_value = str(self.token_input.value or "")
 
         if not token_value.strip():
@@ -192,6 +240,8 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
         if consumed_row is None:
             await interaction.followup.send(_NO_LONGER_VALID, ephemeral=True)
             return
+
+        await _mark_button_consumed(interaction, kind="mcp")
 
         mcp_server_url = consumed_row.mcp_server_url
         if mcp_server_url is None:
@@ -333,7 +383,7 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
         self.add_item(self.pat_in)
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.response.defer()
 
         pat = str(self.pat_in.value or "").strip()
         if not pat:
@@ -348,6 +398,8 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
         if consumed_row is None:
             await interaction.followup.send(_NO_LONGER_VALID, ephemeral=True)
             return
+
+        await _mark_button_consumed(interaction, kind="skill_repo")
 
         url, branch, path = split_skill_repo_target(consumed_row.target)
         # The token appears only as a masked tail, never in full, and never
@@ -543,7 +595,7 @@ class RepoBindModal(discord.ui.Modal, title="Bind repo"):
         self.add_item(self.pat_in)
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer(ephemeral=True, thinking=True)
+        await interaction.response.defer()
 
         if await refuse_if_shared_and_not_admin_for_request(
             interaction,
@@ -564,6 +616,8 @@ class RepoBindModal(discord.ui.Modal, title="Bind repo"):
         if consumed_row is None:
             await interaction.followup.send(_NO_LONGER_VALID, ephemeral=True)
             return
+
+        await _mark_button_consumed(interaction, kind="repo")
 
         # Log the repo and branch, and the token ONLY as a masked tail when
         # present — never the plain value, never the (now-consumed) request

--- a/packages/adapters/discord/tests/test_credential_modals.py
+++ b/packages/adapters/discord/tests/test_credential_modals.py
@@ -317,7 +317,22 @@ def _interaction() -> MagicMock:
     interaction = MagicMock()
     interaction.response.defer = AsyncMock()
     interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
     return interaction
+
+
+def _consumed_button_labels(interaction: MagicMock) -> list[str]:
+    """Labels of the disabled buttons the modal edited onto the request message."""
+    labels: list[str] = []
+    for call in interaction.edit_original_response.call_args_list:
+        view = call.kwargs.get("view")
+        if view is None:
+            continue
+        for item in view.children:
+            if isinstance(item, discord.ui.Button):
+                labels.append(str(item.label))
+                assert item.disabled, "the confirmation button must be disabled"
+    return labels
 
 
 # --- EnvCredentialModal ------------------------------------------------------
@@ -343,6 +358,82 @@ async def test_env_modal_submit_consumes_token_and_writes_agent_file(
     toast = interaction.followup.send.call_args.args[0]
     assert "OPENAI_API_KEY" in toast, "confirmation names the key"
     assert _SECRET_VALUE not in toast, "confirmation never echoes the secret value"
+
+
+async def test_env_modal_successful_submit_disables_the_request_button(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="STRIPE_KEY")
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = _SECRET_VALUE  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    interaction.response.defer.assert_awaited_once_with()
+    assert _consumed_button_labels(interaction) == ["✓ Received"], (
+        "a spent request must leave a disabled confirmation on the button's own message"
+    )
+
+
+async def test_env_modal_rejected_value_leaves_the_request_button_live(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="NEVER_SET")
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = "   "  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    interaction.edit_original_response.assert_not_awaited()
+    assert _consumed_button_labels(interaction) == [], (
+        "nothing was consumed, so the button must stay clickable for a real value"
+    )
+
+
+async def test_env_modal_dead_request_does_not_touch_the_button(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="ONE_SHOT")
+    runtime = _runtime(sessionmaker=db_session_factory)
+
+    first = EnvCredentialModal(runtime=runtime, request_row=row)
+    first.value_input._value = "first-value"  # pyright: ignore[reportPrivateUsage]
+    await first.on_submit(_interaction())
+
+    second = EnvCredentialModal(runtime=runtime, request_row=row)
+    second.value_input._value = "second-value"  # pyright: ignore[reportPrivateUsage]
+    second_interaction = _interaction()
+    await second.on_submit(second_interaction)
+
+    # The resubmission consumed nothing, so it must not redraw the button.
+    second_interaction.edit_original_response.assert_not_awaited()
+
+
+async def test_env_modal_reports_success_even_when_the_button_edit_fails(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_env_request(db_session_factory, target="EDIT_FAILS")
+    runtime = _runtime(sessionmaker=db_session_factory)
+    modal = EnvCredentialModal(runtime=runtime, request_row=row)
+    modal.value_input._value = _SECRET_VALUE  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    interaction.edit_original_response = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(), "message deleted")
+    )
+    await modal.on_submit(interaction)
+
+    rows = await list_agent_files(db_session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert len(rows) == 1, "the secret is written before the confirmation edit is attempted"
+    toast = interaction.followup.send.call_args.args[0]
+    assert "EDIT_FAILS" in toast, (
+        "a failed confirmation edit is a feedback downgrade, never a failed submission"
+    )
 
 
 async def test_env_modal_double_submit_writes_exactly_one_row(
@@ -690,6 +781,38 @@ async def test_mcp_modal_vault_write_failure_surfaces_only_exception_class_name(
     assert "secret=abc123" not in message, (
         "the stringified exception (which can carry the request envelope) must never reach the user"
     )
+
+
+async def test_mcp_modal_disables_the_button_even_when_the_write_below_it_fails(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The consume is what kills the button, not the vault write after it.
+
+    A downstream failure still leaves the request spent, so a button that
+    still looks live would only ever earn an "already used" refusal.
+    """
+
+    def _failing_vault(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("upstream reset by peer")
+
+    row = await _seed_mcp_request(db_session_factory)
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(_failing_vault),
+        public_url=HttpUrl("https://mcp.example.com/mcp"),
+        jwt_secret="x" * 32,
+    )
+    modal = McpCredentialModal(runtime=runtime, request_row=row)
+    modal.token_input._value = _MCP_TOKEN  # pyright: ignore[reportPrivateUsage]
+
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    assert _consumed_button_labels(interaction) == ["✓ Received"], (
+        "a consumed request disables its button regardless of the write's outcome"
+    )
+    message = interaction.followup.send.call_args.args[0]
+    assert "APIConnectionError" in message, "the failure is still reported in the reply"
 
 
 async def test_mcp_modal_never_logs_the_raw_token(


### PR DESCRIPTION
Closes #71.

## The defect

`request_env_credential` posts a button in the thread. Clicking it opens a modal; on submit the modal acked with `defer(ephemeral=True, thinking=True)` and reported purely through `followup.send`. It never touched the message the button lives on.

So a successful paste left the button looking exactly as it did before, with an ephemeral toast as the only confirmation — gone on refresh, invisible to anyone else in the thread. Reported from a live thread, where it read as a no-op.

**The write was never at risk.** `CredentialRequestButton.interaction_check` re-reads the row on every click and refuses a consumed one before the modal opens, so a second click could not store a second secret. This is a feedback bug only.

## The fix

The same one the setup panel already shipped for its own paste: ack with a bare `defer()` — on a modal opened from a component click that is a `deferred_message_update`, whose `@original` is the button's own message — then edit that message to a disabled `✓ Received`. Verified against the installed `discord/interactions.py`, not assumed. Ephemeral followups still work after that ack, so every validation, error and success toast is unchanged.

## Two judgement calls

**All four modals move together.** Env, MCP, skill-repo and repo-bind share the button class and the identical ack defect. Shipping one control that confirms itself next to three that don't is worse than either state alone.

**The edit fires when the consume commits, not when the write succeeds.** A vault write or an attach that fails still leaves the request spent, so the button is dead either way — leaving it live only earns an "already used" refusal on the next click. That is why the label speaks to the submission (`✓ Received`) rather than the outcome, and why it is kind-agnostic: a repo bind with a blank token is a legitimate submission with no token in it.

A failed confirmation edit is caught and logged rather than raised — the consume already happened, and a confirmation that cannot be drawn (message deleted, thread archived) must not read as a failed paste.

## Tests

Five new cases, each confirmed to fail without the source change:

- successful env submit disables the button with the confirmation label
- a rejected value (nothing consumed) leaves the button live
- a resubmission against a dead request does not redraw it
- a successful write still reports success when the button edit raises `HTTPException`
- MCP disables the button even when the vault write below it fails

## Verification

Full discord adapter suite 1038 passed, `pyright` 0 errors, `ruff` clean, 6/6 import contracts, 9/9 anti-pattern rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)