### PR TITLE
feat(defaults): ship the data-analysis workflow as default skills

### DIFF
--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -87,6 +87,16 @@ skills:
     skill_id: workspace-setup
   - type: custom
     skill_id: pymc-artifact-style
+  - type: custom
+    skill_id: data-ingestion
+  - type: custom
+    skill_id: data-validation
+  - type: custom
+    skill_id: data-cleaning
+  - type: custom
+    skill_id: exploratory-data-analysis
+  - type: custom
+    skill_id: eda-storytelling
 tools:
   - type: agent_toolset_20260401
     configs:

--- a/defaults/environments/default.yaml
+++ b/defaults/environments/default.yaml
@@ -8,5 +8,18 @@ config:
     # typst-cli` would). The artifact-style skill bundles the PyMC report class
     # and its fonts, and needs a compiler present to render them; without this
     # every report turn spends its first minute on `pip install typst`.
+    #
+    # `duckdb` and `pyarrow` are the only two every data skill needs. The image
+    # already ships pandas 3.0, numpy, scipy, scikit-learn, matplotlib, seaborn,
+    # openpyxl and tabulate (probed, 2026-08-19), but `pd.read_parquet` raises
+    # ImportError without pyarrow and parquet is this pipeline's own artifact
+    # format, while duckdb is how anything larger than memory gets aggregated —
+    # and via `INSTALL <engine>; LOAD; ATTACH` it reaches Postgres, MySQL and
+    # SQLite without a per-vendor driver baked in here. A database queried in
+    # place needs `sqlalchemy` plus that vendor's driver; the data-ingestion
+    # skill installs both on the turn that needs them, because which vendor it
+    # is depends on the deployment, and network access is unrestricted.
     pip:
       - typst
+      - duckdb
+      - pyarrow

