### PR TITLE
fix(core): make an agent's MCP credential reach every caller, not just its author

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
@@ -13,6 +13,7 @@ from daimon.adapters.discord.agent_setup.state import PanelState
 from daimon.adapters.discord.agent_setup.tenant import resolve_tenant_for_panel
 from daimon.adapters.discord.agent_setup.write import call_reconcile_for_panel, mask_tail
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.agent_mcp_credentials import save_agent_mcp_credential
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.defaults.mcp_merge import get_reserved_mcp_rejection
 from daimon.core.ma_identity import derive_agent_uuid
@@ -166,6 +167,25 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
         #    per-agent vault when it does not yet exist. Failures here are
         #    surfaced to the user but do not unwind reconcile.
         try:
+            # Agent-scoped copy first: the server is attached to the AGENT, so
+            # every caller's session needs this credential mirrored in at
+            # create time. Without this row the server works only for whoever
+            # filled in this modal.
+            if self.runtime.turn_deps.fernet is not None:
+                await save_agent_mcp_credential(
+                    sessionmaker=self.runtime.sessionmaker,
+                    fernet=self.runtime.turn_deps.fernet,
+                    tenant_id=tenant_id,
+                    agent_id=agent_uuid,
+                    mcp_server_url=url,
+                    plaintext_token=token,
+                )
+            else:
+                _log.warning(
+                    "mcp_add.no_fernet_for_agent_scope",
+                    mcp_name=name,
+                    agent_name=selected_name,
+                )
             await add_external_mcp_credential(
                 self.runtime.anthropic,
                 account_id=self.state.account_id,

--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -62,6 +62,7 @@ from daimon.adapters.discord.credential_repo_bind import (
     resolve_repo_binding_credential,
 )
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.agent_mcp_credentials import save_agent_mcp_credential
 from daimon.core.credential_requests import split_skill_repo_target
 from daimon.core.defaults.ma_index import find_agent_by_derived_uuid, find_attach_mount_collision
 from daimon.core.defaults.report import Action, ResourceOutcome
@@ -207,6 +208,24 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
             token_masked=mask_tail(token_value),
         )
         try:
