### PR TITLE
fix(slack): five Slack-parity defects — retries, in-thread notices, lint scope, CLI platform

### DIFF
--- a/packages/adapters/cli/daimon/adapters/cli/commands/agents.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/agents.py
@@ -443,7 +443,7 @@ def agents_backfill_toolset_command(
 ) -> None:
     """Patch every tenant-tagged agent missing the base agent_toolset_20260401.
 
-    Enumerates every registered discord workspace, lists non-archived agents
+    Enumerates every registered Discord and Slack workspace, lists non-archived agents
     per tenant, and adds the base agent toolset to any agent that lacks it.
     Agents that already carry the toolset are skipped. Re-running selects zero
     agents (idempotent by construction).
@@ -466,7 +466,10 @@ async def agents_backfill_toolset(
     dry_run: bool,
 ) -> None:
     """Async implementation of backfill-toolset."""
+    # Chat platforms only: a Slack tenant's agents need the base toolset just as
+    # much as a Discord tenant's. The operator's own `cli` tenant is left alone.
     tenant_rows = await list_tenants_by_platform(rt.sessionmaker, platform="discord")
+    tenant_rows += await list_tenants_by_platform(rt.sessionmaker, platform="slack")
 
     report_rows: list[_BackfillRow] = []
     for tenant_row in tenant_rows:
@@ -549,11 +552,13 @@ def agents_rekey_command(
 ) -> None:
     """Re-key existing guild-tenant agents' daimon_account to the derived guild account.
 
-    Enumerates every registered discord workspace, compares each agent's current
-    daimon_account against the deterministically-derived guild account for that
-    tenant, and updates any agent still pointing at a per-user account.
+    Enumerates every registered Discord and Slack workspace, compares each
+    agent's current daimon_account against the deterministically-derived guild
+    account for that tenant, and updates any agent still pointing at a per-user
+    account. Slack stamps the same derived account on create/fork/edit
+    (slack/agent_setup/submit.py), so its agents belong in this sweep.
 
-    Pre-48 operator-tenant agents (no discord workspace) are never enumerated.
+    Operator-tenant agents (no chat workspace) are never enumerated.
     Already-guild-owned and system agents (no daimon_account) are skipped.
     """
     settings = load_settings()
@@ -574,8 +579,11 @@ async def agents_rekey(
     dry_run: bool,
 ) -> None:
     """Async implementation of rekey-guild-ownership."""
-    # Enumerate all registered discord tenants (no raw .list() — ISO-01).
+    # Enumerate registered chat tenants (no raw .list() — ISO-01). Filtering to
+    # discord silently left every Slack tenant's agents un-rekeyed; the operator's
+    # own `cli` tenant stays excluded, as the docstring promises.
     tenant_rows = await list_tenants_by_platform(rt.sessionmaker, platform="discord")
+    tenant_rows += await list_tenants_by_platform(rt.sessionmaker, platform="slack")
 
     # Collect items that need re-keying — (tenant_id, guild_account, agent_id,
     # name, current_acct) — plus the names already claimed by guild-owned agents

--- a/packages/adapters/cli/daimon/adapters/cli/commands/tenants.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/tenants.py
@@ -24,10 +24,15 @@ from rich.console import Console
 tenants_app = typer.Typer(help="Tenants: list and delete.")
 
 
+_VALID_PLATFORMS = ("discord", "cli", "slack")
+
+
 def _validate_platform(value: str) -> Platform:
-    if value in ("discord", "cli"):
+    if value in _VALID_PLATFORMS:
         return value  # type: ignore[return-value]
-    raise typer.BadParameter(f"unsupported platform {value!r}; valid: discord, cli")
+    raise typer.BadParameter(
+        f"unsupported platform {value!r}; valid: {', '.join(_VALID_PLATFORMS)}"
+    )
 
 
 @tenants_app.command("list")

--- a/packages/adapters/cli/tests/commands/test_agents_backfill_toolset.py
+++ b/packages/adapters/cli/tests/commands/test_agents_backfill_toolset.py
@@ -332,3 +332,49 @@ async def test_backfill_second_run_selects_zero_agents(
         "second run against already-patched agents must select zero agents "
         "and issue zero agents.update calls (structural idempotence)"
     )
+
+
+@pytest.mark.asyncio
+async def test_backfill_patches_slack_tenant_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A Slack tenant's toolless agent is patched too.
+
+    The command enumerated `platform="discord"` only, so every Slack install's
+    agents were silently skipped by this maintenance sweep.
+    """
+    workspace_id = "T_BACKFILL_SLACK"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=workspace_id)
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=workspace_id)
+
+    agent_id = "agent_toolless_slack_001"
+    agent_data = _agent_json(
+        agent_id=agent_id,
+        name="toolless-slack-agent",
+        version=2,
+        metadata={"daimon_tenant": str(tenant_id), "daimon_name": "toolless-slack-agent"},
+        tools=[],
+    )
+
+    update_bodies: list[dict[str, object]] = []
+
+    def on_update(req: httpx.Request, _m: object) -> httpx.Response:
+        update_bodies.append(json.loads(req.content))
+        return httpx.Response(200, json=agent_data)
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, m: list_response([agent_data]))
+    router.add(
+        "GET", rf"/v1/agents/{agent_id}", lambda req, m: httpx.Response(200, json=agent_data)
+    )
+    router.add("POST", rf"/v1/agents/{agent_id}", on_update)
+
+    console = Console(file=StringIO(), force_terminal=False, highlight=False, width=120)
+    rt = _build_rt(db_session_factory, router)
+
+    await agents_backfill_toolset(rt=rt, console=console, yes=True, dry_run=False)
+
+    assert len(update_bodies) == 1, (
+        "a slack tenant's toolless agent must be patched, not skipped by a platform filter"
+    )