--- a/defaults/skills/data-cleaning/SKILL.md
+++ b/defaults/skills/data-cleaning/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: data-cleaning
+description: Mutate data without destroying the evidence — dedup, dtype coercion, missing-value decisions, outlier flagging, category and unit normalisation, joins, pivots and aggregations to a new grain, and columns the source does not contain — appending a row to run/changelog.jsonl for every operation, whether what you write is one parquet file, one part per table, parquet parts of a log too large to load, a saved warehouse query, or cleaned files plus their index frame. The source is never edited in place, and under pandas 3 copy-on-write a chained assignment like df[mask]["col"] = 0 silently changes nothing. Use when a validation check failed, when the grain has duplicates, wrong dtypes or unparseable dates, when a source is too large or raw to query repeatedly and must be materialised once as typed parquet parts, when a collection needs an index frame derived, when a metric or label no column holds must be defined, or when asked to clean, dedup, impute, join, reshape or fix a dataset.
+---
+
+# Data cleaning
+
+Cleaned data with no record of what changed is worse than the dirty data it came
+from: nobody can separate a real 40% collapse in orders from a dedup on the wrong
+key. This is the only stage that mutates data, and it runs only if something does.
+
+**Applies to** one flat export, twelve related tables, a 4 GB log you never load,
+a warehouse table queried in place, 500 emails in a folder. **Clean in the medium
+the data lives in** — a parquet file, filtered parts, a saved query, or cleaned
+items plus their index frame, and deriving that frame or a column no source holds
+is a mutation like any other. **Enter here** when a cell, a row count or the grain
+changes, **stop here** when the cleaned data is the deliverable.
+
+## Never edit the source, and never mutate without a log row
+
+**The source is the one thing you cannot recreate.** Re-read it as text and coerce
+as `data-ingestion` did, write beside `run/raw/` and never into it, and clean data
+queried in place with a saved `SELECT`, never an `UPDATE`.
+
+**Every operation that changes a cell, a row count or the grain appends one row.**
+The rationalization is always "this one is obvious", and a whitespace strip that
+collapsed two distinct SKUs leaves no trace at all. Scale the trail to the data,
+never the checks: one small source states each mutation inline in its reply.
+
+```python
+import json, os, pandas as pd
+df = pd.read_csv("run/raw/orders.csv", dtype="str", keep_default_na=False, na_values=[""])
+df["qty"] = pd.to_numeric(df["qty"], errors="coerce").astype("Int64")
+
+def log_change(op, column, rows_affected, rule, before, after):
+    os.makedirs("run", exist_ok=True)
+    with open("run/changelog.jsonl", "a") as fh:
+        fh.write(json.dumps({"op": op, "column": column, "rule": rule,
+            "rows_affected": int(rows_affected), "before": int(before), "after": int(after)}) + "\n")
+```
+
+## Write every edit through `.loc`
+
+Under pandas 3 copy-on-write, chained assignment only warns, leaves the frame
+unchanged, and makes the log claim an edit that never happened. Same for
+`inplace=True` on a slice.
+
+```python
+# ❌ SILENT NO-OP — warns, and qty is still -1 afterwards
+df[df["qty"] < 0]["qty"] = 0
+# ✅ one step, and the mask gives you the count to log
+mask = df["qty"] < 0
+df.loc[mask, "qty"] = 0
+log_change("clip_to_zero", "qty", mask.sum(), "negative qty is impossible", len(df), len(df))
+```
+
+## Every treatment has a default, and a case where the default is wrong
+
+| Problem | Default treatment | When not to |
+|---|---|---|
+| Duplicate on the grain | sort by a tiebreaker, keep one, log the rule | the copies disagree on a column you care about — that is a source bug |
+| Wrong dtype from read | `astype`, or `pd.to_datetime(errors="coerce")` | over ~1% fails to parse — a read bug, see the `data-ingestion` skill |
+| Outliers | flag in a new boolean column, from quantiles taken per group when one frame pools several populations | the value is impossible, not merely extreme — then it is a coercion |
+| Free-text categories | map through an explicit dict, assert nothing is unmapped | the long tail is the finding, not noise |
+| Mixed units, or a scale pointing the other way | convert to one unit and one direction, rename the column to carry it (`q7_reversed`) | the unit is not recoverable per row — stop and ask |
+
+## Normalise and coerce before you deduplicate
+
+Both change what counts as equal. Normalise through an explicit dict, asserting
+`set(key.dropna()) - set(MAPPING)` is empty first — a `.fillna(original)` fallback
+is how "Canada " and "CA" reach the report as two categories.
+
+```python
+parsed = pd.to_datetime(df["ordered_at"], errors="coerce", format="ISO8601")
+lost = df["ordered_at"].notna() & parsed.isna()       # errors="coerce" nulls silently
+print(df.loc[lost, "ordered_at"].head().tolist())     # look before you accept it
+df["ordered_at"] = parsed
+log_change("to_datetime", "ordered_at", lost.sum(), "ISO8601, bad -> NaT", len(df), len(df))
+```
+
+Then deduplicate, where the grain admits it — a repeated sensor reading is data,
+not a duplicate. Where it is one, a tiebreaker, then `df.drop_duplicates(`.
+
+## Leave a gap rather than invent a value
+
+| Option | Use when | The trap |
+|---|---|---|
+| Leave it — the default | almost always; pandas skips nulls in `mean`, `sum`, `groupby` | a later join or `groupby` drops those rows without saying so |
+| Drop rows | the null makes the row unusable for this question | bare `dropna()` is `how="any"` over every column and halves a wide frame |
+| Impute | you have a stated reason, you log the method, and you add a `<col>_imputed` boolean so EDA can split on it | "fill missing revenue with the column mean so the totals work" is the banned move — a mean into a column whose distribution you then report shrinks the variance and manufactures precision |
+
+## Flag outliers; a dropped outlier is a deleted finding
+
+An extreme value is only wrong if it is impossible: a 90,000 order is a fact until
+someone proves it a typo, and the biggest customer is what a blind 3-sigma filter
+deletes first. Flag it — `(df[c] < q1 - 3*(q3-q1)) | (df[c] > q3 + 3*(q3-q1))`,
+from `df[c].quantile([0.25, 0.75])` or `df.groupby(circuit)[c]` when one frame
+pools several populations, into a `<col>_outlier` boolean, `before` and `after`
+equal. Impossible values are the other case: coerce or drop those.
+
+## What you write, and who reads it
+
+Only the data changes shape; the log never does. Downstream resolves the data
+positionally — `run/clean.parquet`, else `run/clean/`, else `run/clean.sql`.
+
+| Data | Cleaned artifact |
+|---|---|
+| One frame | `run/clean.parquet` |
+| Related tables, extracted | one parquet per table under `run/clean/`, plus `joined.parquet` when a join is the analysis grain |
+| Too big to load | `run/clean/part-*.parquet`, from `duckdb.sql("COPY (SELECT …) TO 'run/clean' (FORMAT parquet, PER_THREAD_OUTPUT true, FILENAME_PATTERN 'part-{i}')")` — bare `TO 'run/clean'` writes one CSV *file* called `clean` |
+| Queried in place | `run/clean.sql`, the SELECT that produces the grain — including the join when several tables are queried together — plus a bounded `run/clean_sample.parquet` |
+| Files, not rows | cleaned items under `run/clean/items/`, index frame at `run/clean.parquet` — deriving that frame is the mutation, so this stage runs for a collection even when no cell changes |
+
+`run/changelog.jsonl` holds one object per transformation in applied order —
+`{"op", "column", "rows_affected", "rule", "before", "after"}` — ending in a
+terminal `{"op": "write_clean", "path": …, "format": …}` row that tells the next
+stage where the data is. `rule` says *why*, and the new grain when one changes:
+"keep earliest `created_at` per `order_id`", not "removed duplicates". Anything
+that changes the grain lands here alone — a `df.merge(`, a `df.pivot_table(` whose
+`aggfunc` and `fill_value` you chose, an aggregation of events to sessions —
+proved not to have fanned out by `validate="1:m"`, or in SQL by an unchanged
+`count(*)` and `count(distinct …)` either side; then re-validate on the new grain.
+A metric no column holds — churn, retention, a per-item label — is a definition
+you take from the user and log as the `rule`.
+
+Re-run `data-validation` on what you wrote; one treatment routinely breaks another
+check. Then hand it to `exploratory-data-analysis` or to modeling, the log going
+with it for `eda-storytelling`. You may be the last stage: name any stage you
+skipped that could have changed the answer — and on a `pass` with nothing to
+treat, say so and pass the source on with the manifest's dtypes.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| An edit "ran" but the values are unchanged | chained assignment — pandas 3 only warns with `ChainedAssignmentError` | one step: `df.loc[mask, col] = value` |
+| `TypeError: Invalid value '0' for dtype 'str'` | assigning a number into a column ingestion read as text | coerce the column first, or assign the string |
+| Row count fell further than the log accounts for | bare `dropna()` (`how="any"` over all columns), or a merge that dropped non-matches | subset the columns; log `before`/`after` around every mutation |
+| Row count *rose* after a later join, or a reshape averaged duplicate rows and left absent cells `NaN` | the dedup key was not the grain, so the join went many-to-many; `df.pivot_table(` defaults to `aggfunc="mean"` and fills nothing | pass `validate="1:m"` to `df.merge(`, and `aggfunc="sum"` with `fill_value=0` deliberately; re-check the grain |
+| `run/changelog.jsonl` holds operations from an earlier attempt | `log_change` appends, and the file survives a re-run | delete `run/changelog.jsonl` when you restart the run, not at the end |

