### PR TITLE
fix(slack): mention-gate app_mention turns; keep emphasis asterisks out of autolinked URLs

### DIFF
--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -52,7 +52,11 @@ from daimon.adapters.slack.attachments import (
 )
 from daimon.adapters.slack.billing_panel.actions import handle_billing_command, handle_topup_select
 from daimon.adapters.slack.context import build_context_xml, build_delta_xml
-from daimon.adapters.slack.gating import is_external_interactive, is_slack_connect_external
+from daimon.adapters.slack.gating import (
+    is_external_interactive,
+    is_slack_connect_external,
+    mentions_bot,
+)
 from daimon.adapters.slack.help import handle_help_command
 from daimon.adapters.slack.interactions import resolve_web_client
 from daimon.adapters.slack.lifecycle import SlackTurnLifecycle
@@ -171,6 +175,9 @@ class SlackApp:
         self._bg_tasks: set[asyncio.Task[None]] = set()
         # Cancel registry: status_ts -> (cancel Event, author_id).
         self._cancel_registry: dict[str, tuple[asyncio.Event, str]] = {}
+        # Bot user id per workspace, resolved lazily via auth.test. The id is
+        # immutable for a given app+workspace, so the cache never invalidates.
+        self._bot_user_ids: dict[str, str] = {}
         # Drain flag — set on SIGTERM; blocks new mention handling.
         self.draining: bool = False
 
@@ -623,8 +630,9 @@ class SlackApp:
         3. TOKEN RESOLVE: get_slack_bot_token; drop on None.
         4. PER-EVENT CLIENT: decrypt + AsyncWebClient(token=...) — never cached.
         5. SLACK CONNECT GATE: ephemeral rejection for external-workspace senders.
-        6. TENANT RESOLVE: derive_tenant_uuid.
-        7. Handoff to _orchestrate.
+        6. EXPLICIT MENTION GATE: drop events whose text lacks <@bot_user_id>.
+        7. TENANT RESOLVE: derive_tenant_uuid.
+        8. Handoff to _orchestrate.
 
         The full handler body is wrapped in the listener-boundary catch
         (DaimonError | anthropic.APIError | SlackApiError).  Core helpers
@@ -675,10 +683,29 @@ class SlackApp:
                 )
                 return
 
-            # (5) TENANT RESOLVE.
+            # (5) EXPLICIT MENTION GATE — Slack has been observed delivering
+            # app_mention events for un-mentioned thread replies; require the
+            # <@bot_user_id> token in the text (Discord parity). The bot user id
+            # is resolved once per workspace via auth.test and cached.
+            bot_user_id = self._bot_user_ids.get(team_id)
+            if bot_user_id is None:
+                auth_resp = await client.auth_test()  # pyright: ignore[reportUnknownMemberType]
+                bot_user_id = str(auth_resp.get("user_id") or "")
+                if bot_user_id:
+                    self._bot_user_ids[team_id] = bot_user_id
+            if not mentions_bot(event, bot_user_id=bot_user_id):
+                log.info(
+                    "slack.event_dropped.no_explicit_mention",
+                    team_id=team_id,
+                    channel=channel,
+                    event_ts=event_ts,
+                )
+                return
+
+            # (6) TENANT RESOLVE.
             tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
 
-            # (6) Orchestration seam — turn body is delegated here.
+            # (7) Orchestration seam — turn body is delegated here.
             await self._orchestrate(
                 event,
                 team_id=team_id,

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -629,8 +629,10 @@ class SlackApp:
         2. DEDUP: insert_if_new before any other work.
         3. TOKEN RESOLVE: get_slack_bot_token; drop on None.
         4. PER-EVENT CLIENT: decrypt + AsyncWebClient(token=...) — never cached.
-        5. SLACK CONNECT GATE: ephemeral rejection for external-workspace senders.
-        6. EXPLICIT MENTION GATE: drop events whose text lacks <@bot_user_id>.
+        5. EXPLICIT MENTION GATE: drop events whose text lacks <@bot_user_id>;
+           runs before the Connect gate so un-mentioned external senders are
+           dropped silently rather than sent a rejection ephemeral.
+        6. SLACK CONNECT GATE: ephemeral rejection for external-workspace senders.
         7. TENANT RESOLVE: derive_tenant_uuid.
         8. Handoff to _orchestrate.
 
@@ -671,22 +673,15 @@ class SlackApp:
             token = decrypt_token(fernet, row.encrypted_token)
             client = AsyncWebClient(token=token)  # per-event only
 
-            # (4) SLACK CONNECT GATE — reject external-workspace senders.
-            if is_slack_connect_external(event, team_id=team_id):
-                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-                    channel=channel,
-                    user=event.get("user") or "",
-                    text=(
-                        "Sorry, I can only respond to members of this workspace. "
-                        "Please ask a workspace member to mention me instead."
-                    ),
-                )
-                return
-
-            # (5) EXPLICIT MENTION GATE — Slack has been observed delivering
+            # (4) EXPLICIT MENTION GATE — Slack has been observed delivering
             # app_mention events for un-mentioned thread replies; require the
