### PR TITLE
fix(defaults): stop the boot sweep exhausting the org Skills API rate limit

### DIFF
--- a/packages/adapters/cli/daimon/adapters/cli/runtime.py
+++ b/packages/adapters/cli/daimon/adapters/cli/runtime.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from anthropic import AsyncAnthropic
 from daimon.core.config import Settings
+from daimon.core.constants import MA_MAX_RETRIES
 from daimon.core.db import build_engine, build_session_factory
 from daimon.core.defaults.loader import parse_deployment_default
 from daimon.core.ma_resolver import ResolverCache, new_resolver_cache
@@ -33,6 +34,7 @@ async def build_runtime(settings: Settings) -> AsyncIterator[CliRuntime]:
     async with AsyncAnthropic(
         api_key=settings.anthropic.api_key.get_secret_value(),
         base_url=str(settings.anthropic.base_url),
+        max_retries=MA_MAX_RETRIES,
     ) as anthropic:
         try:
             yield CliRuntime(

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -75,8 +75,14 @@ _EMBED_COLOR = theme.COLOR_BLURPLE  # Blurple — repo standard (help.py D-FORMA
 # mid-stream.
 _DRAIN_GRACE_S: float = 60.0
 
-# Bounded concurrency for the on_ready re-seed sweep.
-_SWEEP_CONCURRENCY = 4
+# Bounded concurrency for the on_ready re-seed sweep. Each tenant reconcile
+# issues roughly two dozen Skills API calls (a read per seeded skill, plus an
+# upload per skill that changed), and that API is rate limited per ORG at 100
+# requests/minute -- shared across every deployment on the operator's key. At 4
+# a cold sweep of 16 tenants exceeded it and the promote of 2026-08-20 landed
+# only 5 of 16 tenants' skills before 429ing; the agent reconcile then failed
+# attaching skills the sweep had never created.
+_SWEEP_CONCURRENCY = 2
 
 # Wall-clock ceiling on a single turn. Not a latency target -- legitimate
 # agentic turns run many minutes (notebooks, model fits), so this is set well

--- a/packages/adapters/discord/daimon/adapters/discord/runtime.py
+++ b/packages/adapters/discord/daimon/adapters/discord/runtime.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from anthropic import AsyncAnthropic
 from daimon.core.billing import BillingConfig, load_billing_config
 from daimon.core.config import Settings
+from daimon.core.constants import MA_MAX_RETRIES
 from daimon.core.db import build_engine, build_session_factory
 from daimon.core.defaults.loader import parse_deployment_default
 from daimon.core.github_credentials import build_multifernet
@@ -85,6 +86,7 @@ async def build_runtime(settings: Settings) -> AsyncIterator[DiscordRuntime]:
     async with AsyncAnthropic(
         api_key=settings.anthropic.api_key.get_secret_value(),
         base_url=str(settings.anthropic.base_url),
+        max_retries=MA_MAX_RETRIES,
     ) as anthropic:
         notebook_rate_limiter = RateLimiter(
             max_requests=settings.notebook.publish_rate_per_hour,

--- a/packages/core/daimon/core/constants.py
+++ b/packages/core/daimon/core/constants.py
@@ -35,3 +35,12 @@ DEFAULT_AGENT_MODEL: str = "claude-sonnet-5"
 # value here, because that number has moved before.
 AGENT_SKILL_CAP: int = 20
 AGENT_MCP_CAP: int = 20
+
+# How many times the SDK retries a request before giving up. The SDK's own
+# default is 2, which retries a 429 twice honouring `retry-after` and then
+# raises. That is enough for a burst and not enough for a sustained overage:
+# the Skills API is capped per ORG at 100 requests/minute, so a cold defaults
+# sweep across every tenant can sit over the line for longer than two retries
+# can wait out. Every adapter runtime passes this when constructing its
+# client, so a boot-time sweep paces itself instead of failing half-applied.
+MA_MAX_RETRIES: int = 8


### PR DESCRIPTION
## What broke

The production promote of 2026-08-20 (`03689b8`) deployed cleanly — images, migrations, mcp revision, VM refresh and health gate all green — and then failed its last gate:

```
verify: FAILED — 6/8 ready tenant(s) diverged or unverifiable
```

The cause is in the deploy log:

```
defaults.sweep_failed kind=skill
  error='429 rate_limit_error: This request would exceed your organization's
  rate limit of 100 requests per minute (limit_type: Skills API)'
defaults.reconcile_failed kind=agent name=daimon
  error="custom skill 'data-ingestion' not found in this tenant's skill namespace on MA"
```

The skill sweep was rate limited partway through, so the agent reconcile that runs after it tried to attach skills that had never been created. Read against the MA API afterwards, 5 of 16 production tenants held their full seeded set and **58 seeded skills were missing** across the rest — a ragged partial apply, not a clean failure.

## Why

`on_ready` reconciles 4 tenants concurrently (`_SWEEP_CONCURRENCY = 4`). Each tenant reconcile issues roughly two dozen Skills API calls: a read per seeded skill, plus an upload for each one whose fingerprint changed. The Skills API is capped **per organization** at 100 requests/minute — shared across every deployment on the operator's key, not per tenant and not per deployment.

The SDK already retries a 429 honouring `retry-after` (verified against the installed 0.117.0: `DEFAULT_MAX_RETRIES = 2`, and `_should_retry` returns `True` on 429). Two retries is enough to ride out a burst. It is not enough for a sustained overage, which is what a cold sweep across every tenant produces — the sweep keeps generating new requests while the retries are waiting, so it stays over the line for longer than two backoffs can cover.

This is the ceiling from the skill-count growth issue arriving earlier than expected, and by a different route: the binding limit is requests/minute, not the 1000-skill count.

## The change

- `_SWEEP_CONCURRENCY` 4 → 2.
- New `MA_MAX_RETRIES = 8` in `daimon.core.constants`, passed by the Discord and CLI runtimes when constructing their client. Both paths matter: the Discord runtime owns the boot sweep, and the CLI runtime is what the deploy's `defaults verify` gate runs — the six "unverifiable" tenants were tenants whose *comparison* failed, which is the same 429 hitting reads.

Two knobs rather than one on purpose. Lowering concurrency addresses asking too fast; raising the retry ceiling addresses giving up too early. Either alone leaves a plausible re-failure.

## What this does not do

It does not repair the tenants that are already half-applied — the sweep is fingerprint-gated and idempotent, so re-running it converges them, and that is happening separately.

It also carries no test. The knobs are configuration, and the behaviour they govern is a live rate limit on a shared org key; the only real proof is a cold sweep across every tenant on staging, which is the same shape as the run that found the bug. Worth saying plainly rather than adding a unit test that asserts a constant equals itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)