--- a/defaults/skills/data-ingestion/SKILL.md
+++ b/defaults/skills/data-ingestion/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: data-ingestion
+description: Load whatever the request points at — one CSV or Excel export, twelve related tables, a folder of 500 emails, a 4 GB log you never load, a warehouse table you query in place — and record every source in run/manifest.json with the grain one row represents, the axis it is ordered by, its row count, columns and dtypes. Read as text and coerce on purpose — pd.read_csv inference turns order_id 00123 into the integer 123, and a paged pull that stops early looks identical to a complete one. Use when a user attaches a file or a folder, points you at a database, warehouse or API, or asks for analysis of data you have not loaded yet.
+---
+
+# Data ingestion
+
+A load that "worked" is the most expensive failure in an analysis. Nothing
+raises, a frame comes back, and four stages later a number is wrong because
+`order_id` lost its leading zeros, a `Total` row became a data row, or the API
+returned page one of forty. You decide the shape everything downstream assumes;
+`run/manifest.json` is where you say so out loud.
+
+**Applies to** whatever the request points at: one flat export, twelve related
+tables, a folder of 500 emails, a 4 GB log you never load, a warehouse table you
+query in place. **One entry per source** — every table, directory of parts and
+warehouse query gets its own key in `run/manifest.json`, with a recorded `query`
+and a verified count where the bytes are not yours to keep. **Enter here** when
+data is not loaded and recorded yet; **stop here** when "what did I just get"
+was the question; already-typed data skips the text read, not the entry.
+
+## Read as text, then coerce on purpose
+
+**Type inference is where downstream bugs are born.** `pd.read_csv` with no
+`dtype=` reads `00123` as the integer `123`, deleting the zeros that make it an
+identifier, and turns a column holding one `N/A` into `float64`. Read as string,
+coerce only what you compute on, and count the casualties:
+
+```python
+import pandas as pd
+
+text = pd.read_csv("run/raw/orders.csv", dtype="str",
+                   keep_default_na=False, na_values=[""])
+df = text.copy()
+df["qty"] = pd.to_numeric(text["qty"], errors="coerce").astype("Int64")
+df["created_at"] = pd.to_datetime(text["created_at"], format="ISO8601",
+                                  errors="coerce", utc=True)
+for col in ("qty", "created_at"):
+    lost = text[col].notna() & df[col].isna()
+    if lost.any():
+        print(col, int(lost.sum()), "unparseable:",
+              text.loc[lost, col].head(3).tolist())
+```
+
+`keep_default_na=False` keeps `NA`, `None` and `null` as literal text, not
+someone else's idea of missing; `errors="coerce"` makes a bad value `NaT`/`<NA>`
+and the loop stops it being silent. An ID you can do arithmetic on is a bug.
+
+## Size and sniff the source before you load it
+
+```bash
+ls -l run/raw/orders.csv && head -c 400 run/raw/orders.csv   # .gz: zcat f.gz | head -c 400
+```
+
+That shows the real delimiter and the header depth; `ls -R` and `unzip -l` do
+the same for a folder or an archive, and `file-handling` owns never reading a
+whole data file to find out. Past a few GB nothing loads, and decompressing to
+make it load fills the disk: leave the `.gz` alone, count from it with
+`duckdb.sql("SELECT count(*) FROM 'log.csv.gz'").df()`, and fold a chunked
+`pd.read_csv` in fixed memory.
+
+## Every source has one trap, and this is it
+
+| Source | How to read it | The trap |
+|---|---|---|
+| CSV / TSV, or a table pasted into the message | `pd.read_csv(..., dtype="str")`; a spreadsheet paste is tab-separated, so `sep="\t"` | European exports: `sep=";"`, `decimal=","`, `thousands="."` — the default read gives one column, or numbers as text; a survey's second header row of question wording, or a pasted `Total` row, arrives as data — peek first, as with Excel |
+| Excel `.xlsx` | `pd.ExcelFile`, then `pd.read_excel(header=n)` | it is a formatted report, not a table — title rows, spacer rows, a `Total` row that becomes data |
+| JSON / JSONL | one document is `json.load(f)` then `pd.json_normalize(doc["features"], sep="__")`; JSONL that fits in memory is `json.loads` per line into `pd.json_normalize(recs, sep="__")`, and past that project only the columns you need with `duckdb.read_json(path, columns={...})` — a `.gz` reads in place | `pd.read_json(lines=True)` "succeeds" and hands you a column of dicts; nested lists survive normalization as Python lists, so hold a geometry or a tag list out of the frame; a list comprehension of `json.loads` over a 4 GB log OOMs before it raises, and an auto-inferred schema silently drops keys absent from its sample |
+| SQL file: `.sqlite`, or a `.sql` dump | `sqlite3` or duckdb, then query it | `SELECT *` on a view, or on a table with soft-deleted rows still in it; a dump is DDL + INSERTs in a vendor dialect, and regexing INSERT lines drops any row with an escaped quote |
+| Warehouse or live database | query in place: `pd.read_sql` on a bounded SELECT, `count(*)` for the row count; only duckdb and pyarrow ship here, so `pip install sqlalchemy` plus the vendor driver (`psycopg2-binary`, `snowflake-sqlalchemy`, `sqlalchemy-bigquery` — a bare `postgresql://` DSN resolves to psycopg2, not psycopg 3) and take the DSN from an agent env credential, never from chat — `workspace-setup` owns adding one | extracting the table to get a frame — you cannot, and the manifest wants the `query` and the DSN with its credentials stripped, not a `sha256` |
+| Paged API | the loop below | a short final page and an early stop look exactly like completion |
+| Many parts: a folder, a zip, 12 sheets in one workbook, a 12-table export | same-shaped parts stack into one entry — `pd.read_excel(xl, sheet_name=None)`, then `pd.concat(parts, names=["plate"]).reset_index(level="plate")`, because the part's name is data; compare the parts' columns and dtypes before you stack, and differently-shaped tables get one entry each with the join left to `data-cleaning` | the part name discarded, so no row knows which sheet it came from; part 007 read with different dtypes than its siblings; or a join done in whatever cell needed it and logged nowhere |
+| A collection: 500 emails, images, JSON documents | leave the items where they are and build an index frame — one row per item, carrying `path`, an item id and the attributes you pulled out; a collection can be one document rather than many files, and then a GeoJSON feature's own id stands in for the `path` | forcing the corpus itself into a frame. Decoding the domain — image internals, audio, protein sequences — is the analysis's job, not ingestion's |
+
+An Excel sheet is a report, not a table — peek before you choose `header=`:
+
+```python
+import pandas as pd
+
+xl = pd.ExcelFile("run/raw/report.xlsx")   # xl.sheet_names lists every tab
+print(pd.read_excel(xl, sheet_name="Q3 Summary", header=None, nrows=8).to_string())
+df = pd.read_excel(xl, sheet_name="Q3 Summary", header=3, dtype="str")
+df = df[df["Region"].notna() & (df["Region"] != "Total")]
+```
+
+## A paged pull is incomplete until you have proved it complete
+
+**The worst outcome here is a partial pull that looks whole** — half the rows
+analyze cleanly and every conclusion is wrong. Assert the count you got against
+the source's own total, and never read a rate limit as the end of the data:
+
+```python
+import os, time, requests
+
+url = "https://api.example.com/v1/orders?page=1&per_page=100"
+headers = {"Authorization": f"Bearer {os.environ['API_TOKEN']}"}
+rows, body = [], None
+while url:
+    r = requests.get(url, headers=headers, timeout=30)
+    if r.status_code == 429:
+        time.sleep(int(r.headers.get("Retry-After", "5")))
+        continue
+    r.raise_for_status()
+    body = r.json()
+    rows.extend(body["data"])
+    url = body.get("next_page_url")
+assert len(rows) == body["meta"]["total"], f"partial pull: {len(rows)} rows"
+```
+
+If no total is reported, say completeness is unverified. A 404 stops the run,
+and a missing DSN or token is requested through `workspace-setup` rather than
+pasted into chat — never invent a plausible frame.
+
+## What you write: `run/raw/` and `run/manifest.json`
+
+A chat attachment is a signed URL: `curl -sS "<url>" -o run/raw/<name>`, so
+`run/raw/` holds the bytes as retrieved — there is none for a warehouse table
+you query in place. Later stages write beside it; none edit what you wrote.
+
+```python
+import datetime, hashlib, json, pathlib
+src = pathlib.Path("run/raw/orders.csv")
+pathlib.Path("run/manifest.json").write_text(json.dumps({"orders": {
+    "source": "https://api.example.com/v1/orders",
+    "retrieved_at": datetime.datetime.now(datetime.UTC).isoformat(),
+    "grain": "one row per order line, ordered by created_at",
+    "rows": len(df),           # or a duckdb count(*), when nothing was loaded
+    "cols": list(df.columns),  # just the projection, when that is all you read
+    "dtypes_as_read": {c: str(t) for c, t in df.dtypes.items()},
+    "sha256": hashlib.file_digest(src.open("rb"), "sha256").hexdigest(),
+}}, indent=2))
+```
+
+Required per entry: `source`, `retrieved_at`, `grain`, `rows`, `cols`,
+`dtypes_as_read`, and either a `sha256` — for a directory of items, the item
+count and the decode failures you verified instead — or, bytes not yours, the
+`query` plus a count checked against the source's own total. `grain` is the
+sentence "one row of this represents ___, ordered by ___": per (store, week), by
+week. Ask when the source will not say. Name the ordering column too: validation
+and EDA bucket along the axis you name, and a composite grain has more than one.
+
+Hand the manifest to `data-validation`; you asserted only that the data is
+loaded and counted, so if the answer ships from here, name the stages nobody
+ran. A 40-row paste needs no `run/`; the manifest is one sentence in your reply.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `UnicodeDecodeError`, or names arrive as `Ã©` / `ï»¿id` | the export is cp1252, or has a UTF-8 BOM | `encoding="cp1252"` or `encoding="utf-8-sig"`, chosen from the peek |
+| `df["Region"]` raises `KeyError` though the header looks right | trailing whitespace in the header cells | `df.columns = df.columns.str.strip()` before anything else |
+| Dates all land in the first 12 days of each month | `d/m` vs `m/d` resolved per value | pass an explicit `format=`, and count the `NaT`s the coerce produced |
+| A date column holds `45231` | Excel serial dates | `pd.to_datetime(s.astype("Int64"), unit="D", origin="1899-12-30")` |
+| `df.dtypes == object` selects no columns | pandas 3 reads text as `str` dtype, not `object` | `pd.api.types.is_string_dtype(s)`, or `df.select_dtypes("str")` |
+| Two pulls minutes apart return different row counts | a live source paginating over a moving table | sort by a stable key server-side; `retrieved_at` in the manifest is what dates the answer |

