### PR TITLE
chore(compose): health-check the adapter services

### DIFF
--- a/apps/notebook-host/Dockerfile
+++ b/apps/notebook-host/Dockerfile
@@ -25,6 +25,12 @@ RUN uv sync --no-dev --extra ds --extra pymc
 RUN mkdir -p /data/notebooks
 ENV DAIMON_NOTEBOOK__DATA_DIR=/data/notebooks
 
+# No USER directive on purpose. The host runs as root so it can drop each
+# spawned marimo process into its own uid (see notebook_host/jail.py); the
+# lifespan gate in main.py refuses to boot when it cannot. Adding a non-root
+# USER here only forces DAIMON_NOTEBOOK__ALLOW_UNJAILED_SPAWN=true, which is
+# strictly weaker isolation.
+
 EXPOSE 8001
 
 CMD ["uv", "run", "python", "-m", "notebook_host"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,11 @@ services:
       DAIMON_DATABASE__URL: postgresql+asyncpg://${POSTGRES_USER:-daimon}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required (see .env.example)}@postgres:5432/${POSTGRES_DB:-daimon}
       DAIMON_ANTHROPIC__API_KEY: ${DAIMON_ANTHROPIC__API_KEY:?DAIMON_ANTHROPIC__API_KEY is required}
     entrypoint: ["python", "-m", "daimon.adapters.discord"]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8081/')\""]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
 
   # Opt-in: `docker compose --profile slack up -d`. Needs DAIMON_SLACK__* and
@@ -90,6 +95,11 @@ services:
       DAIMON_ANTHROPIC__API_KEY: ${DAIMON_ANTHROPIC__API_KEY:?DAIMON_ANTHROPIC__API_KEY is required}
       DAIMON_MCP__PUBLIC_URL: ${DAIMON_MCP__PUBLIC_URL:?DAIMON_MCP__PUBLIC_URL is required}
     entrypoint: ["python", "-m", "daimon.adapters.slack"]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8083/')\""]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
 
   scheduler:
@@ -106,6 +116,11 @@ services:
       DAIMON_MCP__JWT_SECRET: ${DAIMON_MCP__JWT_SECRET:?DAIMON_MCP__JWT_SECRET is required}
       DAIMON_MCP__PUBLIC_URL: ${DAIMON_MCP__PUBLIC_URL:?DAIMON_MCP__PUBLIC_URL is required}
     entrypoint: ["daimon-scheduler"]
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8082/')\""]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
`postgres` and `mcp` already declare a compose `healthcheck:`; `discord`, `slack` and `scheduler` relied on process liveness alone, so a wedged event loop still looked healthy to `docker compose ps`.

Each of those processes already serves `daimon.core.health`'s liveness responder on its own port (8081 / 8083 / 8082), co-located on the working event loop — a hung loop stops answering. This points a healthcheck at it. The responder does not parse the request, so any path works; `/` mirrors the shape of the existing `mcp` check.

Also adds a comment to `apps/notebook-host/Dockerfile` recording why it has no `USER` directive, so the next reader doesn't "fix" it.

### Verification

- `docker compose config -q` passes with the new stanzas.
- Confirmed the liveness responder answers `200` on `/`, not just on a known path.
- Built `apps/notebook-host/Dockerfile` with a non-root `USER` added and ran it: the host fails closed with `JailUnavailableError: cannot apply the notebook jail on this host (not root, …); refusing to boot`. That's the evidence behind the comment — and behind closing #2.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)