-            # <@bot_user_id> token in the text (Discord parity). The bot user id
-            # is resolved once per workspace via auth.test and cached.
+            # <@bot_user_id> token in the text (Discord parity). Runs BEFORE the
+            # Slack Connect gate so external senders who never addressed the bot
+            # are dropped silently instead of receiving a rejection ephemeral.
+            # The bot user id is resolved once per workspace via auth.test and
+            # cached; a failed resolution propagates to the listener boundary
+            # and drops the event (dedup already recorded it, so a Slack retry
+            # will not re-deliver — accepted for this once-per-process call).
             bot_user_id = self._bot_user_ids.get(team_id)
             if bot_user_id is None:
                 auth_resp = await client.auth_test()  # pyright: ignore[reportUnknownMemberType]
@@ -699,6 +694,18 @@ class SlackApp:
                     team_id=team_id,
                     channel=channel,
                     event_ts=event_ts,
+                )
+                return
+
+            # (5) SLACK CONNECT GATE — reject external-workspace senders.
+            if is_slack_connect_external(event, team_id=team_id):
+                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
+                    channel=channel,
+                    user=event.get("user") or "",
+                    text=(
+                        "Sorry, I can only respond to members of this workspace. "
+                        "Please ask a workspace member to mention me instead."
+                    ),
                 )
                 return
 

--- a/packages/adapters/slack/daimon/adapters/slack/gating.py
+++ b/packages/adapters/slack/daimon/adapters/slack/gating.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any, cast
 
 
@@ -12,11 +13,16 @@ def mentions_bot(event: dict[str, Any], *, bot_user_id: str) -> bool:
     replies that never mention the bot (official docs say the event fires only
     on direct mentions). This is the Discord-parity belt-and-braces gate — the
     Discord adapter checks ``message.mentions`` explicitly on every message.
-    Fails closed on an empty/unresolved ``bot_user_id``. Pure: no I/O.
+
+    Accepts both mention encodings: canonical ``<@U123>`` and the legacy
+    pipe-labelled ``<@U123|display-name>``. Fails closed on an
+    empty/unresolved ``bot_user_id``. Pure: no I/O.
     """
     if not bot_user_id:
         return False
-    return f"<@{bot_user_id}>" in str(event.get("text") or "")
+    text = str(event.get("text") or "")
+    pattern = rf"<@{re.escape(bot_user_id)}(?:\|[^>]*)?>"
+    return re.search(pattern, text) is not None
 
 
 def is_slack_connect_external(event: dict[str, Any], *, team_id: str) -> bool:

--- a/packages/adapters/slack/daimon/adapters/slack/gating.py
+++ b/packages/adapters/slack/daimon/adapters/slack/gating.py
@@ -5,6 +5,20 @@ from __future__ import annotations
 from typing import Any, cast
 
 
+def mentions_bot(event: dict[str, Any], *, bot_user_id: str) -> bool:
+    """Return True when the event text explicitly mentions the bot user.
+
+    Slack has been observed delivering ``app_mention`` events for thread
+    replies that never mention the bot (official docs say the event fires only
+    on direct mentions). This is the Discord-parity belt-and-braces gate — the
+    Discord adapter checks ``message.mentions`` explicitly on every message.
+    Fails closed on an empty/unresolved ``bot_user_id``. Pure: no I/O.
+    """
+    if not bot_user_id:
+        return False
+    return f"<@{bot_user_id}>" in str(event.get("text") or "")
+
+
 def is_slack_connect_external(event: dict[str, Any], *, team_id: str) -> bool:
     """Return True if the event originates from a different Slack workspace.
 

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -32,7 +32,10 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
     BetaManagedAgentsSpanModelUsage,
 )
 from daimon.adapters.slack.blockkit import EmbedEvent, State, TurnPhase, to_blocks, update
-from daimon.adapters.slack.mrkdwn import escape_mrkdwn_preserving_mentions
+from daimon.adapters.slack.mrkdwn import (
+    escape_mrkdwn_preserving_mentions,
+    linkify_emphasized_urls,
+)
 from daimon.adapters.slack.split import split_for_slack_safe
 from daimon.core.pricing import MODEL_PRICING, cost_of, format_cost
 from daimon.core.turn.lifecycle import InterruptSource, ReconnectReason