--- a/defaults/skills/data-validation/SKILL.md
+++ b/defaults/skills/data-validation/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: data-validation
+description: Decide whether data is fit to analyze before anyone analyzes it. A phase-1 pass runs in seconds — dtypes, the grain one row claims to represent, referential gaps between tables, plausibility ranges, coverage — and emits run/validation.json with a pass/warn/fail verdict; a fail is a stop, not a to-do item. Works the same on a flat export, twelve related tables, a keyless sensor stream, an index frame over 500 documents, or a warehouse table you check with SQL and never load. Phase 2 hunts the structural break — a definition, unit, currency or timezone that changed partway along whatever the data is ordered by. Use when data arrives from ingestion, before any chart, join or model, or when a number looks wrong and you cannot say why.
+---
+
+# Data validation
+
+Data that loads without error is not data that is admissible. The duplicate order
+line that doubles revenue, the `channel` whose vocabulary changed in May, the two
+timezones in one column — none raise; the only signal is a plausible-looking
+answer. You check each source `run/manifest.json` names and emit one verdict.
+
+**Applies to** one flat export, twelve related tables, a 4 GB log or a warehouse
+table you never load, 500 emails as an index frame. **No key, no duplicate check**
+— a stream or an event log has an index, not a key, and repeated readings are
+data; check ordering and gaps, per-group counts against the replicates you expect
+for nested data, and join keys before a join. **Enter here** before any number
+ships; **stop here** on `fail`, or when "is this usable" was the question.
+
+## Phase 1 runs first, and a fail verdict stops the analysis
+
+**Nothing gets reported before phase 1 — no chart, no number, no statement about
+what the data shows.** Looking at the data to decide what to check is fine;
+publishing is not. Take the expected columns, grain and ranges from the user, and
+write masks they can read — a check derived from the data always verdicts `pass`.
+
+```python
+import json
+import pandas as pd
+
+df = pd.read_csv("run/raw/orders.csv", dtype="str", keep_default_na=False, na_values=[""])
+df["amount"] = pd.to_numeric(df["amount"], errors="coerce")
+key = ["order_id"]  # several for a composite grain; [] for an index, then whole-row dupes
+locator = df[key].astype(str).agg("|".join, axis=1) if key else df.index.to_series().astype(str)
+checks = []
+
+def record(check, severity, failing):
+    checks.append({"check": check, "severity": severity, "n_failing": int(failing.sum()),
+                   "example_ids": locator[failing].head(5).tolist()})
+
+record("grain is one row per order_id", "fail", df.duplicated(subset=key or None, keep=False))
+record("amount is positive", "fail", df["amount"] <= 0)
+record("created_at parses", "fail", pd.to_datetime(df["created_at"], errors="coerce").isna())
+record("email is present", "warn", df["email"].isna())
+failed = [c for c in checks if c["n_failing"]]
+verdict = "fail" if any(c["severity"] == "fail" for c in failed) else "warn" if failed else "pass"
+json.dump({"checks": checks, "verdict": verdict}, open("run/validation.json", "w"), indent=2)
+print(verdict, [(c["check"], c["n_failing"]) for c in failed])
+```
+
+**On `fail`, your entire reply is the failure**: the check, `n_failing`, the
+example ids, and the treatments available. Dedup changes the revenue number you
+are about to report, so the user picks it. On `warn`, say it inline.
+
+**When you cannot load it, check it in place** — aggregates where the data lives,
+duckdb over a file or the warehouse's own SQL, one `count(*) FILTER (WHERE …)` per
+check plus a `LIMIT`ed sample of ids, into the same `run/validation.json`.
+
+## Check admissibility, not whatever the source happens to contain
+
+| Check | How to detect | What it blocks |
+|---|---|---|
+| Schema and dtype | `set(df.columns)` against the expected set; `df.dtypes` against `dtypes_as_read` in `run/manifest.json` | a numeric column read as text — every aggregate silently wrong |
+| Grain — what one row is | keyed: `df.duplicated(subset=key, keep=False)`, composite for a panel; sequence-indexed: `idx.is_monotonic_increasing`, `idx.duplicated()`, and `idx.diff().value_counts()` for gaps and sampling-rate changes; grouped: `df.groupby("plate").size()` against the replicates you expect; a collection: `path` is unique by construction, so hash the contents and look for thread copies and auto-replies | every sum, count and join; duplicates multiply, and a gap read as a zero flattens a trend |
+| Referential integrity | `(~df["customer_id"].isin(dim["customer_id"])).sum()`, on every key a join will use | inner joins that drop rows without saying so — `data-cleaning` performs the join, you clear its keys first |
+| Plausibility range | one mask per column — negative amounts, ages over 120, future timestamps; and `df.nunique() == 1`, a constant column that correlates with nothing and returns `NaN` | means, and every ratio built on them |
+| Unit, currency, timezone, CRS | `df.groupby("country", observed=True)["amount"].median()`; `pd.to_datetime(col, errors="coerce", utc=True)`; coordinates inside ±180 and ±90, and not swapped — a swap survives a range check wherever both are under 90 | totals across mixed units; any daily aggregate; every distance and every cluster |
+| Coverage | `bucket.value_counts().sort_index()` against the range requested | a trend drawn over buckets absent from the source; and a span straddling the first or last bucket is truncated, not finished — a session that began before the log starts looks like it abandoned at step one |
+
+## Phase 2 hunts the structural break, which phase 1 cannot see
+
+A structural break is a definition, unit or collection method changing partway
+along whatever the data is ordered by — month, trial number, wavelength. Every
+phase-1 check passes and the column is still two columns glued end to end: an
+attribution window that changed in May, a sensor whose rate halved.
+
+```python
+import pandas as pd
+
+df = pd.read_csv("run/raw/orders.csv", dtype="str", keep_default_na=False, na_values=[""])
+# bucket along the index the manifest names — months, trial blocks, firmware
+# versions — fine enough to span ten of them; a GROUP BY where it lives if huge
+bucket = pd.to_datetime(df["created_at"], errors="coerce").dt.to_period("M")
+levels = df.groupby(bucket, observed=True)["channel"].agg(lambda s: set(s.dropna()))
+for prev, cur in zip(levels.index[:-1], levels.index[1:]):
+    if levels[cur] ^ levels[prev]:
+        print(cur, "vocabulary changed:", sorted(levels[cur] ^ levels[prev]))
+panel = df.groupby(bucket, observed=True).agg(
+    n=("order_id", "size"), null_rate=("email", lambda s: s.isna().mean()),
+    mean_amount=("amount", lambda s: pd.to_numeric(s, errors="coerce").mean()))
+print(panel.round(3).to_string())
+```
+
+A step in `n`, a null rate or a mean is the signature, and so is one level unlike
+the rest; a drift is not. `TV` where `tv` vanished is a rename.
+
+## Detect and report; never repair
+
+**No `fillna`, `astype`, `df.drop_duplicates`, `clip` or join here.** A treatment
+applied here never reaches `run/changelog.jsonl`; `data-cleaning` owns every
+mutation, and a read bug goes back to `data-ingestion`, not forward.
+
+## Write run/validation.json, then hand off
+
+Keep passing checks in the file; a check nobody ran must not look like a pass. A
+phase-2 break is a check row too, naming its bucket in `check`. **Scale the
+trail to the data, never the checks** — 40 rows pasted in the message get the
+same grain, dtype and coverage checks and the same look for a definition that
+changed late, stated as a clause in your reply instead of written under `run/`.
+
+You may be the first stage here and you may be the last. On `fail`, or a `warn`
+the user accepted, name the treatment, hand to `data-cleaning`, then re-run this
+stage on what it wrote — a cleaned frame not re-validated is unproven. On `pass`
+with nothing to treat, cleaning is ceremony: say so, hand the source on with the
+dtypes the manifest recorded, and name any stage you skipped that mattered.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Totals are roughly double the finance number | duplicate rows on a composite grain you assumed was a primary key | the key is `(order_id, line_no)`, not `order_id` — re-check `df.duplicated(subset=key)` |
+| A trend inflects exactly at a bucket boundary | structural break — definition or collection changed | phase 2; two series, or stop and ask |
+| Every check passes but a mean is absurd | mixed units or currencies in one column | median by group; a 100× gap is a unit, not a customer |
+| Daily counts show two humps a day apart | naive timestamps in mixed timezones | `pd.to_datetime(col, utc=True)`, then confirm what the source meant |
+| The user says the data is already clean | "clean" says where it came from, not what was checked; a BI export is aggregated and re-stated | run phase 1 anyway, and ask what the tool already aggregated or attributed |