--- a/packages/adapters/cli/tests/commands/test_agents_rekey.py
+++ b/packages/adapters/cli/tests/commands/test_agents_rekey.py
@@ -644,3 +644,60 @@ async def test_rekey_suffix_never_collides_with_later_bare_name(
     assert len(final_names) == 3, (
         f"post-rekey names must be unique within the tenant, got {sorted(final_names)}"
     )
+
+
+@pytest.mark.asyncio
+async def test_rekey_updates_slack_tenant_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A Slack tenant's user-owned agent is re-keyed too.
+
+    Slack stamps the same derived guild account on create/fork/edit, but the
+    command enumerated `platform="discord"` only, so Slack agents were left
+    pointing at a per-user account forever.
+    """
+    workspace_id = "T_REKEY_SLACK"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=workspace_id)
+    guild_account = derive_guild_account_uuid(tenant_id)
+    user_account = _user_account_id()
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=workspace_id)
+
+    agent_id = "agent_slack_rekey_001"
+    agent_data = _agent_json(
+        agent_id=agent_id,
+        name="slack-agent",
+        version=4,
+        metadata={
+            "daimon_tenant": str(tenant_id),
+            "daimon_name": "slack-agent",
+            "daimon_account": str(user_account),
+        },
+    )
+
+    update_bodies: list[dict[str, object]] = []
+
+    def on_update(req: httpx.Request, _m: object) -> httpx.Response:
+        update_bodies.append(json.loads(req.content))
+        return httpx.Response(200, json=agent_data)
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, m: list_response([agent_data]))
+    router.add(
+        "GET", rf"/v1/agents/{agent_id}", lambda req, m: httpx.Response(200, json=agent_data)
+    )
+    router.add("POST", rf"/v1/agents/{agent_id}", on_update)
+
+    console = Console(file=StringIO(), force_terminal=False, highlight=False, width=120)
+    rt = _build_rt(db_session_factory, router)
+
+    await agents_rekey(rt=rt, console=console, yes=True, dry_run=False)
+
+    assert len(update_bodies) == 1, (
+        "a slack tenant's user-owned agent must be re-keyed, not skipped by a platform filter"
+    )
+    raw_meta = update_bodies[0].get("metadata")
+    assert isinstance(raw_meta, dict), "update body must include metadata dict"
+    assert cast(dict[str, object], raw_meta).get("daimon_account") == str(guild_account), (
+        "daimon_account must be re-keyed to the derived guild account"
+    )

--- a/packages/adapters/cli/tests/commands/test_tenants.py
+++ b/packages/adapters/cli/tests/commands/test_tenants.py
@@ -5,6 +5,7 @@ from io import StringIO
 from typing import cast
 
 import pytest
+import typer
 from anthropic import AsyncAnthropic
 from daimon.adapters.cli.commands.tenants import tenants_delete, tenants_list
 from daimon.adapters.cli.runtime import CliRuntime
@@ -213,3 +214,45 @@ async def test_tenants_list_filters_by_platform(
     assert platforms == {"discord"}, "should only return discord tenants when filtered"
     cli_ids = [d["external_id"] for d in data if d["platform"] == "cli"]
     assert len(cli_ids) == 0, "cli tenants should be excluded when filtered to discord"
+
+
+@pytest.mark.asyncio
+async def test_tenants_list_filters_by_slack_platform(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    stub_anthropic: AsyncAnthropic,
+) -> None:
+    """`--platform slack` must be accepted — slack is a real Platform value.
+
+    The validator previously allowed only discord and cli, so every Slack
+    install was unreachable from `daimon tenants list` and `tenants delete`.
+    """
+    rt = _build_rt(db_session_factory, stub_anthropic)
+    console = _make_console()
+
+    async with db_session_factory() as s, s.begin():
+        await make_tenant(s, platform="slack", workspace_id="T_FILTER_SLACK")
+        await make_tenant(s, platform="discord", workspace_id="filter-guild-2")
+
+    await tenants_list(rt=rt, console=console, platform="slack", as_json=True)
+
+    out = cast(StringIO, console.file).getvalue()
+    data = json.loads(out)
+    assert {d["platform"] for d in data} == {"slack"}, (
+        "should only return slack tenants when filtered to slack"
+    )
+    assert "T_FILTER_SLACK" in {d["external_id"] for d in data}, (
+        "the seeded slack tenant must be listed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tenants_list_rejects_unknown_platform(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    stub_anthropic: AsyncAnthropic,
+) -> None:
+    """An unrecognized platform still fails loudly rather than deriving a wrong UUID."""
+    rt = _build_rt(db_session_factory, stub_anthropic)
+    console = _make_console()
+
+    with pytest.raises(typer.BadParameter, match="discord, cli, slack"):
+        await tenants_list(rt=rt, console=console, platform="teams", as_json=True)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_client.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_client.py
@@ -17,6 +17,11 @@ from daimon.core.slack_oauth import build_slack_connect_url
 from daimon.core.stores.slack_bot_tokens import get_slack_bot_token
 from daimon.core.stores.slack_user_tokens import get_slack_user_token
 from fastmcp.exceptions import ToolError
+from slack_sdk.http_retry.async_handler import AsyncRetryHandler
+from slack_sdk.http_retry.builtin_async_handlers import (
+    AsyncRateLimitErrorRetryHandler,
+    async_default_handlers,
+)
 from slack_sdk.web.async_client import AsyncWebClient
 
 
@@ -30,6 +35,18 @@ def _require_team_id(auth: AuthIdentity) -> str:  # pyright: ignore[reportUnused
     if auth.external_id is None:
         raise ToolError("slack tools require a workspace context")
     return auth.external_id
+
+
+def _build_retry_handlers() -> list[AsyncRetryHandler]:
+    """Retry handlers for every AsyncWebClient built here.
+
+    slack_sdk defaults to connection-error retries only, so a 429 reaches the
+    tool caller as a bare error. Slack caps non-Marketplace apps at one
+    ``conversations.history``/``conversations.replies`` call per minute, which
+    the model-facing read tools trip easily. Duplicated from the Slack
+    adapter's ``build_retry_handlers`` — adapters must not import each other.
+    """
+    return [*async_default_handlers(), AsyncRateLimitErrorRetryHandler()]
 
 
 async def slack_web_client(runtime: McpRuntime, *, team_id: str) -> AsyncWebClient:
@@ -48,7 +65,7 @@ async def slack_web_client(runtime: McpRuntime, *, team_id: str) -> AsyncWebClie
         token = decrypt_token(runtime.fernet, row.encrypted_token)
     except InvalidToken as err:
         raise ToolError("workspace bot token could not be decrypted") from err
-    return AsyncWebClient(token=token)
+    return AsyncWebClient(token=token, retry_handlers=_build_retry_handlers())
 
 
 @dataclass(frozen=True)
@@ -85,7 +102,10 @@ async def slack_read_client(
                 "your connected Slack token could not be decrypted — "
                 "disconnect and reconnect via /privacy"
             ) from err
-        return SlackReadClient(client=AsyncWebClient(token=user_token), runs_as_user=True)
+        return SlackReadClient(
+            client=AsyncWebClient(token=user_token, retry_handlers=_build_retry_handlers()),
+            runs_as_user=True,
+        )
     return SlackReadClient(
         client=await slack_web_client(runtime, team_id=team_id), runs_as_user=False
     )

--- a/packages/adapters/mcp/tests/tools/test_slack_client.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_client.py
@@ -33,6 +33,10 @@ from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
 from daimon.core.stores.slack_user_tokens import upsert_slack_user_token
 from fastmcp.exceptions import ToolError
 from pydantic import HttpUrl, PostgresDsn, SecretStr
+from slack_sdk.http_retry.builtin_async_handlers import (
+    AsyncConnectionErrorRetryHandler,
+    AsyncRateLimitErrorRetryHandler,
+)
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -258,3 +262,50 @@ def test_build_connect_hint_contains_signed_connect_url() -> None:
         "hint must carry the per-user signed connect URL"
     )
     assert "admin" in hint, "hint must warn about admin-approval workspaces"
+
+
+@pytest.mark.asyncio
+async def test_slack_clients_register_rate_limit_retry_handler(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Both the bot-token and user-token read clients must retry 429s.
+
+    Slack caps non-Marketplace apps at one conversations.history /
+    conversations.replies call per minute, and these are the clients the
+    model-facing Slack read tools run on. slack_sdk's default handler set is
+    connection-error only, which must survive alongside the addition.
+    """
+    fernet_key = SecretStr(Fernet.generate_key().decode("ascii"))
+    fernet = build_multifernet((fernet_key.get_secret_value(),))
+    async with committing_sessionmaker() as session:
+        await upsert_slack_bot_token(
+            session, team_id="T_RETRY", encrypted_token=encrypt_token(fernet, "xoxb-bot")
+        )
+        await upsert_slack_user_token(
+            session,
+            team_id="T_RETRY",
+            slack_user_id="U_RETRY",
+            encrypted_token=encrypt_token(fernet, "xoxp-user"),
+            scopes="channels:history",
+        )
+        await session.commit()
+
+    runtime = McpRuntime(
+        session_factory=committing_sessionmaker,
+        client=MagicMock(spec=AsyncAnthropic),
+        settings=_build_settings(fernet_key=fernet_key),
+        deployment_default=DeploymentDefault(),
+        fernet=fernet,
+    )
+
+    bot_client = await slack_web_client(runtime, team_id="T_RETRY")
+    read = await slack_read_client(runtime, team_id="T_RETRY", slack_user_id="U_RETRY")
+
+    for label, client in (("bot", bot_client), ("user", read.client)):
+        handler_types = {type(handler) for handler in client.retry_handlers}
+        assert AsyncRateLimitErrorRetryHandler in handler_types, (
+            f"the {label} client must retry a 429 rather than raise on the first one"
+        )
+        assert AsyncConnectionErrorRetryHandler in handler_types, (
+            f"the {label} client must keep the SDK's default connection-error retry"
+        )

--- a/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
+++ b/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
@@ -35,6 +35,7 @@ from anthropic import AsyncAnthropic
 from daimon.adapters.scheduler.settings import SchedulerSettings
 from daimon.core.billing import BillingConfig, is_over_cap, load_billing_config
 from daimon.core.config import Settings, load_settings
+from daimon.core.constants import MA_MAX_RETRIES
 from daimon.core.db import build_engine, build_session_factory
 from daimon.core.defaults.loader import parse_deployment_default
 from daimon.core.defaults.provisioning import reconcile_tenant_defaults
@@ -387,6 +388,7 @@ async def run(
         else AsyncAnthropic(
             api_key=settings.anthropic.api_key.get_secret_value(),
             base_url=str(settings.anthropic.base_url),
+            max_retries=MA_MAX_RETRIES,
         )
     )
 

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -670,6 +670,11 @@ class SlackApp:
                 await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
                     channel=channel,
                     user=event.get("user") or "",
+                    # Without thread_ts an in-thread mention's rejection lands at
+                    # channel root while the sender watches the thread. Only the real
+                    # thread_ts — never a ts fallback, which would tuck the notice
+                    # into a thread that does not exist yet. None is dropped by the SDK.
+                    thread_ts=event.get("thread_ts"),
                     text=(
                         "Sorry, I can only respond to members of this workspace. "
                         "Please ask a workspace member to mention me instead."
@@ -809,6 +814,8 @@ class SlackApp:
             await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
                 channel=channel,
                 user=str(event.get("user") or ""),
+                # Real thread only — a shed root mention has no thread yet.
+                thread_ts=event.get("thread_ts"),
                 text=(
                     "This workspace has too many chats in flight right now — try again in a moment."
                 ),

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -54,7 +54,7 @@ from daimon.adapters.slack.billing_panel.actions import handle_billing_command, 
 from daimon.adapters.slack.context import build_context_xml, build_delta_xml
 from daimon.adapters.slack.gating import is_external_interactive, is_slack_connect_external
 from daimon.adapters.slack.help import handle_help_command
-from daimon.adapters.slack.interactions import resolve_web_client
+from daimon.adapters.slack.interactions import build_retry_handlers, resolve_web_client
 from daimon.adapters.slack.lifecycle import SlackTurnLifecycle
 from daimon.adapters.slack.memory import handle_memory_command
 from daimon.adapters.slack.privacy_panel.actions import (
@@ -661,7 +661,9 @@ class SlackApp:
                 tuple(k.get_secret_value() for k in self.runtime.settings.crypto.keys)
             )
             token = decrypt_token(fernet, row.encrypted_token)
-            client = AsyncWebClient(token=token)  # per-event only
+            client = AsyncWebClient(  # per-event only
+                token=token, retry_handlers=build_retry_handlers()
+            )
 
             # (4) SLACK CONNECT GATE — reject external-workspace senders.
             if is_slack_connect_external(event, team_id=team_id):

--- a/packages/adapters/slack/daimon/adapters/slack/interactions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/interactions.py
@@ -12,7 +12,25 @@ from __future__ import annotations
 from daimon.adapters.slack.runtime import SlackRuntime
 from daimon.core.github_credentials import build_multifernet, decrypt_token
 from daimon.core.stores.slack_bot_tokens import get_slack_bot_token
+from slack_sdk.http_retry.async_handler import AsyncRetryHandler
+from slack_sdk.http_retry.builtin_async_handlers import (
+    AsyncRateLimitErrorRetryHandler,
+    async_default_handlers,
+)
 from slack_sdk.web.async_client import AsyncWebClient
+
+
+def build_retry_handlers() -> list[AsyncRetryHandler]:
+    """Retry handlers for every AsyncWebClient we construct.
+
+    slack_sdk's default is connection-error retries only, so a 429 surfaces
+    immediately as ``SlackApiError``. Slack caps non-Marketplace apps at one
+    ``conversations.history``/``conversations.replies`` call per minute, and
+    the listener boundary posts nothing on failure, so an unretried 429 reads
+    as a dead bot. ``AsyncRateLimitErrorRetryHandler`` honours ``Retry-After``;
+    its default single retry is deliberate, since that wait can be 60s.
+    """
+    return [*async_default_handlers(), AsyncRateLimitErrorRetryHandler()]
 
 
 async def resolve_web_client(runtime: SlackRuntime, *, team_id: str) -> AsyncWebClient | None:
@@ -38,4 +56,6 @@ async def resolve_web_client(runtime: SlackRuntime, *, team_id: str) -> AsyncWeb
         return None
     fernet = build_multifernet(tuple(k.get_secret_value() for k in runtime.settings.crypto.keys))
     token = decrypt_token(fernet, row.encrypted_token)
-    return AsyncWebClient(token=token)  # per-event only — never cache
+    return AsyncWebClient(  # per-event only — never cache
+        token=token, retry_handlers=build_retry_handlers()
+    )

--- a/packages/adapters/slack/daimon/adapters/slack/runtime.py
+++ b/packages/adapters/slack/daimon/adapters/slack/runtime.py
@@ -10,6 +10,7 @@ import httpx
 from anthropic import AsyncAnthropic
 from daimon.core.billing import BillingConfig, load_billing_config
 from daimon.core.config import Settings
+from daimon.core.constants import MA_MAX_RETRIES
 from daimon.core.db import build_engine, build_session_factory
 from daimon.core.defaults.loader import parse_deployment_default
 from daimon.core.github_credentials import build_multifernet
@@ -93,6 +94,7 @@ async def build_runtime(settings: Settings) -> AsyncIterator[SlackRuntime]:
         AsyncAnthropic(
             api_key=settings.anthropic.api_key.get_secret_value(),
             base_url=str(settings.anthropic.base_url),
+            max_retries=MA_MAX_RETRIES,
         ) as anthropic,
         httpx.AsyncClient(timeout=30.0) as http_client,
     ):

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -2399,3 +2399,108 @@ async def test_on_request_view_submission_match_acks_update_and_spawns_purge() -
         "matching username must ack with response_action=update (Deleting… view)"
     )
     mock_purge.assert_called_once()  # pyright: ignore[reportUnknownMemberType]
