### PR TITLE
fix(core): propagate a rotated MCP token to every caller, in place

### DIFF
--- a/packages/core/daimon/core/agent_mcp_credentials.py
+++ b/packages/core/daimon/core/agent_mcp_credentials.py
@@ -17,6 +17,10 @@ caller has, exactly as the per-agent PAT reaches the Copilot credential.
 Encryption reuses the GitHub PAT's MultiFernet helpers; they are generic and
 key rotation is shared.
 
+A rotated token reaches every caller too: each credential this module writes
+carries a version stamp, and a vault whose stamp is stale (or missing) gets an
+in-place update on the next turn.
+
 No try/except — exceptions propagate. An empty tuple means "this agent has no
 external MCP credentials", never "something broke".
 """
@@ -34,6 +38,15 @@ from daimon.core.mcp_vault import ensure_agent_mcp_vault
 from daimon.core.stores import agent_mcp_credentials as cred_store
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+# Stamped on every credential this module writes, so a later turn can tell
+# whether a vault's credential carries the token currently in the DB. The value
+# is the DB row's ``updated_at``, so both sides of the comparison come from OUR
+# clock — no dependence on MA's, and nothing derived from the token itself.
+# An unstamped credential (written before this existed, or by
+# ``add_external_mcp_credential``) reads as "unknown version" and is refreshed
+# once, which self-heals vaults already holding a stale token.
+METADATA_VERSION_KEY = "daimon_token_version"
+
 
 @dataclass(frozen=True, slots=True)
 class ResolvedMcpCredential:
@@ -41,6 +54,7 @@ class ResolvedMcpCredential:
 
     mcp_server_url: str
     token: str
+    version: str
 
 
 async def save_agent_mcp_credential(
@@ -77,6 +91,7 @@ async def resolve_agent_mcp_credentials(
         ResolvedMcpCredential(
             mcp_server_url=row.mcp_server_url,
             token=decrypt_token(fernet, row.encrypted_token),
+            version=row.updated_at.isoformat(),
         )
         for row in rows
     )
@@ -88,19 +103,29 @@ async def mirror_credentials_into_vault(
     vault_id: str,
     credentials: tuple[ResolvedMcpCredential, ...],
 ) -> None:
-    """Create any credential ``vault_id`` is missing. Never deletes.
+    """Bring ``vault_id`` in line with the agent's stored credentials.
 
-    Create-if-missing, NOT delete-then-create. The vault is shared across every
-    thread of one (account, agent), and this runs on reused sessions too, so a
-    delete could yank a credential out from under a concurrent in-flight turn in
-    another thread — the A3 race that got the per-turn re-stamp limb removed from
-    ``ensure_agent_mcp_vault``. Skipping URLs that already have a credential is
-    both race-free and idempotent.
+    Three cases per stored credential, decided by the ``METADATA_VERSION_KEY``
+    stamp on the vault's credential at that URL:
 
-    Consequence: a ROTATED token does not reach a vault that already holds one at
-    that URL. Rotation needs its own fan-out (see #78) — this function's job is
-    to make an agent-level server reachable by callers who have no credential for
-    it at all, which is the failure in the wild.
+    - nothing at that URL → create it (the caller who never had one)
+    - stamp differs, or is absent → the token was rotated (or the credential
+      predates the stamp) → update it in place
+    - stamp matches → already current, no call
+
+    **Never deletes.** Rotation is an in-place ``credentials.update``: MA accepts
+    a token-only ``static_bearer`` auth body and keeps the URL, verified against
+    the live API on 2026-08-14 (a body carrying ``mcp_server_url`` is a 400 —
+    the URL is immutable, and a duplicate POST at the same URL is still a 409).
+    That matters because this vault is shared across every thread of one
+    (account, agent) and this runs on reused sessions: a delete could yank a
+    credential out from under a concurrent in-flight turn in another thread —
+    the A3 race that got the per-turn re-stamp limb removed from
+    ``ensure_agent_mcp_vault``. An update has no window where the credential is
+    absent, so that race does not exist here.
+
+    Note: ``mcp_vault.py`` still documents PATCH as 405-blocked. That was true
+    when it was written and is not any more.
 
     Deliberately NOT degrade-not-block: unlike the Copilot and memory mounts,
     a missing credential here means MA hard-fails the whole turn at MCP init.
@@ -110,22 +135,39 @@ async def mirror_credentials_into_vault(
     """
     if not credentials:
         return