--- a/defaults/skills/eda-storytelling/SKILL.md
+++ b/defaults/skills/eda-storytelling/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: eda-storytelling
+description: Turn a finished analysis into something a person reads and acts on — lead with the finding that settles the question or moves the decision, trace every number back to a run/findings.jsonl, run/changelog.jsonl or run/manifest.json record, and cut the rest. Works from whatever the analysis produced — one flat export, twelve joined tables, a warehouse table queried in place, an index frame over a corpus, a fitted model's posterior. Carries the data-validation verdict, the data-cleaning change log and any stage nobody ran into the writeup as caveats instead of burying them. Use when a single data question has to be answered in one chat reply, when writing up an analysis, when drafting a report, summary or readout of what the data or a fitted model showed, or when a pile of charts and tables needs an argument.
+---
+
+# EDA storytelling
+
+The failure is the stats dump: nine charts, a `describe()` transcript, a
+correlation matrix, no argument. It reads as thorough and is unusable — the
+reader cannot tell which of forty numbers mattered, so acts on none. You consume
+`exploratory-data-analysis`'s `run/findings.jsonl` and the `run/validation.json`
+verdict, and emit one document: what is at stake, and the numbers that settle it.
+
+**Applies to** whatever the analysis produced: one flat export, twelve joined
+tables, a 4 GB log nobody loaded, a warehouse table queried in place, an index
+frame over 500 emails. **A skipped stage is a caveat, not a silence** — the
+record behind a number may be a manifest entry, a validation check, a change-log
+row or a findings row, and a stage nobody ran is named, with why. **Enter here**
+when there are numbers and a reader; **stop here** — you are the last stage.
+
+## Every number traces to a record, or it does not ship
+
+**A claim with no `run/findings.jsonl` or `run/changelog.jsonl` row behind it is
+a fabricated number**, however sure you are you computed it earlier — recalled
+values come back rounded, pre-cleaning, or carrying the wrong `n`. Cite by `id`
+while drafting, strip the markers in the final pass, and check between:
+
+```python
+import json, re
+from pathlib import Path
+rows = [json.loads(line)
+        for p in (Path("run/findings.jsonl"), Path("run/changelog.jsonl")) if p.exists()
+        for line in p.read_text().splitlines() if line.strip()]
+man = Path("run/manifest.json")            # a row count traces to a source entry
+ids = ({r.get("id") or r["op"] for r in rows}
+       | (set(json.loads(man.read_text())) if man.exists() else set()))
+cited = set(re.findall(r"\[([a-z][a-z0-9_-]*)\](?!\()", Path("draft.md").read_text()))
+assert not cited - ids, f"claims with no backing record: {sorted(cited - ids)}"
+```
+
+Recompute an unbacked number and append its row, or delete the sentence — there
+is no third fix. Scale the trail to the data, never the checks: a paste answered
+inline has no `run/` to cite, and every number in it is computed this turn.
+
+## Lead with the finding that settles the question
+
+**Name what is at stake in the first two sentences** — the decision the reader
+is choosing between, or, in diagnostic or scientific work, the question they
+asked — then the finding that moves it. Method and `n` follow in the same
+paragraph, never as a preamble; order by how much a finding moves the answer,
+not by pipeline stage. **Cutting is the skill:** of thirty findings two reach
+the reader, the rest stay in `run/findings.jsonl`. When the data cannot settle
+the question, that is the headline — "this cannot tell you whether the campaign
+worked, because exposure was never recorded" is a deliverable, and at n=40 so is
+"these 40 points cannot separate a trend from noise".
+
+## Every chart answers a question you already asked in the prose
+
+The sentence before states the question, the chart answers it, the one after
+says what it means. **If you cannot write that question, cut the chart** — it
+exists because it was easy to make. One claim per chart, never two.
+
+## State the uncertainty once, beside the number, then stop
+
+Carry the `n` and the `caveat` from the finding's row into the sentence making
+the claim; a limitation covering the whole analysis is stated once, in the
+caveats block. Hedging every sentence says nothing while looking careful.
+
+- Round to what `n` supports: 41% of 11,731, not 41.0126%.
+- Say **measured** or **estimated**; anything imputed or fitted is estimated,
+  and a number resting on a definition you chose — a 30-minute session window,
+  a funnel step order, a complaint taxonomy — names that definition beside it.
+- Give an association its direction and size. Significance and cause are model
+  output: cite the model that produced them, or do not write them in.
+
+## Carry the verdict and the change log in as caveats, not footnotes
+
+From `run/validation.json`: a waived check that could move a reported number is
+a caveat, stated at that number; an unresolved FAIL is not a caveat — the claim
+does not ship. Cite change-log rows as "312 duplicates dropped, earliest kept".
+
+| Change-log row | Tell the reader | Why |
+|---|---|---|
+| imputation, outlier treatment, a derived label or category, drops hitting a reported segment | yes, at the claim | it can bias the number they act on |
+| dedup removing more than 1% of rows | yes, once in the caveats | it moves every denominator |
+| dtype coercion, whitespace strip, rename, the terminal write-clean row | no | it cannot change a reported number |
+
+**A stage nobody ran is a caveat too** — "no validation was asked for, so these
+totals are unvetted"; write up what ran, do not run the rest to tidy that away.
+
+## The same numbers, twice
+
+```
+❌ everything computed, nothing decided
+11,731 rows x 14 cols. email 41.0% null | phone 12.3% null | source 0.0% null
+Spearman: email_missing~signup_year 0.62, order_value~tenure 0.31, ...
+[8 charts] The data shows interesting patterns. Further analysis is recommended.
+```
+
+```
+✅ the same findings.jsonl rows, written for a reader
+We cannot email 41% of the customer list, and the gap is not random.
+
+Of 11,731 customers, 4,810 have no email, almost all from the 2023 partner
+backfill: 89% of those rows lack one against 6% of normal signups. So a campaign
+here reaches about 6,900 people, not 11,700, and it drops partner-sourced
+customers, who spend more per order (median $84 against $61, n=11,731). Budget
+for the smaller reach, or pull emails from the partner feed first — the excluded
+segment is the higher-value one. All figures are measured, none imputed; the 312
+dropped duplicate order_ids move every count by under 3%.
+```
+
+**Sentences that never ship:**
+
+- "Correlation does not imply causation" *instead of* stating the correlation.
+- Any conclusion the reader cannot check against a number you gave them.
+
+## Pick the medium, then hand the rendering off
+
+One finding answers in the chat reply; a client deliverable is a PDF report
+styled by `pymc-artifact-style`; to poke at the data they want a notebook
+(`marimo_notebooks`). Both land in `/mnt/session/outputs/`, per `file-handling`.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| User replies "so what?" | No question or decision named; findings ordered by pipeline stage | Open with what is at stake and the one finding that moves it |
+| A number in the draft has no backing row | It came from a scrolled-away cell or from memory | Recompute and append the row with its `how`, or cut the sentence |
+| A claim rests on a stage nobody ran | Validation or cleaning was skipped and the writeup does not say so | Name the skipped stage as a caveat at that claim, or run it |
+| Every sentence hedges | Uncertainty restated per sentence instead of once per claim | One `caveat` at the claim; global limits go in the caveats block once |
+| Reader acts on a number cleaning invented | Imputed values reported as measured | Label the layer estimated and cite the imputation change-log row |
+| A conclusion asserts cause | An EDA correlation written up as a mechanism | Give direction and size; a causal claim needs a model, cited as one |