@@ -241,7 +244,11 @@ class SlackTurnLifecycle:
                 self.final_ts = self._status_ts
                 return
 
-            chunks = split_for_slack_safe(escape_mrkdwn_preserving_mentions(final_text))
+            # Linkify BEFORE escaping — linkify reads raw markdown; escaping
+            # introduces no new URLs or asterisks.
+            chunks = split_for_slack_safe(
+                escape_mrkdwn_preserving_mentions(linkify_emphasized_urls(final_text))
+            )
             first_chunk = chunks[0]
             # First chunk + the cost/usage footer replace the status message
             # in place; the terminal footer carries elapsed/tokens/cost and drops

--- a/packages/adapters/slack/daimon/adapters/slack/mrkdwn.py
+++ b/packages/adapters/slack/daimon/adapters/slack/mrkdwn.py
@@ -47,6 +47,25 @@ def escape_mrkdwn(text: str) -> str:
 _ESCAPED_MENTION = re.compile(r"&lt;([@#][A-Z0-9]+(?:\|[^&<>]*)?)&gt;")
 
 
+# A bare http(s) URL whose very next characters are 1-3 asterisks followed by
+# whitespace/punctuation/end — i.e. an emphasis closer, not part of the URL.
+# The URL charset excludes ()[]<> and whitespace so URLs already inside
+# [label](url) links (which end at the ')') never match.
+_EMPHASIZED_URL = re.compile(r"(https?://[^\s<>()\[\]]+?)(?=\*{1,3}(?:[\s.,;:!?]|$))")
+
+
+def linkify_emphasized_urls(text: str) -> str:
+    """Rewrite bare URLs that sit against an emphasis closer to ``[url](url)``.
+
+    In Slack's native ``markdown`` block the bare-URL autolinker is greedy and
+    ``*`` is a valid URL character, so ``**https://x**`` renders with the
+    closing asterisks absorbed into the link target (broken link with a
+    trailing ``*``, unclosed bold). Making the link explicit removes the
+    ambiguity while leaving the surrounding emphasis intact.
+    """
+    return _EMPHASIZED_URL.sub(lambda m: f"[{m.group(1)}]({m.group(1)})", text)
+
+
 def escape_mrkdwn_preserving_mentions(text: str) -> str:
     """Escape mrkdwn control chars but keep live ``<@user>`` / ``<#channel>`` links.
 

--- a/packages/adapters/slack/daimon/adapters/slack/mrkdwn.py
+++ b/packages/adapters/slack/daimon/adapters/slack/mrkdwn.py
@@ -48,10 +48,17 @@ _ESCAPED_MENTION = re.compile(r"&lt;([@#][A-Z0-9]+(?:\|[^&<>]*)?)&gt;")
 
 
 # A bare http(s) URL whose very next characters are 1-3 asterisks followed by
-# whitespace/punctuation/end — i.e. an emphasis closer, not part of the URL.
+# anything that cannot continue a URL or the asterisk run — i.e. an emphasis
+# closer, not part of the URL. The URL must not itself end in an asterisk, so
+# a 4+ asterisk run (not a valid closer) never donates its head to the URL.
 # The URL charset excludes ()[]<> and whitespace so URLs already inside
 # [label](url) links (which end at the ')') never match.
-_EMPHASIZED_URL = re.compile(r"(https?://[^\s<>()\[\]]+?)(?=\*{1,3}(?:[\s.,;:!?]|$))")
+_EMPHASIZED_URL = re.compile(r"(https?://[^\s<>()\[\]]*?[^\s<>()\[\]*])(?=\*{1,3}(?:[^\w*]|$))")
+
+# Code segments the linkifier must never touch: a fenced block (closed, or
+# open-to-end — Slack renders an unterminated fence as code), or an inline
+# single-backtick span.
+_CODE_SEGMENT = re.compile(r"```[\s\S]*?(?:```|$)|`[^`\n]*`")
 
 
 def linkify_emphasized_urls(text: str) -> str:
@@ -62,8 +69,23 @@ def linkify_emphasized_urls(text: str) -> str:
     closing asterisks absorbed into the link target (broken link with a
     trailing ``*``, unclosed bold). Making the link explicit removes the
     ambiguity while leaving the surrounding emphasis intact.
+
+    Fenced code blocks and inline code spans are passed through verbatim —
+    emphasis has no meaning there and the content must render exactly as
+    written.
     """