+            # Agent-scoped copy first: the server is attached to the AGENT, so
+            # every caller's session needs this credential mirrored in at
+            # create time. Without this row the server works only for whoever
+            # filled in this modal.
+            if self._runtime.turn_deps.fernet is not None:
+                await save_agent_mcp_credential(
+                    sessionmaker=self._runtime.sessionmaker,
+                    fernet=self._runtime.turn_deps.fernet,
+                    tenant_id=consumed_row.tenant_id,
+                    agent_id=consumed_row.agent_id,
+                    mcp_server_url=mcp_server_url,
+                    plaintext_token=token_value,
+                )
+            else:
+                _log.warning(
+                    "credential_modal.no_fernet_for_agent_scope",
+                    mcp_server_url=mcp_server_url,
+                )
             await add_external_mcp_credential(
                 self._runtime.anthropic,
                 account_id=consumed_row.account_id,

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -98,7 +98,10 @@ def _runtime_for_view(
         if deployment_default is not None
         else DeploymentDefault(),
         resolver_cache=new_resolver_cache(),
-        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+        # fernet is real: the MCP modal encrypts an agent-scoped copy of the token.
+        turn_deps=MagicMock(  # pyright: ignore[reportArgumentType]  # never runs a turn
+            fernet=build_multifernet((Fernet.generate_key().decode(),))
+        ),
     )
 
 
@@ -242,7 +245,10 @@ async def test_inline_pat_persisted_encrypted(
         billing_config=None,
         deployment_default=DeploymentDefault(),
         resolver_cache=new_resolver_cache(),
-        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+        # fernet is real: the MCP modal encrypts an agent-scoped copy of the token.
+        turn_deps=MagicMock(  # pyright: ignore[reportArgumentType]  # never runs a turn
+            fernet=build_multifernet((Fernet.generate_key().decode(),))
+        ),
     )
 
     # The credential is stored under agent_id (per-agent principal), not account_id.
@@ -304,7 +310,10 @@ async def test_store_inline_pat_writes_per_agent_overlay(
         billing_config=None,
         deployment_default=DeploymentDefault(),
         resolver_cache=new_resolver_cache(),
-        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+        # fernet is real: the MCP modal encrypts an agent-scoped copy of the token.
+        turn_deps=MagicMock(  # pyright: ignore[reportArgumentType]  # never runs a turn
+            fernet=build_multifernet((Fernet.generate_key().decode(),))
+        ),
     )
 
     agent_a = uuid.uuid4()
@@ -742,6 +751,10 @@ async def test_add_mcp_modal_writes_vault_credential_after_reconcile(
     Reconcile signal observed BEFORE the credential POST."""
     from daimon.core.defaults.report import Action, ResourceOutcome
 
+    # The modal now persists an agent-scoped copy of the token, which FKs to
+    # tenants — seed the row the tenant_id fixture names.
+    async with db_session_factory() as _session, _session.begin():
+        await make_tenant(_session, id=tenant_id, workspace_id="guild-mcp-modal-write")
     agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=_VAULT_MA_AGENT_ID)
 
     reconcile_order: list[str] = []
@@ -854,6 +867,10 @@ async def test_add_mcp_modal_resubmit_replaces_prior_vault_credential(
     across both submissions; one DELETE on the second."""
     from daimon.core.defaults.report import Action, ResourceOutcome
 
+    # The modal now persists an agent-scoped copy of the token, which FKs to
+    # tenants — seed the row the tenant_id fixture names.
+    async with db_session_factory() as _session, _session.begin():
+        await make_tenant(_session, id=tenant_id, workspace_id="guild-mcp-modal-resubmit")
     agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=_VAULT_MA_AGENT_ID)
 
     async def spy_reconcile(runtime: Any, state: PanelState, *, tenant_id: uuid.UUID) -> Any:

--- a/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
@@ -20,15 +20,19 @@ from anthropic.types.beta import BetaManagedAgentsAgent
 from anthropic.types.beta.beta_managed_agents_model_config import (
     BetaManagedAgentsModelConfig,
 )
+from cryptography.fernet import Fernet
 from daimon.adapters.discord.agent_setup import modals_mcp as modals_mcp_mod
 from daimon.adapters.discord.agent_setup.modals import AddMcpModal
 from daimon.adapters.discord.agent_setup.state import PanelState, RosterEntry
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.github_credentials import build_multifernet
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.notebooks._rate_limit import RateLimiter
 from daimon.core.scope import DeploymentDefault
 from daimon.core.specs import AgentSpec
+from daimon.core.stores import agent_mcp_credentials as cred_store
+from daimon.testing.factories import make_tenant
 from daimon.testing.ma import build_stub_anthropic
 from pydantic import HttpUrl
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -95,7 +99,10 @@ def _runtime(
         if deployment_default is not None
         else DeploymentDefault(),
         resolver_cache=new_resolver_cache(),
-        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # never runs a turn
+        # fernet is real: the MCP modal encrypts an agent-scoped copy of the token.
+        turn_deps=MagicMock(  # pyright: ignore[reportArgumentType]  # never runs a turn
+            fernet=build_multifernet((Fernet.generate_key().decode(),))
+        ),
     )
 
 
@@ -161,6 +168,10 @@ async def test_add_mcp_modal_resolves_agent_uuid_and_writes_per_agent_vault(
     The vault handler checks the display_name so this assertion verifies that
     agent_uuid is derived correctly and the vault is looked up by the right key.
     """
+    # The modal now persists an agent-scoped copy of the token, which FKs to
+    # tenants — seed the row the tenant_id fixture names.
+    async with db_session_factory() as _session, _session.begin():
+        await make_tenant(_session, id=tenant_id, workspace_id="guild-mcp-modal-vault")
     agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=_MA_AGENT_ID)
     per_agent_display = f"daimon-mcp:{account_id}:{agent_uuid}"
 
@@ -240,6 +251,15 @@ async def test_add_mcp_modal_resolves_agent_uuid_and_writes_per_agent_vault(
     )
     assert creds_created[0]["auth"]["token"] == "tok_xxxx_1234", (
         "credential token must be the user-submitted value"
+    )
+    # The vault write alone only serves the submitter. The agent-scoped row is
+    # what lets every OTHER caller's session mount the same credential.
+    async with db_session_factory() as session:
+        stored = await cred_store.list_credentials(
+            session, tenant_id=tenant_id, agent_id=agent_uuid
+        )
+    assert [row.mcp_server_url for row in stored] == ["https://ext.example.com/mcp"], (
+        "the modal must persist an agent-scoped copy for other callers' sessions"
     )
 
 

--- a/packages/adapters/discord/tests/test_credential_modals.py
+++ b/packages/adapters/discord/tests/test_credential_modals.py
@@ -41,6 +41,7 @@ from daimon.core.credential_requests import (
 )
 from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
 from daimon.core.defaults.report import Action, ResourceOutcome
+from daimon.core.github_credentials import build_multifernet
 from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.notebooks._rate_limit import RateLimiter
@@ -95,7 +96,10 @@ def _runtime(
         billing_config=None,
         deployment_default=DeploymentDefault(),
         resolver_cache=new_resolver_cache(),
-        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # credential-modal tests never run a turn
+        # fernet is real: the MCP modal encrypts an agent-scoped copy of the token.
+        turn_deps=MagicMock(  # pyright: ignore[reportArgumentType]  # credential-modal tests never run a turn
+            fernet=build_multifernet((Fernet.generate_key().decode(),))
+        ),
     )
 
 

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
@@ -1222,10 +1222,31 @@ async def run_add_mcp_submission(
             if mcp.public_url is not None and mcp.jwt_secret is not None:
                 import datetime as dt
 
+                from daimon.core.agent_mcp_credentials import save_agent_mcp_credential
                 from daimon.core.mcp_vault import add_external_mcp_credential
 
                 agent_uuid = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(ma_agent.id))
                 jwt_secret = mcp.jwt_secret.get_secret_value().encode()
+                # Agent-scoped copy first: the server is attached to the AGENT,
+                # so every caller's session needs this credential mirrored in
+                # at create time. Without this row the server works only for
+                # whoever submitted this panel.
+                if runtime.turn_deps.fernet is not None:
+                    await save_agent_mcp_credential(
+                        sessionmaker=runtime.sessionmaker,
+                        fernet=runtime.turn_deps.fernet,
+                        tenant_id=tenant_id,
+                        agent_id=agent_uuid,
+                        mcp_server_url=mcp_url,
+                        plaintext_token=token,
+                    )
+                else:
+                    log.warning(
+                        "slack.agent_setup.add_mcp.no_fernet_for_agent_scope",
+                        team_id=team_id,
+                        agent_name=agent_name,
+                        mcp_name=mcp_name,
+                    )
                 await add_external_mcp_credential(
                     runtime.anthropic,
                     account_id=account_id,

--- a/packages/core/alembic/versions/0010_agent_mcp_credentials.py
+++ b/packages/core/alembic/versions/0010_agent_mcp_credentials.py
@@ -1,0 +1,60 @@
+"""Agent-scoped storage for an external MCP server's bearer token.
+
+Revision ID: 0010_agent_mcp_credentials
+Revises: 0009_seeded_skills
+Create Date: 2026-08-14
+
+downgrade: safe
+
+No backfill is possible. MA vault credentials are write-only, so the tokens
+already sitting in individual callers' vaults cannot be read back out — each
+agent-level external MCP server needs its token re-entered once for the
+per-session mirror to have anything to mirror. Until then those servers keep
+working for whoever attached them and keep failing for everyone else, which is
+exactly the pre-migration behaviour.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0010_agent_mcp_credentials"
+down_revision: str | None = "0009_seeded_skills"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_mcp_credentials",
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("tenant_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("mcp_server_url", sa.Text(), nullable=False),
+        sa.Column("encrypted_token", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id", name="pk_agent_mcp_credentials"),
+        sa.UniqueConstraint(
+            "tenant_id",
+            "agent_id",
+            "mcp_server_url",
+            name="uq_agent_mcp_credentials_tenant_agent_url",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("agent_mcp_credentials")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -493,6 +493,51 @@ class AgentGoogleBinding(Base):
     )
 
 
+class AgentMcpCredential(Base):
+    """Agent-scoped bearer token for an external MCP server attached to an agent.
+
+    The MCP server itself is attached to the agent (`mcp_attach`), so every
+    caller who mentions the agent gets its toolset. MA resolves the credential
+    from the vault mounted on the session, and that vault is per
+    (account, agent) — so a token written into only the attacher's vault leaves
+    every other caller's turn failing at MCP init. Keeping the token here, at
+    (tenant, agent), lets `create_session` mirror it into whichever vault the
+    current caller has, the same way the per-agent PAT reaches the Copilot
+    credential. MA credentials are write-only, so this is the only place the
+    token can be re-read from.
+
+    Encrypted with the same MultiFernet as the GitHub PAT.
+    """
+
+    __tablename__ = "agent_mcp_credentials"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "agent_id",
+            "mcp_server_url",
+            name="uq_agent_mcp_credentials_tenant_agent_url",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    # No FK: agents live in MA, not the local DB (same rationale as UserSkill.agent_name).
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    mcp_server_url: Mapped[str] = mapped_column(Text, nullable=False)
+    encrypted_token: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class UsageEvent(Base):
     """Per-turn token row for billing/observability.
 

--- a/packages/core/daimon/core/agent_mcp_credentials.py
+++ b/packages/core/daimon/core/agent_mcp_credentials.py
@@ -1,0 +1,176 @@
+"""Agent-scoped external MCP credentials: store them once, mirror them per session.
+
+An external MCP server is attached to the *agent*, so every caller who mentions
+that agent gets its toolset. The credential MA uses to talk to that server is
+resolved from the vault mounted on the session, and that vault is per
+(account, agent) — the caller's. A token written only into the attacher's vault
+therefore fails every other caller's turn at MCP init, with retries exhausted:
+
+    MCP server '<name>' initialize failed: no credential is stored for this
+    server URL — check that the agent's MCP server URL matches the URL in the vault
+
+MA credentials are write-only, so the token cannot be copied out of the
+attacher's vault after the fact. Keeping it here — encrypted, at (tenant, agent)
+— is what lets ``create_session`` mirror it into whichever vault the current
+caller has, exactly as the per-agent PAT reaches the Copilot credential.
+
+Encryption reuses the GitHub PAT's MultiFernet helpers; they are generic and
+key rotation is shared.
+
+No try/except — exceptions propagate. An empty tuple means "this agent has no
+external MCP credentials", never "something broke".
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from dataclasses import dataclass
+
+from anthropic import AsyncAnthropic
+from cryptography.fernet import MultiFernet
+from daimon.core.github_credentials import decrypt_token, encrypt_token
+from daimon.core.mcp_vault import ensure_agent_mcp_vault
+from daimon.core.stores import agent_mcp_credentials as cred_store
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedMcpCredential:
+    """A decrypted credential, ready to mirror into a vault."""
+
+    mcp_server_url: str
+    token: str
+
+
+async def save_agent_mcp_credential(
+    *,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    mcp_server_url: str,
+    plaintext_token: str,
+) -> None:
+    """Encrypt and UPSERT the token for one of the agent's MCP servers."""
+    async with sessionmaker() as session, session.begin():
+        await cred_store.upsert_credential(
+            session,
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            mcp_server_url=mcp_server_url,
+            encrypted_token=encrypt_token(fernet, plaintext_token),
+        )
+
+
+async def resolve_agent_mcp_credentials(
+    *,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+) -> tuple[ResolvedMcpCredential, ...]:
+    """Every stored credential for this agent, decrypted."""
+    async with sessionmaker() as session:
+        rows = await cred_store.list_credentials(session, tenant_id=tenant_id, agent_id=agent_id)
+    return tuple(
+        ResolvedMcpCredential(
+            mcp_server_url=row.mcp_server_url,
+            token=decrypt_token(fernet, row.encrypted_token),
+        )
+        for row in rows
+    )
+
+
+async def mirror_credentials_into_vault(
+    client: AsyncAnthropic,
+    *,
+    vault_id: str,
+    credentials: tuple[ResolvedMcpCredential, ...],
+) -> None:
+    """Create any credential ``vault_id`` is missing. Never deletes.
+
+    Create-if-missing, NOT delete-then-create. The vault is shared across every
+    thread of one (account, agent), and this runs on reused sessions too, so a
+    delete could yank a credential out from under a concurrent in-flight turn in
+    another thread — the A3 race that got the per-turn re-stamp limb removed from
+    ``ensure_agent_mcp_vault``. Skipping URLs that already have a credential is
+    both race-free and idempotent.
+
+    Consequence: a ROTATED token does not reach a vault that already holds one at
+    that URL. Rotation needs its own fan-out (see #78) — this function's job is
+    to make an agent-level server reachable by callers who have no credential for
+    it at all, which is the failure in the wild.
+
+    Deliberately NOT degrade-not-block: unlike the Copilot and memory mounts,
+    a missing credential here means MA hard-fails the whole turn at MCP init.
+    Swallowing an error would only convert this clear failure into that
+    confusing one, so ``anthropic.APIError`` propagates (the loud-failure
+    precedent is ``resolve_clone_token``).
+    """
+    if not credentials:
+        return
+    present: set[str] = set()
+    async for existing in client.beta.vaults.credentials.list(vault_id=vault_id):
+        if existing.auth.type != "static_bearer":
+            continue
+        present.add(existing.auth.mcp_server_url)
+
+    for cred in credentials:
+        if cred.mcp_server_url in present:
+            continue
+        await client.beta.vaults.credentials.create(
+            vault_id=vault_id,
+            auth={
+                "type": "static_bearer",
+                "mcp_server_url": cred.mcp_server_url,
+                "token": cred.token,
+            },
+        )
+
+
+async def sync_agent_mcp_credentials(
+    client: AsyncAnthropic,
+    *,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    account_id: uuid.UUID,
+    jwt_secret: bytes,
+    public_url: str,
+    now: dt.datetime,
+) -> None:
+    """Ensure this caller's vault holds the agent's external MCP credentials.
+
+    For the REUSED-session path. ``create_session`` mirrors at create time, but a
+    reused thread session never calls it — so a credential added after that
+    session was created would never reach it, and the caller would keep failing
+    at MCP init until their session happened to be recreated. That is precisely
+    the "someone else has to re-add it" outcome this whole fix exists to remove.
+
+    A reused session's ``vault_ids`` are fixed at create time, but the vault's
+    *contents* are read at each turn's MCP init — so writing into the vault the
+    session already mounts does reach it on the next turn.
+
+    Cheap for the common case: the DB read gates every MA call, so an agent with
+    no external MCP servers pays one indexed query and nothing else.
+    """
+    credentials = await resolve_agent_mcp_credentials(
+        sessionmaker=sessionmaker,
+        fernet=fernet,
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+    )
+    if not credentials:
+        return
+    vault_id = await ensure_agent_mcp_vault(
+        client,
+        account_id=account_id,
+        agent_id=agent_id,
+        jwt_secret=jwt_secret,
+        public_url=public_url,
+        now=now,
+        session_factory=sessionmaker,
+    )
+    await mirror_credentials_into_vault(client, vault_id=vault_id, credentials=credentials)

--- a/packages/core/daimon/core/sessions.py
+++ b/packages/core/daimon/core/sessions.py
@@ -18,6 +18,10 @@ from anthropic import AsyncAnthropic, omit
 from anthropic.types.beta import BetaEnvironment, BetaManagedAgentsAgent, BetaManagedAgentsSession
 from anthropic.types.beta.session_create_params import Resource
 from cryptography.fernet import MultiFernet
+from daimon.core.agent_mcp_credentials import (
+    mirror_credentials_into_vault,
+    resolve_agent_mcp_credentials,
+)
 from daimon.core.config import McpSettings
 from daimon.core.credential_env import upload_env_and_mount
 from daimon.core.defaults.metadata import MA_METADATA_KEY_ACCOUNT, MA_METADATA_KEY_TENANT
@@ -69,6 +73,15 @@ async def create_session(
     ``anthropic.APIError`` on that call is logged and swallowed rather than
     propagated (SYNC-04) — the session still gets created, just without the
     Copilot credential mounted that turn.
+
+    The agent's stored external-MCP credentials are mirrored into the same
+    vault on every session create (``resolve_agent_mcp_credentials`` +
+    ``mirror_credentials_into_vault``). The servers themselves live on the agent
+    spec, so a credential held only in the vault of whoever attached one leaves
+    every other caller's turn failing at MCP init; mirroring per session is what
+    makes an agent-level server work for an agent-level audience. Unlike the
+    Copilot and memory mounts this is NOT degrade-not-block — a missing
+    credential hard-fails the turn at MA, so ``anthropic.APIError`` propagates.
 
     When ``tenant_id``, ``agent_uuid``, and ``session_factory`` are all
     provided, the agent's tenant-scoped secrets are assembled into a ``.env``
@@ -155,6 +168,31 @@ async def create_session(
                 agent_uuid=str(agent_uuid) if agent_uuid is not None else None,
                 error=str(exc),
             )
+
+    # External MCP servers are attached to the AGENT, so every caller who
+    # mentions it gets the toolset — but MA resolves each server's credential
+    # from the vault mounted here, which is the CALLER's. Mirror the agent's
+    # stored credentials in on every session create (same shape as the Copilot
+    # mirror above) or callers who did not personally attach a server fail the
+    # whole turn at MCP init. Not degrade-not-block: see
+    # mirror_credentials_into_vault.
+    if (
+        vault_id is not None
+        and tenant_id is not None
+        and agent_uuid is not None
+        and session_factory is not None
+        and fernet is not None
+    ):
+        await mirror_credentials_into_vault(
+            anthropic,
+            vault_id=vault_id,
+            credentials=await resolve_agent_mcp_credentials(
+                sessionmaker=session_factory,
+                fernet=fernet,
+                tenant_id=tenant_id,
+                agent_id=agent_uuid,
+            ),
+        )
 
     resources: list[Resource] = []
     if tenant_id is not None and agent_uuid is not None and session_factory is not None:

--- a/packages/core/daimon/core/stores/agent_mcp_credentials.py
+++ b/packages/core/daimon/core/stores/agent_mcp_credentials.py
@@ -1,0 +1,87 @@
+"""Async store for agent_mcp_credentials.
+
+UPSERT on (tenant_id, agent_id, mcp_server_url): re-entering a token for a
+server the agent already has replaces the ciphertext and bumps updated_at.
+No try/except — DB exceptions propagate to the caller's boundary.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from daimon.core._models import AgentMcpCredential
+from daimon.core.stores.domain import AgentMcpCredentialRow
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def upsert_credential(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    mcp_server_url: str,
+    encrypted_token: bytes,
+) -> AgentMcpCredentialRow:
+    now = datetime.now(tz=UTC)
+    stmt = (
+        pg_insert(AgentMcpCredential)
+        .values(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            mcp_server_url=mcp_server_url,
+            encrypted_token=encrypted_token,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_update(
+            constraint="uq_agent_mcp_credentials_tenant_agent_url",
+            set_={"encrypted_token": encrypted_token, "updated_at": now},
+        )
+        .returning(AgentMcpCredential)
+    )
+    result = await session.execute(stmt)
+    return AgentMcpCredentialRow.model_validate(result.scalar_one())
+
+
+async def list_credentials(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+) -> tuple[AgentMcpCredentialRow, ...]:
+    """Every stored credential for this agent, oldest first."""
+    result = await session.execute(
+        select(AgentMcpCredential)
+        .where(
+            AgentMcpCredential.tenant_id == tenant_id,
+            AgentMcpCredential.agent_id == agent_id,
+        )
+        .order_by(AgentMcpCredential.created_at)
+    )
+    return tuple(AgentMcpCredentialRow.model_validate(orm) for orm in result.scalars())
+
+
+async def delete_credential(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    mcp_server_url: str,
+) -> bool:
+    """Delete the credential for one server. ``True`` when a row was removed."""
+    result = await session.execute(
+        select(AgentMcpCredential).where(
+            AgentMcpCredential.tenant_id == tenant_id,
+            AgentMcpCredential.agent_id == agent_id,
+            AgentMcpCredential.mcp_server_url == mcp_server_url,
+        )
+    )
+    orm = result.scalar_one_or_none()
+    if orm is None:
+        return False
+    await session.delete(orm)
+    return True

--- a/packages/core/daimon/core/stores/domain.py
+++ b/packages/core/daimon/core/stores/domain.py
@@ -204,6 +204,18 @@ class GitHubCredentialRow(BaseModel):
     updated_at: datetime
 
 
+class AgentMcpCredentialRow(BaseModel):
+    model_config = ConfigDict(from_attributes=True, frozen=True)
+
+    id: uuid.UUID
+    tenant_id: uuid.UUID
+    agent_id: uuid.UUID
+    mcp_server_url: str
+    encrypted_token: bytes
+    created_at: datetime
+    updated_at: datetime
+
+
 class SlackBotTokenRow(BaseModel):
     model_config = ConfigDict(from_attributes=True, frozen=True)
 

--- a/packages/core/daimon/core/turn/prepare.py
+++ b/packages/core/daimon/core/turn/prepare.py
@@ -12,10 +12,12 @@ a non-public field. Adapters never see or construct billing wiring.
 
 from __future__ import annotations
 
+import datetime as dt
 import functools
 import uuid
 from dataclasses import dataclass
 
+from daimon.core.agent_mcp_credentials import sync_agent_mcp_credentials
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.pricing import MODEL_PRICING
 from daimon.core.sessions import create_session
@@ -172,6 +174,30 @@ async def bind_session(
             mapping_id = existing.id
             watermark = existing.watermark_message_id
             reused = True
+            # A reused session skips create_session, so it would never pick up
+            # an external MCP credential added to the agent after it was
+            # created — the caller would keep failing at MCP init until their
+            # session happened to be recreated. The vault this session already
+            # mounts is read at each turn's MCP init, so writing into it here
+            # reaches this session on this turn.
+            if (
+                deps.fernet is not None
+                and deps.mcp.public_url is not None
+                and deps.mcp.jwt_secret is not None
+            ):
+                await sync_agent_mcp_credentials(
+                    deps.anthropic,
+                    sessionmaker=deps.sessionmaker,
+                    fernet=deps.fernet,
+                    tenant_id=tenant_id,
+                    agent_id=derive_agent_uuid(
+                        tenant_id=tenant_id, ma_agent_id=str(admission.agent.id)
+                    ),
+                    account_id=admission.account_id,
+                    jwt_secret=deps.mcp.jwt_secret.get_secret_value().encode(),
+                    public_url=str(deps.mcp.public_url),
+                    now=dt.datetime.now(dt.UTC),
+                )
 
     if not reused:
         ma_session_id, mapping_id = await create_fresh_session(

--- a/packages/core/tests/stores/test_agent_mcp_credentials.py
+++ b/packages/core/tests/stores/test_agent_mcp_credentials.py
@@ -1,0 +1,191 @@
+"""Tests for the agent-scoped external MCP credential store."""
+
+from __future__ import annotations
+
+import uuid
+
+from cryptography.fernet import Fernet
+from daimon.core.agent_mcp_credentials import (
+    resolve_agent_mcp_credentials,
+    save_agent_mcp_credential,
+)
+from daimon.core.github_credentials import build_multifernet
+from daimon.core.stores import agent_mcp_credentials as cred_store
+from daimon.core.stores.domain import AgentMcpCredentialRow
+from daimon.testing.factories import make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+async def test_upsert_credential_returns_pydantic_row(db_session: AsyncSession) -> None:
+    tenant = await make_tenant(db_session)
+    agent_id = uuid.uuid4()
+
+    row = await cred_store.upsert_credential(
+        db_session,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        mcp_server_url="https://example.com/mcp",
+        encrypted_token=b"ciphertext",
+    )
+
+    assert isinstance(row, AgentMcpCredentialRow), "store should return Pydantic, not ORM"
+    assert row.mcp_server_url == "https://example.com/mcp"
+    assert row.encrypted_token == b"ciphertext"
+
+
+async def test_upsert_credential_replaces_token_for_the_same_url(
+    db_session: AsyncSession,
+) -> None:
+    """Re-entering a token for a server the agent already has must replace it,
+    not accumulate rows MA would then race over."""
+    tenant = await make_tenant(db_session)
+    agent_id = uuid.uuid4()
+
+    await cred_store.upsert_credential(
+        db_session,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        mcp_server_url="https://example.com/mcp",
+        encrypted_token=b"old",
+    )
+    await cred_store.upsert_credential(
+        db_session,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        mcp_server_url="https://example.com/mcp",
+        encrypted_token=b"new",
+    )
+
+    rows = await cred_store.list_credentials(db_session, tenant_id=tenant.id, agent_id=agent_id)
+    assert len(rows) == 1, "one row per (tenant, agent, url)"
+    assert rows[0].encrypted_token == b"new", "the newer token wins"
+
+
+async def test_list_credentials_scopes_to_the_requested_agent(db_session: AsyncSession) -> None:
+    tenant = await make_tenant(db_session)
+    mine = uuid.uuid4()
+    theirs = uuid.uuid4()
+
+    await cred_store.upsert_credential(
+        db_session,
+        tenant_id=tenant.id,
+        agent_id=mine,
+        mcp_server_url="https://mine.example.com/mcp",
+        encrypted_token=b"a",
+    )
+    await cred_store.upsert_credential(
+        db_session,
+        tenant_id=tenant.id,
+        agent_id=theirs,
+        mcp_server_url="https://theirs.example.com/mcp",
+        encrypted_token=b"b",
+    )
+
+    rows = await cred_store.list_credentials(db_session, tenant_id=tenant.id, agent_id=mine)
+    assert [r.mcp_server_url for r in rows] == ["https://mine.example.com/mcp"], (
+        "another agent's credential must never leak into this agent's session"
+    )
+
+
+async def test_delete_credential_reports_whether_a_row_was_removed(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+    agent_id = uuid.uuid4()
+    await cred_store.upsert_credential(
+        db_session,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        mcp_server_url="https://example.com/mcp",
+        encrypted_token=b"x",
+    )
+
+    assert (
+        await cred_store.delete_credential(
+            db_session,
+            tenant_id=tenant.id,
+            agent_id=agent_id,
+            mcp_server_url="https://example.com/mcp",
+        )
+        is True
+    ), "deleting an existing credential reports True"
+    assert (
+        await cred_store.delete_credential(
+            db_session,
+            tenant_id=tenant.id,
+            agent_id=agent_id,
+            mcp_server_url="https://example.com/mcp",
+        )
+        is False
+    ), "deleting an absent credential is idempotent and reports False"
+
+
+async def test_save_then_resolve_round_trips_the_plaintext_token(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The token is what MA needs; encryption must be transparent to callers."""
+    tenant = await make_tenant(db_session)
+    agent_id = uuid.uuid4()
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+
+    await save_agent_mcp_credential(
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        mcp_server_url="https://internal.example.com/mcp",
+        plaintext_token="tok_secret",
+    )
+
+    resolved = await resolve_agent_mcp_credentials(
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+    )
+
+    assert len(resolved) == 1
+    assert resolved[0].mcp_server_url == "https://internal.example.com/mcp"
+    assert resolved[0].token == "tok_secret", "resolve must return the decrypted token"
+
+
+async def test_resolve_returns_empty_for_an_agent_with_no_credentials(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Empty means 'no external MCP servers', never 'something broke'."""
+    tenant = await make_tenant(db_session)
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+
+    resolved = await resolve_agent_mcp_credentials(
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        tenant_id=tenant.id,
+        agent_id=uuid.uuid4(),
+    )
+
+    assert resolved == (), "no rows resolves to an empty tuple"
+
+
+async def test_stored_token_is_not_recoverable_without_the_key(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The DB row must hold ciphertext — this table is the only place the token
+    is readable, so a DB dump alone must not yield live MCP tokens."""
+    tenant = await make_tenant(db_session)
+    agent_id = uuid.uuid4()
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+
+    await save_agent_mcp_credential(
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        tenant_id=tenant.id,
+        agent_id=agent_id,
+        mcp_server_url="https://internal.example.com/mcp",
+        plaintext_token="tok_secret",
+    )
+
+    rows = await cred_store.list_credentials(db_session, tenant_id=tenant.id, agent_id=agent_id)
+    assert b"tok_secret" not in rows[0].encrypted_token, "token must be stored encrypted"

--- a/packages/core/tests/test_sessions.py
+++ b/packages/core/tests/test_sessions.py
@@ -17,6 +17,7 @@ from anthropic.types.beta import (
 from cryptography.fernet import Fernet, MultiFernet
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from daimon.core.agent_mcp_credentials import save_agent_mcp_credential
 from daimon.core.config import McpSettings
 from daimon.core.errors import DaimonError
 from daimon.core.github_credentials import build_multifernet, upsert_credential_encrypted
@@ -1861,3 +1862,209 @@ async def test_create_session_degrades_when_memory_provisioning_fails(
     assert all(r.get("type") != "memory_store" for r in captured.get("resources", [])), (
         "failed memory provisioning must degrade to a memory-less session, not raise"
     )
+
+
+# --- Agent-scoped external MCP credentials mirror into the caller's vault ----
+
+
+def _warm_vault_mirror_handler(
+    *,
+    account_id: uuid.UUID,
+    agent_uuid: uuid.UUID,
+    public_url: str,
+    credential_post_bodies: list[dict[str, Any]],
+    credential_deletes: list[str],
+    session_create_bodies: list[dict[str, Any]],
+    session_id: str,
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Warm vault holding only the caller's own daimon-mcp credential.
+
+    No credential for any external server yet — which is exactly the state a
+    caller who did not attach the server arrives in.
+    """
+    display = f"daimon-mcp:{account_id}:{agent_uuid}"
+    memory_handler = make_fake_memory_store_handler()
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        try:
+            return memory_handler(request)
+        except NotHandled:
+            pass
+        if request.method == "GET" and request.url.path == "/v1/vaults":
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "vlt_caller",
+                            "type": "vault",
+                            "display_name": display,
+                            "metadata": None,
+                            "archived_at": None,
+                            "created_at": "2026-04-01T00:00:00Z",
+                        }
+                    ],
+                    "has_more": False,
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/vaults/vlt_caller/credentials":
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "vcrd_daimon_mcp",
+                            "type": "credential",
+                            "vault_id": "vlt_caller",
+                            "auth": {"type": "static_bearer", "mcp_server_url": public_url},
+                        }
+                    ],
+                    "has_more": False,
+                },
+            )
+        if request.method == "DELETE" and "/credentials/" in request.url.path:
+            credential_deletes.append(request.url.path.rsplit("/", 1)[-1])
+            return httpx.Response(200, json={"id": "vcrd_gone", "type": "credential"})
+        if request.method == "POST" and request.url.path == "/v1/vaults/vlt_caller/credentials":
+            body = json.loads(request.content)
+            credential_post_bodies.append(body)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "vcrd_mirrored",
+                    "type": "credential",
+                    "vault_id": "vlt_caller",
+                    "auth": {
+                        "type": "static_bearer",
+                        "mcp_server_url": body["auth"]["mcp_server_url"],
+                    },
+                },
+            )
+        if request.method == "POST" and request.url.path.endswith("/v1/sessions"):
+            body = json.loads(request.content)
+            session_create_bodies.append(body)
+            return httpx.Response(
+                200,
+                json=_session_body(
+                    session_id=session_id,
+                    agent_id=body["agent"],
+                    environment_id=body["environment_id"],
+                ),
+            )
+        raise AssertionError(f"unexpected call: {request.method} {request.url.path}")
+
+    return _handler
+
+
+async def test_create_session_mirrors_agent_mcp_credential_for_a_caller_who_did_not_attach_it(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The regression: an external MCP server is attached to the agent, so a
+    second caller's session must carry its credential too. Before the fix the
+    token lived only in the attacher's vault and this caller's turn died with
+    mcp_authentication_failed_error."""
+    tenant = await make_tenant(db_session)
+    agent_uuid = uuid.uuid4()
+    attacher_account_id = uuid.UUID("00000000-0000-0000-0000-00000000aaaa")
+    other_account_id = uuid.UUID("00000000-0000-0000-0000-00000000bbbb")
+    public_url = "https://mcp.example.com/mcp"
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+
+    # The attacher stored the credential agent-scoped, as the setup panel does.
+    await save_agent_mcp_credential(
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        tenant_id=tenant.id,
+        agent_id=agent_uuid,
+        mcp_server_url="https://internal.example.com/mcp",
+        plaintext_token="tok_internal",
+    )
+    assert attacher_account_id != other_account_id
+
+    agent = _make_agent(anthropic_id="ag_mirror")
+    env = _make_env(anthropic_id="env_mirror")
+    cred_bodies: list[dict[str, Any]] = []
+    cred_deletes: list[str] = []
+    session_bodies: list[dict[str, Any]] = []
+    client = build_fake_anthropic_http(
+        _warm_vault_mirror_handler(
+            account_id=other_account_id,
+            agent_uuid=agent_uuid,
+            public_url=public_url,
+            credential_post_bodies=cred_bodies,
+            credential_deletes=cred_deletes,
+            session_create_bodies=session_bodies,
+            session_id="sess_mirror",
+        )
+    )
+
+    await create_session(
+        client,
+        agent=agent,
+        environment=env,
+        account_id=other_account_id,
+        mcp_settings=McpSettings(jwt_secret=SecretStr("x" * 32), public_url=HttpUrl(public_url)),
+        tenant_id=tenant.id,
+        agent_uuid=agent_uuid,
+        session_factory=db_session_factory,
+        fernet=fernet,
+    )
+
+    mirrored = [
+        b for b in cred_bodies if b["auth"]["mcp_server_url"].startswith("https://internal")
+    ]
+    assert len(mirrored) == 1, (
+        "the agent's external MCP credential must be mirrored into this caller's vault"
+    )
+    assert mirrored[0]["auth"]["token"] == "tok_internal", "mirrored cred carries the stored token"
+    assert "vcrd_daimon_mcp" not in cred_deletes, (
+        "mirroring must not disturb the caller's own daimon-mcp credential"
+    )
+    assert session_bodies[0].get("vault_ids") == ["vlt_caller"], (
+        "the mirrored cred rides the caller's own vault"
+    )
+
+
+async def test_create_session_mirrors_nothing_when_agent_has_no_stored_mcp_credentials(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """No stored credentials means no credential POSTs — the mirror must not
+    invent work for the common case of an agent with only daimon-mcp."""
+    tenant = await make_tenant(db_session)
+    agent_uuid = uuid.uuid4()
+    account_id = uuid.UUID("00000000-0000-0000-0000-00000000cccc")
+    public_url = "https://mcp.example.com/mcp"
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+
+    cred_bodies: list[dict[str, Any]] = []
+    cred_deletes: list[str] = []
+    session_bodies: list[dict[str, Any]] = []
+    client = build_fake_anthropic_http(
+        _warm_vault_mirror_handler(
+            account_id=account_id,
+            agent_uuid=agent_uuid,
+            public_url=public_url,
+            credential_post_bodies=cred_bodies,
+            credential_deletes=cred_deletes,
+            session_create_bodies=session_bodies,
+            session_id="sess_nomirror",
+        )
+    )
+
+    await create_session(
+        client,
+        agent=_make_agent(anthropic_id="ag_nomirror"),
+        environment=_make_env(anthropic_id="env_nomirror"),
+        account_id=account_id,
+        mcp_settings=McpSettings(jwt_secret=SecretStr("x" * 32), public_url=HttpUrl(public_url)),
+        tenant_id=tenant.id,
+        agent_uuid=agent_uuid,
+        session_factory=db_session_factory,
+        fernet=fernet,
+    )
+
+    assert cred_bodies == [], "no stored credentials means no credential POSTs"
+    assert cred_deletes == [], "and nothing deleted"
+    assert len(session_bodies) == 1, "the session is still created"

--- a/packages/core/tests/turn/test_prepare.py
+++ b/packages/core/tests/turn/test_prepare.py
@@ -20,8 +20,12 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_request_end_ev
 from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
     BetaManagedAgentsSpanModelUsage,
 )
+from cryptography.fernet import Fernet
+from daimon.core.agent_mcp_credentials import save_agent_mcp_credential
 from daimon.core.config import McpSettings
 from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
+from daimon.core.github_credentials import build_multifernet
+from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.scope import DeploymentDefault, ResolvedConfig
 from daimon.core.stores import usage_events
@@ -34,6 +38,7 @@ from daimon.testing.ma import (
     build_fake_anthropic,
     make_fake_memory_store_handler,
 )
+from pydantic import HttpUrl, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from daimon.testing.factories import (  # isort: skip
@@ -359,3 +364,200 @@ def test_prepared_turn_public_fields_exclude_recorder() -> None:
         "reused",
         "session_account_id",
     }, "PreparedTurn must expose exactly the documented public fields"
+
+
+async def test_bind_session_syncs_agent_mcp_credential_into_a_reused_session_vault(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The regression that made an agent-level MCP server one person's private
+    tool: a reused session skips create_session, so a credential added to the
+    agent after that session existed never reached this caller and every one of
+    their turns died at MCP init. The admin adds it once; this caller does
+    nothing and their live session picks it up on the next turn."""
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await make_thread_session(
+        db_session,
+        tenant=tenant,
+        account=account,
+        platform="discord",
+        thread_id="thread-reuse-mcp",
+        ma_session_id="sess_live",
+        watermark_message_id="msg-1",
+    )
+    await db_session.commit()
+
+    public_url = "https://mcp.example.com/mcp"
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+    agent = _agent(agent_id="ag_reuse", tenant_id=tenant.id)
+    agent_uuid = derive_agent_uuid(tenant_id=tenant.id, ma_agent_id="ag_reuse")
+
+    # Someone else (the admin) attached the server and stored the token.
+    await save_agent_mcp_credential(
+        sessionmaker=db_session_factory,
+        fernet=fernet,
+        tenant_id=tenant.id,
+        agent_id=agent_uuid,
+        mcp_server_url="https://internal.example.com/mcp",
+        plaintext_token="tok_internal",
+    )
+
+    display = f"daimon-mcp:{account.id}:{agent_uuid}"
+    created: list[dict[str, object]] = []
+    deleted: list[str] = []
+
+    router = MARouter()
+
+    def _explode(_request: httpx.Request, _match: object) -> httpx.Response:
+        raise AssertionError("create_session must not be called on a reuse hit")
+
+    def _vaults(_request: httpx.Request, _match: object) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "vlt_caller",
+                        "type": "vault",
+                        "display_name": display,
+                        "metadata": None,
+                        "archived_at": None,
+                        "created_at": "2026-04-01T00:00:00Z",
+                    }
+                ],
+                "has_more": False,
+            },
+        )
+
+    def _list_creds(_request: httpx.Request, _match: object) -> httpx.Response:
+        # Only this caller's own daimon-mcp credential — nothing for the
+        # external server, which is the state that used to fail the turn.
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "vcrd_daimon_mcp",
+                        "type": "credential",
+                        "vault_id": "vlt_caller",
+                        "auth": {"type": "static_bearer", "mcp_server_url": public_url},
+                    }
+                ],
+                "has_more": False,
+            },
+        )
+
+    def _create_cred(request: httpx.Request, _match: object) -> httpx.Response:
+        import json
+
+        body = json.loads(request.content)
+        created.append(body)
+        return httpx.Response(
+            200,
+            json={
+                "id": "vcrd_new",
+                "type": "credential",
+                "vault_id": "vlt_caller",
+                "auth": {
+                    "type": "static_bearer",
+                    "mcp_server_url": body["auth"]["mcp_server_url"],
+                },
+            },
+        )
+
+    def _delete_cred(request: httpx.Request, _match: object) -> httpx.Response:
+        deleted.append(request.url.path.rsplit("/", 1)[-1])
+        return httpx.Response(200, json={"id": "vcrd_gone", "type": "credential"})
+
+    router.add("POST", r"/v1/sessions", _explode)
+    router.add("GET", r"/v1/vaults$", _vaults)
+    router.add("GET", r"/v1/vaults/vlt_caller/credentials", _list_creds)
+    router.add("POST", r"/v1/vaults/vlt_caller/credentials", _create_cred)
+    router.add("DELETE", r"/v1/vaults/vlt_caller/credentials/.*", _delete_cred)
+
+    deps = dataclasses.replace(
+        _deps(sessionmaker=db_session_factory, router=router),
+        anthropic=build_fake_anthropic(router.dispatch),
+        fernet=fernet,
+        mcp=McpSettings(jwt_secret=SecretStr("x" * 32), public_url=HttpUrl(public_url)),
+    )
+    admission = _admission(
+        account_id=account.id, agent=agent, env=_env(env_id="env_reuse", tenant_id=tenant.id)
+    )
+
+    prepared = await bind_session(
+        deps,
+        admission,
+        tenant_id=tenant.id,
+        platform="discord",
+        external_user_id="user-not-the-admin",
+        thread_id="thread-reuse-mcp",
+        session_account_id=account.id,
+        reuse_existing=True,
+    )
+
+    assert prepared.reused is True, "this must still be the reuse path"
+    urls = [c["auth"]["mcp_server_url"] for c in created]  # pyright: ignore[reportIndexIssue]
+    assert urls == ["https://internal.example.com/mcp"], (
+        "the agent's external MCP credential must be created in this caller's vault"
+    )
+    assert created[0]["auth"]["token"] == "tok_internal"  # pyright: ignore[reportIndexIssue]
+    assert deleted == [], (
+        "the sync must never delete — the vault is shared across this caller's "
+        "threads and a concurrent turn may be using a credential"
+    )
+
+
+async def test_bind_session_reuse_skips_mcp_sync_when_agent_has_no_stored_credentials(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The common case pays one indexed query and touches MA not at all."""
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+    await make_thread_session(
+        db_session,
+        tenant=tenant,
+        account=account,
+        platform="discord",
+        thread_id="thread-reuse-plain",
+        ma_session_id="sess_live",
+        watermark_message_id="msg-1",
+    )
+    await db_session.commit()
+
+    router = MARouter()
+
+    def _explode(request: httpx.Request, _match: object) -> httpx.Response:
+        raise AssertionError(f"no MA call expected, got {request.method} {request.url.path}")
+
+    router.add("POST", r"/v1/sessions", _explode)
+    router.add("GET", r"/v1/vaults$", _explode)
+
+    deps = dataclasses.replace(
+        _deps(sessionmaker=db_session_factory, router=router),
+        anthropic=build_fake_anthropic(router.dispatch),
+        fernet=build_multifernet((Fernet.generate_key().decode(),)),
+        mcp=McpSettings(
+            jwt_secret=SecretStr("x" * 32), public_url=HttpUrl("https://mcp.example.com/mcp")
+        ),
+    )
+    admission = _admission(
+        account_id=account.id,
+        agent=_agent(agent_id="ag_plain", tenant_id=tenant.id),
+        env=_env(env_id="env_plain", tenant_id=tenant.id),
+    )
+
+    prepared = await bind_session(
+        deps,
+        admission,
+        tenant_id=tenant.id,
+        platform="discord",
+        external_user_id="user-1",
+        thread_id="thread-reuse-plain",
+        session_account_id=account.id,
+        reuse_existing=True,
+    )
+
+    assert prepared.reused is True, "reuse path unchanged for agents with no external MCP"


### PR DESCRIPTION
Fixes #78.

## The bug

An external MCP server is attached to the **agent**, so everyone who mentions that agent gets its toolset. Its credential went into the vault of whoever filled in the setup modal, and a session mounts exactly one vault — the caller's. So for anyone else, MA had the toolset and no credential, and failed the whole turn at init with `mcp_authentication_failed_error`, retries exhausted.

In the wild: the person who attached the server ran clean turns with 14 successful tool calls against it, while a second person in the same thread failed every turn, minutes apart, same agent, same URL.

## How it works now

- The token is stored **agent-scoped** — encrypted at `(tenant_id, agent_id, mcp_server_url)`, same MultiFernet as the per-agent PAT. MA credentials are write-only, so this is the only place it can be re-read from.
- **Every turn ensures the caller's vault holds it.** Fresh session: in `create_session`, alongside the Copilot mirror that already worked this way. Reused session: in `bind_session` — a reused session never calls `create_session`, so without this a credential added after that session existed would never reach it, and that caller would keep failing until their session happened to be recreated.
- One person adds the server once. Everyone else does nothing, including in threads whose sessions are already live.

## Create-if-missing, never delete

The vault is shared across one caller's threads, so deleting a credential could pull it out from under a concurrent in-flight turn — the race that got the per-turn re-stamp limb removed from `ensure_agent_mcp_vault`. Skipping URLs that already have a credential is race-free and idempotent.

Consequence: a **rotated** token does not overwrite a vault that already holds one at that URL. That needs its own fan-out and is left in #78.

## Cost

An agent with no external MCP server pays one indexed query per reused turn and makes no MA calls — the DB read gates everything.

## Deploy note

No backfill is possible. Each agent-level external MCP server needs its token re-entered once before the sync has anything to sync; until then those servers keep working for whoever attached them and keep failing for everyone else, exactly as today. Migration `0010_agent_mcp_credentials`.

## Tests

Both regressions were confirmed to fail without their fix (stash the source file, watch the assertion break):

- `test_create_session_mirrors_agent_mcp_credential_for_a_caller_who_did_not_attach_it`
- `test_bind_session_syncs_agent_mcp_credential_into_a_reused_session_vault`

Plus: no-op paths for agents with no stored credentials, the never-delete assertion, seven store tests, and a write-through assertion on the Discord setup modal.

Three modal tests were passing a `MagicMock` fernet under a "never runs a turn" comment — they now build a real `MultiFernet` and seed the tenant row. That mock is part of why this shipped unnoticed: the existing coverage proved `attach_mcp_server` works in a live session **for the account that attached it**, and nothing exercised a second caller. Worth a standing rule that any agent-level resource gets a two-caller test.

4515 passed, 4 skipped. pyright 0 errors, ruff clean, 6/6 import contracts, anti-pattern lint 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