+
+
+async def test_handle_app_mention_slack_connect_external_when_in_thread_rejects_in_thread(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """An in-thread Slack Connect rejection must carry the event's thread_ts.
+
+    Without it the notice posts at channel root while the sender is watching
+    the thread, and a refused mention is indistinguishable from a dead bot.
+    """
+    team_id = "T_APP_CONNECT_THREAD"
+    parent_ts = "1000000009.000001"
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
+    await upsert_slack_bot_token(
+        db_session,
+        team_id=team_id,
+        encrypted_token=encrypt_token(fernet, "xoxb-connect-thread"),
+    )
+    await db_session.flush()
+
+    app = _make_app(db_session_factory, crypto_key=fernet_key)
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "channel": "C_TEST",
+        "event_ts": "1000000009.000002",
+        "ts": "1000000009.000002",
+        "thread_ts": parent_ts,
+        "user": "U_EXTERNAL",
+        "user_team": "T_EXTERNAL",
+        "text": "<@U_BOT> hello",
+    }
+
+    await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
+
+    ephemeral_calls = [
+        req
+        for (_, url), reqs in fake_slack_web_client.mock.requests.items()
+        if url == URL("https://slack.com/api/chat.postEphemeral")
+        for req in reqs
+    ]
+    assert len(ephemeral_calls) == 1, "the Connect rejection must be posted exactly once"
+    assert ephemeral_calls[0].kwargs["json"]["thread_ts"] == parent_ts, (
+        "an in-thread rejection must be posted into that thread, not at channel root"
+    )
+
+
+async def test_orchestrate_tenant_cap_when_in_thread_sheds_in_thread(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """An in-thread over-cap load shed must carry the event's thread_ts.
+
+    A shed turn posts nothing else, so a notice at channel root leaves the
+    thread looking exactly like a dropped turn.
+    """
+    team_id = "T_ORCH_CAP_THREAD"
+    channel = "C_TEST"
+    event_ts = "9000000009.000002"
+    parent_ts = "9000000009.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+    cap = 1
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
+
+    app, _ = _make_orchestrate_app(db_session_factory, max_concurrent_turns_per_tenant=cap)
+    app._inflight[tenant_id] = cap  # pyright: ignore[reportPrivateUsage]
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": event_ts,
+        "event_ts": event_ts,
+        "thread_ts": parent_ts,
+        "channel": channel,
+        "user": "U_TEST_CAP_THREAD",
+        "text": "<@U_BOT> hello",
+    }
+
+    with patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn:
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            event,
+            team_id=team_id,
+            channel=channel,
+            event_ts=event_ts,
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+        )
+
+    ephemeral_calls = [
+        req
+        for (_, url), reqs in fake_slack_web_client.mock.requests.items()
+        if url == URL("https://slack.com/api/chat.postEphemeral")
+        for req in reqs
+    ]
+    assert len(ephemeral_calls) == 1, "the load shed must be announced exactly once"
+    assert ephemeral_calls[0].kwargs["json"]["thread_ts"] == parent_ts, (
+        "an in-thread shed must be announced in that thread, not at channel root"
+    )
+    mock_run_turn.assert_not_called()  # pyright: ignore[reportUnknownMemberType]

