### PR TITLE
fix(core): keep the title's extension when a mime resolves to nothing

### DIFF
--- a/packages/core/daimon/core/media/filenames.py
+++ b/packages/core/daimon/core/media/filenames.py
@@ -15,14 +15,21 @@ _TITLE_SLUG = re.compile(r"[^A-Za-z0-9._-]+")
 # Used when mimetypes cannot decide — better an opaque extension than a wrong one.
 _FALLBACK_EXT = ".bin"
 
-# Mime types that carry no real format information. An agent uploading a parquet
-# file or a JSONL log has no better mime to declare than octet-stream or
-# application/json, and deriving from those is how `orders.parquet` became
-# `orders.parquet.bin` and `changelog.jsonl` became `changelog.jsonl.json`. When
-# the mime is this vague the title's own extension is the more specific fact, so
-# it wins. A SPECIFIC mime still overrides the title, which is the point of
-# deriving at all: a PNG titled `report.pdf` must not preview as a PDF.
-_GENERIC_MIMES = frozenset(
+# Mime types that carry no format information the title does not already have.
+# An agent uploading a parquet file or a JSONL log has no accurate mime to
+# declare, and deriving from what it guesses is how `orders.parquet` became
+# `orders.parquet.bin` and `changelog.jsonl` became `changelog.jsonl.json`.
+#
+# Two ways a mime ends up uninformative, and BOTH must be caught -- an earlier
+# fix listed only the first, and live turns immediately produced the second:
+#   1. it is a known catch-all (`application/octet-stream`, `application/json`)
+#   2. `mimetypes` has never heard of it, so it resolves to the fallback. Agents
+#      invent plausible types -- `application/jsonl` was observed on staging --
+#      and an invented type is no more informative than octet-stream.
+# In both cases the title's own extension is the more specific fact, so it wins.
+# A mime resolving to a REAL extension still overrides the title, which is the
+# point of deriving at all: a PNG titled `report.pdf` must not preview as a PDF.
+_CATCH_ALL_MIMES = frozenset(
     {
         "application/octet-stream",
         "application/json",
@@ -63,13 +70,16 @@ def display_filename_for(title: str, mime_type: str) -> str:
 
     The extension is appended only when the title does not already end in it —
     an agent that helpfully passes "chart.jpg" should not get "chart.jpg.jpg" —
-    and never when the mime type is too generic to know better than the title
-    (see :data:`_GENERIC_MIMES`).
+    and never when the mime carries no more information than the title already
+    does (see :data:`_CATCH_ALL_MIMES`).
     """
     cleaned = sanitize_title(title)
     ext = extension_for_mime(mime_type)
     if cleaned.lower().endswith(ext.lower()):
         return cleaned
-    if mime_type.split(";")[0].strip().lower() in _GENERIC_MIMES and _HAS_EXTENSION.search(cleaned):
+    uninformative = (
+        mime_type.split(";")[0].strip().lower() in _CATCH_ALL_MIMES or ext == _FALLBACK_EXT
+    )
+    if uninformative and _HAS_EXTENSION.search(cleaned):
         return cleaned
     return f"{cleaned}{ext}"

--- a/packages/core/tests/media/test_filenames.py
+++ b/packages/core/tests/media/test_filenames.py
@@ -49,9 +49,15 @@ def test_display_filename_does_not_double_a_matching_extension() -> None:
         ("notes.md", "text/plain"),
         ("clean.sql", "application/octet-stream"),
         ("changelog.jsonl", "application/json; charset=utf-8"),
+        # Types mimetypes has never heard of. Agents invent these -- every one
+        # below was observed on staging or is its obvious sibling -- and an
+        # invented type is no more informative than octet-stream.
+        ("changelog.jsonl", "application/jsonl"),
+        ("findings.jsonl", "application/x-ndjson"),
+        ("orders.parquet", "application/vnd.apache.parquet"),
     ],
 )
-def test_display_filename_keeps_the_title_extension_when_the_mime_is_generic(
+def test_display_filename_keeps_the_title_extension_when_the_mime_is_uninformative(
     title: str, mime_type: str
 ) -> None:
     assert display_filename_for(title, mime_type) == title, (


### PR DESCRIPTION
Follow-up to #87, from the staging re-run that verified it.

#87 fixed `orders.parquet.bin` by listing four known catch-all mimes. A live turn produced **`application/jsonl`** within minutes — an invented type `mimetypes` has never heard of, so it falls through to the `.bin` fallback and misses the list entirely. Result: `orders.parquet` arrived clean, `changelog.jsonl` still arrived as `changelog.jsonl.bin`.

The rule is not "is this mime on a list" but **"did this mime resolve to anything"**. If the derived extension is the fallback, `mimetypes` had no idea, and the title's own extension is the more specific fact. That also covers `application/x-ndjson` and `application/vnd.apache.parquet`, both of which an agent will reasonably invent for this pipeline's own artifact formats.

A mime that resolves to a real extension still overrides the title — `report.pdf` + `image/png` is still `report.pdf.png`.

## Checklist

- [x] Tests added or updated — three invented-mime cases added to `test_filenames.py`
- [x] `uv run pytest` passes locally — 733 in core media + mcp
- [x] `uv run pyright` passes locally (strict mode) — 0 errors
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)