### PR TITLE
Slack message feedback: vote buttons on the final answer

### DIFF
--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -62,6 +62,11 @@ from daimon.adapters.slack.credential_requests import (
     run_repo_bind_credential_submission,
     run_skill_repo_credential_submission,
 )
+from daimon.adapters.slack.feedback import (
+    evaluate_feedback_text_submission,
+    handle_feedback_vote,
+    run_feedback_text_submission,
+)
 from daimon.adapters.slack.gating import is_external_interactive, is_slack_connect_external
 from daimon.adapters.slack.help import handle_help_command
 from daimon.adapters.slack.interactions import build_retry_handlers, resolve_web_client
@@ -581,6 +586,39 @@ class SlackApp:
                             log.info("slack.on_request.unknown_credential_kind", kind=_d.kind)
 
                     self._spawn(_run_credential_submission())
+            elif cb_id == "feedback_text":
+                # Pure evaluate (no I/O) — must run before the single ack.
+                _fb_decision = evaluate_feedback_text_submission(payload)
+                await (
+                    client.send_socket_mode_response(  # ACK WITH PAYLOAD — pure call above, no I/O
+                        SocketModeResponse(
+                            envelope_id=req.envelope_id,
+                            payload=_fb_decision.response_payload,
+                        )
+                    )
+                )
+                if _fb_decision.proceed:
+                    _fb_team_info: dict[str, Any] = payload.get("team") or {}
+                    _fb_user_info: dict[str, Any] = payload.get("user") or {}
+
+                    async def _run_feedback_text(
+                        *,
+                        _t: str = str(_fb_team_info.get("id") or ""),
+                        _u: str = str(_fb_user_info.get("id") or ""),
+                        _c: str = _fb_decision.channel_id,
+                        _f: str = _fb_decision.feedback_id,
+                        _x: str = _fb_decision.text,
+                    ) -> None:
+                        await run_feedback_text_submission(
+                            self.runtime,
+                            team_id=_t,
+                            user_id=_u,
+                            channel_id=_c,
+                            feedback_id=_f,
+                            text=_x,
+                        )
+
+                    self._spawn(_run_feedback_text())
             else:
                 # Unknown view_submission callback_id — log and ack empty (T-82-20).
                 log.info("slack.on_request.unknown_view_submission_callback", callback_id=cb_id)
@@ -657,6 +695,8 @@ class SlackApp:
                     self._spawn(handle_agent_setup_action(self.runtime, payload))
                 elif action_id == SLACK_CREDENTIAL_ACTION_ID:
                     self._spawn(handle_credential_request_click(self.runtime, payload))
+                elif action_id.startswith("feedback_vote:"):
+                    self._spawn(handle_feedback_vote(self.runtime, payload))
         else:
             # Log unrecognised envelope types so the envelope key can be
             # confirmed or corrected from staging logs (T-82-20).

