### PR TITLE
Refresh VM env and compose assets on every deploy; split clone-failure copy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,6 +125,20 @@ jobs:
               # at root docker config, where the boot startup script ran
               # `gcloud auth configure-docker`.
               export DOCKER_CONFIG=/root/.docker
+              # Ordering matters: refresh env -> refresh compose assets ->
+              # pull -> up -d. Recreating (up -d) is what makes a container
+              # read the new env_file; docker restart does NOT, which cost
+              # real time in the past. DAIMON_IMAGE must keep coming from the
+              # freshly computed tag exported above and must never be
+              # re-derived from VM metadata (stale metadata rolls the image
+              # back). The refresh script (from the companion infra repo, via
+              # the assets bucket) exits nonzero on a permission or transient
+              # Secret Manager failure, failing the deploy — intended: a
+              # config the pipeline cannot assemble must not read green.
+              sudo gcloud storage cp gs://${{ vars.GCP_AR_REPO }}-assets/daimon-refresh-env /usr/local/bin/daimon-refresh-env
+              sudo chmod 755 /usr/local/bin/daimon-refresh-env
+              sudo /usr/local/bin/daimon-refresh-env
+              sudo gcloud storage cp gs://${{ vars.GCP_AR_REPO }}-assets/compose.worker.yml /etc/daimon/compose.worker.yml
               cd /etc/daimon
               sudo -E docker compose -f compose.worker.yml pull
               sudo -E docker compose -f compose.worker.yml up -d --remove-orphans
@@ -147,6 +161,21 @@ jobs:
               # Same DOCKER_CONFIG redirect as the workers refresh: use root
               # docker config (has the Artifact Registry credential helper).
               export DOCKER_CONFIG=/root/.docker
+              # Ordering matters: refresh env -> refresh compose assets ->
+              # pull -> up -d. Recreating (up -d) is what makes a container
+              # read the new env_file; docker restart does NOT. NOTEBOOK_IMAGE
+              # must keep coming from the freshly computed tag exported above
+              # and must never be re-derived from VM metadata (stale metadata
+              # rolls the image back). The refresh script (from the companion
+              # infra repo, via the assets bucket) exits nonzero on a
+              # permission or transient Secret Manager failure, failing the
+              # deploy — intended: a config the pipeline cannot assemble must
+              # not read green.
+              sudo gcloud storage cp gs://${{ vars.GCP_AR_REPO }}-assets/daimon-refresh-env /usr/local/bin/daimon-refresh-env
+              sudo chmod 755 /usr/local/bin/daimon-refresh-env
+              sudo /usr/local/bin/daimon-refresh-env
+              sudo gcloud storage cp gs://${{ vars.GCP_AR_REPO }}-assets/compose.notebook.yml /etc/daimon/compose.notebook.yml
+              sudo gcloud storage cp gs://${{ vars.GCP_AR_REPO }}-assets/Caddyfile /etc/daimon/Caddyfile
               cd /etc/daimon
               sudo -E docker compose -f compose.notebook.yml pull
               sudo -E docker compose -f compose.notebook.yml up -d --remove-orphans