-    return _EMPHASIZED_URL.sub(lambda m: f"[{m.group(1)}]({m.group(1)})", text)
+
+    def _rewrite(segment: str) -> str:
+        return _EMPHASIZED_URL.sub(lambda m: f"[{m.group(1)}]({m.group(1)})", segment)
+
+    parts: list[str] = []
+    last = 0
+    for code in _CODE_SEGMENT.finditer(text):
+        parts.append(_rewrite(text[last : code.start()]))
+        parts.append(code.group(0))
+        last = code.end()
+    parts.append(_rewrite(text[last:]))
+    return "".join(parts)
 
 
 def escape_mrkdwn_preserving_mentions(text: str) -> str:

--- a/packages/adapters/slack/tests/conftest.py
+++ b/packages/adapters/slack/tests/conftest.py
@@ -18,7 +18,6 @@ _SLACK_API_BASE = "https://slack.com/api"
 # Slack API methods that use POST with JSON body (params in body, not query string).
 # Exact URL match works for these since params are not in the URL.
 _SLACK_POST_JSON_METHODS: tuple[str, ...] = (
-    "auth.test",
     "chat.postMessage",
     "chat.update",
     "chat.postEphemeral",
@@ -87,6 +86,13 @@ def _register_slack_defaults(mock: AioResponsesMock) -> None:
             payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
             repeat=True,
         )