--- a/packages/adapters/slack/daimon/adapters/slack/feedback.py
+++ b/packages/adapters/slack/daimon/adapters/slack/feedback.py
@@ -1,0 +1,306 @@
+"""Slack message-feedback surface — vote buttons, modal, and handlers.
+
+Discord captures feedback through seeded reactions; Slack deliberately does
+not (see the scope discussion in ``daimon.core.message_feedback``), so this
+module uses buttons on the final answer message instead. A button click is a
+``block_actions`` payload — it already carries team, channel, message ``ts``
+and the clicking user, and its ``trigger_id`` can open the "What went wrong?"
+modal directly, so no new OAuth scope and no DM bridge is needed.
+
+The answer message is shared across every viewer, which is why the two vote
+buttons never change appearance after a click: a selected state on a shared
+surface would broadcast one person's vote to the channel. Per-user
+acknowledgement happens through an ephemeral instead.
+
+Hygiene contract (mirrors the Discord feedback modal): the submitted text is
+somebody's unsolicited criticism and belongs in exactly one place — the
+database row. It never enters a log record, an action_id, private_metadata,
+or any non-ephemeral message. Log lines carry the feedback row id only.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import uuid
+from typing import Any, cast
+
+import structlog
+from daimon.adapters.slack.interactions import resolve_web_client
+from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.message_feedback import Vote, should_trigger_feedback_dm
+from daimon.core.stores.identity import find_platform_principal
+from daimon.core.stores.message_feedback import attach_feedback_text, record_vote
+from daimon.core.stores.tenants import get_tenant
+from daimon.core.stores.thread_sessions import get_latest_thread_session
+
+__all__ = [
+    "FEEDBACK_TEXT_CALLBACK_ID",
+    "FEEDBACK_VOTE_DOWN",
+    "FEEDBACK_VOTE_UP",
+    "FeedbackTextDecision",
+    "build_feedback_actions_block",
+    "build_feedback_modal",
+    "evaluate_feedback_text_submission",
+    "handle_feedback_vote",
+    "run_feedback_text_submission",
+    "vote_for_action_id",
+]
+
+log = structlog.get_logger()
+
+_THANKS_VOTE = "Thanks — noted."
+_THANKS_TEXT = "Thanks — your feedback has been recorded."
+_NO_LONGER_AVAILABLE = "This feedback request is no longer available."
+
+FEEDBACK_VOTE_UP = "feedback_vote:up"
+FEEDBACK_VOTE_DOWN = "feedback_vote:down"
+FEEDBACK_TEXT_CALLBACK_ID = "feedback_text"
+
+_TEXT_BLOCK_ID = "feedback_text_block"
+_TEXT_INPUT_ID = "feedback_text_input"
+
+
+def build_feedback_actions_block() -> dict[str, Any]:
+    """The 👍/👎 actions block appended to the last chunk of a final answer.
+
+    Both buttons are deliberately unstyled — the message is shared, so any
+    per-click visual state would leak one viewer's vote to everyone else.
+    """
+    return {
+        "type": "actions",
+        "block_id": "feedback_vote",
+        "elements": [
+            {
+                "type": "button",
+                "action_id": FEEDBACK_VOTE_UP,
+                "text": {"type": "plain_text", "text": "\N{THUMBS UP SIGN}"},
+            },
+            {
+                "type": "button",
+                "action_id": FEEDBACK_VOTE_DOWN,
+                "text": {"type": "plain_text", "text": "\N{THUMBS DOWN SIGN}"},
+            },
+        ],
+    }
+
+
+def vote_for_action_id(action_id: str) -> Vote | None:
+    """Classify a block_actions action_id as a vote, or None for anything else."""
+    if action_id == FEEDBACK_VOTE_UP:
+        return "up"
+    if action_id == FEEDBACK_VOTE_DOWN:
+        return "down"
+    return None
+
+
+def build_feedback_modal(*, feedback_id: str, channel_id: str) -> dict[str, Any]:
+    """The "What went wrong?" modal opened on a genuinely new down-vote.
+
+    ``private_metadata`` carries the feedback row id (the write handle for
+    ``attach_feedback_text``) and the channel id (a view_submission payload
+    has no channel of its own, and the post-submit ephemeral needs one).
+    """
+    return {
+        "type": "modal",
+        "callback_id": FEEDBACK_TEXT_CALLBACK_ID,
+        "private_metadata": json.dumps(
+            {"feedback_id": feedback_id, "channel_id": channel_id},
+            separators=(",", ":"),
+        ),
+        "title": {"type": "plain_text", "text": "What went wrong?"},
+        "submit": {"type": "plain_text", "text": "Send"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": [
+            {
+                "type": "input",
+                "block_id": _TEXT_BLOCK_ID,
+                "label": {"type": "plain_text", "text": "What went wrong?"},
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": _TEXT_INPUT_ID,
+                    "multiline": True,
+                    "max_length": 4000,
+                },
+            }
+        ],
+    }
+
+
+@dataclasses.dataclass(frozen=True)
+class FeedbackTextDecision:
+    """Outcome of the pure pre-ack evaluation of a feedback_text submission.
+
+    ``response_payload`` is the ack body (``response_action: errors``) when
+    the submission is rejected, or None for an empty ack that closes the
+    modal. ``text`` is carried in memory only — it must never be logged.
+    """
+
+    proceed: bool
+    response_payload: dict[str, Any] | None
+    text: str
+    feedback_id: str
+    channel_id: str
+
+
+def evaluate_feedback_text_submission(payload: dict[str, Any]) -> FeedbackTextDecision:
+    """Pure (no I/O) evaluation of the feedback_text view_submission.
+
+    The client already enforces the input as required, but that is not
+    trusted alone: whitespace-only text is rejected server-side with a field
+    error so the person can retype rather than lose the modal.
+    """
+    view: dict[str, Any] = payload.get("view") or {}
+    meta: dict[str, Any]
+    try:
+        meta = json.loads(str(view.get("private_metadata") or "") or "{}")
+    except json.JSONDecodeError:
+        meta = {}
+    state: dict[str, Any] = view.get("state") or {}
+    values: dict[str, Any] = state.get("values") or {}
+    block: dict[str, Any] = values.get(_TEXT_BLOCK_ID) or {}
+    element: dict[str, Any] = block.get(_TEXT_INPUT_ID) or {}
+    raw_text = str(element.get("value") or "")
+    feedback_id = str(meta.get("feedback_id") or "")
+    channel_id = str(meta.get("channel_id") or "")
+
+    if not raw_text.strip():
+        return FeedbackTextDecision(
+            proceed=False,
+            response_payload={
+                "response_action": "errors",
+                "errors": {_TEXT_BLOCK_ID: "Feedback cannot be empty — try again."},
+            },
+            text="",
+            feedback_id=feedback_id,
+            channel_id=channel_id,
+        )
+    return FeedbackTextDecision(
+        proceed=True,
+        response_payload=None,
+        text=raw_text,
+        feedback_id=feedback_id,
+        channel_id=channel_id,
+    )
+
+
+async def handle_feedback_vote(runtime: SlackRuntime, payload: dict[str, Any]) -> None:
+    """Record a 👍/👎 button click as a vote; open the modal on a new down-vote.
+
+    The button lives only on bot-authored answer messages, so the
+    bot-authorship question the Discord reaction listener has to settle does
+    not arise here — the action_id itself is the classification.
+
+    Identity handling mirrors the Discord listener: the principal lookup is
+    read-only (a vote must not mint an identity record), and the thread
+    session is a best-effort attribution hint only.
+    """
+    team_info: dict[str, Any] = payload.get("team") or {}
+    user_info: dict[str, Any] = payload.get("user") or {}
+    channel_info: dict[str, Any] = payload.get("channel") or {}
+    container: dict[str, Any] = payload.get("container") or {}
+    message: dict[str, Any] = payload.get("message") or {}
+    team_id = str(team_info.get("id") or "")
+    user_id = str(user_info.get("id") or "")
+    channel_id = str(channel_info.get("id") or "")
+    message_ts = str(container.get("message_ts") or "")
+    thread_ts = str(message.get("thread_ts") or "") or message_ts
+    trigger_id = str(payload.get("trigger_id") or "")
+    actions: list[dict[str, Any]] = payload.get("actions") or []
+    action_id = str(actions[0].get("action_id") or "") if actions else ""
+
+    vote = vote_for_action_id(action_id)
+    if vote is None or not (team_id and user_id and channel_id and message_ts):
+        return
+
+    client = await resolve_web_client(runtime, team_id=team_id)
+    if client is None:
+        return
+
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+    async with runtime.sessionmaker() as session, session.begin():
+        tenant = await get_tenant(session, tenant_id)
+        if tenant is None:
+            log.info("feedback.tenant_missing", tenant_id=str(tenant_id))
+            return
+
+        thread_row = await get_latest_thread_session(
+            session, tenant_id=tenant_id, platform="slack", thread_id=thread_ts
+        )
+        principal = await find_platform_principal(
+            session, tenant_id=tenant_id, platform="slack", external_id=user_id
+        )
+        result = await record_vote(
+            session,
+            tenant_id=tenant_id,
+            platform="slack",
+            message_id=message_ts,
+            channel_id=channel_id,
+            platform_user_id=user_id,
+            account_id=principal.account_id if principal is not None else None,
+            ma_session_id=thread_row.ma_session_id if thread_row is not None else None,
+            vote=vote,
+        )
+
+    previous_vote = cast("Vote | None", result.previous_vote)
+    log.info(
+        "feedback.vote_recorded",
+        message_id=message_ts,
+        vote=vote,
+        is_new_vote=previous_vote != vote,
+    )
+
+    if should_trigger_feedback_dm(previous_vote=previous_vote, new_vote=vote) and trigger_id:
+        await client.views_open(  # pyright: ignore[reportUnknownMemberType]
+            trigger_id=trigger_id,
+            view=build_feedback_modal(feedback_id=str(result.row.id), channel_id=channel_id),
+        )
+        return
+
+    await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+        channel=channel_id, user=user_id, text=_THANKS_VOTE
+    )
+
+
+async def run_feedback_text_submission(
+    runtime: SlackRuntime,
+    *,
+    team_id: str,
+    user_id: str,
+    channel_id: str,
+    feedback_id: str,
+    text: str,
+) -> None:
+    """Write the modal's free text through the ownership-predicated store call.
+
+    A ``None`` from ``attach_feedback_text`` covers both "the row was purged"
+    and "this row belongs to someone else" — the ephemeral reply deliberately
+    does not distinguish the two, so a submission carrying someone else's row
+    id learns nothing about whether that row exists.
+    """
+    try:
+        row_id = uuid.UUID(feedback_id)
+    except ValueError:
+        log.info("feedback.submission_bad_row_id")
+        return
+
+    client = await resolve_web_client(runtime, team_id=team_id)
+    if client is None:
+        return
+
+    async with runtime.sessionmaker() as session, session.begin():
+        updated = await attach_feedback_text(
+            session, feedback_id=row_id, platform_user_id=user_id, feedback_text=text
+        )
+
+    if updated is None:
+        log.info("feedback.submission_no_longer_available", feedback_id=feedback_id)
+        reply = _NO_LONGER_AVAILABLE
+    else:
+        log.info("feedback.submission_recorded", feedback_id=feedback_id)
+        reply = _THANKS_TEXT
+
+    await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+        channel=channel_id, user=user_id, text=reply
+    )

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -34,6 +34,7 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
     BetaManagedAgentsSpanModelUsage,
 )
 from daimon.adapters.slack.blockkit import EmbedEvent, State, TurnPhase, to_blocks, update
+from daimon.adapters.slack.feedback import build_feedback_actions_block
 from daimon.adapters.slack.mrkdwn import escape_mrkdwn_preserving_mentions
 from daimon.adapters.slack.split import split_for_slack_safe
 from daimon.core.observability import capture_exception_with_scope
@@ -310,23 +311,30 @@ class SlackTurnLifecycle:
             first_chunk = chunks[0]
             # First chunk + the cost/usage footer replace the status message
             # in place; the terminal footer carries elapsed/tokens/cost and drops
-            # the cancel button.
+            # the cancel button. The feedback vote buttons ride the LAST chunk
+            # only, so a vote's message_id keys the same message final_ts (and
+            # the watermark) point at.
             self._terminal = True
             first_blocks: list[dict[str, Any]] = [
                 {"type": "markdown", "text": first_chunk},
                 *to_blocks(self._state, now=self._clock()),
             ]
+            if len(chunks) == 1:
+                first_blocks.append(build_feedback_actions_block())
             await self._post_or_update(first_blocks, _notification_text(first_chunk))
             surface_replaced = True
             assert self._status_ts is not None  # narrowing — _post_or_update always sets it
             current_ts = self._status_ts
 
             # Overflow chunks posted as new thread replies.
-            for chunk in chunks[1:]:
+            for i, chunk in enumerate(chunks[1:], start=2):
+                chunk_blocks: list[dict[str, Any]] = [{"type": "markdown", "text": chunk}]
+                if i == len(chunks):
+                    chunk_blocks.append(build_feedback_actions_block())
                 resp = await self._client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
                     channel=self._channel,
                     thread_ts=self._thread_ts,
-                    blocks=[{"type": "markdown", "text": chunk}],
+                    blocks=chunk_blocks,
                     text=_notification_text(chunk),
                 )
                 current_ts = cast(str, resp["ts"])  # pyright: ignore[reportUnknownVariableType]

--- a/packages/adapters/slack/tests/__snapshots__/test_lifecycle_snapshots.ambr
+++ b/packages/adapters/slack/tests/__snapshots__/test_lifecycle_snapshots.ambr
@@ -149,6 +149,28 @@
             ]),
             'type': 'context',
           }),
+          dict({
+            'block_id': 'feedback_vote',
+            'elements': list([
+              dict({
+                'action_id': 'feedback_vote:up',
+                'text': dict({
+                  'text': '👍',
+                  'type': 'plain_text',
+                }),
+                'type': 'button',
+              }),
+              dict({
+                'action_id': 'feedback_vote:down',
+                'text': dict({
+                  'text': '👎',
+                  'type': 'plain_text',
+                }),
+                'type': 'button',
+              }),
+            ]),
+            'type': 'actions',
+          }),
         ]),
         'text': 'Here is the answer.',
       }),

--- a/packages/adapters/slack/tests/test_app_feedback_dispatch.py
+++ b/packages/adapters/slack/tests/test_app_feedback_dispatch.py
@@ -1,0 +1,159 @@
+"""Dispatch tests for the feedback routes in SlackApp.on_request.
+
+Covers:
+- feedback_vote:* block_action: empty ack first, then handle_feedback_vote spawns
+- feedback_text view_submission: valid text acks empty and spawns
+  run_feedback_text_submission; whitespace-only text acks with a
+  response_action errors payload and spawns nothing
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+from anthropic import AsyncAnthropic
+from daimon.adapters.slack.app import SlackApp
+from daimon.adapters.slack.feedback import FEEDBACK_TEXT_CALLBACK_ID, FEEDBACK_VOTE_UP
+from daimon.adapters.slack.runtime import SlackRuntime
+from pydantic import SecretStr
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode.response import SocketModeResponse
+
+
+@dataclasses.dataclass
+class _FakeSocketClient:
+    """Minimal Socket Mode client fake — records call order and ack payloads."""
+
+    call_log: list[str] = dataclasses.field(default_factory=list[str])
+    sent_responses: list[SocketModeResponse] = dataclasses.field(
+        default_factory=list[SocketModeResponse]
+    )
+
+    async def send_socket_mode_response(self, response: SocketModeResponse) -> None:
+        self.call_log.append("send_socket_mode_response")
+        self.sent_responses.append(response)
+
+    async def close(self) -> None:
+        self.call_log.append("close")
+
+
+def _make_app() -> SlackApp:
+    settings = MagicMock()
+    settings.crypto.keys = (SecretStr("dummykey"),)
+    settings.slack.max_concurrent_turns_per_tenant = 3
+    runtime = SlackRuntime(
+        settings=settings,
+        anthropic=MagicMock(spec=AsyncAnthropic),
+        sessionmaker=MagicMock(),
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+    return SlackApp(runtime=runtime)
+
+
+async def _drain(app: SlackApp) -> None:
+    pending = list(app._bg_tasks)  # pyright: ignore[reportPrivateUsage]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _vote_request() -> SocketModeRequest:
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id="env_feedback_vote_001",
+        payload={
+            "type": "block_actions",
+            "team": {"id": "T_TEST"},
+            "user": {"id": "U_TEST", "team_id": "T_TEST"},
+            "channel": {"id": "C_TEST"},
+            "container": {"message_ts": "1700000001.000100"},
+            "trigger_id": "trig_feedback_001",
+            "actions": [{"action_id": FEEDBACK_VOTE_UP}],
+        },
+    )
+
+
+def _text_submission_request(text: str) -> SocketModeRequest:
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id="env_feedback_text_001",
+        payload={
+            "type": "view_submission",
+            "team": {"id": "T_TEST"},
+            "user": {"id": "U_TEST"},
+            "view": {
+                "callback_id": FEEDBACK_TEXT_CALLBACK_ID,
+                "id": "V_TEST",
+                "private_metadata": json.dumps(
+                    {"feedback_id": "0b6ef01e-9f0a-4bb6-a30c-111111111111", "channel_id": "C_TEST"}
+                ),
+                "state": {
+                    "values": {
+                        "feedback_text_block": {"feedback_text_input": {"value": text}},
+                    }
+                },
+            },
+        },
+    )
+
+
+async def test_feedback_vote_block_action_acks_then_spawns_handler() -> None:
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+    spawned: list[str] = []
+
+    async def _fake_handle(runtime: Any, payload: Any) -> None:
+        spawned.append(str(payload["actions"][0]["action_id"]))
+
+    with patch("daimon.adapters.slack.app.handle_feedback_vote", new=_fake_handle):
+        await app.on_request(fake_client, _vote_request())  # type: ignore[arg-type]
+        await _drain(app)
+
+    assert fake_client.call_log[0] == "send_socket_mode_response", (
+        "a feedback vote must ack first, before any handler work"
+    )
+    assert spawned == [FEEDBACK_VOTE_UP], "handle_feedback_vote must be spawned for the vote"
+
+
+async def test_feedback_text_submission_valid_acks_empty_and_spawns_run() -> None:
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+    ran: list[str] = []
+
+    async def _fake_run(runtime: Any, **kwargs: Any) -> None:
+        ran.append(str(kwargs["text"]))
+
+    with patch("daimon.adapters.slack.app.run_feedback_text_submission", new=_fake_run):
+        await app.on_request(fake_client, _text_submission_request("it was wrong"))  # type: ignore[arg-type]
+        await _drain(app)
+
+    assert fake_client.sent_responses[0].payload is None, (
+        "valid feedback text must ack empty so the modal closes"
+    )
+    assert ran == ["it was wrong"], "run_feedback_text_submission must receive the text"
+
+
+async def test_feedback_text_submission_whitespace_acks_errors_and_spawns_nothing() -> None:
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+    ran: list[str] = []
+
+    async def _fake_run(runtime: Any, **kwargs: Any) -> None:
+        ran.append(str(kwargs["text"]))
+
+    with patch("daimon.adapters.slack.app.run_feedback_text_submission", new=_fake_run):
+        await app.on_request(fake_client, _text_submission_request("   "))  # type: ignore[arg-type]
+        await _drain(app)
+
+    ack = fake_client.sent_responses[0].payload
+    assert isinstance(ack, dict) and ack.get("response_action") == "errors", (
+        "whitespace-only text must ack with a field error"
+    )
+    assert ran == [], "a rejected submission must not spawn the background write"