-    present: set[str] = set()
+    # url -> (credential_id, stamped version or None)
+    existing_by_url: dict[str, tuple[str, str | None]] = {}
     async for existing in client.beta.vaults.credentials.list(vault_id=vault_id):
         if existing.auth.type != "static_bearer":
             continue
-        present.add(existing.auth.mcp_server_url)
+        metadata = existing.metadata or {}
+        existing_by_url[existing.auth.mcp_server_url] = (
+            existing.id,
+            metadata.get(METADATA_VERSION_KEY),
+        )
 
     for cred in credentials:
-        if cred.mcp_server_url in present:
+        found = existing_by_url.get(cred.mcp_server_url)
+        if found is None:
+            await client.beta.vaults.credentials.create(
+                vault_id=vault_id,
+                auth={
+                    "type": "static_bearer",
+                    "mcp_server_url": cred.mcp_server_url,
+                    "token": cred.token,
+                },
+                metadata={METADATA_VERSION_KEY: cred.version},
+            )
             continue
-        await client.beta.vaults.credentials.create(
+        credential_id, stamped_version = found
+        if stamped_version == cred.version:
+            continue
+        await client.beta.vaults.credentials.update(
+            credential_id,
             vault_id=vault_id,
-            auth={
-                "type": "static_bearer",
-                "mcp_server_url": cred.mcp_server_url,
-                "token": cred.token,
-            },
+            # Token only: MA rejects an update body carrying mcp_server_url.
+            auth={"type": "static_bearer", "token": cred.token},
+            metadata={METADATA_VERSION_KEY: cred.version},
         )
 
 

--- a/packages/core/tests/stores/test_agent_mcp_credentials.py
+++ b/packages/core/tests/stores/test_agent_mcp_credentials.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import uuid
+from collections.abc import Callable
+from typing import Any
 
+import httpx
 from cryptography.fernet import Fernet
 from daimon.core.agent_mcp_credentials import (
+    METADATA_VERSION_KEY,
+    ResolvedMcpCredential,
+    mirror_credentials_into_vault,
     resolve_agent_mcp_credentials,
     save_agent_mcp_credential,
 )
@@ -13,6 +20,7 @@ from daimon.core.github_credentials import build_multifernet
 from daimon.core.stores import agent_mcp_credentials as cred_store
 from daimon.core.stores.domain import AgentMcpCredentialRow
 from daimon.testing.factories import make_tenant
+from daimon.testing.ma import build_fake_anthropic
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -189,3 +197,182 @@ async def test_stored_token_is_not_recoverable_without_the_key(
 
     rows = await cred_store.list_credentials(db_session, tenant_id=tenant.id, agent_id=agent_id)
     assert b"tok_secret" not in rows[0].encrypted_token, "token must be stored encrypted"
+
+
+# --- mirror: create / rotate-in-place / skip ---------------------------------
+
+
+def _vault_handler(
+    *,
+    creds: list[dict[str, Any]],
+    created: list[dict[str, Any]],
+    updated: list[tuple[str, dict[str, Any]]],
+    deleted: list[str],
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Serves one vault's credential endpoints, recording every mutation."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path.endswith("/credentials"):
+            return httpx.Response(200, json={"data": creds, "has_more": False})
+        if request.method == "POST" and request.url.path.endswith("/credentials"):
+            body = json.loads(request.content)
+            created.append(body)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "vcrd_created",
+                    "type": "credential",
+                    "vault_id": "vlt_1",
+                    "auth": {
+                        "type": "static_bearer",
+                        "mcp_server_url": body["auth"]["mcp_server_url"],
+                    },
+                    "metadata": body.get("metadata"),
+                },
+            )
+        if request.method == "POST" and "/credentials/" in request.url.path:
+            # The SDK issues an update as a POST to /credentials/{id}.
+            body = json.loads(request.content)
+            updated.append((request.url.path.rsplit("/", 1)[-1], body))
+            return httpx.Response(
+                200,
+                json={
+                    "id": request.url.path.rsplit("/", 1)[-1],
+                    "type": "credential",
+                    "vault_id": "vlt_1",
+                    "auth": {"type": "static_bearer", "mcp_server_url": _URL},
+                    "metadata": body.get("metadata"),
+                },
+            )
+        if request.method == "DELETE":
+            deleted.append(request.url.path.rsplit("/", 1)[-1])
+            return httpx.Response(200, json={"id": "gone", "type": "credential"})
+        raise AssertionError(f"unexpected call: {request.method} {request.url.path}")
+
+    return _handler
+
+
+_URL = "https://internal.example.com/mcp"
+
+
+def _stored(*, token: str, version: str) -> tuple[ResolvedMcpCredential, ...]:
+    return (ResolvedMcpCredential(mcp_server_url=_URL, token=token, version=version),)
+
+
+async def test_mirror_creates_credential_when_the_vault_has_none_at_that_url() -> None:
+    created: list[dict[str, Any]] = []
+    updated: list[tuple[str, dict[str, Any]]] = []
+    deleted: list[str] = []
+    client = build_fake_anthropic(
+        _vault_handler(creds=[], created=created, updated=updated, deleted=deleted)
+    )
+
+    await mirror_credentials_into_vault(
+        client, vault_id="vlt_1", credentials=_stored(token="tok_1", version="v1")
+    )
+
+    assert len(created) == 1, "a caller with no credential gets one created"
+    assert created[0]["auth"]["token"] == "tok_1"
+    assert created[0]["metadata"] == {METADATA_VERSION_KEY: "v1"}, "creation stamps the version"
+    assert updated == [] and deleted == []
+
+
+async def test_mirror_updates_in_place_when_the_stored_token_was_rotated() -> None:
+    """Rotation must reach a caller who is not the rotator — and must do it with
+    an update, never a delete, since a concurrent turn may be using the vault."""
+    created: list[dict[str, Any]] = []
+    updated: list[tuple[str, dict[str, Any]]] = []
+    deleted: list[str] = []
+    client = build_fake_anthropic(
+        _vault_handler(
+            creds=[
+                {
+                    "id": "vcrd_old",
+                    "type": "credential",
+                    "vault_id": "vlt_1",
+                    "auth": {"type": "static_bearer", "mcp_server_url": _URL},
+                    "metadata": {METADATA_VERSION_KEY: "v1"},
+                }
+            ],
+            created=created,
+            updated=updated,
+            deleted=deleted,
+        )
+    )
+
+    await mirror_credentials_into_vault(
+        client, vault_id="vlt_1", credentials=_stored(token="tok_2", version="v2")
+    )
+
+    assert len(updated) == 1, "a stale stamp must trigger exactly one update"
+    credential_id, body = updated[0]
+    assert credential_id == "vcrd_old", "the existing credential is updated, not a new one"
+    assert body["auth"] == {"type": "static_bearer", "token": "tok_2"}, (
+        "update body carries the token only — MA 400s on mcp_server_url"
+    )
+    assert body["metadata"] == {METADATA_VERSION_KEY: "v2"}, "the new version is stamped"
+    assert deleted == [], "never delete: a concurrent turn may hold this credential"
+    assert created == [], "no duplicate POST — MA 409s on the same URL anyway"
+
+
+async def test_mirror_refreshes_an_unstamped_credential_once() -> None:
+    """Credentials written before the stamp existed (or by the attach path) are
+    of unknown vintage, so they get refreshed once and stamped — which self-heals
+    a vault already holding a stale token."""
+    created: list[dict[str, Any]] = []
+    updated: list[tuple[str, dict[str, Any]]] = []
+    deleted: list[str] = []
+    client = build_fake_anthropic(
+        _vault_handler(
+            creds=[
+                {
+                    "id": "vcrd_unstamped",
+                    "type": "credential",
+                    "vault_id": "vlt_1",
+                    "auth": {"type": "static_bearer", "mcp_server_url": _URL},
+                    "metadata": None,
+                }
+            ],
+            created=created,
+            updated=updated,
+            deleted=deleted,
+        )
+    )
+
+    await mirror_credentials_into_vault(
+        client, vault_id="vlt_1", credentials=_stored(token="tok_now", version="v9")
+    )
+
+    assert len(updated) == 1, "an unstamped credential is refreshed"
+    assert updated[0][1]["metadata"] == {METADATA_VERSION_KEY: "v9"}
+
+
+async def test_mirror_makes_no_call_when_the_stamp_is_already_current() -> None:
+    """The steady state: every turn after the first must not touch MA."""
+    created: list[dict[str, Any]] = []
+    updated: list[tuple[str, dict[str, Any]]] = []
+    deleted: list[str] = []
+    client = build_fake_anthropic(
+        _vault_handler(
+            creds=[
+                {
+                    "id": "vcrd_current",
+                    "type": "credential",
+                    "vault_id": "vlt_1",
+                    "auth": {"type": "static_bearer", "mcp_server_url": _URL},
+                    "metadata": {METADATA_VERSION_KEY: "v5"},
+                }
+            ],
+            created=created,
+            updated=updated,
+            deleted=deleted,
+        )
+    )
+
+    await mirror_credentials_into_vault(
+        client, vault_id="vlt_1", credentials=_stored(token="tok_5", version="v5")
+    )
+
+    assert created == [] and updated == [] and deleted == [], (
+        "a matching stamp means the vault is already current"
+    )


### PR DESCRIPTION
Closes #78. Follows #80, which fixed the create case and deliberately left rotation open.

## The gap

#80's sync was create-if-missing. So a caller whose vault already held a credential at that URL kept the **old** token indefinitely. Rotate — which you mostly do after a leak — and everyone except the rotator is authenticating with the revoked token: the same whole-turn MCP-init failure #80 fixed, arriving from the other direction, and invisible to the person who rotated because their own vault is the one the attach path updates.

## PATCH works — probed, not assumed

`mcp_vault.py` documents MA as blocking PATCH with 405. That's no longer true. Against the live API today:

| call | result |
|---|---|
| `credentials.update(id, vault_id, auth={"type":"static_bearer","token": new})` | **200**, URL preserved, `updated_at` bumped |
| same, with `mcp_server_url` in the body | 400 `unknown field "mcp_server_url"` — the URL is immutable |
| duplicate `credentials.create` at an existing URL | 409, unchanged |

So a refresh is an in-place update. No delete, therefore no window where the credential is absent — the A3 race that motivated create-if-missing simply doesn't apply to this shape. (I left the stale 405 note in `mcp_vault.py` alone rather than editing code this PR doesn't touch; the new code says so where a reader will hit it.)

## How staleness is detected

Every credential this module writes carries a `daimon_token_version` metadata stamp holding the DB row's `updated_at`:

- nothing at that URL → create, stamped
- stamp differs or missing → refresh in place, re-stamped
- stamp matches → **no MA call**

Both sides of the comparison come from our own DB, so there's no dependence on MA's clock, and nothing derived from the token is stored anywhere new.

"Missing" is doing real work: it covers credentials written before this existed and the ones `add_external_mcp_credential` still writes on attach. Vaults out there holding a stale token get corrected on their next turn rather than needing manual cleanup.

## Tests

- creates when the vault has none at that URL, and stamps the version
- **rotation**: stale stamp → exactly one update, on the existing credential id, token-only body, re-stamped, and zero deletes
- unstamped credential refreshed once
- matching stamp → no MA call at all (the steady state; this is what keeps a reused turn cheap)

4527 passed, 4 skipped. pyright 0 errors, ruff clean, 6/6 import contracts, anti-pattern lint 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