+    # auth.test carries the bot's own user id, mirroring the real API — the
+    # mention gate resolves it once per workspace.
+    mock.post(  # pyright: ignore[reportUnknownMemberType]
+        f"{_SLACK_API_BASE}/auth.test",
+        payload={"ok": True, "user_id": "U_BOT"},
+        repeat=True,
+    )
     # views methods return a view object so handlers can read resp["view"]["id"].
     for method in _SLACK_VIEWS_METHODS:
         mock.post(  # pyright: ignore[reportUnknownMemberType]

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -2520,3 +2520,113 @@ async def test_handle_app_mention_resolves_bot_user_id_via_auth_test(
     assert app._bot_user_ids[team_id] == "U_BOT", (  # pyright: ignore[reportPrivateUsage]
         "the resolved bot user id must be cached per team to avoid repeated auth.test calls"
     )
+
+
+async def test_handle_app_mention_external_without_mention_gets_no_ephemeral(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An un-mentioned event from an external (Slack Connect) sender is dropped
+    silently: the mention gate runs BEFORE the Connect rejection, so external
+    users are not spammed with rejection ephemerals for messages that never
+    addressed the bot."""
+    team_id = "T_APP_GATE_BEFORE_CONNECT"
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
+    await upsert_slack_bot_token(
+        db_session,
+        team_id=team_id,
+        encrypted_token=encrypt_token(fernet, "xoxb-gate-order-test"),
+    )
+    await db_session.flush()
+
+    app = _make_app(db_session_factory, crypto_key=fernet_key)
+    app._bot_user_ids[team_id] = "U_BOT"  # pyright: ignore[reportPrivateUsage]
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "channel": "C_TEST",
+        "event_ts": "1000000012.000001",
+        "ts": "1000000012.000001",
+        "user": "U_EXTERNAL",
+        "user_team": "T_EXTERNAL",
+        "text": "just chatting in the thread",
+    }
+
+    with aioresponses() as mock:
+        await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
+        ephemeral_calls = [
+            req
+            for (_, url), reqs in mock.requests.items()
+            if url == URL("https://slack.com/api/chat.postEphemeral")
+            for req in reqs
+        ]
+
+    assert ephemeral_calls == [], (
+        "an external sender who never mentioned the bot must not receive the "
+        "Slack Connect rejection ephemeral"
+    )
+
+
+async def test_handle_app_mention_auth_test_failure_drops_without_raising(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A failing auth.test on cold-cache resolution is absorbed by the listener
+    boundary: the event is dropped, nothing raises, and no turn runs. (Dedup has
+    already recorded the event, so a Slack retry will not re-deliver it — the
+    mention is lost for this process; acceptable once per workspace lifetime.)"""
+    team_id = "T_APP_AUTH_FAIL"
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
+    await upsert_slack_bot_token(
+        db_session,
+        team_id=team_id,
+        encrypted_token=encrypt_token(fernet, "xoxb-auth-fail-test"),
+    )
+    await db_session.flush()
+
+    app = _make_app(db_session_factory, crypto_key=fernet_key)
+
+    orchestrate_calls: list[dict[str, Any]] = []
+
+    async def _spy_orchestrate(
+        event: dict[str, Any],
+        *,
+        team_id: str,
+        channel: str,
+        event_ts: str,
+        web_client: Any,
+        tenant_id: uuid.UUID,
+    ) -> None:
+        orchestrate_calls.append({"event_ts": event_ts})
+
+    app._orchestrate = _spy_orchestrate  # type: ignore[method-assign]
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "channel": "C_TEST",
+        "event_ts": "1000000013.000001",
+        "ts": "1000000013.000001",
+        "user": "U_TEST",
+        "text": "<@U_BOT> hello",
+    }
+
+    with aioresponses() as mock:
+        mock.post(
+            "https://slack.com/api/auth.test",
+            payload={"ok": False, "error": "invalid_auth"},
+            repeat=True,
+        )
+        await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
+
+    assert orchestrate_calls == [], (
+        "a failed auth.test must drop the event at the listener boundary, not run a turn"
+    )
+    assert team_id not in app._bot_user_ids, (  # pyright: ignore[reportPrivateUsage]
+        "a failed resolution must not poison the bot-user-id cache"
+    )

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import httpx
+from aioresponses import aioresponses
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import (
     BetaManagedAgentsModelConfig,
@@ -326,6 +327,8 @@ async def test_handle_app_mention_dedup_when_same_event_ts_drops_second_invocati
     await db_session.flush()
 
     app = _make_app(db_session_factory, crypto_key=fernet_key)
+    # Pre-seed the bot-user-id cache so the mention gate needs no auth.test call.
+    app._bot_user_ids[team_id] = "U_BOT"  # pyright: ignore[reportPrivateUsage]
 
     orchestrate_calls: list[dict[str, Any]] = []
 
@@ -2399,3 +2402,121 @@ async def test_on_request_view_submission_match_acks_update_and_spawns_purge() -
         "matching username must ack with response_action=update (Deleting… view)"
     )
     mock_purge.assert_called_once()  # pyright: ignore[reportUnknownMemberType]
+
+
+async def test_handle_app_mention_without_explicit_mention_drops(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An app_mention event whose text does NOT contain <@bot_user_id> must be
+    dropped before the orchestration seam (Discord parity: explicit-mention gate).
+
+    Slack has been observed delivering app_mention for un-mentioned thread
+    replies; without this gate every such reply runs a full billed turn.
+    """
+    team_id = "T_APP_MENTION_GATE"
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
+    await upsert_slack_bot_token(
+        db_session,
+        team_id=team_id,
+        encrypted_token=encrypt_token(fernet, "xoxb-gate-test"),
+    )
+    await db_session.flush()
+
+    app = _make_app(db_session_factory, crypto_key=fernet_key)
+    # Pre-seed the bot-user-id cache so no auth.test call is needed.
+    app._bot_user_ids[team_id] = "U_BOT"  # pyright: ignore[reportPrivateUsage]
+
+    orchestrate_calls: list[dict[str, Any]] = []
+
+    async def _spy_orchestrate(
+        event: dict[str, Any],
+        *,
+        team_id: str,
+        channel: str,
+        event_ts: str,
+        web_client: Any,
+        tenant_id: uuid.UUID,
+    ) -> None:
+        orchestrate_calls.append({"event_ts": event_ts})
+
+    app._orchestrate = _spy_orchestrate  # type: ignore[method-assign]
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "channel": "C_TEST",
+        "event_ts": "1000000010.000001",
+        "ts": "1000000010.000001",
+        "user": "U_TEST",
+        "text": "make a marimo notebook about our most recent fails",
+    }
+
+    await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
+
+    assert len(orchestrate_calls) == 0, (
+        "an event without an explicit <@bot> mention token must be dropped by the "
+        "mention gate and never reach orchestration"
+    )
+
+
+async def test_handle_app_mention_resolves_bot_user_id_via_auth_test(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """On a cold cache the handler resolves its bot user id via auth.test,
+    caches it per team, and admits an explicitly mentioned event."""
+    team_id = "T_APP_AUTH_RESOLVE"
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
+    await upsert_slack_bot_token(
+        db_session,
+        team_id=team_id,
+        encrypted_token=encrypt_token(fernet, "xoxb-auth-resolve-test"),
+    )
+    await db_session.flush()
+
+    app = _make_app(db_session_factory, crypto_key=fernet_key)
+
+    orchestrate_calls: list[dict[str, Any]] = []
+
+    async def _spy_orchestrate(
+        event: dict[str, Any],
+        *,
+        team_id: str,
+        channel: str,
+        event_ts: str,
+        web_client: Any,
+        tenant_id: uuid.UUID,
+    ) -> None:
+        orchestrate_calls.append({"event_ts": event_ts})
+
+    app._orchestrate = _spy_orchestrate  # type: ignore[method-assign]
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "channel": "C_TEST",
+        "event_ts": "1000000011.000001",
+        "ts": "1000000011.000001",
+        "user": "U_TEST",
+        "text": "<@U_BOT> what's our rejection rate?",
+    }
+
+    with aioresponses() as mock:
+        mock.post(
+            "https://slack.com/api/auth.test",
+            payload={"ok": True, "user_id": "U_BOT", "team_id": team_id},
+            repeat=True,
+        )
+        await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
+
+    assert len(orchestrate_calls) == 1, (
+        "an explicitly mentioned event must pass the gate after auth.test resolution"
+    )
+    assert app._bot_user_ids[team_id] == "U_BOT", (  # pyright: ignore[reportPrivateUsage]
+        "the resolved bot user id must be cached per team to avoid repeated auth.test calls"
+    )

--- a/packages/adapters/slack/tests/test_gating.py
+++ b/packages/adapters/slack/tests/test_gating.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from daimon.adapters.slack.gating import (
     is_external_interactive,
     is_slack_connect_external,
+    mentions_bot,
 )
 
 
@@ -59,3 +60,42 @@ async def test_fake_slack_web_client_intercepts_registered_method(
     assert resp["ok"] is True, (
         "transport-level fake should intercept auth.test and return canned ok=True"
     )
+
+
+class TestMentionsBot:
+    """Explicit-mention gate: the event text must contain <@bot_user_id>.
+
+    Slack has been observed delivering app_mention events for un-mentioned
+    thread replies; this belt-and-braces check is the Discord-parity gate
+    (discord/bot.py checks message.mentions explicitly on every message).
+    """
+
+    def test_returns_true_when_text_contains_bot_mention_token(self) -> None:
+        event = {"text": "<@U_BOT> what's our rejection rate?"}
+        assert mentions_bot(event, bot_user_id="U_BOT") is True, (
+            "text containing <@bot_user_id> must pass the mention gate"
+        )
+
+    def test_returns_false_when_text_has_no_mention(self) -> None:
+        event = {"text": "make a marimo notebook about our most recent fails"}
+        assert mentions_bot(event, bot_user_id="U_BOT") is False, (
+            "an un-mentioned thread reply must be gated out even if Slack "
+            "delivered it as app_mention"
+        )
+
+    def test_returns_false_when_other_user_is_mentioned(self) -> None:
+        event = {"text": "<@U_OTHER> can you look at this?"}
+        assert mentions_bot(event, bot_user_id="U_BOT") is False, (
+            "a mention of a different user must not pass the gate"
+        )
+
+    def test_returns_false_when_text_missing(self) -> None:
+        assert mentions_bot({}, bot_user_id="U_BOT") is False, (
+            "an event with no text field must not pass the gate"
+        )
+
+    def test_returns_false_when_bot_user_id_empty(self) -> None:
+        event = {"text": "<@> hello"}
+        assert mentions_bot(event, bot_user_id="") is False, (
+            "an unresolved (empty) bot_user_id must fail closed"
+        )

--- a/packages/adapters/slack/tests/test_gating.py
+++ b/packages/adapters/slack/tests/test_gating.py
@@ -99,3 +99,16 @@ class TestMentionsBot:
         assert mentions_bot(event, bot_user_id="") is False, (
             "an unresolved (empty) bot_user_id must fail closed"
         )
+
+    def test_returns_true_for_pipe_labelled_mention_token(self) -> None:
+        event = {"text": "<@U_BOT|daimon> hello"}
+        assert mentions_bot(event, bot_user_id="U_BOT") is True, (
+            "the legacy pipe-labelled mention encoding <@id|label> is a real "
+            "mention and must pass the gate"
+        )
+
+    def test_returns_false_when_bot_id_is_prefix_of_another_id(self) -> None:
+        event = {"text": "<@U_BOT2> hello"}
+        assert mentions_bot(event, bot_user_id="U_BOT") is False, (
+            "a mention of a user whose id merely starts with the bot's id must not pass the gate"
+        )

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -440,3 +440,22 @@ async def test_lifecycle_satisfies_turn_lifecycle_protocol(fake_slack_web_client
     assert callable(bound.on_reconnect), "on_reconnect must be callable"
     assert callable(bound.on_rate_limited), "on_rate_limited must be callable"
     assert callable(bound.on_interrupt_sent), "on_interrupt_sent must be callable"
+
+
+async def test_terminal_success_linkifies_emphasized_urls(fake_slack_web_client: Any) -> None:
+    """A final answer wrapping a bare URL in ** must be normalized to an explicit
+    markdown link before posting, so Slack's autolinker cannot absorb the closing
+    asterisks into the URL (reported: notebook URL rendered with a trailing '*')."""
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    state = TurnState(
+        content=[TextBlock(kind="text", text="Here: **🔗 https://x.up.railway.app/n/abc**")]
+    )
+    await lc.on_terminal_success(state)
+
+    blocks = _last_update_blocks(fake_slack_web_client)
+    assert blocks[0]["type"] == "markdown"
+    assert (
+        "[https://x.up.railway.app/n/abc](https://x.up.railway.app/n/abc)" in blocks[0]["text"]
+    ), "the emphasized bare URL must be rewritten to an explicit [url](url) link"

--- a/packages/adapters/slack/tests/test_mrkdwn.py
+++ b/packages/adapters/slack/tests/test_mrkdwn.py
@@ -10,7 +10,11 @@ These tests verify the ordering invariant.
 
 from __future__ import annotations
 
-from daimon.adapters.slack.mrkdwn import escape_mrkdwn, escape_mrkdwn_preserving_mentions
+from daimon.adapters.slack.mrkdwn import (
+    escape_mrkdwn,
+    escape_mrkdwn_preserving_mentions,
+    linkify_emphasized_urls,
+)
 
 
 def test_plain_text_unchanged() -> None:
@@ -122,3 +126,51 @@ def test_literal_entity_text_is_not_falsely_restored() -> None:
     assert escape_mrkdwn_preserving_mentions("&lt;@U1&gt;") == "&amp;lt;@U1&amp;gt;", (
         "pre-escaped literal entity text must not be mistaken for a real mention"
     )
+
+
+# ---------------------------------------------------------------------------
+# linkify_emphasized_urls — bare URLs wrapped in emphasis
+# ---------------------------------------------------------------------------
+
+
+def test_linkify_bold_wrapped_bare_url_becomes_markdown_link() -> None:
+    """A bare URL immediately before a closing ** must be rewritten to a
+    [url](url) markdown link, so Slack's autolinker cannot absorb the
+    asterisks into the link target (reported: notebook URL rendered with a
+    trailing '*')."""
+    text = "Here's the notebook: **🔗 https://x.up.railway.app/n/abc**"
+    expected = (
+        "Here's the notebook: "
+        "**🔗 [https://x.up.railway.app/n/abc](https://x.up.railway.app/n/abc)**"
+    )
+    assert linkify_emphasized_urls(text) == expected, (
+        "URL followed by ** must be converted to an explicit markdown link"
+    )
+
+
+def test_linkify_single_asterisk_wrapped_url() -> None:
+    text = "see *https://example.com/a* now"
+    assert linkify_emphasized_urls(text) == (
+        "see *[https://example.com/a](https://example.com/a)* now"
+    ), "URL followed by a single * must also be converted"
+
+
+def test_linkify_plain_url_unchanged() -> None:
+    text = "see https://example.com/a for details"
+    assert linkify_emphasized_urls(text) == text, (
+        "a bare URL not followed by emphasis must be left untouched"
+    )
+
+
+def test_linkify_existing_markdown_link_unchanged() -> None:
+    text = "**[notebook](https://example.com/a)**"
+    assert linkify_emphasized_urls(text) == text, (
+        "a URL already inside a [label](url) link must not be rewritten"
+    )
+
+
+def test_linkify_url_with_interior_asterisk_only_strips_trailing_emphasis() -> None:
+    text = "**https://example.com/a*b**"
+    assert linkify_emphasized_urls(text) == (
+        "**[https://example.com/a*b](https://example.com/a*b)**"
+    ), "asterisks inside the URL path stay in the URL; only trailing emphasis is excluded"

--- a/packages/adapters/slack/tests/test_mrkdwn.py
+++ b/packages/adapters/slack/tests/test_mrkdwn.py
@@ -174,3 +174,49 @@ def test_linkify_url_with_interior_asterisk_only_strips_trailing_emphasis() -> N
     assert linkify_emphasized_urls(text) == (
         "**[https://example.com/a*b](https://example.com/a*b)**"
     ), "asterisks inside the URL path stay in the URL; only trailing emphasis is excluded"
+
+
+def test_linkify_url_in_parentheses() -> None:
+    text = "(see **https://example.com/a**)"
+    assert linkify_emphasized_urls(text) == (
+        "(see **[https://example.com/a](https://example.com/a)**)"
+    ), "an emphasis closer followed by ')' must still trigger linkification"
+
+
+def test_linkify_url_followed_by_quote_and_dash() -> None:
+    assert linkify_emphasized_urls('"**https://example.com/a**"') == (
+        '"**[https://example.com/a](https://example.com/a)**"'
+    ), "an emphasis closer followed by a quote must still trigger linkification"
+    assert linkify_emphasized_urls("**https://example.com/a**—done") == (
+        "**[https://example.com/a](https://example.com/a)**—done"
+    ), "an emphasis closer followed by an em-dash must still trigger linkification"
+
+
+def test_linkify_leaves_four_asterisk_runs_alone() -> None:
+    text = "**https://example.com/a****"
+    assert linkify_emphasized_urls(text) == text, (
+        "a 4+ asterisk run is not a 1-3 emphasis closer; the URL must not be "
+        "rewritten (previously the regex backtracked an asterisk into the URL)"
+    )
+
+
+def test_linkify_skips_fenced_code_blocks() -> None:
+    text = "before\n```\n**https://example.com/a**\n```\nafter **https://example.com/b**"
+    assert linkify_emphasized_urls(text) == (
+        "before\n```\n**https://example.com/a**\n```\n"
+        "after **[https://example.com/b](https://example.com/b)**"
+    ), "text inside a fenced code block must not be rewritten"
+
+
+def test_linkify_skips_inline_code_spans() -> None:
+    text = "use `**https://example.com/a** ` verbatim"
+    assert linkify_emphasized_urls(text) == text, (
+        "text inside an inline code span must not be rewritten"
+    )
+
+
+def test_linkify_treats_unterminated_fence_as_code() -> None:
+    text = "```\n**https://example.com/a**"
+    assert linkify_emphasized_urls(text) == text, (
+        "an opened-but-unclosed fence renders as code in Slack; its content must not be rewritten"
+    )

--- a/tests/parity/drivers/slack_driver.py
+++ b/tests/parity/drivers/slack_driver.py
@@ -46,7 +46,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 _SLACK_API_BASE = "https://slack.com/api"
 _POST_JSON_METHODS: tuple[str, ...] = (
-    "auth.test",
     "chat.postMessage",
     "chat.update",
     "chat.postEphemeral",
@@ -77,6 +76,13 @@ def _register_slack_defaults(mock: AioResponsesMock) -> None:
             payload={"ok": True, "ts": "1000000000.000001", "channel": "C_PARITY"},
             repeat=True,
         )
+    # auth.test carries the bot's own user id (the mention gate resolves it once
+    # per workspace); the driver's events mention <@U_BOT> accordingly.
+    mock.post(  # pyright: ignore[reportUnknownMemberType]
+        f"{_SLACK_API_BASE}/auth.test",
+        payload={"ok": True, "user_id": "U_BOT"},
+        repeat=True,
+    )
     mock.post(_REACTIONS_ADD_PATTERN, payload={"ok": True}, repeat=True)  # pyright: ignore[reportUnknownMemberType]
     mock.get(  # pyright: ignore[reportUnknownMemberType]
         _CONVERSATIONS_REPLIES_PATTERN,


### PR DESCRIPTION
## Summary

Two Slack adapter fixes reported by an enterprise install of daimon open source.

### 1. Bot answered thread replies that never mentioned it

Slack's docs say `app_mention` fires only on direct mentions, but the events observably arrive for un-mentioned replies in threads the bot participates in — and `_handle_app_mention` trusted the event type alone, so every such reply ran a full billed turn.

The handler now requires the `<@bot_user_id>` token in the event text before orchestrating a turn (the same explicit check the Discord adapter does with `message.mentions`). The bot's user id is resolved once per workspace via `auth.test` and cached for the process lifetime. Gated events are dropped with a `slack.event_dropped.no_explicit_mention` log line so operators can see what Slack delivered.

Behavior change: thread follow-ups now require mentioning the bot each time, matching Discord. If thread-following is wanted as UX, it should be a deliberate feature, not a side effect of trusting event delivery.

### 2. Notebook URLs rendered with a trailing `*`

A final answer like `**🔗 https://…/notebook**` broke in Slack's native `markdown` block: the bare-URL autolinker is greedy and `*` is a valid URL character, so the closing asterisks were absorbed into the link target — dead link with a trailing `*`, unclosed bold.

`linkify_emphasized_urls` now rewrites bare URLs that sit directly against an emphasis closer to explicit `[url](url)` links before posting. URLs already inside `[label](url)` links, plain URLs, and asterisks interior to a URL path are untouched.

## Testing

- New unit tests for `mentions_bot` (5) and `linkify_emphasized_urls` (5), written failing-first.
- New handler tests: un-mentioned event dropped before orchestration; cold-cache `auth.test` resolution + per-team caching.
- New lifecycle test: emphasized bare URL is linkified in the posted markdown block.
- Parity driver and Slack test conftest `auth.test` fakes now return `user_id`, matching the real API.
- Full suite: 4535 passed; the 3 remaining failures (notebook-host jail ×2, credential-request concurrency) reproduce on clean `main` in this environment and are unrelated.