### PR TITLE
docs(slack): document the self-hosted Slack setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ or self-host it from this repo.
 
 Most chat bots are one agent shared across a workspace. daimon is
 many-to-many: you deploy it once, on your own Anthropic API key, and any
-number of Discord servers install it from that single deployment. Every
-server is isolated: one tenant, its own data, scoped to that server. Adding
-a server takes about two minutes: invite the bot, `@mention` it, and it sets
-itself up. From there, everyone in the server can just ask it for things.
+number of Discord servers and Slack workspaces install it from that single
+deployment. Every install is isolated: one tenant, its own data, scoped to
+that server or workspace. Adding one takes about two minutes: invite the bot,
+`@mention` it, and it sets itself up. From there, everyone there can just ask
+it for things.
 
 Built on [Anthropic Managed Agents](https://platform.claude.com/docs/en/managed-agents/quickstart)
 by [PyMC Labs](https://www.pymc-labs.com), the team behind the PyMC project.
@@ -190,6 +191,26 @@ The `export` is required because the `alembic` CLI reads the shell
 environment and does not auto-load `.env`.
 
 </details>
+
+## Run it on Slack too (optional)
+
+Slack needs a publicly reachable `DAIMON_MCP__PUBLIC_URL` — the bot token is
+issued by an OAuth install callback served by the `mcp` process, not read from
+an env var, and Slack won't redirect to `localhost`.
+
+1. Create the Slack app from
+   [`docs/slack-app-manifest.yaml`](docs/slack-app-manifest.yaml) and follow the
+   steps in its header comment. It fills in the scopes, slash commands, events,
+   and Socket Mode toggles for you.
+2. Put the resulting `DAIMON_SLACK__SIGNING_SECRET`, `DAIMON_SLACK__APP_TOKEN`,
+   `DAIMON_SLACK__CLIENT_ID`, and `DAIMON_SLACK__CLIENT_SECRET` in `.env`, plus
+   `DAIMON_CRYPTO__KEYS` (a Fernet key — the adapter refuses to start without
+   one, since it stores workspace tokens encrypted).
+3. `docker compose --profile slack up --build -d`
+4. Open `https://<your-host>/oauth/slack/install` and install to a workspace.
+
+[`docs/slack.md`](docs/slack.md) covers the trust model for per-user Slack
+access, which operators should read before enabling it.
 
 ## Layout
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,26 @@ services:
     entrypoint: ["python", "-m", "daimon.adapters.discord"]
     restart: unless-stopped
 
+  # Opt-in: `docker compose --profile slack up -d`. Needs DAIMON_SLACK__* and
+  # DAIMON_CRYPTO__KEYS in .env — no `:?` guards here, or Discord-only
+  # deployments would fail to interpolate the file.
+  # Setup: docs/slack-app-manifest.yaml.
+  slack:
+    build: .
+    profiles: ["slack"]
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      DAIMON_DATABASE__URL: postgresql+asyncpg://${POSTGRES_USER:-daimon}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required (see .env.example)}@postgres:5432/${POSTGRES_DB:-daimon}
+      DAIMON_ANTHROPIC__API_KEY: ${DAIMON_ANTHROPIC__API_KEY:?DAIMON_ANTHROPIC__API_KEY is required}
+      DAIMON_MCP__PUBLIC_URL: ${DAIMON_MCP__PUBLIC_URL:?DAIMON_MCP__PUBLIC_URL is required}
+    entrypoint: ["python", "-m", "daimon.adapters.slack"]
+    restart: unless-stopped
+
   scheduler:
     build: .
     depends_on:

--- a/docs/slack-app-manifest.yaml
+++ b/docs/slack-app-manifest.yaml
@@ -1,0 +1,89 @@
+# Slack app manifest for a daimon deployment.
+#
+# 1. https://api.slack.com/apps → Create New App → From a manifest → paste this.
+# 2. Replace DAIMON_HOST with the host of your DAIMON_MCP__PUBLIC_URL (must be
+#    a public HTTPS host — Slack will not redirect to localhost).
+# 3. Basic Information → App-Level Tokens → generate one with `connections:write`
+#    → DAIMON_SLACK__APP_TOKEN. Signing secret and OAuth client id/secret are on
+#    the same page → DAIMON_SLACK__SIGNING_SECRET / __CLIENT_ID / __CLIENT_SECRET.
+# 4. Manage Distribution → activate public distribution (the install flow needs it).
+# 5. Visit https://DAIMON_HOST/oauth/slack/install and install to your workspace.
+#    The bot token is stored encrypted in daimon's database by that callback —
+#    there is no env var for it.
+#
+# The scope lists mirror SLACK_BOT_SCOPES / SLACK_USER_SCOPES in
+# packages/core/daimon/core/slack_oauth.py. They are code constants, not config:
+# if you edit them here, edit them there too or the install will fail.
+
+display_information:
+  name: daimon
+  description: Data-science agent that writes and runs code, fits models, and delivers charts and notebooks in-thread.
+  background_color: "#0b110e"
+
+features:
+  bot_user:
+    display_name: daimon
+    always_online: true
+  slash_commands:
+    - command: /help
+      description: List commands and the @mention entrypoint
+      should_escape: false
+    - command: /agent-setup
+      description: Manage this workspace's agents
+      should_escape: false
+    - command: /routines
+      description: Show scheduled routines for this workspace
+      should_escape: false
+    - command: /memory
+      description: Read what daimon remembers for an agent
+      should_escape: false
+    - command: /billing
+      description: Show your billing usage (admins see per-member breakdown)
+      should_escape: false
+    - command: /privacy
+      description: See, export, or delete what daimon stores about you
+      should_escape: false
+
+oauth_config:
+  redirect_urls:
+    - https://DAIMON_HOST/oauth/slack/callback
+  scopes:
+    bot:
+      - app_mentions:read
+      - chat:write
+      - commands
+      - users:read
+      - channels:history
+      - groups:history
+      - reactions:write
+      - files:read
+      - channels:read
+      - groups:read
+    # Requested only when a member opts in via "Connect Slack"; reads then run
+    # with that member's own permissions. See docs/slack.md for the trust model.
+    user:
+      - users:read
+      - channels:history
+      - groups:history
+      - channels:read
+      - groups:read
+      - im:history
+      - mpim:history
+      - im:read
+      - mpim:read
+      - search:read
+
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - app_uninstalled
+      - tokens_revoked
+  interactivity:
+    is_enabled: true
+  socket_mode_enabled: true
+  # Enterprise Grid org installs are rejected by the OAuth callback.
+  org_deploy_enabled: false
+  # Leave off: daimon stores the refresh token but never exchanges it, so a
+  # rotating bot token would expire and stay expired.
+  token_rotation_enabled: false


### PR DESCRIPTION
Self-hosting on Slack worked, but nothing documented it. The README's setup walkthrough is Discord-only, `docker-compose.yml` had no `slack` service, and the Slack app's scopes, slash commands, and event subscriptions had to be reconstructed by reading `daimon.core.slack_oauth` and the adapter's dispatch. This closes that gap without changing any behavior.

## Changes

**`docker-compose.yml`** — a `slack` service behind `profiles: ["slack"]`, started with `docker compose --profile slack up -d`. The default `docker compose up` is unchanged.

No `:?` guards on the Slack-specific vars: Compose interpolates the entire file before filtering by profile, so a required-guard on `DAIMON_SLACK__*` would break interpolation for Discord-only deployments. The adapter already fail-fasts on its own — exit 0 with no Slack settings, exit 1 with no `DAIMON_CRYPTO__KEYS`.

**`docs/slack-app-manifest.yaml`** — creates the app in one paste, with the scopes, six slash commands, `app_mention` / `app_uninstalled` / `tokens_revoked` subscriptions, and the Socket Mode + interactivity toggles already set. The header comment carries the app-token, distribution, and install steps.

`token_rotation_enabled: false`, deliberately: the OAuth callback stores a refresh token but nothing ever exchanges it, so a rotating bot token would expire and stay expired.

**`README.md`** — a "Run it on Slack too" section after the Discord walkthrough, covering the two things that aren't guessable: `DAIMON_MCP__PUBLIC_URL` must be a public HTTPS host (Slack won't redirect to localhost), and the bot token comes from the OAuth install callback rather than an env var. Also mentions Slack alongside Discord in the many-to-many pitch, where it was missing.

## Verification

- `docker compose config --services` resolves cleanly with and without `--profile slack`; the default set is unchanged.
- The manifest's bot and user scope lists match `SLACK_BOT_SCOPES` / `SLACK_USER_SCOPES` exactly, and its slash commands match `app.py`'s dispatch — checked by parsing all three.

Those scope lists are code constants duplicated into the manifest, so they can drift. Left unlinted for now; worth a check in `scripts/` if it happens once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)