--- a/defaults/skills/exploratory-data-analysis/SKILL.md
+++ b/defaults/skills/exploratory-data-analysis/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: exploratory-data-analysis
+description: Profile and interrogate data before anyone makes a claim about it — a cleaned frame, a folder of parquet parts, a warehouse table you query in place, or an index frame over a corpus of documents. Summary statistics do not identify a distribution — Anscombe's quartet shares a mean, variance and correlation across four unrelated shapes — so nothing is reported that has not been plotted. Covers dtype and cardinality profiling, missingness structure, Spearman against Pearson, a correlation matrix read as blocks instead of skimmed for its biggest cells, subgroup checks and whether one named group, batch or run is an outlier against the rest, variation along whatever index orders the data, writing one row per finding to run/findings.jsonl and handing it on to modeling. Use when asked to explore or profile a dataset, before a model is fit, when one group, device, batch or period looks wrong and you need to say how it differs, or when a pile of numbers has to become defensible findings.
+---
+
+# Exploratory data analysis
+
+Anscombe's quartet is four datasets sharing a mean, variance, correlation and
+regression line, and four completely different shapes. A statistic you have not
+plotted is not evidence. You look at every column you mean to talk about, and
+append one row per finding to `run/findings.jsonl`.
+
+**Applies to** whatever earlier stages left you: one cleaned frame, parquet
+parts too big to load, a warehouse table you query in place, an index frame over
+500 emails. **Your index may not be a calendar** — trial number, wavelength and
+sequence position order data too, so bucket along the manifest's `grain`.
+**Enter here** once the data is admissible, **stop here** when a description
+answers it — *why* and *what drives* want a fit, so hand that on to modeling.
+
+## Look at a column before you summarise it
+
+**Never report a mean, a correlation or a slope you have not seen plotted.** A
+second mode, a floor at zero, a ceiling at 100, a spike at a `-999` sentinel and
+one 10,000× outlier all leave the mean printable and change what it means.
+Resolve your input: `run/clean.parquet`, else `run/clean/`, else `run/clean.sql`
+— aggregate with it, plot the `run/clean_sample.parquet` beside it — else the
+manifest's source with the dtypes it recorded, else the paste itself.
+
+```python
+import pandas as pd
+df = pd.read_parquet("run/clean.parquet")  # parts or in place: duckdb aggregates, then a sample
+print(len(df), "rows")
+print(pd.DataFrame({"dtype": df.dtypes.astype(str), "pct_missing": df.isna().mean().round(3),
+                    "n_unique": df.nunique(dropna=True)}))
+print(df.select_dtypes("number").quantile([0, .01, .25, .5, .75, .99, 1]).T)
+```
+
+Percentiles .01 and .99 beside min and max are where a sentinel or a misplaced
+decimal shows; `.describe()` hides both. Styling is `pymc-artifact-style`'s.
+
+## Match the method to the question
+
+| Question | Compute | Chart form |
+|---|---|---|
+| What is in this column? | quantiles at 0/.01/.25/.5/.75/.99/1, `nunique`, `skew()` | histogram, 50+ bins; ECDF when the tail is long |
+| What is in this collection? | the index frame's own profile — `n_chars` per document, pixel dims, coordinate bounds, node degree — then quantiles as above | histogram of item size; iterate every item in code, read only a sample into context (`file-handling`); plot coordinates in projected metres, since a degree of longitude shrinks with latitude and there is no basemap here |
+| Do two numerics move together? | `corr("pearson")` and `corr("spearman")` | scatter, with binned medians over it |
+| Do groups differ? | `groupby().agg(n=…, median=…)`, then the same aggregate within each level of anything that could have produced the difference | small multiples or box plots, never a bare bar of means |
+| Does it vary along the index? | count *and* metric per bucket of whatever the `grain` orders — month, trial, wavelength bin, store | line of the row count first, the metric second; drop or label a partial final bucket |
+| Which rows — or which named group — are extreme? | distance from the median in MADs; for a group, summarise per group first, then MADs across the group summaries, and say what `n` groups supports | scatter with the flagged points marked; group summaries as a strip plot |
+
+## Missingness is a variable, not a gap
+
+**Test whether missingness depends on something before you treat it as noise.**
+Missing-at-random and missing-because-of-something print the same null rate and
+mean opposite things.
+
+```python
+missing = df["email"].isna().rename("email_missing")
+bucket = df["created_at"].dt.to_period("M")   # or trial // 100, or a wavelength bin
+print(missing.groupby(df["region"]).mean().round(3))  # by segment
+print(missing.groupby(bucket).mean().round(3))        # along the index
+print(df.groupby(missing)["amount"].median())         # vs the outcome
+```
+
+Flat across segments and buckets is collection noise. A jump at one boundary is
+a schema change, and that window may not be comparable. A rate that tracks the
+outcome biases any analysis that drops those rows — report it, do not treat it.
+
+## Check every relationship against rank and against subgroup
+
+**Compute Spearman alongside Pearson and read the pairs where they disagree.** A
+large gap means the relationship is curved, or that a few points carry the fit.
+
+```python
+num = df.select_dtypes("number").drop(columns=["order_id"])
+pairs = pd.DataFrame({"pearson": num.corr("pearson").stack(),
+                      "spearman": num.corr("spearman").stack()})
+pairs = pairs[pairs.index.get_level_values(0) < pairs.index.get_level_values(1)]
+pairs["gap"] = (pairs["spearman"] - pairs["pearson"]).abs()
+print(pairs.sort_values("gap", ascending=False).round(3).head(10))
+print(df.groupby("region")[["amount", "tenure_days"]].corr("spearman")
+        .xs("amount", level=1)["tenure_days"].round(3))   # a sign no group repeats is noise
+```
+
+## What you must not compute
+
+- **No correlation matrix skimmed for its biggest cells** — 40 columns give 780
+  pairs and the largest are what noise produces. Read it as structure: cluster
+  or factor it, show the reordered heatmap, say how many blocks you kept.
+- **No p-value or significance claim from a comparison you chose after seeing
+  the data.** Report effect size, direction and `n`. A test, a fit or a causal
+  claim is modeling output — modeling is a real next stage when `n` can support
+  one; see the handoff below.
+- **No edits to the frame.** Flag an outlier; `data-cleaning` treats and logs it.
+- **No pattern reported before you ask whether collection made it** — a cliff at
+  a round number, a mode at the form default, a gap on weekends.
+
+## What you write: run/findings.jsonl
+
+One row per finding, appended as you go; `how` is the expression that re-derives
+the number — pandas, SQL or a shell one-liner. When `n` cannot carry a claim,
+the finding is the plot, the direction and the size, and the `caveat` says so.
+
+```json
+{"id": "missing-email-rate", "claim": "40% of rows have no email", "value": 0.404, "n": 12043, "how": "df['email'].isna().mean()", "caveat": "concentrated in the east region"}
+```
+
+Charts stay under `run/`; a notebook to poke at is `marimo_notebooks`'s. You may
+be the whole answer or one step in it: run this stage, skip what nobody asked
+for, and name a skipped stage that could change the answer.
+
+Hand `run/findings.jsonl` to `eda-storytelling`, which picks what the reader
+sees, a posterior included — and to modeling when a fit was asked: a
+`pymc-marketing-*` skill (mmm, clv, priors) if one is attached, otherwise the
+simplest PyMC model that answers the question at this `n`. Name its likelihood
+and priors, say what a real MMM or CLV has that yours lacks (adstock,
+saturation, a hierarchy), and do not ship it under that name. Record what a
+profile lacks: the
+grain one row represents, the index column and its regularity, which columns
+group rows, their level counts, what nests in what, each item or covariate's
+unit, missing rate and range, the outcome's distribution and any floor or
+ceiling, and every Pearson/Spearman gap that says a relationship is curved.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| A "strong correlation" that no segment reproduces | pooled Pearson driven by group sizes or a few points | Spearman plus the per-group check above; report the subgroup result |
+| Mean and median disagree wildly, the write-up quotes the mean | heavy tail or an un-flagged outlier | Quote the median with an IQR, flag the tail as its own finding |
+| The reply is 400 lines of `.describe()` and a pairplot | volume substituted for judgement | Cut to findings that change a decision; the rest stays in `run/` |
+| A claim has no `findings.jsonl` row | the number was computed in passing, never recorded | Record it or drop it — `eda-storytelling` rejects unsourced numbers |