--- a/packages/adapters/slack/tests/test_feedback.py
+++ b/packages/adapters/slack/tests/test_feedback.py
@@ -1,0 +1,366 @@
+"""Tests for the Slack message-feedback surface (feedback.py).
+
+Behavioral assertions — grouped by unit:
+
+Pure builders / classification:
+  - build_feedback_actions_block renders one actions block with the two vote
+    buttons and no other elements.
+  - vote_for_action_id classifies the two known action_ids and nothing else.
+  - build_feedback_modal carries the feedback row id and channel through
+    private_metadata and uses the feedback_text callback_id.
+  - evaluate_feedback_text_submission rejects whitespace-only text with a
+    response_action errors payload and passes real text through untouched.
+
+handle_feedback_vote (real Postgres + transport-level FakeSlackWebClient):
+  - Up-vote records a row and acks with chat.postEphemeral; no modal.
+  - Fresh down-vote opens the modal carrying the vote row's id.
+  - Repeat down-vote does not re-open the modal.
+  - Unregistered tenant records nothing and stays silent.
+
+run_feedback_text_submission:
+  - Attaches text to the voter's own row and acks ephemerally.
+  - Someone else's row id writes nothing and does not reveal whether the
+    row exists.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import yarl
+from cryptography.fernet import Fernet
+from daimon.adapters.slack.feedback import (
+    FEEDBACK_TEXT_CALLBACK_ID,
+    FEEDBACK_VOTE_DOWN,
+    FEEDBACK_VOTE_UP,
+    build_feedback_actions_block,
+    build_feedback_modal,
+    evaluate_feedback_text_submission,
+    handle_feedback_vote,
+    run_feedback_text_submission,
+    vote_for_action_id,
+)
+from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+from daimon.testing.factories import make_tenant
+from daimon.testing.ma import build_fake_anthropic, make_fake_ma_handler
+from pydantic import SecretStr
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+# ---------------------------------------------------------------------------
+# build_feedback_actions_block
+# ---------------------------------------------------------------------------
+
+
+def test_actions_block_has_exactly_the_two_vote_buttons() -> None:
+    block = build_feedback_actions_block()
+    assert block["type"] == "actions"
+    action_ids = [e["action_id"] for e in block["elements"]]
+    assert action_ids == [FEEDBACK_VOTE_UP, FEEDBACK_VOTE_DOWN]
+
+
+def test_vote_buttons_carry_no_state_or_style() -> None:
+    """The message is shared across viewers — a styled button would leak one
+    person's vote to everyone, so both buttons must stay unstyled."""
+    block = build_feedback_actions_block()
+    for element in block["elements"]:
+        assert "style" not in element
+
+
+# ---------------------------------------------------------------------------
+# vote_for_action_id
+# ---------------------------------------------------------------------------
+
+
+def test_vote_for_action_id_classifies_up() -> None:
+    assert vote_for_action_id(FEEDBACK_VOTE_UP) == "up"
+
+
+def test_vote_for_action_id_classifies_down() -> None:
+    assert vote_for_action_id(FEEDBACK_VOTE_DOWN) == "down"
+
+
+def test_vote_for_action_id_rejects_unknown() -> None:
+    assert vote_for_action_id("cancel_turn") is None
+    assert vote_for_action_id("") is None
+    assert vote_for_action_id("feedback_vote:sideways") is None
+
+
+# ---------------------------------------------------------------------------
+# build_feedback_modal
+# ---------------------------------------------------------------------------
+
+
+def test_modal_carries_feedback_id_and_channel_in_private_metadata() -> None:
+    view = build_feedback_modal(
+        feedback_id="0b6ef01e-9f0a-4bb6-a30c-111111111111",
+        channel_id="C_FEED",
+    )
+    assert view["callback_id"] == FEEDBACK_TEXT_CALLBACK_ID
+    meta = json.loads(view["private_metadata"])
+    assert meta["feedback_id"] == "0b6ef01e-9f0a-4bb6-a30c-111111111111"
+    assert meta["channel_id"] == "C_FEED"
+
+
+def test_modal_has_one_required_text_input() -> None:
+    view = build_feedback_modal(feedback_id="x", channel_id="C")
+    inputs = [b for b in view["blocks"] if b["type"] == "input"]
+    assert len(inputs) == 1
+    assert inputs[0]["element"]["multiline"] is True
+
+
+# ---------------------------------------------------------------------------
+# evaluate_feedback_text_submission
+# ---------------------------------------------------------------------------
+
+
+def _submission_payload(text: str) -> dict[str, Any]:
+    return {
+        "type": "view_submission",
+        "team": {"id": "T_FEED"},
+        "user": {"id": "U_FEED"},
+        "view": {
+            "callback_id": FEEDBACK_TEXT_CALLBACK_ID,
+            "private_metadata": json.dumps(
+                {"feedback_id": "0b6ef01e-9f0a-4bb6-a30c-111111111111", "channel_id": "C_FEED"}
+            ),
+            "state": {
+                "values": {
+                    "feedback_text_block": {"feedback_text_input": {"value": text}},
+                }
+            },
+        },
+    }
+
+
+def test_whitespace_only_text_is_rejected_with_field_error() -> None:
+    decision = evaluate_feedback_text_submission(_submission_payload("   \n"))
+    assert decision.proceed is False
+    assert decision.response_payload is not None
+    assert decision.response_payload["response_action"] == "errors"
+    assert "feedback_text_block" in decision.response_payload["errors"]
+
+
+def test_real_text_proceeds_with_empty_ack() -> None:
+    decision = evaluate_feedback_text_submission(_submission_payload("the answer was wrong"))
+    assert decision.proceed is True
+    assert decision.response_payload is None
+    assert decision.text == "the answer was wrong"
+    assert decision.feedback_id == "0b6ef01e-9f0a-4bb6-a30c-111111111111"
+    assert decision.channel_id == "C_FEED"
+
+
+# ---------------------------------------------------------------------------
+# handle_feedback_vote / run_feedback_text_submission
+# ---------------------------------------------------------------------------
+
+_TEAM_ID = "T_FEEDBACK"
+_USER_ID = "U_VOTER"
+_CHANNEL_ID = "C_FEED"
+_MESSAGE_TS = "1700000001.000100"
+
+_EPHEMERAL_URL = yarl.URL("https://slack.com/api/chat.postEphemeral")
+_VIEWS_OPEN_URL = yarl.URL("https://slack.com/api/views.open")
+
+
+async def _seed_team(session: AsyncSession, *, team_id: str = _TEAM_ID) -> tuple[uuid.UUID, str]:
+    """Create tenant + bot token for a team. Returns (tenant_id, fernet_key)."""
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+    tenant = await make_tenant(session, platform="slack", workspace_id=team_id)
+    await upsert_slack_bot_token(
+        session, team_id=team_id, encrypted_token=encrypt_token(fernet, "xoxb-test")
+    )
+    await session.flush()
+    return tenant.id, fernet_key
+
+
+def _build_runtime(fernet_key: str, db_factory: async_sessionmaker[AsyncSession]) -> SlackRuntime:
+    settings = MagicMock()
+    settings.crypto.keys = (SecretStr(fernet_key),)
+    return SlackRuntime(
+        settings=settings,
+        anthropic=build_fake_anthropic(make_fake_ma_handler()),
+        sessionmaker=db_factory,
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+
+def _vote_payload(action_id: str, *, team_id: str = _TEAM_ID) -> dict[str, Any]:
+    return {
+        "type": "block_actions",
+        "team": {"id": team_id},
+        "user": {"id": _USER_ID},
+        "channel": {"id": _CHANNEL_ID},
+        "container": {"message_ts": _MESSAGE_TS},
+        "message": {"ts": _MESSAGE_TS, "thread_ts": "1700000000.000001"},
+        "trigger_id": "TRIGGER_TEST",
+        "actions": [{"action_id": action_id}],
+    }
+
+
+async def _vote_rows(session: AsyncSession) -> list[Any]:
+    """Read vote rows via plain SQL — adapter tests must not import core._models."""
+    result = await session.execute(
+        text(
+            "SELECT id, vote, message_id, platform_user_id, feedback_text"
+            " FROM message_feedback ORDER BY created_at"
+        )
+    )
+    return list(result.mappings())
+
+
+@pytest.mark.asyncio
+async def test_up_vote_records_row_and_acks_ephemerally(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    _tenant_id, fernet_key = await _seed_team(db_session)
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_feedback_vote(runtime, _vote_payload(FEEDBACK_VOTE_UP))
+
+    async with db_session_factory() as s:
+        rows = await _vote_rows(s)
+    assert len(rows) == 1, "up-vote must upsert exactly one vote row"
+    assert rows[0]["vote"] == "up"
+    assert rows[0]["message_id"] == _MESSAGE_TS
+    assert rows[0]["platform_user_id"] == _USER_ID
+    assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests, (
+        "the voter must get a per-user ephemeral acknowledgement"
+    )
+    assert ("POST", _VIEWS_OPEN_URL) not in fake_slack_web_client.mock.requests, (
+        "an up-vote must not open the what-went-wrong modal"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fresh_down_vote_opens_modal_with_row_id(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    _tenant_id, fernet_key = await _seed_team(db_session)
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_feedback_vote(runtime, _vote_payload(FEEDBACK_VOTE_DOWN))
+
+    async with db_session_factory() as s:
+        rows = await _vote_rows(s)
+    assert len(rows) == 1 and rows[0]["vote"] == "down"
+    opens = fake_slack_web_client.mock.requests.get(("POST", _VIEWS_OPEN_URL), [])
+    assert len(opens) == 1, "a genuinely new down-vote must open the modal"
+    view = opens[0].kwargs["json"]["view"]
+    meta = json.loads(view["private_metadata"])
+    assert meta["feedback_id"] == str(rows[0]["id"]), (
+        "the modal must carry the vote row's id as the write handle"
+    )
+    assert meta["channel_id"] == _CHANNEL_ID
+
+
+@pytest.mark.asyncio
+async def test_repeat_down_vote_does_not_reopen_modal(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    _tenant_id, fernet_key = await _seed_team(db_session)
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_feedback_vote(runtime, _vote_payload(FEEDBACK_VOTE_DOWN))
+    await handle_feedback_vote(runtime, _vote_payload(FEEDBACK_VOTE_DOWN))
+
+    opens = fake_slack_web_client.mock.requests.get(("POST", _VIEWS_OPEN_URL), [])
+    assert len(opens) == 1, "a repeat down-vote must not re-open the modal"
+
+
+@pytest.mark.asyncio
+async def test_unregistered_tenant_records_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    # Bot token exists (client resolvable) but no tenant row for this team.
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+    await upsert_slack_bot_token(
+        db_session, team_id="T_GHOST", encrypted_token=encrypt_token(fernet, "xoxb-test")
+    )
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_feedback_vote(runtime, _vote_payload(FEEDBACK_VOTE_UP, team_id="T_GHOST"))
+
+    async with db_session_factory() as s:
+        rows = await _vote_rows(s)
+    assert rows == [], "a vote in an unregistered workspace must record nothing"
+
+
+@pytest.mark.asyncio
+async def test_submission_attaches_text_to_own_row(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    _tenant_id, fernet_key = await _seed_team(db_session)
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    await handle_feedback_vote(runtime, _vote_payload(FEEDBACK_VOTE_DOWN))
+    async with db_session_factory() as s:
+        row_id = (await _vote_rows(s))[0]["id"]
+
+    await run_feedback_text_submission(
+        runtime,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        feedback_id=str(row_id),
+        text="the numbers were wrong",
+    )
+
+    async with db_session_factory() as s:
+        rows = await _vote_rows(s)
+    assert rows[0]["feedback_text"] == "the numbers were wrong"
+
+
+@pytest.mark.asyncio
+async def test_submission_for_someone_elses_row_writes_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    _tenant_id, fernet_key = await _seed_team(db_session)
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    await handle_feedback_vote(runtime, _vote_payload(FEEDBACK_VOTE_DOWN))
+    async with db_session_factory() as s:
+        row_id = (await _vote_rows(s))[0]["id"]
+
+    await run_feedback_text_submission(
+        runtime,
+        team_id=_TEAM_ID,
+        user_id="U_SOMEONE_ELSE",
+        channel_id=_CHANNEL_ID,
+        feedback_id=str(row_id),
+        text="hijack attempt",
+    )
+
+    async with db_session_factory() as s:
+        rows = await _vote_rows(s)
+    assert rows[0]["feedback_text"] is None, (
+        "a submission carrying someone else's row id must write nothing"
+    )

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -93,6 +93,16 @@ def _has_actions_block(blocks: list[dict[str, Any]]) -> bool:
     return any(b.get("type") == "actions" for b in blocks)
 
 
+def _action_ids(blocks: list[dict[str, Any]]) -> list[str]:
+    """All action_ids across every actions block, in render order."""
+    return [
+        el["action_id"]
+        for b in blocks
+        if b.get("type") == "actions"
+        for el in b.get("elements", [])
+    ]
+
+
 def _block_text(blocks: list[dict[str, Any]]) -> str:
     """Flatten all rendered text in a block list for substring assertions."""
     parts: list[str] = []
@@ -307,7 +317,9 @@ async def test_terminal_success_replaces_status_in_place(fake_slack_web_client: 
     assert any(b["type"] == "context" for b in blocks), (
         "terminal message must include the cost/usage footer context block"
     )
-    assert not _has_actions_block(blocks), "cancel button must be removed on terminal success"
+    assert "cancel_turn" not in _action_ids(blocks), (
+        "cancel button must be removed on terminal success"
+    )
 
 
 async def test_terminal_success_overflow_posts_and_widens_final_ts(
@@ -803,3 +815,69 @@ async def test_lifecycle_satisfies_turn_lifecycle_protocol(fake_slack_web_client
     assert callable(bound.on_reconnect), "on_reconnect must be callable"
     assert callable(bound.on_rate_limited), "on_rate_limited must be callable"
     assert callable(bound.on_interrupt_sent), "on_interrupt_sent must be callable"
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Feedback vote buttons on the final answer
+# ---------------------------------------------------------------------------
+
+
+async def test_terminal_success_appends_feedback_buttons(fake_slack_web_client: Any) -> None:
+    """An answered turn carries the 👍/👎 vote buttons on the final message."""
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    state = TurnState(content=[TextBlock(kind="text", text="The answer is 42.")])
+    await lc.on_terminal_success(state)
+
+    ids = _action_ids(_last_update_blocks(fake_slack_web_client))
+    assert "feedback_vote:up" in ids and "feedback_vote:down" in ids, (
+        "answered turn must render the two feedback vote buttons"
+    )
+
+
+async def test_overflow_puts_feedback_buttons_on_last_chunk_only(
+    fake_slack_web_client: Any,
+) -> None:
+    """With overflow, only the LAST posted chunk carries the vote buttons.
+
+    The buttons must sit on the message final_ts points at, so a vote's
+    message_id keys the same message the watermark does.
+    """
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    long_text = "x" * 24000  # three chunks at _SLACK_LIMIT=11800
+    state = TurnState(content=[TextBlock(kind="text", text=long_text)])
+    await lc.on_terminal_success(state)
+
+    assert "feedback_vote:up" not in _action_ids(_last_update_blocks(fake_slack_web_client)), (
+        "the in-place first chunk must NOT carry vote buttons when overflow follows"
+    )
+    posts = fake_slack_web_client.mock.requests.get(("POST", _POST_URL), [])
+    overflow_bodies = [c.kwargs["json"] for c in posts[1:]]  # posts[0] is the status message
+    assert len(overflow_bodies) >= 2, "expected at least two overflow chunks"
+    for body in overflow_bodies[:-1]:
+        assert "feedback_vote:up" not in _action_ids(body["blocks"]), (
+            "intermediate overflow chunks must not carry vote buttons"
+        )
+    assert "feedback_vote:up" in _action_ids(overflow_bodies[-1]["blocks"]), (
+        "the last overflow chunk must carry the vote buttons"
+    )
+
+
+async def test_tool_only_turn_gets_no_feedback_buttons(fake_slack_web_client: Any) -> None:
+    """A turn with no final answer text must not invite feedback on it."""
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    state = TurnState(
+        content=[
+            ToolUseBlock(kind="tool_use", id="tu_1", type="agent.tool_use", name="bash", input={}),
+        ]
+    )
+    await lc.on_terminal_success(state)
+
+    assert "feedback_vote:up" not in _action_ids(_last_update_blocks(fake_slack_web_client)), (
+        "tool-only turn has no answer to vote on"
+    )

--- a/packages/core/daimon/core/message_feedback.py
+++ b/packages/core/daimon/core/message_feedback.py
@@ -23,18 +23,20 @@ actually keyed on -- the row id is the only handle that is self-sufficient
 there. It is a random UUID, so it is not enumerable, and the write path that
 consumes it additionally gates on the clicking user's own platform id.
 
-Message feedback is deliberately Discord-only. A reaction event on either
-platform carries no interaction handle of its own, so both platforms would
-need the same button-in-DM bridge to turn a down-vote into private feedback
--- the actual blocker is that Slack's bot token lacks the two scopes that
-bridge would need: `reactions:read` (observe the reaction at all) and
-`im:write` (open the direct message to collect feedback). Adding either
-scope forces every installed workspace through a re-authorization flow, so
-the Discord-only scope is a deliberate, not accidental, exemption.
-`tests/parity/test_message_feedback_discord_only.py` is the executable
-record of that exemption -- it fails the day Slack's bot scopes grow either
-`reactions:read` or `im:write` without a Slack feedback path landing
-alongside them.
+Capture differs per platform. Discord seeds thumbs reactions and listens for
+them; a reaction event carries no interaction handle, so Discord bridges a
+down-vote into private feedback via a button delivered in a direct message
+(the `custom_id` grammar above). Slack deliberately does NOT use reactions:
+observing them would need the `reactions:read` bot scope and the DM bridge
+would need `im:write`, and adding either scope forces every installed
+workspace through a re-authorization flow. Slack instead renders vote
+buttons on the final answer message itself
+(`daimon.adapters.slack.feedback`) -- a button click is a block_actions
+payload whose `trigger_id` opens the feedback modal directly, so neither
+scope is needed and `vote_for_reaction`/`is_bot_authored` below have no
+Slack callers. `tests/parity/test_message_feedback_discord_only.py` is the
+executable record of that split -- it fails if either scope quietly appears
+or the Slack button surface disappears.
 """
 
 from __future__ import annotations

--- a/tests/parity/test_message_feedback_discord_only.py
+++ b/tests/parity/test_message_feedback_discord_only.py
@@ -1,37 +1,54 @@
-"""Executable record of message feedback's deliberate Discord-only scope.
+"""Executable record of message feedback's per-platform capture mechanisms.
 
-An absent capability file in this suite is mechanically indistinguishable
-from an oversight: nothing else in the test suite would fail if Slack's bot
-scopes silently grew the two permissions a Slack feedback path would need,
-without anyone building that path or updating the platform-neutral core's
-documented scope. Asserting the exemption here, rather than merely
-documenting it in a comment, makes that drift fail loudly instead of
-silently.
+Discord captures votes through seeded reactions; Slack captures them through
+buttons on the final answer message, chosen specifically so the bot token
+never needs the ``reactions:read`` and ``im:write`` scopes (adding either
+forces every installed workspace through re-authorization). Asserting both
+halves here, rather than merely documenting them, makes drift fail loudly:
+a scope quietly growing without a reason, or the Slack surface disappearing
+while the core still claims both platforms are covered.
 
-No platform parametrization, no database -- this is a scope check, not a
-scenario test.
+No platform parametrization, no database -- this is a scope-and-surface
+check, not a scenario test.
 """
 
 from __future__ import annotations
 
 import daimon.core.message_feedback
+from daimon.adapters.slack.feedback import handle_feedback_vote, run_feedback_text_submission
 from daimon.core.slack_oauth import SLACK_BOT_SCOPES
 
 
 def test_slack_bot_scopes_still_lack_the_reaction_feedback_scopes() -> None:
     assert "reactions:read" not in SLACK_BOT_SCOPES and "im:write" not in SLACK_BOT_SCOPES, (
-        "message feedback is Discord-only because Slack cannot observe reactions or open a "
-        "direct message without the reactions:read and im:write bot scopes; if this test "
-        "fails, either build the Slack feedback path or update this exemption record -- do "
-        "not simply delete the assertion"
+        "Slack feedback deliberately uses buttons instead of reactions so the bot token "
+        "never needs reactions:read or im:write (either scope forces every installed "
+        "workspace to re-authorize); if a scope grew, either the button path was replaced "
+        "on purpose -- update this record -- or the scope is an accident and must go"
     )
 
 
-def test_message_feedback_core_documents_the_discord_only_scope() -> None:
+def test_slack_feedback_surface_exists() -> None:
+    assert callable(handle_feedback_vote) and callable(run_feedback_text_submission), (
+        "the Slack button-based feedback path must exist alongside Discord's reaction path; "
+        "if it was removed on purpose, restore the Discord-only exemption this test replaced"
+    )
+
+
+def test_message_feedback_core_documents_the_per_platform_split() -> None:
     doc = daimon.core.message_feedback.__doc__
 
     assert doc is not None, "daimon.core.message_feedback must carry a module docstring"
     assert "reactions:read" in doc, (
-        "the module docstring must name the reactions:read scope Slack lacks"
+        "the module docstring must name the reactions:read scope the Slack button path avoids"
     )
-    assert "im:write" in doc, "the module docstring must name the im:write scope Slack lacks"
+    assert "im:write" in doc, (
+        "the module docstring must name the im:write scope the Slack button path avoids"
+    )
+    assert "button" in doc.lower(), (
+        "the module docstring must describe the Slack button-based capture path"
+    )
+    assert "Discord-only" not in doc, (
+        "the module docstring must not still claim message feedback is Discord-only -- "
+        "the Slack button path exists now"
+    )


### PR DESCRIPTION
Closes #92.

## Summary

On Discord every answered turn is a feedback opportunity; on Slack an answered turn produced no quality signal at all. This ports the feedback pipeline to Slack — but not the reaction shape the issue sketched.

**Why buttons instead of reactions.** Observing reactions needs `reactions:read`, and the down-vote DM bridge needs `im:write`. Adding either bot scope forces every installed workspace to re-authorize, which turns a feature into an operator migration. Buttons need neither: the final answer's last chunk carries a thumbs-up/down actions block, and a click arrives as a `block_actions` payload that already names the team, channel, message ts and clicker. Its `trigger_id` opens the "what went wrong" modal directly on a genuinely new down-vote — same flip semantics as Discord via `should_trigger_feedback_dm` — so the DM hop disappears entirely.

The buttons stay visually neutral: the message is shared, and any selected state would leak one viewer's vote to the channel. Acknowledgement is a per-user ephemeral.

The write path mirrors the Discord listener's hygiene: read-only principal lookup so a bystander's vote mints no identity row, thread session as a best-effort attribution hint, and modal text lands through the ownership-predicated `attach_feedback_text`, so a forged row id writes nothing and learns nothing. Feedback text never enters a log line, an `action_id`, or `private_metadata`.

`tests/parity/test_message_feedback_discord_only.py` flips from asserting the Discord-only exemption to asserting the split: the two scopes must stay absent AND the Slack button surface must exist.

No manifest change, no new scopes, nothing operator-visible on deploy.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally
- [x] `uv run pyright` passes locally (strict mode)
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)

Note on pytest: the full suite runs 4564 passed, 3 failed locally — two notebook-host uid/chown tests and `test_credential_requests.py::test_concurrent_consume_of_one_token_succeeds_exactly_once`. All three fail identically on `main` in this environment (macOS uid semantics; stale local test-database schema) and touch nothing this branch changes.