--- a/packages/adapters/slack/tests/test_interactions.py
+++ b/packages/adapters/slack/tests/test_interactions.py
@@ -23,6 +23,10 @@ from daimon.adapters.slack.runtime import SlackRuntime
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
 from pydantic import SecretStr
+from slack_sdk.http_retry.builtin_async_handlers import (
+    AsyncConnectionErrorRetryHandler,
+    AsyncRateLimitErrorRetryHandler,
+)
 from slack_sdk.web.async_client import AsyncWebClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -87,4 +91,48 @@ async def test_resolve_web_client_returns_async_web_client_with_decrypted_token(
     assert isinstance(result, AsyncWebClient), "resolve_web_client should return an AsyncWebClient"
     assert result.token == plaintext_token, (
         "resolve_web_client should decrypt and use the stored token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_web_client_registers_rate_limit_retry_handler(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The resolved client must retry 429s, not raise on the first one.
+
+    slack_sdk's default handler set is connection-error only, so without this
+    every rate-limited call raises SlackApiError into a boundary that posts
+    nothing. The connection-error default must survive alongside it.
+    """
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+    await upsert_slack_bot_token(
+        db_session,
+        team_id="T_RETRY",
+        encrypted_token=encrypt_token(fernet, "xoxb-retry-handlers"),
+    )
+    await db_session.flush()
+
+    settings = MagicMock()
+    settings.crypto.keys = (SecretStr(fernet_key),)
+    runtime = SlackRuntime(
+        settings=settings,
+        anthropic=MagicMock(spec=AsyncAnthropic),
+        sessionmaker=db_session_factory,
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+    client = await resolve_web_client(runtime, team_id="T_RETRY")
+
+    assert client is not None, "a seeded token row must yield a client"
+    handler_types = {type(handler) for handler in client.retry_handlers}
+    assert AsyncRateLimitErrorRetryHandler in handler_types, (
+        "a 429 must be retried, not raised on the first response"
+    )
+    assert AsyncConnectionErrorRetryHandler in handler_types, (
+        "the SDK's default connection-error retry must survive the override"
     )

--- a/scripts/lint_anti_patterns.sh
+++ b/scripts/lint_anti_patterns.sh
@@ -73,6 +73,7 @@ PROD_SEARCH_PATHS=(
   "packages/adapters/discord/daimon"
   "packages/adapters/mcp/daimon"
   "packages/adapters/scheduler/daimon"
+  "packages/adapters/slack/daimon"
 )
 
 # Files where each rule's match is acceptable (e.g. the fixture file itself
@@ -89,6 +90,7 @@ ALLOWLIST_T5=(
   "mcp/tools/agents.py"
   "cli/commands/agents.py"
   "discord/agent_setup/write.py"
+  "slack/agent_setup/write.py"
   # preflight probe agents are archived immediately — never host sessions/skills.
   "core/defaults/preflight.py"
 )


### PR DESCRIPTION
## Summary

Five small, independent Slack-parity defects, one commit each. Every one is a live gap where the Slack path silently does less than the Discord path.

| Commit | Fix |
|---|---|
| `chore(lint)` | `PROD_SEARCH_PATHS` covered every package **except** the Slack adapter, so T4/T5/T7/T8 never looked at Slack production code. Adding it immediately surfaced the real `beta.agents.create` in `slack/agent_setup/write.py` (it guarantees the base toolset the same way its Discord twin does, so it joins `ALLOWLIST_T5` — the twin was already listed, which is what makes the omission an oversight). |
| `fix(adapters)` MA retries | `slack/runtime.py` and `scheduler/main.py` built `AsyncAnthropic` with no `max_retries`, running on the SDK default of 2 while Discord and the CLI ride out 8. A transient MA 429/5xx that Discord survives failed a Slack turn — into a boundary that posts nothing. |
| `fix(adapters)` Slack retries | Every `AsyncWebClient` was constructed bare, and slack_sdk 3.42's default handler set is `AsyncConnectionErrorRetryHandler` **only**, so every 429 raised `SlackApiError` on the first response. Slack caps non-Marketplace apps at 1 `conversations.history`/`conversations.replies` call per minute, which both the turn-context builder and the model-facing read tools trip. |
| `fix(slack)` thread_ts | The Slack Connect rejection and the over-cap load shed omitted `thread_ts`, so an in-thread mention got its refusal at channel root. Neither site posts anything else, so a refused mention was indistinguishable from a dropped one. |
| `fix(cli)` | `tenants._validate_platform` accepted only `discord`/`cli`, making every Slack install unreachable from `tenants list` / `tenants delete`. `agents backfill-toolset` and `agents rekey-guild-ownership` hardcoded `platform="discord"`, silently skipping every Slack tenant. |

## Two decisions worth a look

**Retry count.** `AsyncRateLimitErrorRetryHandler` keeps its default single retry. It honours `Retry-After`, and under the 1/min cap that wait can be a full minute — more retries means a turn parked for minutes, which is worse than a legible failure. Also: passing an explicit `retry_handlers=` list *replaces* the SDK default entirely, so the connection-error handler is re-added at every site; dropping it would have traded one bug for another.

**`thread_ts` with no `ts` fallback.** Only the event's real `thread_ts` is passed. A `ts` fallback would tuck the notice into a thread that does not exist yet on a channel-root mention. The first-turn Connect nudge keeps its fallback because its status message lives in that same synthetic thread; these two sites have no such anchor. Net effect: in-thread mentions fixed, root mentions unchanged.

The retry helper is duplicated in the MCP package rather than shared — adapters must not import each other, and lifting it to core would mean adding `slack-sdk` to core's dependencies for one two-line function.

## Testing

6 new tests, each verified failing with its fix reverted and passing with it:

- in-thread Connect rejection and in-thread over-cap shed each assert `thread_ts` on the posted `chat.postEphemeral` body (via the existing `aioresponses` transport fake, so the real SDK serialisation runs)
- rate-limit **and** connection-error handlers present on the Slack per-event client and on both MCP clients (bot-token and user-token paths)
- `tenants list --platform slack` returns only Slack tenants; an unknown platform still raises `BadParameter`
- `backfill-toolset` patches a Slack tenant's toolless agent; `rekey-guild-ownership` re-keys a Slack tenant's user-owned agent to the derived guild account

No test for the two `max_retries=` kwargs — a literal constant on a constructor call.

Full suite: **4570 passed, 4 skipped**. `pyright` 0 errors, `ruff check` clean, `lint-imports` 6/6 kept, anti-pattern lint 9/9 clean with Slack now in scope.

## Notes

- Also drops a stale internal designator from a `rekey-guild-ownership` docstring line this PR was already editing.
- The `thread_ts` commit fixes #96. #95 (the Cancel button's silent refusals) is the related-but-separate half and is not in here.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