### PR DESCRIPTION
## Summary

Ships the core data-analysis workflow as default skills, so an operator's agent can take data from arrival to a written finding without per-deployment setup. Closes the authoring half of #85.

Five new skills, all mounted on the seeded `daimon` agent:

| Skill | Lines | Owns |
|---|---|---|
| `data-ingestion` | 155 | CSV/Excel/JSON/SQL/paged APIs/many-file sources → a known grain + `run/manifest.json` |
| `data-validation` | 125 | Phase-1 gate → `run/validation.json` verdict; phase-2 structural-break hunt |
| `data-cleaning` | 140 | Mutations + `run/changelog.jsonl`; writes the cleaned artifact |
| `exploratory-data-analysis` | 131 | Profiling, distributions, missingness, relationships → `run/findings.jsonl` |
| `eda-storytelling` | 133 | What to say and in what order |

Stages hand off through files under `run/`, not prose — each reads the previous stage's artifact — so the chain is checkable rather than aspirational.

### Written against no particular data shape

A deployment gets whatever its users have, so the anchor concept is **grain** — "one row of this represents ___, ordered by ___" — rather than a primary key:

- a sensor stream, an event log and a survey have a grain but no key, and repeated readings there are *data*, not duplicates. `df.duplicated(subset=key)` is therefore one mechanic for checking grain, not the spine of validation.
- non-rectangular sources (a corpus, a folder of images, geospatial features, a graph) run the same chain over a derived **index frame**, one row per item. A graph is two index frames, and edges-to-nodes becomes a referential-integrity check.
- four of the five artifacts are JSON *about* the data, so they are shape-independent: a duckdb aggregate over a 4 GB log and a pandas mask over 12k rows write the same `validation.json`. Only the cleaned-data artifact varies.
- stages are enterable and leavable mid-chain — "what's in this file", "is this usable", "clean this up", "fit a model on this already-clean export" all work — and a stage nobody ran is named in the writeup as a caveat rather than silently missing.

