### PR TITLE
fix(defaults): make the run/ artifact contract hold, and stop mangling its filenames

### DIFF
--- a/defaults/skills/data-cleaning/SKILL.md
+++ b/defaults/skills/data-cleaning/SKILL.md
@@ -33,10 +33,15 @@ df = pd.read_csv("run/raw/orders.csv", dtype="str", keep_default_na=False, na_va
 df["qty"] = pd.to_numeric(df["qty"], errors="coerce").astype("Int64")
 
 def log_change(op, column, rows_affected, rule, before, after):
+    """The ONLY writer for run/changelog.jsonl. Copy it verbatim; these six keys
+    are the contract, not a suggested shape. Renaming one to `detail`, `rows_in`
+    or `rows_out` breaks eda-storytelling's citation check, which keys on `op`."""
     os.makedirs("run", exist_ok=True)
+    row = {"op": op, "column": column, "rule": rule, "rows_affected": int(rows_affected),
+           "before": int(before), "after": int(after)}
+    assert set(row) == {"op", "column", "rule", "rows_affected", "before", "after"}
     with open("run/changelog.jsonl", "a") as fh:
-        fh.write(json.dumps({"op": op, "column": column, "rule": rule,
-            "rows_affected": int(rows_affected), "before": int(before), "after": int(after)}) + "\n")
+        fh.write(json.dumps(row) + "\n")
 ```
 
 ## Write every edit through `.loc`
@@ -78,8 +83,25 @@ df["ordered_at"] = parsed
 log_change("to_datetime", "ordered_at", lost.sum(), "ISO8601, bad -> NaT", len(df), len(df))
 ```
 
-Then deduplicate, where the grain admits it — a repeated sensor reading is data,
-not a duplicate. Where it is one, a tiebreaker, then `df.drop_duplicates(`.
+Then deduplicate — but only where the grain admits it, and the grain says so far
+more often than the data does.
+
+**No key, no dedup. This is a gate, not a preference.** You may deduplicate only
+on a key the user stated or `run/manifest.json` recorded as the grain. Where the
+grain is an index — a sensor stream, an event log, a survey — identical rows are
+*data*: one device reporting twice in the same second is two readings, and
+`df.drop_duplicates(` deletes the second one along with the sampling rate. That
+the rows are byte-identical is not evidence they are copies; it is what a
+repeated measurement looks like.
+
+Deciding they were "re-ingested duplicates rather than genuine repeat readings"
+is not a call available from the data — it needs a key, or the user. Without one:
+do not drop them, report the count as a finding, and lead with the number
+computed over every row. Offering both a raw and a deduplicated figure is not a
+substitute for asking; the headline is the raw one until someone says otherwise.
+
+Where a key does exist, take a tiebreaker, then `df.drop_duplicates(`, and log
+the key you used in the `rule`.
 
 ## Leave a gap rather than invent a value
 
@@ -125,8 +147,8 @@ you take from the user and log as the `rule`.
 
 Re-run `data-validation` on what you wrote; one treatment routinely breaks another
 check. Then hand it to `exploratory-data-analysis` or to modeling, the log going
-with it for `eda-storytelling`. You may be the last stage: name any stage you
-skipped that could have changed the answer — and on a `pass` with nothing to
+with it for `eda-storytelling`. You may be the last stage: then end the reply
+with the literal `Stages: … · skipped: …` line that skill defines — and on a `pass` with nothing to
 treat, say so and pass the source on with the manifest's dtypes.
 
 ## Common failure modes

--- a/defaults/skills/data-ingestion/SKILL.md
+++ b/defaults/skills/data-ingestion/SKILL.md
@@ -140,8 +140,8 @@ week. Ask when the source will not say. Name the ordering column too: validation
 and EDA bucket along the axis you name, and a composite grain has more than one.
 
 Hand the manifest to `data-validation`; you asserted only that the data is
-loaded and counted, so if the answer ships from here, name the stages nobody
-ran. A 40-row paste needs no `run/`; the manifest is one sentence in your reply.
+loaded and counted, so if the answer ships from here, end the reply with the
+literal `Stages: … · skipped: …` line `eda-storytelling` defines. A 40-row paste needs no `run/`; the manifest is one sentence in your reply.
 
 ## Common failure modes
 

--- a/defaults/skills/data-validation/SKILL.md
+++ b/defaults/skills/data-validation/SKILL.md
@@ -52,6 +52,13 @@ print(verdict, [(c["check"], c["n_failing"]) for c in failed])
 example ids, and the treatments available. Dedup changes the revenue number you
 are about to report, so the user picks it. On `warn`, say it inline.
 
+**That includes the conditional.** "If you confirm dedup, the total would be
+$260" is the number shipping with a hedge attached — the reader keeps the figure
+and forgets the condition, and you have pre-committed them to a treatment they
+never chose. Name the treatments and what each would change about the shape of
+the answer, not the value it would produce. Compute it on the next turn, after
+they pick.
+
 **When you cannot load it, check it in place** — aggregates where the data lives,
 duckdb over a file or the warehouse's own SQL, one `count(*) FILTER (WHERE …)` per
 check plus a `LIMIT`ed sample of ids, into the same `run/validation.json`.
@@ -112,7 +119,8 @@ You may be the first stage here and you may be the last. On `fail`, or a `warn`
 the user accepted, name the treatment, hand to `data-cleaning`, then re-run this
 stage on what it wrote — a cleaned frame not re-validated is unproven. On `pass`
 with nothing to treat, cleaning is ceremony: say so, hand the source on with the
-dtypes the manifest recorded, and name any stage you skipped that mattered.
+dtypes the manifest recorded. If the answer ships from here, end the reply with
+the literal `Stages: … · skipped: …` line `eda-storytelling` defines.
 
 ## Common failure modes
 

--- a/defaults/skills/eda-storytelling/SKILL.md
+++ b/defaults/skills/eda-storytelling/SKILL.md
@@ -85,8 +85,18 @@ does not ship. Cite change-log rows as "312 duplicates dropped, earliest kept".
 | dedup removing more than 1% of rows | yes, once in the caveats | it moves every denominator |
 | dtype coercion, whitespace strip, rename, the terminal write-clean row | no | it cannot change a reported number |
 
-**A stage nobody ran is a caveat too** — "no validation was asked for, so these
-totals are unvetted"; write up what ran, do not run the rest to tidy that away.
+**A stage nobody ran is a caveat too, and it is a required line, not a mood.**
+Every writeup ends with one literal line naming both sides:
+
+```
+Stages: ingestion, validation (pass) · skipped: cleaning (nothing to treat), EDA (not asked)
+```
+
+Write it even when nothing was skipped — then it reads `skipped: none`, and the
+reader learns the chain ran rather than guessing. Interrogating a claim that the
+data is already clean is not the same as validating it: if you did not write
+`run/validation.json` this turn, validation is skipped, however clean the data
+looked. Write up what ran; do not run the rest to tidy the line away.
 
 ## The same numbers, twice
 

--- a/defaults/skills/exploratory-data-analysis/SKILL.md
+++ b/defaults/skills/exploratory-data-analysis/SKILL.md
@@ -102,13 +102,36 @@ One row per finding, appended as you go; `how` is the expression that re-derives
 the number — pandas, SQL or a shell one-liner. When `n` cannot carry a claim,
 the finding is the plot, the direction and the size, and the `caveat` says so.
 
-```json
-{"id": "missing-email-rate", "claim": "40% of rows have no email", "value": 0.404, "n": 12043, "how": "df['email'].isna().mean()", "caveat": "concentrated in the east region"}
+```python
+import json, os
+
+def record_finding(id, claim, value, n, how, caveat=None):
+    """The ONLY writer for run/findings.jsonl. Copy it verbatim; these six keys are
+    the contract. `id` is what eda-storytelling cites a claim by, and `how` is what
+    lets someone re-derive the number — a row named {"finding": ...} instead has
+    neither, and the citation check rejects it."""
+    os.makedirs("run", exist_ok=True)
+    row = {"id": id, "claim": claim, "value": value, "n": int(n), "how": how,
+           "caveat": caveat}
+    assert set(row) == {"id", "claim", "value", "n", "how", "caveat"}
+    with open("run/findings.jsonl", "a") as fh:
+        fh.write(json.dumps(row) + "\n")
+
+record_finding("missing-email-rate", "40% of rows have no email", 0.404, 12043,
+               "df['email'].isna().mean()", "concentrated in the east region")
 ```
+
+`id` is a stable kebab-case slug you choose; `value` may be a number, a string or
+a small dict when one number cannot carry the claim. Everything else is required
+even when it feels obvious — a finding with no `n` cannot be rounded honestly,
+and one with no `how` cannot be checked.
 
 Charts stay under `run/`; a notebook to poke at is `marimo_notebooks`'s. You may
 be the whole answer or one step in it: run this stage, skip what nobody asked
-for, and name a skipped stage that could change the answer.
+for, and if the answer ships from here end the reply with the literal
+`Stages: … · skipped: …` line `eda-storytelling` defines. Entering here on an
+export someone called clean does not make validation run: it is `skipped` unless
+you wrote `run/validation.json` this turn.
 
 Hand `run/findings.jsonl` to `eda-storytelling`, which picks what the reader
 sees, a posterior included — and to modeling when a fit was asked: a

--- a/packages/core/daimon/core/media/filenames.py
+++ b/packages/core/daimon/core/media/filenames.py
@@ -15,6 +15,24 @@ _TITLE_SLUG = re.compile(r"[^A-Za-z0-9._-]+")
 # Used when mimetypes cannot decide — better an opaque extension than a wrong one.
 _FALLBACK_EXT = ".bin"
 
+# Mime types that carry no real format information. An agent uploading a parquet
+# file or a JSONL log has no better mime to declare than octet-stream or
+# application/json, and deriving from those is how `orders.parquet` became
+# `orders.parquet.bin` and `changelog.jsonl` became `changelog.jsonl.json`. When
+# the mime is this vague the title's own extension is the more specific fact, so
+# it wins. A SPECIFIC mime still overrides the title, which is the point of
+# deriving at all: a PNG titled `report.pdf` must not preview as a PDF.
+_GENERIC_MIMES = frozenset(
+    {
+        "application/octet-stream",
+        "application/json",
+        "text/plain",
+        "binary/octet-stream",
+    }
+)
+
+_HAS_EXTENSION = re.compile(r"\.[A-Za-z0-9]{1,8}$")
+
 
 def extension_for_mime(mime_type: str) -> str:
     """Return the file extension a chat client should see for ``mime_type``."""
@@ -44,10 +62,14 @@ def display_filename_for(title: str, mime_type: str) -> str:
     """Build the user-visible filename for an agent-supplied title.
 
     The extension is appended only when the title does not already end in it —
-    an agent that helpfully passes "chart.jpg" should not get "chart.jpg.jpg".
+    an agent that helpfully passes "chart.jpg" should not get "chart.jpg.jpg" —
+    and never when the mime type is too generic to know better than the title
+    (see :data:`_GENERIC_MIMES`).
     """
     cleaned = sanitize_title(title)
     ext = extension_for_mime(mime_type)
     if cleaned.lower().endswith(ext.lower()):
+        return cleaned
+    if mime_type.split(";")[0].strip().lower() in _GENERIC_MIMES and _HAS_EXTENSION.search(cleaned):
         return cleaned
     return f"{cleaned}{ext}"

--- a/packages/core/tests/media/test_filenames.py
+++ b/packages/core/tests/media/test_filenames.py
@@ -1,0 +1,74 @@
+"""Filename derivation for chat attachments."""
+
+from __future__ import annotations
+
+import pytest
+from daimon.core.media.filenames import display_filename_for, extension_for_mime, sanitize_title
+
+
+@pytest.mark.parametrize(
+    ("mime_type", "expected"),
+    [
+        ("image/png", ".png"),
+        ("image/jpeg", ".jpg"),
+        ("application/pdf", ".pdf"),
+        ("application/octet-stream", ".bin"),
+    ],
+)
+def test_extension_for_mime_maps_known_types(mime_type: str, expected: str) -> None:
+    assert extension_for_mime(mime_type) == expected, f"{mime_type} should resolve to {expected}"
+
+
+def test_sanitize_title_strips_path_separators() -> None:
+    assert sanitize_title("../../etc/passwd") == "etc_passwd", (
+        "a title must not be able to carry a path separator"
+    )
+
+
+def test_display_filename_appends_extension_when_title_has_none() -> None:
+    assert display_filename_for("chart", "image/png") == "chart.png", (
+        "a bare title should gain the extension its mime implies"
+    )
+
+
+def test_display_filename_does_not_double_a_matching_extension() -> None:
+    assert display_filename_for("chart.png", "image/png") == "chart.png", (
+        "an agent that already supplied the right extension must not get chart.png.png"
+    )
+
+
+@pytest.mark.parametrize(
+    ("title", "mime_type"),
+    [
+        # The data-analysis skills' own artifact formats. mimetypes knows neither
+        # .jsonl nor .parquet, and an agent has no better mime to declare.
+        ("changelog.jsonl", "application/json"),
+        ("findings.jsonl", "application/octet-stream"),
+        ("orders.parquet", "application/octet-stream"),
+        ("clean.parquet", "binary/octet-stream"),
+        ("notes.md", "text/plain"),
+        ("clean.sql", "application/octet-stream"),
+        ("changelog.jsonl", "application/json; charset=utf-8"),
+    ],
+)
+def test_display_filename_keeps_the_title_extension_when_the_mime_is_generic(
+    title: str, mime_type: str
+) -> None:
+    assert display_filename_for(title, mime_type) == title, (
+        "a generic mime carries no format information, so the title's own "
+        "extension is the more specific fact and must survive"
+    )
+
+
+def test_display_filename_lets_a_specific_mime_override_a_lying_title() -> None:
+    assert display_filename_for("report.pdf", "image/png") == "report.pdf.png", (
+        "deriving from a SPECIFIC mime is the whole point: a PNG must not "
+        "preview as a PDF because the agent titled it one"
+    )
+
+
+def test_display_filename_still_falls_back_for_a_generic_mime_and_no_extension() -> None:
+    assert display_filename_for("dump", "application/octet-stream") == "dump.bin", (
+        "with neither a usable mime nor a title extension there is nothing to "
+        "preserve, so the opaque fallback still applies"
+    )


### PR DESCRIPTION
## Summary

Follow-up to #86, from a live QA pass on staging: 10 billed turns against fixtures whose right answers were computed before each turn, so every verdict is a diff against a number the agent never saw rather than a judgement of its own account.

**The chain works.** Every number it produced was correct, twice more correct than the fixture's own expectation — it found an exact tie between two regions where the fixture only asked which was highest, and it reverse-engineered the generator behind a "clean" export (`amount = 20 + (i*7) % 130`) rather than reporting region as a spurious driver.

**The schemas do not.** `manifest.json` and `validation.json` came back byte-correct on every run. `changelog.jsonl` and `findings.jsonl` were improvised on every run:

```
changelog.jsonl  spec {op, column, rows_affected, rule, before, after}
                 live {op, detail, rows_in, rows_out} / {op, detail, rows_removed}
findings.jsonl   spec {id, claim, value, n, how, caveat}
                 live {finding, metric, means, tie, tie_value, ...} / {finding, n_used, value}
```

The difference was in the skill text, not the model: the two that held ship a complete writer with literal keys inline. `changelog` shipped a `log_change()` helper the agent had to re-call correctly; `findings` shipped only an example JSON line and no writer at all.

Consequence: `eda-storytelling` ships a real citation check — `{r.get("id") or r["op"] for r in rows}` — and run against artifacts from a real turn it raises **`KeyError 'op'`**. The one mechanically checkable claim in #86 did not hold on live output. The numbers survived only because each stage re-derives instead of reading the previous stage's file, which is the opposite of the design.

Both artifacts now ship a single named writer that asserts its own key set. Verified by running the shipped check end to end against artifacts written by the patched writers.

## The other three findings

**A keyless sensor stream got deduplicated.** 255 rows, one sensor, no key, 15 byte-identical rows that are data — the device reports twice in the same second. The agent dropped them and led with the deduped mean. Every number it gave was right and it disclosed both means; it made a forbidden call transparently rather than secretly. But the reported answer moved on a treatment nobody approved, on a grain with no key — the exact failure the skill exists to prevent. "No key, no dedup" was a boundary-block clause plus a mid-paragraph aside; it is now a gate that says identical rows are data, that "re-ingested duplicates rather than genuine repeat readings" is not a call available from the data, and that the raw number stays the headline until someone with a key says otherwise.

**Entering mid-chain, no stage was ever named as skipped.** No manifest, no validation artifact, no "these totals are unvetted" caveat — the writeup read as a complete analysis. That instruction was a trailing sentence in five separate files. It is now one required literal line (`Stages: … · skipped: …`), written even when nothing was skipped, and the four upstream skills point at it instead of paraphrasing. Interrogating a claim that data is already clean is explicitly not the same as validating it.

**A `fail` verdict shipped a conditional number.** Validation correctly verdicted `fail`, refused the total, and handed the treatments back — then added "clean total would be `260.00`". The reader keeps the figure and forgets the condition. Naming what a treatment would change about the answer is fine; naming the value it would produce is not.

## The code change

`display_filename_for` derived the extension from the declared mime even when that mime carried no format information, so `changelog.jsonl` arrived as `changelog.jsonl.json` and `orders.parquet` as `orders.parquet.bin`. Bytes were always intact (`PAR1` at both ends, reads back correctly) — this is naming — but parquet is this pipeline's own artifact format, so it hit every run, and `.jsonl.json` actively lies about what the file is.

A generic mime (`application/octet-stream`, `application/json`, `text/plain`) now yields to the title's own extension. A specific mime still overrides the title, which is the whole point of deriving: a PNG titled `report.pdf` must not preview as a PDF. New `packages/core/tests/media/test_filenames.py` covers both directions plus the fallback.

## Not addressed here

**S10 — the per-turn cost of ten skills.** Measured off MA usage records: a 3-skill agent's turn wrote 8,265 input tokens, an 11-skill agent's `ping` wrote 15,157. That is ~860 per skill, 4–5× what the frontmatter descriptions alone account for, so MA injects materially more than the `description` field. Confounded by different tenants and prompts, so it needs a clean same-tenant A/B before anyone acts on it. #86's demote question for `eda-storytelling` / `data-cleaning` is live again rather than settled.

## Checklist

- [x] Tests added or updated for any behavior change — `test_filenames.py`, 16 cases
- [x] `uv run pytest` passes locally
- [x] `uv run pyright` passes locally (strict mode) — 0 errors
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