--- a/packages/core/daimon/core/github_repo_auth.py
+++ b/packages/core/daimon/core/github_repo_auth.py
@@ -298,6 +298,30 @@ async def resolve_clone_token(
     if mode == "public":
         assert fallback_pat  # narrows: has_fallback_pat implies this is truthy
         return fallback_pat
+
+    app_configured = app_id is not None and app_private_key is not None
+    # The operator branch is checked first because the public+no-fallback case
+    # is the one failure the user cannot fix: the binding is correct, the
+    # deployment just has no public-clone credential configured.
+    if binding.proof_kind == "public" and not has_fallback_pat:
+        log.error(
+            "github_repo_auth.operator_credential_missing",
+            repo_url=binding.repo_url,
+            proof_kind=binding.proof_kind,
+            app_configured=app_configured,
+        )
+        raise DaimonError(
+            f"This deployment has no credential configured for cloning public "
+            f"repositories, so {binding.repo_url} cannot be cloned. The repo binding "
+            "itself is correct — an operator must configure the deployment's GitHub "
+            "credentials."
+        )
+    if binding.proof_kind is not None and not app_configured:
+        log.error(
+            "github_repo_auth.app_not_configured",
+            repo_url=binding.repo_url,
+            proof_kind=binding.proof_kind,
+        )
     raise DaimonError(
         f"No credential is authorized to clone {binding.repo_url}. Re-bind this repo "
         "with a GitHub token that can read it, from the agent setup panel's GitHub option."

--- a/packages/core/tests/test_github_repo_auth.py
+++ b/packages/core/tests/test_github_repo_auth.py
@@ -13,10 +13,12 @@ an external API.
 from __future__ import annotations
 
 import datetime as dt
+import re
 import uuid
 
 import httpx
 import pytest
+import structlog.testing
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from daimon.core.errors import DaimonError
@@ -407,6 +409,120 @@ async def test_resolve_clone_token_pat_kind_proof_never_unlocks_the_fallback_tie
             app_private_key=None,
             now=1_000_000,
         )
+
+
+# ---------------------------------------------------------------------------
+# Operator-config failures vs user re-bind failures (split failure copy)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_clone_token_public_proof_no_fallback_names_operator_gap() -> None:
+    """A correctly-bound public repo (verified-public proof) failing only
+    because the deployment has no public-clone credential (no fallback PAT,
+    App not configured) is an OPERATOR config gap. The message must name the
+    deployment/operator credential gap and must NOT tell the user to re-bind
+    a binding that is already correct."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"App is not configured; no request expected: {request.url}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    binding = _make_binding(repo_url="acme/oss-repo", ma_secret_ref="anon:", proof_kind="public")
+
+    with pytest.raises(DaimonError) as exc_info:
+        await resolve_clone_token(
+            client,
+            binding=binding,
+            per_agent_pat=None,
+            fallback_pat=None,
+            app_id=None,
+            app_private_key=None,
+            now=1_000_000,
+        )
+
+    message = str(exc_info.value)
+    assert "deployment" in message.lower(), (
+        "the operator-gap copy must name the deployment as what lacks the credential"
+    )
+    assert "operator" in message.lower(), (
+        "the operator-gap copy must say an operator has to configure credentials"
+    )
+    assert re.search(r"[Rr]e-bind", message) is None, (
+        "a correctly-bound public repo must never be blamed on the user's binding — "
+        "the incident's misdiagnosis, asserted as absent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_clone_token_public_proof_no_fallback_emits_operator_event() -> None:
+    """The operator-gap refusal must also emit an operator-facing log event
+    (github_repo_auth.operator_credential_missing) carrying the repo_url, so
+    the config gap is loud in operator logs, not only in the user's thread."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"App is not configured; no request expected: {request.url}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    binding = _make_binding(repo_url="acme/oss-repo", ma_secret_ref="anon:", proof_kind="public")
+
+    with structlog.testing.capture_logs() as logs, pytest.raises(DaimonError):
+        await resolve_clone_token(
+            client,
+            binding=binding,
+            per_agent_pat=None,
+            fallback_pat=None,
+            app_id=None,
+            app_private_key=None,
+            now=1_000_000,
+        )
+
+    operator_events = [
+        e for e in logs if e.get("event") == "github_repo_auth.operator_credential_missing"
+    ]
+    assert len(operator_events) == 1, (
+        "exactly one operator_credential_missing event must be emitted; "
+        f"captured events: {[e.get('event') for e in logs]}"
+    )
+    assert operator_events[0].get("repo_url") == "acme/oss-repo", (
+        "the operator event must carry the repo_url so the log alone identifies the repo"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_clone_token_pat_proof_app_unavailable_keeps_rebind_and_logs() -> None:
+    """A binding with a recorded pat-kind proof, a fallback PAT configured,
+    but the App tier structurally unavailable (app_id=None) still raises the
+    re-bind copy — a token re-bind genuinely fixes that case — AND emits an
+    operator event recording that the App tier was unavailable."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"App is not configured; no request expected: {request.url}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    binding = _make_binding(
+        repo_url="acme/private-repo", ma_secret_ref="inline-pat:agent-1", proof_kind="pat"
+    )
+
+    with structlog.testing.capture_logs() as logs, pytest.raises(DaimonError, match="[Rr]e-bind"):
+        await resolve_clone_token(
+            client,
+            binding=binding,
+            per_agent_pat=None,
+            fallback_pat="ghp_operator_fallback",
+            app_id=None,
+            app_private_key=None,
+            now=1_000_000,
+        )
+
+    app_events = [e for e in logs if e.get("event") == "github_repo_auth.app_not_configured"]
+    assert len(app_events) == 1, (
+        "an app_not_configured operator event must record the structurally unavailable "
+        f"App tier; captured events: {[e.get('event') for e in logs]}"
+    )
+    assert app_events[0].get("repo_url") == "acme/private-repo", (
+        "the app_not_configured event must carry the repo_url"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- **deploy.yml**: both VM refresh steps now install and run a shared env-refresh script (delivered from the companion infra repo via the assets bucket) and re-fetch their compose assets before `pull` / `up -d`. The bucket URI is derived from `vars.GCP_AR_REPO` — no literal names.
- **core (`github_repo_auth`)**: a correctly-bound public repo that cannot clone only because the deployment has no public-clone credential now raises operator-facing copy and logs `github_repo_auth.operator_credential_missing`, instead of telling the user to re-bind a binding that is already correct. When a recorded proof exists but the App tier is structurally unavailable, an operator event (`github_repo_auth.app_not_configured`) is emitted and the re-bind copy stays — a token re-bind genuinely fixes that case. TDD: failing tests first, then the split.

## Why

Deploys previously only pulled images and recreated containers: the env file and compose files on the VMs were assembled once at boot and never reconciled, so declared-secret changes silently never reached running containers, and the resulting clone failures blamed the user's binding for an operator config gap.

## Trade-off (intentional)

The refresh script is fail-closed: a permission or transient Secret Manager failure exits nonzero and **fails the deploy**, leaving the previous env file untouched. A config the pipeline cannot assemble must not read green — that is the point, stated out loud.

## Verification

- `pytest packages/core/tests/test_github_repo_auth.py` — 55 passed (including the pre-existing re-bind regression, untouched)
- `pyright` strict + `ruff` clean on the touched package
- deploy.yml parses; refresh ordering (env → compose assets → pull → recreate) commented at both call sites