No router skill: the skill platform already routes on the frontmatter `description` field, so a dispatcher would duplicate it and cost an eleventh skill on every turn. The routing work went into the descriptions, each of which names the shapes it applies to.

`exploratory-data-analysis` hands off to modeling instead of dead-ending: a `pymc-marketing-*` skill when one is attached, otherwise the simplest PyMC model that answers the question, with what it lacks stated and without borrowing the name of the model it is not.

### Environment

`pyarrow` and `duckdb` join `typst`. Probed against a live sandbox session rather than assumed — the image already ships pandas 3.0.5, numpy, scipy, matplotlib, seaborn, openpyxl and tabulate, and both additions are genuinely absent. `pd.read_parquet` raises ImportError without pyarrow and parquet is this pipeline's own artifact format; duckdb is how anything larger than memory gets aggregated, and via `ATTACH` it reaches Postgres, MySQL and SQLite without baking a per-vendor driver into a default environment.

A Postgres driver was tried and reverted: a bare `postgresql://` DSN resolves to the **psycopg2** dialect, so shipping psycopg 3 would have produced the exact `ModuleNotFoundError` it was meant to prevent. `data-ingestion` installs `sqlalchemy` plus the right vendor driver on the turn that needs one.

### Reviewer notes

- **Skill load doubles**, 5 → 10 on the seeded agent. This is the main thing to push back on. `eda-storytelling` and `data-cleaning` are the two most defensible to demote to `defaults/agents-optional/` if it is too much.
- `tests/integration/test_seeded_prompt_tool_claims.py` scans every skill the seeded agent references and treats a bare `snake_case(` in prose outside a code fence as a claim about a real MCP tool. Inline pandas calls are therefore qualified (`pd.read_csv(`, `df.drop_duplicates(`) throughout — worth knowing before editing these files.
- **Not addressed here:** a `defaults/` change reaches new installs only. A healthy `ready` tenant resolves its agent on the first try, so the resolver-miss self-heal never fires and the tenant keeps its old spec; existing installs need a manual `daimon defaults apply` after deploy. Splitting that into its own issue.

## Checklist

- [x] Tests added or updated for any behavior change — no Python changed; the existing seeded-defaults gates (`test_seeded_prompt_tool_claims.py`, `test_seeded_prompt_prose_claims.py`) already walk the real `defaults/` tree and cover the new files
- [x] `uv run pytest` passes locally — 4527 passed, 4 skipped
- [x] `uv run pyright` passes locally (strict mode) — 0 errors
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts) — 6 kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
