### PR TITLE
Slack credential requests: chat-initiated buttons and single-use modals

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -4,17 +4,18 @@ request_repo_binding.
 These three tools replace the "go open /agent-setup" redirect for a task that
 needs an env secret, an auth-required MCP server, or a repo bound to an
 agent: the agent mints a single-use, TTL-bounded ``credential_requests`` row
-and posts a target-naming button in the thread
-(``tools/discord/_credential_button.py``). Clicking the button opens a
-native Discord modal in a different process (the Discord bot, worker VM) —
-the secret itself never travels through either process's tool arguments, so
+and posts a target-naming button in the thread (``tools/discord/`` or
+``tools/slack/_credential_button.py``, by the caller's platform). Clicking
+the button opens a native modal in a different process (the platform bot,
+worker VM) — the secret itself never travels through either process's tool
+arguments, so
 none of the three tools below has a token/secret/value parameter, and none
 should ever be added.
 
 Deliberately NOT admin-gated — the chat-mutation admin check other tools call
 at the top of their impl is intentionally absent here. Authorization for the
-actual credential write happens at click time instead, when the Discord
-button's ``interaction_check`` compares the clicking user against
+actual credential write happens at click time instead, when the button's
+click gate compares the clicking user against
 ``requester_platform_user_id`` on the minted row. This widens today's
 admin-only credential writes (``/agent-setup``'s mutation buttons are
 ``is_admin``-only) in exchange for one-click UX — a deliberate, accepted
@@ -34,6 +35,9 @@ from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools._ctx import _auth  # pyright: ignore[reportPrivateUsage]
 from daimon.adapters.mcp.tools.discord import (
     _post_credential_button_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.slack._credential_button import (
+    _post_slack_credential_button_impl,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.core.credential_requests import (
     DEFAULT_TTL,
@@ -73,6 +77,21 @@ class RequestCredentialResult(BaseModel):
     target: str
     expires_at: datetime
     message_id: str
+
+
+def _require_requestable_platform(auth: AuthIdentity) -> str:
+    """Refuse before the mint when the click could never be dispatched.
+
+    The row is minted before the button is posted, so a caller whose platform
+    context cannot carry a button (no bound identity, or a Slack caller with
+    no workspace) must be refused here — after the mint the failure surfaces
+    as "created but posting failed", leaving a dead row behind.
+    """
+    if auth.platform_user_id is None:
+        raise ToolError("credential requests require a platform-bound identity")
+    if auth.platform == "slack" and auth.external_id is None:
+        raise ToolError("credential requests require a workspace context")
+    return auth.platform_user_id
 
 
 async def _resolve_agent_uuid(
@@ -117,8 +136,13 @@ async def _mint_and_post(
             channel_id=channel_id,
             expires_at=expires_at,
         )
+    post = (
+        _post_slack_credential_button_impl
+        if auth.platform == "slack"
+        else _post_credential_button_impl
+    )
     try:
-        message_id = await _post_credential_button_impl(
+        message_id = await post(
             runtime,
             auth,
             channel_id=channel_id,
@@ -149,10 +173,7 @@ async def _request_env_credential_impl(
     purpose: str,
     channel_id: str,
 ) -> RequestCredentialResult:
-    if auth.platform == "slack":
-        raise ToolError("request_env_credential is not supported on Slack yet")
-    if auth.platform_user_id is None:
-        raise ToolError("credential requests require a platform-bound identity")
+    requester = _require_requestable_platform(auth)
     if not _POSIX_KEY_RE.match(key):
         raise ToolError(
             "env key must match [A-Za-z_][A-Za-z0-9_]* "
@@ -166,7 +187,7 @@ async def _request_env_credential_impl(
         target=key,
         mcp_server_url=None,
         agent_id=agent_id,
-        requester_platform_user_id=auth.platform_user_id,
+        requester_platform_user_id=requester,
         agent_name=agent_name,
         purpose=purpose,
         channel_id=channel_id,
@@ -182,10 +203,7 @@ async def _request_mcp_credential_impl(
     url: str,
     channel_id: str,
 ) -> RequestCredentialResult:
-    if auth.platform == "slack":
-        raise ToolError("request_mcp_credential is not supported on Slack yet")
-    if auth.platform_user_id is None:
-        raise ToolError("credential requests require a platform-bound identity")
+    requester = _require_requestable_platform(auth)
     if urlparse(url).scheme not in ("http", "https"):
         raise ToolError("mcp server url must be http or https")
     # Normalise the trailing slash once, here, before the URL is persisted.
@@ -203,7 +221,7 @@ async def _request_mcp_credential_impl(
         target=server_name,
         mcp_server_url=url,
         agent_id=agent_id,
-        requester_platform_user_id=auth.platform_user_id,
+        requester_platform_user_id=requester,
         agent_name=agent_name,
         purpose=f"connecting the MCP server '{server_name}'",
         channel_id=channel_id,
@@ -226,10 +244,7 @@ async def _request_skill_repo_credential_impl(
     purpose: str,
     channel_id: str,
 ) -> RequestCredentialResult:
-    if auth.platform == "slack":
-        raise ToolError("request_skill_repo_credential is not supported on Slack yet")
-    if auth.platform_user_id is None:
-        raise ToolError("credential requests require a platform-bound identity")
+    requester = _require_requestable_platform(auth)
     if urlparse(repo_url).scheme not in ("http", "https"):
         raise ToolError("repo url must be http or https, e.g. https://github.com/owner/repo")
     if not _OWNER_REPO_RE.fullmatch(normalize_owner_repo(repo_url)):
@@ -250,7 +265,7 @@ async def _request_skill_repo_credential_impl(
         target=build_skill_repo_target(repo_url, branch, path),
         mcp_server_url=None,
         agent_id=agent_id,
-        requester_platform_user_id=auth.platform_user_id,
+        requester_platform_user_id=requester,
         agent_name=agent_name,
         purpose=purpose,
         channel_id=channel_id,
@@ -266,10 +281,7 @@ async def _request_repo_binding_impl(
     purpose: str,
     channel_id: str,
 ) -> RequestCredentialResult:
-    if auth.platform == "slack":
-        raise ToolError("request_repo_binding is not supported on Slack yet")
-    if auth.platform_user_id is None:
-        raise ToolError("credential requests require a platform-bound identity")
+    requester = _require_requestable_platform(auth)
     if urlparse(repo_url).scheme not in ("http", "https"):
         raise ToolError("repo url must be http or https, e.g. https://github.com/owner/repo")
     if not _OWNER_REPO_RE.fullmatch(normalize_owner_repo(repo_url)):
@@ -284,7 +296,7 @@ async def _request_repo_binding_impl(
         target=repo_url,
         mcp_server_url=None,
         agent_id=agent_id,
-        requester_platform_user_id=auth.platform_user_id,
+        requester_platform_user_id=requester,
         agent_name=agent_name,
         purpose=purpose,
         channel_id=channel_id,
@@ -304,7 +316,7 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
 
         Call this INSTEAD of ever accepting a secret value in chat. Posts a
         button in the thread naming the exact env key; clicking it opens a
-        native Discord modal where the user enters the value privately — it
+        private form where the user enters the value — it
         never appears in this channel or in your context. Once added, the
         credential becomes usable by everyone who talks to ``agent_name``.
         """
@@ -330,8 +342,8 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
         Call this INSTEAD of ever accepting a token value in chat, and instead
         of ``attach_mcp_server`` when the server requires authentication.
         Posts a button in the thread naming the exact server; clicking it
-        opens a native Discord modal where the user enters the token
-        privately — it never appears in this channel or in your context.
+        opens a private form where the user enters the token —
+        it never appears in this channel or in your context.
         Once added, the credential becomes usable by everyone who talks to
         ``agent_name``.
         """
@@ -401,7 +413,7 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
 
         Call this INSTEAD of ever telling the user to open ``/agent-setup``
         to bind a repository. Posts a button in the thread naming the exact
-        repo and agent; clicking it opens a native Discord modal where the
+        repo and agent; clicking it opens a private form where the
         user confirms the branch and, only if the repo is private and not
         otherwise readable, pastes a GitHub token that never appears in this
         channel or in your context.

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_credential_button.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_credential_button.py
@@ -15,6 +15,13 @@ single-use token rides in `value` under the fixed `SLACK_ACTION_ID`.
 Reuses the read tools' channel-visibility discipline (`conversations.info` →
 `check_channel_access`) so posting a credential button proves the requester
 may see the channel before anything lands in it.
+
+The button posts at the channel's top level, never in a thread. On Discord a
+thread IS a channel, so `channel_id` alone lands the button where the
+conversation is; a Slack thread is a (channel, ts) pair and the four request
+tools' shared contract carries no `thread_ts`. Threading the button means
+widening that cross-platform tool schema — until then, a request made
+mid-thread posts its button to the channel root.
 """
 
 from __future__ import annotations

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_credential_button.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_credential_button.py
@@ -1,0 +1,129 @@
+"""Post the credential-request button to a Slack channel.
+
+Posted from the MCP process (Cloud Run); dispatched later by the Slack bot
+process via `handle_credential_request_click`. The two processes cannot
+import each other (import-linter's independence contract), so this module
+imports only the core wire-contract pieces (`SLACK_ACTION_ID`,
+`build_button_label`) — never the Slack adapter's handler, and never a
+re-derived action id. A divergent copy here would silently stop the button
+from dispatching in the other process.
+
+Unlike Discord's custom_id encoding, Slack routes block_actions by
+`action_id` and a button carries a free-form `value`, so the opaque
+single-use token rides in `value` under the fixed `SLACK_ACTION_ID`.
+
+Reuses the read tools' channel-visibility discipline (`conversations.info` →
+`check_channel_access`) so posting a credential button proves the requester
+may see the channel before anything lands in it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.slack._client import (
+    _require_slack_identity,  # pyright: ignore[reportPrivateUsage]
+    _require_team_id,  # pyright: ignore[reportPrivateUsage]
+    slack_web_client,
+)
+from daimon.adapters.mcp.tools.slack._visibility import check_channel_access
+from daimon.core.credential_requests import (
+    MAX_SLACK_BUTTON_LABEL_CHARS,
+    SLACK_ACTION_ID,
+    CredentialRequestKind,
+    build_button_label,
+)
+from fastmcp.exceptions import ToolError
+from slack_sdk.errors import SlackApiError
+
+_KIND_NOUN: dict[CredentialRequestKind, str] = {
+    "env": "an environment secret",
+    "mcp": "an MCP server credential",
+    "repo": "a repo binding",
+    "skill_repo": "a GitHub token to import skills",
+}
+
+
+def _build_message_text(
+    *,
+    requester_platform_user_id: str,
+    agent_name: str,
+    kind: CredentialRequestKind,
+    target: str,
+    purpose: str,
+) -> str:
+    """The message body, in Slack mrkdwn (single-asterisk bold, `<@U…>` mention)."""
+    if kind == "repo":
+        return (
+            f"<@{requester_platform_user_id}> wants to bind a repo to *{agent_name}* "
+            f"(`{target}`) — {purpose}\n"
+            "Click the button below to open a private form confirming the branch, "
+            "and — only if the repo isn't publicly readable — a GitHub token that "
+            "never appears in this channel."
+        )
+    return (
+        f"<@{requester_platform_user_id}> *{agent_name}* needs {_KIND_NOUN[kind]} "
+        f"(`{target}`) — {purpose}\n"
+        "Click the button below to enter the value privately in a form; "
+        "it will never appear in this channel.\n"
+        f"Once added, this credential becomes usable by everyone who talks to "
+        f"*{agent_name}*."
+    )
+
+
+async def _post_slack_credential_button_impl(  # pyright: ignore[reportUnusedFunction]
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    kind: CredentialRequestKind,
+    target: str,
+    token: str,
+    agent_name: str,
+    purpose: str,
+) -> str:
+    """Post a target-naming credential button. Returns the sent message ts."""
+    requester_id = _require_slack_identity(auth)
+    team_id = _require_team_id(auth)
+    client = await slack_web_client(runtime, team_id=team_id)
+
+    try:
+        info = await client.conversations_info(channel=channel_id)  # pyright: ignore[reportUnknownMemberType]
+        channel: dict[str, Any] = dict(info.get("channel") or {})  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+        await check_channel_access(client, channel=channel, user_id=requester_id)
+        text = _build_message_text(
+            requester_platform_user_id=requester_id,
+            agent_name=agent_name,
+            kind=kind,
+            target=target,
+            purpose=purpose,
+        )
+        sent = await client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
+            channel=channel_id,
+            text=text,
+            blocks=[
+                {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "action_id": SLACK_ACTION_ID,
+                            "value": token,
+                            "text": {
+                                "type": "plain_text",
+                                "text": build_button_label(
+                                    kind, target, max_chars=MAX_SLACK_BUTTON_LABEL_CHARS
+                                ),
+                            },
+                        }
+                    ],
+                },
+            ],
+        )
+    except SlackApiError as err:
+        code = str(err.response.get("error", "slack_api_error"))  # pyright: ignore[reportUnknownArgumentType, reportUnknownMemberType]  # slack_sdk response is dict-like
+        raise ToolError(f"posting to the channel failed ({code})") from err
+    return str(sent.get("ts") or "")  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2131,7 +2131,7 @@
         
         Call this INSTEAD of ever accepting a secret value in chat. Posts a
         button in the thread naming the exact env key; clicking it opens a
-        native Discord modal where the user enters the value privately — it
+        private form where the user enters the value — it
         never appears in this channel or in your context. Once added, the
         credential becomes usable by everyone who talks to ``agent_name``.
       ''',
@@ -2167,8 +2167,8 @@
         Call this INSTEAD of ever accepting a token value in chat, and instead
         of ``attach_mcp_server`` when the server requires authentication.
         Posts a button in the thread naming the exact server; clicking it
-        opens a native Discord modal where the user enters the token
-        privately — it never appears in this channel or in your context.
+        opens a private form where the user enters the token —
+        it never appears in this channel or in your context.
         Once added, the credential becomes usable by everyone who talks to
         ``agent_name``.
       ''',
@@ -2203,7 +2203,7 @@
         
         Call this INSTEAD of ever telling the user to open ``/agent-setup``
         to bind a repository. Posts a button in the thread naming the exact
-        repo and agent; clicking it opens a native Discord modal where the
+        repo and agent; clicking it opens a private form where the
         user confirms the branch and, only if the repo is private and not
         otherwise readable, pastes a GitHub token that never appears in this
         channel or in your context.

--- a/packages/adapters/mcp/tests/tools/test_credential_requests.py
+++ b/packages/adapters/mcp/tests/tools/test_credential_requests.py
@@ -440,26 +440,26 @@ async def test_request_env_credential_succeeds_for_non_admin_caller(
 # ---------------------------------------------------------------------------
 
 
-async def test_request_env_credential_rejects_slack_caller(
+async def test_request_env_credential_rejects_slack_caller_without_workspace(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
     runtime = _runtime(committing_sessionmaker)
     auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
-    with pytest.raises(ToolError, match="not supported on Slack"):
+    with pytest.raises(ToolError, match="workspace context"):
         await _request_env_credential_impl(
             runtime, auth, agent_name="daimon", key="OPENAI_API_KEY", purpose="x", channel_id="222"
         )
     assert await _row_count(db_session) == 0, "a rejected slack call must create no row"
 
 
-async def test_request_mcp_credential_rejects_slack_caller(
+async def test_request_mcp_credential_rejects_slack_caller_without_workspace(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
     runtime = _runtime(committing_sessionmaker)
     auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
-    with pytest.raises(ToolError, match="not supported on Slack"):
+    with pytest.raises(ToolError, match="workspace context"):
         await _request_mcp_credential_impl(
             runtime,
             auth,
@@ -720,3 +720,163 @@ async def test_request_env_credential_raises_when_button_post_fails(
     assert await _row_count(db_session) == 1, (
         "the credential request row is created before the button post is attempted"
     )
+
+
+# ---------------------------------------------------------------------------
+# Slack callers: the same mint, a Slack button post
+# ---------------------------------------------------------------------------
+
+_SLACK_TEAM_ID = "T_TEST"
+_SLACK_USER_ID = "U_CALLER"
+
+
+def _slack_runtime(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    client: AsyncAnthropic | None = None,
+    fernet: Any = None,
+) -> McpRuntime:
+    settings = Settings(
+        database=DatabaseSettings(url="postgresql+asyncpg://x/y"),  # pyright: ignore[reportArgumentType]
+        anthropic=AnthropicSettings(api_key=SecretStr("k")),
+    )
+    return McpRuntime(
+        session_factory=sessionmaker,
+        client=client if client is not None else MagicMock(),  # type: ignore[arg-type]
+        settings=settings,
+        deployment_default=DeploymentDefault(),
+        fernet=fernet,
+    )
+
+
+async def _seed_slack_bot_token(sessionmaker: async_sessionmaker[AsyncSession]) -> Any:
+    from cryptography.fernet import Fernet
+    from daimon.core.github_credentials import build_multifernet, encrypt_token
+    from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+
+    fernet = build_multifernet((Fernet.generate_key().decode("ascii"),))
+    async with sessionmaker() as session:
+        await upsert_slack_bot_token(
+            session,
+            team_id=_SLACK_TEAM_ID,
+            encrypted_token=encrypt_token(fernet, "xoxb-secret"),
+        )
+        await session.commit()
+    return fernet
+
+
+def _register_slack_post_defaults(m: Any, *, channel_id: str = "C_CRED") -> None:
+    import re as _re
+
+    channel_payload = {
+        "ok": True,
+        "channel": {"id": channel_id, "is_private": False, "is_im": False, "is_mpim": False},
+    }
+    m.post("https://slack.com/api/conversations.info", payload=channel_payload, repeat=True)
+    m.get(
+        _re.compile(r"https://slack\.com/api/conversations\.info.*"),
+        payload=channel_payload,
+        repeat=True,
+    )
+    m.post(
+        _re.compile(r"https://slack\.com/api/users\.info.*"),
+        payload={"ok": True, "user": {"id": _SLACK_USER_ID, "is_restricted": False}},
+        repeat=True,
+    )
+    m.get(
+        _re.compile(r"https://slack\.com/api/users\.info.*"),
+        payload={"ok": True, "user": {"id": _SLACK_USER_ID, "is_restricted": False}},
+        repeat=True,
+    )
+    m.post(
+        "https://slack.com/api/chat.postMessage",
+        payload={"ok": True, "ts": "1700000009.000900", "channel": channel_id},
+        repeat=True,
+    )
+
+
+async def test_request_env_credential_posts_slack_button_carrying_the_token(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    from aioresponses import aioresponses
+    from daimon.core.credential_requests import SLACK_ACTION_ID
+
+    tenant = await make_tenant(db_session, platform="slack", workspace_id=_SLACK_TEAM_ID)
+    await db_session.commit()
+    fernet = await _seed_slack_bot_token(committing_sessionmaker)
+    client = _ma_client_with_agents(
+        [_ma_agent(agent_id="ag_env_slack", name="daimon", tenant_id=tenant.id)]
+    )
+    runtime = _slack_runtime(committing_sessionmaker, client=client, fernet=fernet)
+    auth = _auth_identity(
+        platform="slack",
+        external_id=_SLACK_TEAM_ID,
+        platform_user_id=_SLACK_USER_ID,
+        tenant_id=tenant.id,
+    )
+
+    with aioresponses() as m:
+        _register_slack_post_defaults(m)
+        result = await _request_env_credential_impl(
+            runtime,
+            auth,
+            agent_name="daimon",
+            key="OPENAI_API_KEY",
+            purpose="calling the OpenAI API",
+            channel_id="C_CRED",
+        )
+        import yarl
+
+        posts = m.requests[("POST", yarl.URL("https://slack.com/api/chat.postMessage"))]
+
+    assert result.kind == "env" and result.message_id == "1700000009.000900"
+    assert await _row_count(db_session) == 1
+
+    body = posts[0].kwargs["json"]
+    actions = [b for b in body["blocks"] if b["type"] == "actions"]
+    assert len(actions) == 1, "the posted message must carry exactly one actions block"
+    button = actions[0]["elements"][0]
+    assert button["action_id"] == SLACK_ACTION_ID
+    row = await peek_credential_request(db_session, token=button["value"])
+    assert row is not None and row.kind == "env", (
+        "the button's value must be the minted single-use token"
+    )
+    assert row.requester_platform_user_id == _SLACK_USER_ID
+    assert "OPENAI_API_KEY" in button["text"]["text"]
+    assert len(button["text"]["text"]) <= 75, "Slack caps button text at 75 characters"
+
+
+async def test_request_repo_binding_posts_slack_button(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    from aioresponses import aioresponses
+
+    tenant = await make_tenant(db_session, platform="slack", workspace_id=_SLACK_TEAM_ID)
+    await db_session.commit()
+    fernet = await _seed_slack_bot_token(committing_sessionmaker)
+    client = _ma_client_with_agents(
+        [_ma_agent(agent_id="ag_repo_slack", name="daimon", tenant_id=tenant.id)]
+    )
+    runtime = _slack_runtime(committing_sessionmaker, client=client, fernet=fernet)
+    auth = _auth_identity(
+        platform="slack",
+        external_id=_SLACK_TEAM_ID,
+        platform_user_id=_SLACK_USER_ID,
+        tenant_id=tenant.id,
+    )
+
+    with aioresponses() as m:
+        _register_slack_post_defaults(m)
+        result = await _request_repo_binding_impl(
+            runtime,
+            auth,
+            agent_name="daimon",
+            repo_url="https://github.com/owner/repo",
+            purpose="cloning the project",
+            channel_id="C_CRED",
+        )
+
+    assert result.kind == "repo"
+    assert await _row_count(db_session) == 1

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -52,6 +52,15 @@ from daimon.adapters.slack.attachments import (
 )
 from daimon.adapters.slack.billing_panel.actions import handle_billing_command, handle_topup_select
 from daimon.adapters.slack.context import build_context_xml, build_delta_xml
+from daimon.adapters.slack.credential_requests import (
+    CredentialSubmissionDecision,
+    evaluate_credential_submission,
+    handle_credential_request_click,
+    run_env_credential_submission,
+    run_mcp_credential_submission,
+    run_repo_bind_credential_submission,
+    run_skill_repo_credential_submission,
+)
 from daimon.adapters.slack.gating import is_external_interactive, is_slack_connect_external
 from daimon.adapters.slack.help import handle_help_command
 from daimon.adapters.slack.interactions import build_retry_handlers, resolve_web_client
@@ -80,6 +89,7 @@ from daimon.adapters.slack.vision import (
     download_as_image_blocks,
     is_vision_image,
 )
+from daimon.core.credential_requests import SLACK_ACTION_ID as SLACK_CREDENTIAL_ACTION_ID
 from daimon.core.defaults.provisioning import teardown_slack_install
 from daimon.core.errors import DaimonError
 from daimon.core.github_credentials import build_multifernet, decrypt_token
@@ -478,6 +488,46 @@ class SlackApp:
                             )
 
                     self._spawn(_run_agent_setup_submission())
+            elif cb_id.startswith("credential_request__"):
+                # Pure pre-ack evaluation (Pattern 2, as feedback/agent_setup).
+                _cred_decision = evaluate_credential_submission(payload)
+                await client.send_socket_mode_response(
+                    SocketModeResponse(
+                        envelope_id=req.envelope_id,
+                        payload=_cred_decision.response_payload,
+                    )
+                )
+                if _cred_decision.proceed:
+                    cred_team: dict[str, Any] = payload.get("team") or {}
+                    cred_user: dict[str, Any] = payload.get("user") or {}
+
+                    async def _run_credential_submission(
+                        _d: CredentialSubmissionDecision = _cred_decision,
+                        _team: str = str(cred_team.get("id") or ""),
+                        _user: str = str(cred_user.get("id") or ""),
+                    ) -> None:
+                        common: dict[str, Any] = {
+                            "team_id": _team,
+                            "user_id": _user,
+                            "channel_id": _d.channel_id,
+                            "message_ts": _d.message_ts,
+                            "token": _d.token,
+                            "value": _d.value,
+                        }
+                        if _d.kind == "env":
+                            await run_env_credential_submission(self.runtime, **common)
+                        elif _d.kind == "mcp":
+                            await run_mcp_credential_submission(self.runtime, **common)
+                        elif _d.kind == "skill_repo":
+                            await run_skill_repo_credential_submission(self.runtime, **common)
+                        elif _d.kind == "repo":
+                            await run_repo_bind_credential_submission(
+                                self.runtime, branch=_d.branch, **common
+                            )
+                        else:
+                            log.info("slack.on_request.unknown_credential_kind", kind=_d.kind)
+
+                    self._spawn(_run_credential_submission())
             else:
                 # Unknown view_submission callback_id — log and ack empty (T-82-20).
                 log.info("slack.on_request.unknown_view_submission_callback", callback_id=cb_id)
@@ -552,6 +602,8 @@ class SlackApp:
                     self._spawn(handle_privacy_block_action(self.runtime, payload))
                 elif action_id.startswith("agent_setup__"):
                     self._spawn(handle_agent_setup_action(self.runtime, payload))
+                elif action_id == SLACK_CREDENTIAL_ACTION_ID:
+                    self._spawn(handle_credential_request_click(self.runtime, payload))
         else:
             # Log unrecognised envelope types so the envelope key can be
             # confirmed or corrected from staging logs (T-82-20).

--- a/packages/adapters/slack/daimon/adapters/slack/credential_requests.py
+++ b/packages/adapters/slack/daimon/adapters/slack/credential_requests.py
@@ -1,0 +1,1029 @@
+"""Slack chat-initiated credential requests — click gate, modals, submissions.
+
+The MCP process posts a message with a single button (`SLACK_ACTION_ID`,
+token in the button's `value`); this module is the bot-process half that
+dispatches the click. Slack's interaction model needs no loading-modal
+dance: the click's `block_actions` payload carries a `trigger_id` that opens
+the kind's modal directly, so the pre-open checks below run inline before
+`views_open`.
+
+Authorization mirrors the Discord `CredentialRequestButton` exactly:
+requester-only for every kind (the click's user must match the row's
+`requester_platform_user_id`), expiry and single-use checked at click time,
+and — for the `repo` kind only — a shared-agent admin gate, run once as a
+pre-filter before the modal opens and once more at submission before the
+consume. There is deliberately NO admin gate for the env/mcp/skill_repo
+kinds; see `tools/credential_requests.py` in the MCP adapter for the
+documented trade.
+
+Secret hygiene (the same structural guarantees the Discord modals and the
+panel's paste form document): the submitted value exists only in the modal's
+input state and the decision object's own field — it never enters a log
+record (env logs the key name; mcp/repo log a masked tail), an `action_id`,
+`private_metadata`, or any non-ephemeral message.
+
+The atomic single-use consume runs BEFORE every write, so a request can only
+ever produce one write no matter how many times its modal is (re)submitted —
+the loser of a race, or any resubmission, gets `None` back and writes
+nothing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Final, cast
+
+import httpx
+import structlog
+from daimon.adapters.slack.admin import resolve_is_admin
+from daimon.adapters.slack.agent_setup.write import (
+    load_agent_inline_pat,
+    mask_tail,
+    store_inline_pat,
+)
+from daimon.adapters.slack.interactions import resolve_web_client
+from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.agent_mcp_credentials import save_agent_mcp_credential
+from daimon.core.credential_requests import (
+    MAX_SLACK_BUTTON_LABEL_CHARS,
+    CredentialRequestKind,
+    build_button_label,
+    split_skill_repo_target,
+)
+from daimon.core.defaults.ma_index import find_agent_by_derived_uuid
+from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
+from daimon.core.errors import DaimonError
+from daimon.core.github_repo_auth import normalize_owner_repo
+from daimon.core.github_visibility import is_public_repo, pat_can_access_repo
+from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.mcp_attach import attach_mcp_server_to_agent
+from daimon.core.mcp_vault import add_external_mcp_credential
+from daimon.core.skills.pipeline import run_skill_sync
+from daimon.core.stores import credential_requests as credential_requests_store
+from daimon.core.stores.agent_files import put_agent_file
+from daimon.core.stores.agent_repo_binding import set_binding
+from daimon.core.stores.domain import CredentialRequestRow, RepoAccessProof
+from daimon.core.stores.scoped_config_read import is_agent_reachable_in_tenant
+from slack_sdk.web.async_client import AsyncWebClient
+
+__all__ = [
+    "CRED_CALLBACK_PREFIX",
+    "CredentialSubmissionDecision",
+    "build_credential_modal",
+    "evaluate_credential_submission",
+    "handle_credential_request_click",
+    "run_env_credential_submission",
+    "run_mcp_credential_submission",
+    "run_repo_bind_credential_submission",
+    "run_skill_repo_credential_submission",
+]
+
+log = structlog.get_logger()
+
+CRED_CALLBACK_PREFIX: Final[str] = "credential_request__"
+
+_VALUE_BLOCK = "credential__value"
+_BRANCH_BLOCK = "credential__branch"
+_PAT_BLOCK = "credential__pat"
+
+# Byte cap shared with the panel's paste form (`agent_setup/submit.py`'s
+# _MAX_SECRET_VALUE_BYTES) and the Discord credential modals. Slack's own
+# max_length on the input is a character cap; this is the byte boundary the
+# store actually enforces.
+_MAX_SECRET_VALUE_BYTES: Final[int] = 4096
+
+# Character-identical to the Discord button's refusal strings on purpose —
+# the two surfaces answer the same lifecycle states with the same words.
+_NO_LONGER_VALID = "This request is no longer valid — ask again."
+_WRONG_REQUESTER = "This request was for someone else — ask again in your own thread."
+_EXPIRED = "This request expired — ask again."
+_ALREADY_USED = "This request was already used — ask again."
+_WRONG_WORKSPACE = (
+    "This request isn't for this workspace — ask again from the workspace it was posted in."
+)
+
+# Matches the panel gate's `_SHARED_AGENT_MESSAGE` in spirit; the request row
+# carries a derived agent uuid rather than a roster entry, so the gate below
+# re-derives the panel's decision from primitives, as Discord's
+# `credential_repo_bind` does.
+_SHARED_AGENT_MESSAGE = (
+    ":lock: This agent is shared — it is either the workspace's built-in agent or the "
+    "current default for this workspace or a channel — so changing its repo or its "
+    "environment variables needs workspace-admin permission. Fork it to get an "
+    "editable copy you own; the fork starts with no environment variables of its own."
+)
+
+_AGENT_GONE_MESSAGE = "That agent no longer exists — ask again and a fresh request will be posted."
+
+_MODAL_TITLE: Final[dict[CredentialRequestKind, str]] = {
+    "env": "Add secret",
+    "mcp": "Add MCP credential",
+    "skill_repo": "Import skills",
+    "repo": "Bind repo",
+}
+
+_VALUE_LABEL: Final[dict[CredentialRequestKind, str]] = {
+    "env": "Secret value",
+    "mcp": "Auth token",
+    "skill_repo": "GitHub token",
+}
+
+
+def build_credential_modal(
+    *,
+    kind: CredentialRequestKind,
+    token: str,
+    channel_id: str,
+    message_ts: str,
+    target: str,
+) -> dict[str, Any]:
+    """The per-kind modal opened from a live request's button click.
+
+    Every routing field (agent, key/server/repo name) is already fixed by the
+    request row keyed by ``token``, so the secret kinds collect exactly one
+    field — the value itself. The repo kind collects branch + optional token,
+    the two writable parts of a binding. ``private_metadata`` carries only
+    routing handles (token, channel, the button message's ts) — never a
+    secret, and never the target.
+    """
+    if kind == "repo":
+        blocks: list[dict[str, Any]] = [
+            {
+                "type": "input",
+                "block_id": _BRANCH_BLOCK,
+                "label": {"type": "plain_text", "text": "Branch"},
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": _BRANCH_BLOCK,
+                    "initial_value": "main",
+                    "max_length": 255,
+                },
+            },
+            {
+                "type": "input",
+                "block_id": _PAT_BLOCK,
+                "optional": True,
+                "label": {"type": "plain_text", "text": "GitHub token (optional)"},
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": _PAT_BLOCK,
+                    "max_length": 255,
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "Leave blank for a public repo",
+                    },
+                },
+            },
+        ]
+    else:
+        placeholder = "usable by everyone who talks to this agent"
+        if kind == "skill_repo":
+            url, _branch, _path = split_skill_repo_target(target)
+            placeholder = f"Needs read access to {normalize_owner_repo(url)}"
+        blocks = [
+            {
+                "type": "input",
+                "block_id": _VALUE_BLOCK,
+                "label": {"type": "plain_text", "text": _VALUE_LABEL[kind]},
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": _VALUE_BLOCK,
+                    "multiline": kind == "env",
+                    "max_length": 4000 if kind == "env" else 255,
+                    "placeholder": {
+                        "type": "plain_text",
+                        # Slack caps plain_text placeholders at 150 chars.
+                        "text": placeholder[:150],
+                    },
+                },
+            }
+        ]
+    return {
+        "type": "modal",
+        "callback_id": f"{CRED_CALLBACK_PREFIX}{kind}",
+        "private_metadata": json.dumps(
+            {"token": token, "channel_id": channel_id, "message_ts": message_ts},
+            separators=(",", ":"),
+        ),
+        "title": {"type": "plain_text", "text": _MODAL_TITLE[kind]},
+        "submit": {"type": "plain_text", "text": "Save"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": blocks,
+    }
+
+
+@dataclasses.dataclass(frozen=True)
+class CredentialSubmissionDecision:
+    """Outcome of the pure pre-ack evaluation of a credential view_submission.
+
+    ``response_payload`` is the ack body (``response_action: errors``) when
+    the submission is rejected, or None for an empty ack that closes the
+    modal. ``value`` is the secret and is carried in memory only — it must
+    never be logged. ``branch`` is meaningful for the repo kind only.
+    """
+
+    proceed: bool
+    response_payload: dict[str, Any] | None
+    kind: CredentialRequestKind
+    value: str
+    branch: str
+    token: str
+    channel_id: str
+    message_ts: str
+
+
+def _input_value(values: dict[str, Any], block_id: str) -> str:
+    block: dict[str, Any] = values.get(block_id) or {}
+    element: dict[str, Any] = block.get(block_id) or {}
+    return str(element.get("value") or "")
+
+
+def evaluate_credential_submission(payload: dict[str, Any]) -> CredentialSubmissionDecision:
+    """Pure (no I/O) evaluation of a credential_request__* view_submission.
+
+    Rejects an empty or whitespace-only secret with a field error so the
+    person can retype rather than lose the modal, and enforces the same byte
+    cap the panel's paste form does — Slack's ``max_length`` is a character
+    cap and multi-byte input can clear it while overflowing the store.
+    The repo kind's secret field is optional (blank = public repo) and a
+    blank branch defaults to main.
+    """
+    view: dict[str, Any] = payload.get("view") or {}
+    callback_id = str(view.get("callback_id") or "")
+    kind_str = callback_id.removeprefix(CRED_CALLBACK_PREFIX)
+    kind: CredentialRequestKind = kind_str  # type: ignore[assignment]  # validated by the dispatch prefix match
+    meta: dict[str, Any]
+    try:
+        meta = json.loads(str(view.get("private_metadata") or "") or "{}")
+    except json.JSONDecodeError:
+        meta = {}
+    state: dict[str, Any] = view.get("state") or {}
+    values: dict[str, Any] = state.get("values") or {}
+    token = str(meta.get("token") or "")
+    channel_id = str(meta.get("channel_id") or "")
+    message_ts = str(meta.get("message_ts") or "")
+
+    def _decision(
+        *, proceed: bool, errors: dict[str, str] | None = None, value: str = "", branch: str = ""
+    ) -> CredentialSubmissionDecision:
+        return CredentialSubmissionDecision(
+            proceed=proceed,
+            response_payload=(
+                {"response_action": "errors", "errors": errors} if errors is not None else None
+            ),
+            kind=kind,
+            value=value,
+            branch=branch,
+            token=token,
+            channel_id=channel_id,
+            message_ts=message_ts,
+        )
+
+    if kind == "repo":
+        branch = _input_value(values, _BRANCH_BLOCK).strip() or "main"
+        pat = _input_value(values, _PAT_BLOCK).strip()
+        if len(pat.encode()) > _MAX_SECRET_VALUE_BYTES:
+            return _decision(
+                proceed=False,
+                errors={_PAT_BLOCK: f"Token is too large. Max {_MAX_SECRET_VALUE_BYTES} bytes."},
+            )
+        return _decision(proceed=True, value=pat, branch=branch)
+
+    raw_value = _input_value(values, _VALUE_BLOCK)
+    if not raw_value.strip():
+        return _decision(
+            proceed=False,
+            errors={_VALUE_BLOCK: "Value cannot be empty — try again."},
+        )
+    if len(raw_value.encode()) > _MAX_SECRET_VALUE_BYTES:
+        return _decision(
+            proceed=False,
+            errors={_VALUE_BLOCK: f"Value is too large. Max {_MAX_SECRET_VALUE_BYTES} bytes."},
+        )
+    return _decision(proceed=True, value=raw_value)
+
+
+async def _post_ephemeral(
+    client: AsyncWebClient, *, channel_id: str, user_id: str, text: str
+) -> None:
+    await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+        channel=channel_id, user=user_id, text=text
+    )
+
+
+async def _refuse_if_shared_and_not_admin_for_request(
+    runtime: SlackRuntime,
+    client: AsyncWebClient,
+    *,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    channel_id: str,
+    user_id: str,
+) -> bool:
+    """Click/submit-time re-check for the chat-initiated repo-bind write.
+
+    Re-derives the panel gate's (`agent_setup.gate.refuse_if_shared_and_not_admin`)
+    decision from primitives — a request row carries a derived agent uuid, not
+    the roster name the panel gate expects. The branch ORDER mirrors both the
+    panel gate and Discord's `credential_repo_bind` twin exactly:
+
+    1. A live workspace admin -> allow, before any MA or DB read — what keeps
+       an admin able to bind a repo to the workspace's built-in agent.
+    2. The row's derived uuid resolving to no live MA agent -> refuse, fail
+       closed (archived or deleted since the mint).
+    3. A defaults-managed agent -> refuse; every member shares it.
+    4. Otherwise read reachability fresh and refuse when the agent currently
+       resolves for the workspace or some channel.
+
+    Returns True when the caller must return immediately (refused).
+    """
+    if await resolve_is_admin(client, user_id=user_id):
+        return False
+    agent = await find_agent_by_derived_uuid(
+        runtime.anthropic, tenant_id=tenant_id, agent_id=agent_id
+    )
+    if agent is None:
+        log.warning(
+            "credential_request.agent_gone",
+            tenant_id=str(tenant_id),
+            agent_id=str(agent_id),
+        )
+        await _post_ephemeral(
+            client, channel_id=channel_id, user_id=user_id, text=_AGENT_GONE_MESSAGE
+        )
+        return True
+    if agent.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
+        await _post_ephemeral(
+            client, channel_id=channel_id, user_id=user_id, text=_SHARED_AGENT_MESSAGE
+        )
+        return True
+    async with runtime.sessionmaker() as session:
+        reachable = await is_agent_reachable_in_tenant(
+            session,
+            tenant_id=tenant_id,
+            agent_name=agent.name,
+            default=runtime.deployment_default,
+        )
+    if reachable:
+        await _post_ephemeral(
+            client, channel_id=channel_id, user_id=user_id, text=_SHARED_AGENT_MESSAGE
+        )
+        return True
+    return False
+
+
+async def handle_credential_request_click(runtime: SlackRuntime, payload: dict[str, Any]) -> None:
+    """Dispatch a credential-request button click to the kind's modal.
+
+    The same lifecycle checks Discord's `interaction_check` runs, in the same
+    order: unknown token, wrong requester, expired, already used — each
+    answered with an ephemeral, never a modal. The repo kind additionally
+    runs the shared-agent admin gate as a pre-filter, so a member who was
+    always going to be refused is never asked to paste a token into a form
+    that gets thrown away. The submission re-runs every check that matters
+    (the consume is atomic; the repo gate runs again) — this pre-filter is
+    UX, not the authorization boundary.
+    """
+    team_info: dict[str, Any] = payload.get("team") or {}
+    user_info: dict[str, Any] = payload.get("user") or {}
+    channel_info: dict[str, Any] = payload.get("channel") or {}
+    container: dict[str, Any] = payload.get("container") or {}
+    team_id = str(team_info.get("id") or "")
+    user_id = str(user_info.get("id") or "")
+    channel_id = str(channel_info.get("id") or "")
+    message_ts = str(container.get("message_ts") or "")
+    trigger_id = str(payload.get("trigger_id") or "")
+    actions: list[dict[str, Any]] = payload.get("actions") or []
+    token = str(actions[0].get("value") or "") if actions else ""
+
+    if not (team_id and user_id and channel_id and message_ts and trigger_id and token):
+        return
+
+    client = await resolve_web_client(runtime, team_id=team_id)
+    if client is None:
+        return
+
+    async with runtime.sessionmaker() as session:
+        row = await credential_requests_store.peek_credential_request(session, token=token)
+
+    refusal: str | None = None
+    if row is None:
+        refusal = _NO_LONGER_VALID
+    elif derive_tenant_uuid(platform="slack", workspace_id=team_id) != row.tenant_id:
+        # Defense in depth, as on Discord: the posted button lives in the
+        # workspace the mint named, so a cross-workspace click stays
+        # unreachable by construction rather than by luck.
+        refusal = _WRONG_WORKSPACE
+    elif user_id != row.requester_platform_user_id:
+        refusal = _WRONG_REQUESTER
+    elif row.used_at is not None:
+        refusal = _ALREADY_USED
+    elif row.expires_at < datetime.now(UTC):
+        refusal = _EXPIRED
+    if refusal is not None or row is None:
+        await _post_ephemeral(
+            client, channel_id=channel_id, user_id=user_id, text=refusal or _NO_LONGER_VALID
+        )
+        return
+
+    if row.kind == "repo" and await _refuse_if_shared_and_not_admin_for_request(
+        runtime,
+        client,
+        tenant_id=row.tenant_id,
+        agent_id=row.agent_id,
+        channel_id=channel_id,
+        user_id=user_id,
+    ):
+        return
+
+    await client.views_open(  # pyright: ignore[reportUnknownMemberType]
+        trigger_id=trigger_id,
+        view=build_credential_modal(
+            kind=cast("CredentialRequestKind", row.kind),
+            token=token,
+            channel_id=channel_id,
+            message_ts=message_ts,
+            target=row.target,
+        ),
+    )
+
+
+async def _mark_button_consumed(
+    client: AsyncWebClient,
+    *,
+    channel_id: str,
+    message_ts: str,
+    kind: CredentialRequestKind,
+    target: str,
+) -> None:
+    """Swap the request message for a durable consumed marker, in place.
+
+    Kind-agnostic and about the SUBMISSION rather than the write, exactly as
+    on Discord: this runs the moment the consume commits, before the
+    vault/binding/import after it is known to have worked, and one of those
+    failing still leaves the button dead — leaving it looking live invites a
+    click that cannot succeed. A failed edit is a downgrade in feedback, not
+    in correctness, so it only logs.
+    """
+    label = build_button_label(kind, target, max_chars=MAX_SLACK_BUTTON_LABEL_CHARS)
+    text = f"✓ Received — {label}"
+    try:
+        await client.chat_update(  # pyright: ignore[reportUnknownMemberType]
+            channel=channel_id,
+            ts=message_ts,
+            text=text,
+            blocks=[
+                {
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": text}],
+                }
+            ],
+        )
+    except Exception as err:
+        log.warning(
+            "credential_request.consumed_edit_failed",
+            kind=kind,
+            err_type=type(err).__name__,
+        )
+
+
+async def _consume(
+    runtime: SlackRuntime, *, token: str, now: datetime
+) -> CredentialRequestRow | None:
+    async with runtime.sessionmaker() as session, session.begin():
+        return await credential_requests_store.consume_credential_request(
+            session, token=token, now=now
+        )
+
+
+async def run_env_credential_submission(
+    runtime: SlackRuntime,
+    *,
+    team_id: str,
+    user_id: str,
+    channel_id: str,
+    message_ts: str,
+    token: str,
+    value: str,
+) -> None:
+    """Post-ack: atomic consume + agent_files write, in one transaction.
+
+    The consume and the file write commit together, so the first point the
+    row is durably spent is also the point the secret is durably stored.
+    """
+    client = await resolve_web_client(runtime, team_id=team_id)
+    if client is None:
+        return
+
+    now = datetime.now(UTC)
+    try:
+        async with runtime.sessionmaker() as session, session.begin():
+            consumed = await credential_requests_store.consume_credential_request(
+                session, token=token, now=now
+            )
+            if consumed is None:
+                await _post_ephemeral(
+                    client, channel_id=channel_id, user_id=user_id, text=_NO_LONGER_VALID
+                )
+                return
+            await put_agent_file(
+                session,
+                tenant_id=consumed.tenant_id,
+                agent_id=consumed.agent_id,
+                key=consumed.target,
+                content=value,
+            )
+    except Exception:
+        log.exception("credential_request.env_write_failed", key_present=True)
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text="Something went wrong — please try again.",
+        )
+        return
+
+    # Log the key NAME only — never the value.
+    log.info("credential_request.env.submit", key=consumed.target)
+    await _mark_button_consumed(
+        client, channel_id=channel_id, message_ts=message_ts, kind="env", target=consumed.target
+    )
+    await _post_ephemeral(
+        client,
+        channel_id=channel_id,
+        user_id=user_id,
+        text=(
+            f"Added `{consumed.target}`. Takes effect on the next session — "
+            "anyone who talks to this agent can use it."
+        ),
+    )
+
+
+async def run_mcp_credential_submission(
+    runtime: SlackRuntime,
+    *,
+    team_id: str,
+    user_id: str,
+    channel_id: str,
+    message_ts: str,
+    token: str,
+    value: str,
+) -> None:
+    """Post-ack: consume, then the vault write and the agent attach.
+
+    The configuration check precedes the consume — an unconfigured daimon-mcp
+    must not spend the request. Partial states after the consume are reported
+    truthfully: token stored but not attached is not success.
+    """
+    client = await resolve_web_client(runtime, team_id=team_id)
+    if client is None:
+        return
+
+    mcp = runtime.settings.mcp
+    if mcp.public_url is None or mcp.jwt_secret is None:
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text=(
+                "daimon-mcp is not configured (public_url / jwt_secret missing) — "
+                "credential not written."
+            ),
+        )
+        return
+
+    now = datetime.now(UTC)
+    consumed = await _consume(runtime, token=token, now=now)
+    if consumed is None:
+        await _post_ephemeral(client, channel_id=channel_id, user_id=user_id, text=_NO_LONGER_VALID)
+        return
+
+    await _mark_button_consumed(
+        client, channel_id=channel_id, message_ts=message_ts, kind="mcp", target=consumed.target
+    )
+
+    mcp_server_url = consumed.mcp_server_url
+    if mcp_server_url is None:
+        log.error("credential_request.mcp_missing_server_url", token_tail=token[-4:])
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text="This request is missing its server URL — please ask again.",
+        )
+        return
+
+    log.info(
+        "credential_request.mcp.submit",
+        mcp_server_url=mcp_server_url,
+        token_masked=mask_tail(value),
+    )
+    try:
+        # Agent-scoped copy first: the server is attached to the AGENT, so
+        # every caller's session needs this credential mirrored in at create
+        # time. Without this row the server works only for whoever filled in
+        # this modal.
+        if runtime.turn_deps.fernet is not None:
+            await save_agent_mcp_credential(
+                sessionmaker=runtime.sessionmaker,
+                fernet=runtime.turn_deps.fernet,
+                tenant_id=consumed.tenant_id,
+                agent_id=consumed.agent_id,
+                mcp_server_url=mcp_server_url,
+                plaintext_token=value,
+            )
+        else:
+            log.warning(
+                "credential_request.no_fernet_for_agent_scope",
+                mcp_server_url=mcp_server_url,
+            )
+        await add_external_mcp_credential(
+            runtime.anthropic,
+            account_id=consumed.account_id,
+            agent_id=consumed.agent_id,
+            jwt_secret=mcp.jwt_secret.get_secret_value().encode(),
+            public_url=str(mcp.public_url),
+            mcp_server_url=mcp_server_url,
+            token=value,
+            now=now,
+            session_factory=runtime.sessionmaker,
+        )
+    except Exception as err:
+        log.exception(
+            "credential_request.mcp_write_failed",
+            mcp_server_url=mcp_server_url,
+            err_type=type(err).__name__,
+        )
+        # Exception class name only — a stringified SDK/network error can
+        # carry the request envelope, which is a token-leak surface.
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text=(
+                "Credential request consumed, but storing the auth token failed "
+                f"(`{type(err).__name__}`). Ask for a new request to retry."
+            ),
+        )
+        return
+
+    # The vault credential alone is inert: MA rejects an agent whose
+    # mcp_servers are not each referenced by an mcp_toolset, so a token
+    # stored against a server the agent never declares is unreachable. The
+    # request tool is documented as the replacement for attach_mcp_server on
+    # auth-required servers, so it owes the attach too.
+    agent = await find_agent_by_derived_uuid(
+        runtime.anthropic, tenant_id=consumed.tenant_id, agent_id=consumed.agent_id
+    )
+    if agent is None:
+        log.error("credential_request.mcp_agent_not_found", agent_id=str(consumed.agent_id))
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text=(
+                f"Auth token stored, but the agent could not be found to attach "
+                f"`{mcp_server_url}` to it. The server is not connected yet."
+            ),
+        )
+        return
+    try:
+        await attach_mcp_server_to_agent(
+            runtime.anthropic,
+            agent.id,
+            server_name=consumed.target,
+            url=mcp_server_url,
+        )
+    except Exception as err:
+        log.exception(
+            "credential_request.mcp_attach_failed",
+            mcp_server_url=mcp_server_url,
+            err_type=type(err).__name__,
+        )
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text=(
+                f"Auth token stored, but attaching `{mcp_server_url}` to the agent "
+                f"failed (`{type(err).__name__}`). The server is not connected yet — "
+                "ask the agent to attach it, or request a new credential to retry."
+            ),
+        )
+        return
+
+    await _post_ephemeral(
+        client,
+        channel_id=channel_id,
+        user_id=user_id,
+        text=(
+            f"MCP credential added for `{mcp_server_url}` and attached as "
+            f"`{consumed.target}`. Anyone who talks to this agent can use it."
+        ),
+    )
+
+
+async def _resolve_repo_binding_credential(
+    runtime: SlackRuntime,
+    http_client: httpx.AsyncClient,
+    *,
+    agent_id: uuid.UUID,
+    account_id: uuid.UUID,
+    repo_url: str,
+    pasted_pat: str | None,
+    now: datetime,
+) -> tuple[str, RepoAccessProof]:
+    """Resolve the clone credential for a chat-initiated repo bind.
+
+    The Slack twin of Discord's `credential_repo_bind.resolve_repo_binding_credential`
+    — same order, same messages, same precedence, driven by this adapter's
+    own inline-PAT store helpers. There is deliberately no GitHub App tier:
+    an App installation is keyed by the repo, not by the tenant doing this
+    bind, so its coverage proves nothing about whether *this* binder may read
+    the repo.
+
+    Raises `DaimonError` — never a sentinel — before any write when the
+    presented credential does not clear the repo it names.
+    """
+    owner_repo = normalize_owner_repo(repo_url)
+    pat = (pasted_pat or "").strip()
+    if pat:
+        has_access = await pat_can_access_repo(http_client, owner_repo=owner_repo, pat=pat)
+        if not has_access:
+            raise DaimonError(
+                "That token can't access this repo (or the repo doesn't "
+                "exist). Paste a PAT that has access, or connect GitHub."
+            )
+        ma_secret_ref = await store_inline_pat(
+            runtime, account_id=account_id, agent_id=agent_id, plaintext_pat=pat
+        )
+        return ma_secret_ref, RepoAccessProof(kind="pat", at=now, account_id=account_id)
+
+    existing_pat = await load_agent_inline_pat(runtime, agent_id=agent_id)
+    if existing_pat is not None:
+        covers_new_repo = await pat_can_access_repo(
+            http_client, owner_repo=owner_repo, pat=existing_pat
+        )
+        if not covers_new_repo:
+            raise DaimonError(
+                "This agent already has a stored GitHub token that can't "
+                "access this repo. Paste a token that can, or clear the "
+                "stored one, then bind again."
+            )
+        return f"inline-pat:{agent_id}", RepoAccessProof(kind="pat", at=now, account_id=account_id)
+
+    public = await is_public_repo(http_client, owner_repo=owner_repo)
+    if not public:
+        raise DaimonError(
+            "This repo isn't publicly readable (it's private, or it "
+            "doesn't exist) — paste a GitHub token that can read it to "
+            "bind it."
+        )
+    return "anon:", RepoAccessProof(kind="public", at=now, account_id=account_id)
+
+
+async def run_skill_repo_credential_submission(
+    runtime: SlackRuntime,
+    *,
+    team_id: str,
+    user_id: str,
+    channel_id: str,
+    message_ts: str,
+    token: str,
+    value: str,
+) -> None:
+    """Post-ack: consume, verify the token against the SKILL repo, store,
+    bind, and re-run the import.
+
+    Mirrors Discord's `SkillRepoModal` — no `set_binding`-free variant here
+    either: the skill-sync resolver finds a per-agent token by walking the
+    tenant's `agent_repo_binding` rows for the repo, so storing the
+    credential without binding leaves every later sync resolving no token.
+    No admin gate, matching the env/mcp kinds — `sync_skills` itself gates
+    imports at request time.
+    """
+    client = await resolve_web_client(runtime, team_id=team_id)
+    if client is None:
+        return
+
+    now = datetime.now(UTC)
+    consumed = await _consume(runtime, token=token, now=now)
+    if consumed is None:
+        await _post_ephemeral(client, channel_id=channel_id, user_id=user_id, text=_NO_LONGER_VALID)
+        return
+
+    await _mark_button_consumed(
+        client,
+        channel_id=channel_id,
+        message_ts=message_ts,
+        kind="skill_repo",
+        target=consumed.target,
+    )
+
+    url, branch, path = split_skill_repo_target(consumed.target)
+    log.info(
+        "credential_request.skill_repo.submit",
+        repo_url=url,
+        branch=branch,
+        path=path,
+        pat_masked=mask_tail(value),
+    )
+
+    try:
+        # Verify BEFORE storing: a token that cannot read this repo is not a
+        # credential for it, and storing it would shadow a working one on the
+        # next `get_pat` (the overlay is last-write-wins).
+        if not await pat_can_access_repo(
+            runtime.http_client, owner_repo=normalize_owner_repo(url), pat=value
+        ):
+            await _post_ephemeral(
+                client,
+                channel_id=channel_id,
+                user_id=user_id,
+                text=(
+                    f"That token cannot read `{normalize_owner_repo(url)}`. Nothing was "
+                    "stored, and the request was used up — ask again to retry."
+                ),
+            )
+            return
+        ma_secret_ref, proof = await _resolve_repo_binding_credential(
+            runtime,
+            runtime.http_client,
+            agent_id=consumed.agent_id,
+            account_id=consumed.account_id,
+            repo_url=url,
+            pasted_pat=value,
+            now=now,
+        )
+        async with runtime.sessionmaker.begin() as session:
+            await set_binding(
+                session,
+                tenant_id=consumed.tenant_id,
+                agent_id=consumed.agent_id,
+                repo_url=url,
+                default_branch=branch,
+                ma_secret_ref=ma_secret_ref,
+                proof=proof,
+            )
+        outcomes = await run_skill_sync(
+            runtime.anthropic,
+            runtime.http_client,
+            url=url,
+            branch=branch,
+            path=path,
+            tenant_id=consumed.tenant_id,
+            token=value,
+        )
+    except DaimonError as err:
+        # Written for the user by the raiser — surface verbatim.
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text=(
+                f"Token stored, but the import failed: {err} The request was used up — "
+                "ask again to retry the import."
+            ),
+        )
+        return
+    except Exception as err:
+        log.exception(
+            "credential_request.skill_repo_sync_failed",
+            repo_url=url,
+            err_type=type(err).__name__,
+        )
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text=(
+                f"Token stored, but the import failed (`{type(err).__name__}`). "
+                "Ask again to retry the import."
+            ),
+        )
+        return
+
+    await _post_ephemeral(
+        client,
+        channel_id=channel_id,
+        user_id=user_id,
+        text=(
+            f"Imported {len(outcomes)} skill(s) from `{normalize_owner_repo(url)}`. "
+            "The token is stored and the repo is bound, so future imports from it "
+            "will not ask again."
+        ),
+    )
+
+
+async def run_repo_bind_credential_submission(
+    runtime: SlackRuntime,
+    *,
+    team_id: str,
+    user_id: str,
+    channel_id: str,
+    message_ts: str,
+    token: str,
+    value: str,
+    branch: str,
+) -> None:
+    """Post-ack: gate, atomic consume, credential resolution, binding write.
+
+    The shared-agent admin gate runs again here — immediately before the
+    consume — rather than being trusted from the click-time pre-filter: a
+    member who was an admin when the button was clicked may have lost it
+    between click and submit. This call is the authorization boundary.
+    """
+    client = await resolve_web_client(runtime, team_id=team_id)
+    if client is None:
+        return
+
+    now = datetime.now(UTC)
+    async with runtime.sessionmaker() as session:
+        row = await credential_requests_store.peek_credential_request(session, token=token)
+    if row is None:
+        await _post_ephemeral(client, channel_id=channel_id, user_id=user_id, text=_NO_LONGER_VALID)
+        return
+
+    if await _refuse_if_shared_and_not_admin_for_request(
+        runtime,
+        client,
+        tenant_id=row.tenant_id,
+        agent_id=row.agent_id,
+        channel_id=channel_id,
+        user_id=user_id,
+    ):
+        return
+
+    consumed = await _consume(runtime, token=token, now=now)
+    if consumed is None:
+        await _post_ephemeral(client, channel_id=channel_id, user_id=user_id, text=_NO_LONGER_VALID)
+        return
+
+    await _mark_button_consumed(
+        client, channel_id=channel_id, message_ts=message_ts, kind="repo", target=consumed.target
+    )
+
+    pat = value.strip()
+    # Log the repo and branch, and the token ONLY as a masked tail when
+    # present — never the plain value, never the (now-consumed) request token.
+    log.info(
+        "credential_request.repo.submit",
+        repo_url=consumed.target,
+        branch=branch,
+        pat_masked=mask_tail(pat) if pat else None,
+    )
+
+    try:
+        ma_secret_ref, proof = await _resolve_repo_binding_credential(
+            runtime,
+            runtime.http_client,
+            agent_id=consumed.agent_id,
+            account_id=consumed.account_id,
+            repo_url=consumed.target,
+            pasted_pat=pat or None,
+            now=now,
+        )
+        async with runtime.sessionmaker.begin() as session:
+            await set_binding(
+                session,
+                tenant_id=consumed.tenant_id,
+                agent_id=consumed.agent_id,
+                repo_url=consumed.target,
+                default_branch=branch,
+                ma_secret_ref=ma_secret_ref,
+                proof=proof,
+            )
+    except DaimonError as err:
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text=f"{err} The request was used up — ask again to retry.",
+        )
+        return
+    except Exception as err:
+        log.exception(
+            "credential_request.repo_write_failed",
+            repo_url=consumed.target,
+            err_type=type(err).__name__,
+        )
+        await _post_ephemeral(
+            client,
+            channel_id=channel_id,
+            user_id=user_id,
+            text=(
+                "Credential request consumed, but binding the repo failed "
+                f"(`{type(err).__name__}`). Ask for a new request to retry."
+            ),
+        )
+        return
+
+    await _post_ephemeral(
+        client,
+        channel_id=channel_id,
+        user_id=user_id,
+        text=f"Bound `{consumed.target}` on `{branch}`. Takes effect on the next session.",
+    )

--- a/packages/adapters/slack/daimon/adapters/slack/credential_requests.py
+++ b/packages/adapters/slack/daimon/adapters/slack/credential_requests.py
@@ -36,9 +36,15 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any, Final, cast
 
+import anthropic
 import httpx
 import structlog
-from daimon.adapters.slack.admin import resolve_is_admin
+from anthropic.types.beta import BetaManagedAgentsAgent
+from anthropic.types.beta.beta_managed_agents_skill_params import BetaManagedAgentsSkillParams
+from daimon.adapters.slack.admin import (
+    _dev_allow_all_admin,  # pyright: ignore[reportPrivateUsage]
+    resolve_is_admin,
+)
 from daimon.adapters.slack.agent_setup.write import (
     load_agent_inline_pat,
     mask_tail,
@@ -53,11 +59,14 @@ from daimon.core.credential_requests import (
     build_button_label,
     split_skill_repo_target,
 )
-from daimon.core.defaults.ma_index import find_agent_by_derived_uuid
+from daimon.core.defaults.ma_index import find_agent_by_derived_uuid, find_attach_mount_collision
 from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED
+from daimon.core.defaults.report import Action, ResourceOutcome
+from daimon.core.defaults.spec_merge import merge_skills_with_ma
 from daimon.core.errors import DaimonError
 from daimon.core.github_repo_auth import normalize_owner_repo
 from daimon.core.github_visibility import is_public_repo, pat_can_access_repo
+from daimon.core.ma import update_agent_with_version_retry
 from daimon.core.ma_identity import derive_tenant_uuid
 from daimon.core.mcp_attach import attach_mcp_server_to_agent
 from daimon.core.mcp_vault import add_external_mcp_credential
@@ -340,7 +349,7 @@ async def _refuse_if_shared_and_not_admin_for_request(
 
     Returns True when the caller must return immediately (refused).
     """
-    if await resolve_is_admin(client, user_id=user_id):
+    if await resolve_is_admin(client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)):
         return False
     agent = await find_agent_by_derived_uuid(
         runtime.anthropic, tenant_id=tenant_id, agent_id=agent_id
@@ -419,10 +428,10 @@ async def handle_credential_request_click(runtime: SlackRuntime, payload: dict[s
         refusal = _WRONG_WORKSPACE
     elif user_id != row.requester_platform_user_id:
         refusal = _WRONG_REQUESTER
-    elif row.used_at is not None:
-        refusal = _ALREADY_USED
     elif row.expires_at < datetime.now(UTC):
         refusal = _EXPIRED
+    elif row.used_at is not None:
+        refusal = _ALREADY_USED
     if refusal is not None or row is None:
         await _post_ephemeral(
             client, channel_id=channel_id, user_id=user_id, text=refusal or _NO_LONGER_VALID
@@ -785,6 +794,63 @@ async def _resolve_repo_binding_credential(
     return "anon:", RepoAccessProof(kind="public", at=now, account_id=account_id)
 
 
+async def _attach_skills_to_requested_agent(
+    runtime: SlackRuntime,
+    *,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    outcomes: list[ResourceOutcome],
+) -> str:
+    """Attach the just-imported skills to the agent this request named.
+
+    Importing puts skills in the tenant's shared library; it does not put
+    them on an agent. The request row already names the agent, so doing
+    only the import leaves the user staring at an agent with no skills and
+    no way to tell that anything worked.
+
+    Returns prose rather than raising: the import has already succeeded by
+    the time this runs, so a failure here is partial and both halves must
+    be reported truthfully.
+    """
+    skill_ids = sorted(
+        outcome.anthropic_id
+        for outcome in outcomes
+        if outcome.anthropic_id is not None and outcome.action in (Action.CREATED, Action.UPDATED)
+    )
+    if not skill_ids:
+        return "Nothing new to attach."
+    agent = await find_agent_by_derived_uuid(
+        runtime.anthropic, tenant_id=tenant_id, agent_id=agent_id
+    )
+    if agent is None:
+        return "Could not attach: that agent no longer exists. The skills are in the library."
+    new_skills: list[BetaManagedAgentsSkillParams] = [
+        {"type": "custom", "skill_id": skill_id} for skill_id in skill_ids
+    ]
+
+    async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
+        merged = merge_skills_with_ma(new_skills, fresh)
+        collision = await find_attach_mount_collision(
+            runtime.anthropic, tenant_id=tenant_id, skills=merged
+        )
+        if collision is not None:
+            raise DaimonError(f"cannot attach: {collision}")
+        return await runtime.anthropic.beta.agents.update(
+            fresh.id, version=fresh.version, skills=merged
+        )
+
+    try:
+        await update_agent_with_version_retry(runtime.anthropic, agent.id, _apply)
+    except (DaimonError, anthropic.APIStatusError) as err:
+        log.warning(
+            "credential_request.skill_repo_attach_failed",
+            agent_id=str(agent_id),
+            err_type=type(err).__name__,
+        )
+        return f"Imported, but attaching to `{agent.name}` failed ({type(err).__name__})."
+    return f"Attached {len(skill_ids)} to `{agent.name}`."
+
+
 async def run_skill_repo_credential_submission(
     runtime: SlackRuntime,
     *,
@@ -796,7 +862,7 @@ async def run_skill_repo_credential_submission(
     value: str,
 ) -> None:
     """Post-ack: consume, verify the token against the SKILL repo, store,
-    bind, and re-run the import.
+    bind, re-run the import, and attach the imported skills to the agent.
 
     Mirrors Discord's `SkillRepoModal` — no `set_binding`-free variant here
     either: the skill-sync resolver finds a per-agent token by walking the
@@ -906,14 +972,17 @@ async def run_skill_repo_credential_submission(
         )
         return
 
+    attach_note = await _attach_skills_to_requested_agent(
+        runtime, tenant_id=consumed.tenant_id, agent_id=consumed.agent_id, outcomes=outcomes
+    )
     await _post_ephemeral(
         client,
         channel_id=channel_id,
         user_id=user_id,
         text=(
             f"Imported {len(outcomes)} skill(s) from `{normalize_owner_repo(url)}`. "
-            "The token is stored and the repo is bound, so future imports from it "
-            "will not ask again."
+            f"{attach_note} The token is stored and the repo is bound, so future "
+            "imports from it will not ask again."
         ),
     )
 

--- a/packages/adapters/slack/tests/test_app_credential_dispatch.py
+++ b/packages/adapters/slack/tests/test_app_credential_dispatch.py
@@ -1,0 +1,190 @@
+"""Dispatch tests for the credential-request routes in SlackApp.on_request.
+
+Covers:
+- credential_request block_action: empty ack first, then the click handler
+  is spawned with the payload.
+- credential_request__env view_submission: ack carries the field-error
+  payload for an empty value (no background run spawns), and an empty ack
+  plus a spawned runner for a valid value.
+- An external Slack Connect click never reaches the handler.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+from anthropic import AsyncAnthropic
+from daimon.adapters.slack.app import SlackApp
+from daimon.adapters.slack.runtime import SlackRuntime
+from pydantic import SecretStr
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode.response import SocketModeResponse
+
+
+@dataclasses.dataclass
+class _FakeSocketClient:
+    call_log: list[str] = dataclasses.field(default_factory=list[str])
+    sent_responses: list[SocketModeResponse] = dataclasses.field(
+        default_factory=list[SocketModeResponse]
+    )
+
+    async def send_socket_mode_response(self, response: SocketModeResponse) -> None:
+        self.call_log.append("send_socket_mode_response")
+        self.sent_responses.append(response)
+
+
+def _make_app() -> SlackApp:
+    settings = MagicMock()
+    settings.crypto.keys = (SecretStr("dummykey"),)
+    settings.slack.max_concurrent_turns_per_tenant = 3
+    runtime = SlackRuntime(
+        settings=settings,
+        anthropic=MagicMock(spec=AsyncAnthropic),
+        sessionmaker=MagicMock(),
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+    return SlackApp(runtime=runtime)
+
+
+async def _drain(app: SlackApp) -> None:
+    pending = list(app._bg_tasks)  # pyright: ignore[reportPrivateUsage]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _click_payload(*, external: bool = False) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": "block_actions",
+        "team": {"id": "T_TEST"},
+        "user": {"id": "U_TEST"},
+        "channel": {"id": "C_TEST"},
+        "container": {"message_ts": "1700000003.000300"},
+        "trigger_id": "trig_cred_click",
+        "actions": [{"action_id": "credential_request", "value": "tok_click"}],
+    }
+    if external:
+        payload["user"]["team_id"] = "T_OTHER"
+        payload["is_enterprise_install"] = False
+    return payload
+
+
+def _submission_payload(value: str) -> dict[str, Any]:
+    return {
+        "type": "view_submission",
+        "team": {"id": "T_TEST"},
+        "user": {"id": "U_TEST"},
+        "view": {
+            "callback_id": "credential_request__env",
+            "private_metadata": json.dumps(
+                {
+                    "token": "tok_submit",
+                    "channel_id": "C_TEST",
+                    "message_ts": "1700000003.000300",
+                },
+                separators=(",", ":"),
+            ),
+            "state": {
+                "values": {
+                    "credential__value": {
+                        "credential__value": {"type": "plain_text_input", "value": value}
+                    }
+                }
+            },
+        },
+    }
+
+
+async def test_credential_click_acks_first_then_spawns_handler() -> None:
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+    seen: list[dict[str, Any]] = []
+
+    async def _fake_click(runtime: Any, payload: Any) -> None:
+        seen.append(payload)
+
+    req = SocketModeRequest(
+        type="interactive", envelope_id="env_cred_click_001", payload=_click_payload()
+    )
+    with patch("daimon.adapters.slack.app.handle_credential_request_click", new=_fake_click):
+        await app.on_request(fake_client, req)  # type: ignore[arg-type]
+        await _drain(app)
+
+    assert fake_client.call_log[0] == "send_socket_mode_response"
+    assert len(seen) == 1 and seen[0]["actions"][0]["value"] == "tok_click"
+
+
+async def test_env_submission_with_empty_value_acks_errors_and_spawns_nothing() -> None:
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+    ran: list[str] = []
+
+    async def _fake_run(*args: Any, **kwargs: Any) -> None:
+        ran.append("ran")
+
+    req = SocketModeRequest(
+        type="interactive",
+        envelope_id="env_cred_submit_empty",
+        payload=_submission_payload("   "),
+    )
+    with patch("daimon.adapters.slack.app.run_env_credential_submission", new=_fake_run):
+        await app.on_request(fake_client, req)  # type: ignore[arg-type]
+        await _drain(app)
+
+    ack = fake_client.sent_responses[0].payload
+    assert isinstance(ack, dict) and ack.get("response_action") == "errors", (
+        "an empty value must ack with the field-error payload"
+    )
+    assert not ran, "a rejected submission must not spawn a background run"
+
+
+async def test_env_submission_with_value_acks_empty_and_spawns_runner() -> None:
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+    ran: list[dict[str, Any]] = []
+
+    async def _fake_run(runtime: Any, **kwargs: Any) -> None:
+        ran.append(kwargs)
+
+    req = SocketModeRequest(
+        type="interactive",
+        envelope_id="env_cred_submit_ok",
+        payload=_submission_payload("s3cr3t"),
+    )
+    with patch("daimon.adapters.slack.app.run_env_credential_submission", new=_fake_run):
+        await app.on_request(fake_client, req)  # type: ignore[arg-type]
+        await _drain(app)
+
+    ack = fake_client.sent_responses[0].payload
+    assert not ack, "a valid submission must ack empty (close the modal)"
+    assert len(ran) == 1
+    assert ran[0]["token"] == "tok_submit"
+    assert ran[0]["value"] == "s3cr3t"
+    assert ran[0]["message_ts"] == "1700000003.000300"
+
+
+async def test_external_connect_click_never_reaches_the_handler() -> None:
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+    seen: list[dict[str, Any]] = []
+
+    async def _fake_click(runtime: Any, payload: Any) -> None:
+        seen.append(payload)
+
+    req = SocketModeRequest(
+        type="interactive",
+        envelope_id="env_cred_click_external",
+        payload=_click_payload(external=True),
+    )
+    with patch("daimon.adapters.slack.app.handle_credential_request_click", new=_fake_click):
+        await app.on_request(fake_client, req)  # type: ignore[arg-type]
+        await _drain(app)
+
+    assert not seen, "an external Slack Connect click must be rejected before dispatch"

--- a/packages/adapters/slack/tests/test_credential_requests.py
+++ b/packages/adapters/slack/tests/test_credential_requests.py
@@ -13,8 +13,9 @@ Pure builders / evaluation:
 
 handle_credential_request_click (real Postgres + FakeSlackWebClient):
   - A live request clicked by its requester opens the kind's modal.
-  - Wrong requester / expired / already-used / unknown token each answer
-    with an ephemeral and never open a modal.
+  - Wrong requester / expired / already-used / unknown token / wrong
+    workspace each answer with an ephemeral and never open a modal, and a
+    row that is both expired and used answers "expired" (Discord's order).
   - The repo kind refuses a non-admin whose agent cannot be resolved
     (fail closed) and lets a workspace admin through before any MA read.
 
@@ -23,7 +24,10 @@ run_* submissions:
     updated in place and the requester gets an ephemeral.
   - A second submission of a consumed row writes nothing.
   - mcp: missing daimon-mcp configuration refuses BEFORE the consume.
-  - repo: non-admin refused before the consume; admin + public repo binds.
+  - repo: non-admin refused before the consume; an admin (via the dev
+    override, which must reach this gate) binds a public repo.
+  - skill_repo: the pasted token binds the repo and the imported skills are
+    attached to the agent the request named.
 """
 
 from __future__ import annotations
@@ -32,12 +36,14 @@ import json
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 import yarl
+from anthropic.types.beta import BetaManagedAgentsAgent
 from cryptography.fernet import Fernet
+from daimon.adapters.slack import credential_requests as credential_requests_mod
 from daimon.adapters.slack.credential_requests import (
     CRED_CALLBACK_PREFIX,
     build_credential_modal,
@@ -46,18 +52,23 @@ from daimon.adapters.slack.credential_requests import (
     run_env_credential_submission,
     run_mcp_credential_submission,
     run_repo_bind_credential_submission,
+    run_skill_repo_credential_submission,
 )
 from daimon.adapters.slack.runtime import SlackRuntime
-from daimon.core.credential_requests import mint_request_token
+from daimon.core.credential_requests import build_skill_repo_target, mint_request_token
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
+from daimon.core.defaults.report import Action, ResourceOutcome
 from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
+from daimon.core.stores.agent_repo_binding import get_binding
 from daimon.core.stores.credential_requests import (
+    consume_credential_request,
     create_credential_request,
     peek_credential_request,
 )
 from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
-from daimon.testing.factories import make_tenant
-from daimon.testing.ma import build_fake_anthropic, make_fake_ma_handler
+from daimon.testing.factories import make_account, make_tenant
+from daimon.testing.ma import build_fake_anthropic, list_response, make_fake_ma_handler
 from pydantic import SecretStr
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -196,6 +207,10 @@ async def _seed_team(session: AsyncSession, *, team_id: str = _TEAM_ID) -> tuple
     fernet_key = Fernet.generate_key().decode()
     fernet = build_multifernet((fernet_key,))
     tenant = await make_tenant(session, platform="slack", workspace_id=team_id)
+    # The guild account row the request rows point at: `set_binding` writes
+    # `RepoAccessProof.account_id` with an FK to accounts.id, so any test that
+    # reaches a binding write needs it to exist.
+    await make_account(session, tenant=tenant, id=derive_guild_account_uuid(tenant_id=tenant.id))
     await upsert_slack_bot_token(
         session, team_id=team_id, encrypted_token=encrypt_token(fernet, "xoxb-test")
     )
@@ -212,6 +227,7 @@ async def _seed_request(
     requester: str = _USER_ID,
     expires_in: timedelta = timedelta(minutes=30),
     mcp_server_url: str | None = None,
+    agent_id: uuid.UUID | None = None,
 ) -> str:
     token = mint_request_token()
     await create_credential_request(
@@ -219,7 +235,7 @@ async def _seed_request(
         token=token,
         kind=kind,  # type: ignore[arg-type]
         tenant_id=tenant_id,
-        agent_id=uuid.uuid4(),
+        agent_id=agent_id if agent_id is not None else uuid.uuid4(),
         account_id=derive_guild_account_uuid(tenant_id=tenant_id),
         target=target,
         mcp_server_url=mcp_server_url,
@@ -231,14 +247,24 @@ async def _seed_request(
     return token
 
 
-def _build_runtime(fernet_key: str, db_factory: async_sessionmaker[AsyncSession]) -> SlackRuntime:
+def _build_runtime(
+    fernet_key: str,
+    db_factory: async_sessionmaker[AsyncSession],
+    *,
+    dev_allow_all_admin: bool = False,
+    anthropic_handler: Any = None,
+) -> SlackRuntime:
     settings = MagicMock()
     settings.crypto.keys = (SecretStr(fernet_key),)
     settings.mcp.public_url = None
     settings.mcp.jwt_secret = None
+    # MagicMock attributes are truthy — the admin override must be pinned off
+    # explicitly or every gate test silently runs as a dev-mode admin.
+    settings.slack.dev_allow_all_admin = dev_allow_all_admin
+    settings.github.oauth_scopes = ("repo",)
     return SlackRuntime(
         settings=settings,
-        anthropic=build_fake_anthropic(make_fake_ma_handler()),
+        anthropic=build_fake_anthropic(anthropic_handler or make_fake_ma_handler()),
         sessionmaker=db_factory,
         billing_config=None,
         http_client=MagicMock(spec=httpx.AsyncClient),
@@ -329,6 +355,75 @@ async def test_unknown_token_gets_ephemeral_and_no_modal(
 
     assert ("POST", _VIEWS_OPEN_URL) not in fake_slack_web_client.mock.requests
     assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+
+
+def _ephemeral_texts(fake_slack_web_client: Any) -> list[str]:
+    posts = fake_slack_web_client.mock.requests.get(("POST", _EPHEMERAL_URL), [])
+    return [str((p.kwargs.get("json") or {}).get("text") or "") for p in posts]
+
+
+@pytest.mark.asyncio
+async def test_already_used_request_gets_ephemeral_and_no_modal(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(db_session, tenant_id=tenant_id)
+    consumed = await consume_credential_request(db_session, token=token, now=datetime.now(UTC))
+    assert consumed is not None
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_credential_request_click(runtime, _click_payload(token))
+
+    assert ("POST", _VIEWS_OPEN_URL) not in fake_slack_web_client.mock.requests
+    assert any("already used" in t for t in _ephemeral_texts(fake_slack_web_client))
+
+
+@pytest.mark.asyncio
+async def test_expired_request_answers_expired_even_when_also_used(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """Pins the check order against Discord's `interaction_check`: a row that
+    is both expired and used answers "expired", not "already used"."""
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(db_session, tenant_id=tenant_id, expires_in=timedelta(minutes=-1))
+    await db_session.execute(
+        text("UPDATE credential_requests SET used_at = now() WHERE token = :token"),
+        {"token": token},
+    )
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_credential_request_click(runtime, _click_payload(token))
+
+    texts = _ephemeral_texts(fake_slack_web_client)
+    assert any("expired" in t for t in texts)
+    assert not any("already used" in t for t in texts)
+
+
+@pytest.mark.asyncio
+async def test_cross_workspace_click_gets_ephemeral_and_no_modal(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """A token minted for one workspace clicked from another must refuse even
+    for the right requester — the tenant check, not message routing, is what
+    keeps a leaked token unusable elsewhere."""
+    _tenant_id, fernet_key = await _seed_team(db_session)
+    other = await make_tenant(db_session, platform="slack", workspace_id="T_ELSEWHERE")
+    token = await _seed_request(db_session, tenant_id=other.id)
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_credential_request_click(runtime, _click_payload(token))
+
+    assert ("POST", _VIEWS_OPEN_URL) not in fake_slack_web_client.mock.requests
+    assert any("isn't for this workspace" in t for t in _ephemeral_texts(fake_slack_web_client))
 
 
 @pytest.mark.asyncio
@@ -500,3 +595,149 @@ async def test_repo_submission_refuses_non_admin_before_the_consume(
     )
     assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
     assert ("POST", _CHAT_UPDATE_URL) not in fake_slack_web_client.mock.requests
+
+
+@pytest.mark.asyncio
+async def test_repo_submission_by_admin_binds_a_public_repo(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """The dev override reaches the request gate the same way it reaches the
+    panel gate — without it, `resolve_is_admin` reads `users.info` and this
+    non-admin fake refuses before the consume."""
+    monkeypatch.setattr(credential_requests_mod, "is_public_repo", AsyncMock(return_value=True))
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(
+        db_session, tenant_id=tenant_id, kind="repo", target="https://github.com/o/r"
+    )
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory, dev_allow_all_admin=True)
+
+    await run_repo_bind_credential_submission(
+        runtime,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        message_ts=_MESSAGE_TS,
+        token=token,
+        value="",
+        branch="main",
+    )
+
+    async with db_session_factory() as s:
+        row = await peek_credential_request(s, token=token)
+        assert row is not None and row.used_at is not None
+        binding = await get_binding(s, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    assert binding is not None and binding.ma_secret_ref == "anon:"
+    assert binding.proof_kind == "public"
+    assert ("POST", _CHAT_UPDATE_URL) in fake_slack_web_client.mock.requests
+
+
+# ---------------------------------------------------------------------------
+# run_skill_repo_credential_submission
+# ---------------------------------------------------------------------------
+
+
+def _make_ma_agent(*, ma_agent_id: str, tenant_id: uuid.UUID, name: str) -> BetaManagedAgentsAgent:
+    return BetaManagedAgentsAgent(
+        id=ma_agent_id,
+        type="agent",
+        name=name,
+        model={"id": "claude-sonnet-4-6"},
+        metadata={"daimon_tenant": str(tenant_id)},
+        description=None,
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_skill_repo_submission_binds_and_attaches_the_imported_skills(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """Importing puts skills in the tenant library; the request names an agent,
+    so the submission must also attach them — import-without-attach leaves the
+    user with an agent that has no skills and a success message saying
+    otherwise. The pasted token must also produce an agent_repo_binding row:
+    the skill-sync resolver walks the tenant's bindings for the repo, so
+    without it the stored token is unreachable on every later sync."""
+    monkeypatch.setattr(
+        credential_requests_mod, "pat_can_access_repo", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        credential_requests_mod,
+        "run_skill_sync",
+        AsyncMock(
+            return_value=[
+                ResourceOutcome(
+                    kind="skill",
+                    name="imported-skill",
+                    action=Action.CREATED,
+                    anthropic_id="skill_01imported",
+                )
+            ]
+        ),
+    )
+    tenant_id, fernet_key = await _seed_team(db_session)
+    ma_agent_id = "agent_slack_skill_attach"
+    assert tenant_id == derive_tenant_uuid(platform="slack", workspace_id=_TEAM_ID)
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=ma_agent_id)
+    token = await _seed_request(
+        db_session,
+        tenant_id=tenant_id,
+        kind="skill_repo",
+        target=build_skill_repo_target("https://github.com/o/attach-repo", "main", ""),
+        agent_id=agent_id,
+    )
+    await db_session.commit()
+
+    agent = _make_ma_agent(ma_agent_id=ma_agent_id, tenant_id=tenant_id, name="daimon")
+    updates: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith(agent.id):
+            # Both the version-retry re-fetch and the update itself address the
+            # agent directly and must parse as ONE agent; only the list route
+            # gets the list envelope.
+            if request.method in ("POST", "PATCH"):
+                updates.append(json.loads(request.content))
+            return httpx.Response(200, json=agent.model_dump(mode="json"))
+        return list_response([agent.model_dump(mode="json")])
+
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    await run_skill_repo_credential_submission(
+        runtime,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        message_ts=_MESSAGE_TS,
+        token=token,
+        value="ghp_slack_attach_token",
+    )
+
+    async with db_session_factory() as s:
+        binding = await get_binding(s, tenant_id=tenant_id, agent_id=agent_id)
+    assert binding is not None, (
+        "a pasted skill-repo token must bind the repo — without the binding the "
+        "credential is stored but unreachable"
+    )
+    assert binding.proof_kind == "pat"
+    assert updates, "the submission must call agents.update to attach the imported skills"
+    attached_ids = {entry["skill_id"] for entry in updates[-1]["skills"]}
+    assert "skill_01imported" in attached_ids, (
+        "the newly imported skill must be attached to the agent the request named"
+    )
+    assert any("Attached 1 to `daimon`" in t for t in _ephemeral_texts(fake_slack_web_client)), (
+        "the success ephemeral must report the attach half, not just the import"
+    )

--- a/packages/adapters/slack/tests/test_credential_requests.py
+++ b/packages/adapters/slack/tests/test_credential_requests.py
@@ -1,0 +1,502 @@
+"""Tests for the Slack chat-initiated credential-request surface.
+
+Behavioral assertions — grouped by unit:
+
+Pure builders / evaluation:
+  - build_credential_modal renders one required input per secret kind, the
+    branch+token pair for the repo kind, and carries token/channel/message_ts
+    through private_metadata under the kind's callback_id.
+  - evaluate_credential_submission rejects an empty or oversized value with a
+    response_action errors payload keyed to the input block, defaults a blank
+    repo branch to main, and never copies the secret anywhere but the
+    decision's own field.
+
+handle_credential_request_click (real Postgres + FakeSlackWebClient):
+  - A live request clicked by its requester opens the kind's modal.
+  - Wrong requester / expired / already-used / unknown token each answer
+    with an ephemeral and never open a modal.
+  - The repo kind refuses a non-admin whose agent cannot be resolved
+    (fail closed) and lets a workspace admin through before any MA read.
+
+run_* submissions:
+  - env: consume + agent_files write commit together; the button message is
+    updated in place and the requester gets an ephemeral.
+  - A second submission of a consumed row writes nothing.
+  - mcp: missing daimon-mcp configuration refuses BEFORE the consume.
+  - repo: non-admin refused before the consume; admin + public repo binds.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import yarl
+from cryptography.fernet import Fernet
+from daimon.adapters.slack.credential_requests import (
+    CRED_CALLBACK_PREFIX,
+    build_credential_modal,
+    evaluate_credential_submission,
+    handle_credential_request_click,
+    run_env_credential_submission,
+    run_mcp_credential_submission,
+    run_repo_bind_credential_submission,
+)
+from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.credential_requests import mint_request_token
+from daimon.core.defaults.provisioning import derive_guild_account_uuid
+from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.stores.credential_requests import (
+    create_credential_request,
+    peek_credential_request,
+)
+from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+from daimon.testing.factories import make_tenant
+from daimon.testing.ma import build_fake_anthropic, make_fake_ma_handler
+from pydantic import SecretStr
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_TEAM_ID = "T_CRED"
+_USER_ID = "U_REQUESTER"
+_CHANNEL_ID = "C_CRED"
+_MESSAGE_TS = "1700000002.000200"
+
+_EPHEMERAL_URL = yarl.URL("https://slack.com/api/chat.postEphemeral")
+_VIEWS_OPEN_URL = yarl.URL("https://slack.com/api/views.open")
+_CHAT_UPDATE_URL = yarl.URL("https://slack.com/api/chat.update")
+
+# ---------------------------------------------------------------------------
+# build_credential_modal
+# ---------------------------------------------------------------------------
+
+
+def _modal(kind: str, *, target: str = "OPENAI_API_KEY") -> dict[str, Any]:
+    return build_credential_modal(
+        kind=kind,  # type: ignore[arg-type]
+        token="tok_test",
+        channel_id=_CHANNEL_ID,
+        message_ts=_MESSAGE_TS,
+        target=target,
+    )
+
+
+@pytest.mark.parametrize("kind", ["env", "mcp", "skill_repo"])
+def test_secret_kinds_render_one_required_input(kind: str) -> None:
+    view = _modal(kind)
+    assert view["callback_id"] == f"{CRED_CALLBACK_PREFIX}{kind}"
+    inputs = [b for b in view["blocks"] if b["type"] == "input"]
+    assert len(inputs) == 1
+    assert not inputs[0].get("optional", False)
+
+
+def test_repo_kind_renders_branch_and_optional_token() -> None:
+    view = _modal("repo", target="https://github.com/owner/repo")
+    assert view["callback_id"] == f"{CRED_CALLBACK_PREFIX}repo"
+    inputs = [b for b in view["blocks"] if b["type"] == "input"]
+    assert len(inputs) == 2
+    branch, pat = inputs
+    assert branch["element"]["initial_value"] == "main"
+    assert pat["optional"] is True
+
+
+def test_modal_metadata_carries_token_channel_and_message_ts() -> None:
+    view = _modal("env")
+    meta = json.loads(view["private_metadata"])
+    assert meta["token"] == "tok_test"
+    assert meta["channel_id"] == _CHANNEL_ID
+    assert meta["message_ts"] == _MESSAGE_TS
+
+
+def test_modal_metadata_never_carries_the_target_secret_field() -> None:
+    """The modal is built before any secret exists — nothing but routing
+    handles may appear in private_metadata, ever."""
+    view = _modal("env")
+    meta = json.loads(view["private_metadata"])
+    assert set(meta) <= {"token", "channel_id", "message_ts"}
+
+
+# ---------------------------------------------------------------------------
+# evaluate_credential_submission
+# ---------------------------------------------------------------------------
+
+
+def _submission(kind: str, values: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "view_submission",
+        "team": {"id": _TEAM_ID},
+        "user": {"id": _USER_ID},
+        "view": {
+            "callback_id": f"{CRED_CALLBACK_PREFIX}{kind}",
+            "private_metadata": json.dumps(
+                {"token": "tok_test", "channel_id": _CHANNEL_ID, "message_ts": _MESSAGE_TS},
+                separators=(",", ":"),
+            ),
+            "state": {"values": values},
+        },
+    }
+
+
+def _value_input(value: str) -> dict[str, Any]:
+    return {
+        "credential__value": {"credential__value": {"type": "plain_text_input", "value": value}}
+    }
+
+
+def test_empty_value_is_rejected_with_field_error() -> None:
+    decision = evaluate_credential_submission(_submission("env", _value_input("   ")))
+    assert decision.proceed is False
+    assert decision.response_payload is not None
+    assert decision.response_payload["response_action"] == "errors"
+    assert "credential__value" in decision.response_payload["errors"]
+
+
+def test_oversized_value_is_rejected_with_field_error() -> None:
+    decision = evaluate_credential_submission(
+        _submission("env", _value_input("é" * 3000))  # 6000 bytes, 3000 chars
+    )
+    assert decision.proceed is False
+    assert decision.response_payload is not None
+    assert "credential__value" in decision.response_payload["errors"]
+
+
+def test_valid_value_proceeds_and_carries_routing_fields() -> None:
+    decision = evaluate_credential_submission(_submission("env", _value_input("s3cr3t")))
+    assert decision.proceed is True
+    assert decision.response_payload is None
+    assert decision.kind == "env"
+    assert decision.value == "s3cr3t"
+    assert decision.token == "tok_test"
+    assert decision.channel_id == _CHANNEL_ID
+    assert decision.message_ts == _MESSAGE_TS
+
+
+def test_repo_submission_defaults_blank_branch_to_main() -> None:
+    values = {
+        "credential__branch": {"credential__branch": {"type": "plain_text_input", "value": "  "}},
+        "credential__pat": {"credential__pat": {"type": "plain_text_input", "value": None}},
+    }
+    decision = evaluate_credential_submission(_submission("repo", values))
+    assert decision.proceed is True
+    assert decision.branch == "main"
+    assert decision.value == ""
+
+
+# ---------------------------------------------------------------------------
+# handle_credential_request_click
+# ---------------------------------------------------------------------------
+
+
+async def _seed_team(session: AsyncSession, *, team_id: str = _TEAM_ID) -> tuple[uuid.UUID, str]:
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+    tenant = await make_tenant(session, platform="slack", workspace_id=team_id)
+    await upsert_slack_bot_token(
+        session, team_id=team_id, encrypted_token=encrypt_token(fernet, "xoxb-test")
+    )
+    await session.flush()
+    return tenant.id, fernet_key
+
+
+async def _seed_request(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    kind: str = "env",
+    target: str = "OPENAI_API_KEY",
+    requester: str = _USER_ID,
+    expires_in: timedelta = timedelta(minutes=30),
+    mcp_server_url: str | None = None,
+) -> str:
+    token = mint_request_token()
+    await create_credential_request(
+        session,
+        token=token,
+        kind=kind,  # type: ignore[arg-type]
+        tenant_id=tenant_id,
+        agent_id=uuid.uuid4(),
+        account_id=derive_guild_account_uuid(tenant_id=tenant_id),
+        target=target,
+        mcp_server_url=mcp_server_url,
+        requester_platform_user_id=requester,
+        channel_id=_CHANNEL_ID,
+        expires_at=datetime.now(UTC) + expires_in,
+    )
+    await session.flush()
+    return token
+
+
+def _build_runtime(fernet_key: str, db_factory: async_sessionmaker[AsyncSession]) -> SlackRuntime:
+    settings = MagicMock()
+    settings.crypto.keys = (SecretStr(fernet_key),)
+    settings.mcp.public_url = None
+    settings.mcp.jwt_secret = None
+    return SlackRuntime(
+        settings=settings,
+        anthropic=build_fake_anthropic(make_fake_ma_handler()),
+        sessionmaker=db_factory,
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+
+def _click_payload(token: str, *, user_id: str = _USER_ID) -> dict[str, Any]:
+    return {
+        "type": "block_actions",
+        "team": {"id": _TEAM_ID},
+        "user": {"id": user_id},
+        "channel": {"id": _CHANNEL_ID},
+        "container": {"message_ts": _MESSAGE_TS},
+        "message": {"ts": _MESSAGE_TS},
+        "trigger_id": "TRIGGER_TEST",
+        "actions": [{"action_id": "credential_request", "value": token}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_live_request_clicked_by_requester_opens_the_kind_modal(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(db_session, tenant_id=tenant_id, kind="env")
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_credential_request_click(runtime, _click_payload(token))
+
+    opens = fake_slack_web_client.mock.requests.get(("POST", _VIEWS_OPEN_URL), [])
+    assert len(opens) == 1, "a live request clicked by its requester must open the modal"
+    view = opens[0].kwargs["json"]["view"]
+    assert view["callback_id"] == f"{CRED_CALLBACK_PREFIX}env"
+    meta = json.loads(view["private_metadata"])
+    assert meta["token"] == token
+
+
+@pytest.mark.asyncio
+async def test_wrong_requester_gets_ephemeral_and_no_modal(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(db_session, tenant_id=tenant_id, requester="U_SOMEONE_ELSE")
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_credential_request_click(runtime, _click_payload(token))
+
+    assert ("POST", _VIEWS_OPEN_URL) not in fake_slack_web_client.mock.requests
+    assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+
+
+@pytest.mark.asyncio
+async def test_expired_request_gets_ephemeral_and_no_modal(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(db_session, tenant_id=tenant_id, expires_in=timedelta(minutes=-1))
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_credential_request_click(runtime, _click_payload(token))
+
+    assert ("POST", _VIEWS_OPEN_URL) not in fake_slack_web_client.mock.requests
+    assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+
+
+@pytest.mark.asyncio
+async def test_unknown_token_gets_ephemeral_and_no_modal(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    _tenant_id, fernet_key = await _seed_team(db_session)
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_credential_request_click(runtime, _click_payload("never-minted"))
+
+    assert ("POST", _VIEWS_OPEN_URL) not in fake_slack_web_client.mock.requests
+    assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+
+
+@pytest.mark.asyncio
+async def test_repo_kind_refuses_non_admin_when_agent_cannot_be_resolved(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """Fail closed: the row's derived agent uuid resolving to nothing means
+    the agent was archived or deleted since the mint — a non-admin must not
+    reach the modal."""
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(
+        db_session, tenant_id=tenant_id, kind="repo", target="https://github.com/o/r"
+    )
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await handle_credential_request_click(runtime, _click_payload(token))
+
+    assert ("POST", _VIEWS_OPEN_URL) not in fake_slack_web_client.mock.requests
+    assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+
+
+# ---------------------------------------------------------------------------
+# run_env_credential_submission
+# ---------------------------------------------------------------------------
+
+
+async def _agent_file_rows(session: AsyncSession) -> list[Any]:
+    result = await session.execute(text("SELECT key, content FROM agent_files ORDER BY key"))
+    return list(result.mappings())
+
+
+@pytest.mark.asyncio
+async def test_env_submission_consumes_row_and_writes_the_secret(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(db_session, tenant_id=tenant_id, kind="env")
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await run_env_credential_submission(
+        runtime,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        message_ts=_MESSAGE_TS,
+        token=token,
+        value="s3cr3t-value",
+    )
+
+    async with db_session_factory() as s:
+        rows = await _agent_file_rows(s)
+        row = await peek_credential_request(s, token=token)
+    assert rows and rows[0]["key"] == "OPENAI_API_KEY"
+    assert rows[0]["content"] == "s3cr3t-value"
+    assert row is not None and row.used_at is not None, "the consume must have committed"
+    assert ("POST", _CHAT_UPDATE_URL) in fake_slack_web_client.mock.requests, (
+        "the button message must be swapped for a consumed marker"
+    )
+    assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+
+
+@pytest.mark.asyncio
+async def test_env_submission_of_consumed_row_writes_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(db_session, tenant_id=tenant_id, kind="env")
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    common: dict[str, Any] = {
+        "team_id": _TEAM_ID,
+        "user_id": _USER_ID,
+        "channel_id": _CHANNEL_ID,
+        "message_ts": _MESSAGE_TS,
+        "token": token,
+    }
+    await run_env_credential_submission(runtime, value="first", **common)
+    await run_env_credential_submission(runtime, value="second", **common)
+
+    async with db_session_factory() as s:
+        rows = await _agent_file_rows(s)
+    assert len(rows) == 1 and rows[0]["content"] == "first", (
+        "a consumed row must never produce a second write"
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_mcp_credential_submission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_submission_with_unconfigured_mcp_refuses_before_the_consume(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(
+        db_session,
+        tenant_id=tenant_id,
+        kind="mcp",
+        target="my-server",
+        mcp_server_url="https://mcp.example.com",
+    )
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)  # mcp settings are None
+
+    await run_mcp_credential_submission(
+        runtime,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        message_ts=_MESSAGE_TS,
+        token=token,
+        value="mcp-token",
+    )
+
+    async with db_session_factory() as s:
+        row = await peek_credential_request(s, token=token)
+    assert row is not None and row.used_at is None, (
+        "a config refusal must land before the consume so the request survives"
+    )
+    assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+
+
+# ---------------------------------------------------------------------------
+# run_repo_bind_credential_submission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repo_submission_refuses_non_admin_before_the_consume(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    token = await _seed_request(
+        db_session, tenant_id=tenant_id, kind="repo", target="https://github.com/o/r"
+    )
+    await db_session.commit()
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await run_repo_bind_credential_submission(
+        runtime,
+        team_id=_TEAM_ID,
+        user_id=_USER_ID,
+        channel_id=_CHANNEL_ID,
+        message_ts=_MESSAGE_TS,
+        token=token,
+        value="",
+        branch="main",
+    )
+
+    async with db_session_factory() as s:
+        row = await peek_credential_request(s, token=token)
+    assert row is not None and row.used_at is None, (
+        "the admin gate is the authorization boundary and must precede the consume"
+    )
+    assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+    assert ("POST", _CHAT_UPDATE_URL) not in fake_slack_web_client.mock.requests

--- a/packages/core/daimon/core/credential_requests.py
+++ b/packages/core/daimon/core/credential_requests.py
@@ -55,6 +55,17 @@ DEFAULT_TTL: Final[dt.timedelta] = dt.timedelta(minutes=30)
 # Discord's documented Button.label limit.
 MAX_BUTTON_LABEL_CHARS: Final[int] = 80
 
+# Slack's documented button-element text limit (plain_text, 75 characters).
+MAX_SLACK_BUTTON_LABEL_CHARS: Final[int] = 75
+
+# Slack routes block_actions by action_id, and a button element carries the
+# opaque request token in its `value` field instead of the id itself — the
+# Slack counterpart of Discord's `custom_id` encoding above. Both processes
+# (the MCP server posts the button, the Slack bot dispatches the click) read
+# this one constant, for the same divergent-copy reason the custom_id
+# builders live here.
+SLACK_ACTION_ID: Final[str] = "credential_request"
+
 # The full label prefix for each kind. "env" and "mcp" reproduce the
 # pre-repo-kind wording byte-for-byte. "repo" cannot reuse the "Add {X}
 # credential: " interpolation — a repo binding is not a credential.
@@ -108,15 +119,22 @@ def build_custom_id(token: str) -> str:
     return f"{CUSTOM_ID_PREFIX}{token}"
 
 
-def build_button_label(kind: CredentialRequestKind, target: str) -> str:
+def build_button_label(
+    kind: CredentialRequestKind,
+    target: str,
+    *,
+    max_chars: int = MAX_BUTTON_LABEL_CHARS,
+) -> str:
     """Return the human-readable button label naming the exact target.
 
-    Truncates `target` (with a trailing "…") when it would overflow Discord's
-    80-character button label limit — the label, not the custom_id, is what
-    names the exact target, so it must fit on its own.
+    Truncates `target` (with a trailing "…") when it would overflow the
+    platform's button label limit — the label, not the custom_id, is what
+    names the exact target, so it must fit on its own. Discord callers use
+    the 80-character default; Slack callers pass
+    `MAX_SLACK_BUTTON_LABEL_CHARS` (75).
     """
     prefix = _KIND_LABEL_PREFIX[kind]
-    available = MAX_BUTTON_LABEL_CHARS - len(prefix)
+    available = max_chars - len(prefix)
     if len(target) <= available:
         return f"{prefix}{target}"
     truncated = target[: available - 1] + "…"

--- a/packages/core/tests/test_credential_requests.py
+++ b/packages/core/tests/test_credential_requests.py
@@ -123,3 +123,23 @@ def test_split_skill_repo_target_defaults_match_sync_skills_defaults() -> None:
         "main",
         "",
     )
+
+
+def test_slack_action_id_is_stable() -> None:
+    from daimon.core.credential_requests import SLACK_ACTION_ID
+
+    assert SLACK_ACTION_ID == "credential_request"
+
+
+def test_build_button_label_honours_slack_label_limit() -> None:
+    from daimon.core.credential_requests import MAX_SLACK_BUTTON_LABEL_CHARS
+
+    label = build_button_label("mcp", "x" * 200, max_chars=MAX_SLACK_BUTTON_LABEL_CHARS)
+    assert len(label) == MAX_SLACK_BUTTON_LABEL_CHARS == 75
+    assert label.startswith("Add MCP credential: ")
+    assert label.endswith("…")
+
+
+def test_build_button_label_default_limit_unchanged() -> None:
+    label = build_button_label("mcp", "x" * 200)
+    assert len(label) == MAX_BUTTON_LABEL_CHARS == 80


### PR DESCRIPTION
Closes #93.

## Summary

On Discord, an agent that needs a secret mid-conversation posts a button that opens a single-use modal. On Slack the only path to any credential was leaving the conversation for `/agent-setup`. This ports the whole flow: the four `request_*` MCP tools now post a Slack button, and the Slack bot dispatches the click to the kind's modal and runs the write.

**Wire contract.** Slack routes `block_actions` by `action_id` and gives buttons a `value` field, so the opaque single-use token rides in `value` under one fixed action id instead of Discord's `custom_id` encoding. Both constants live in `daimon.core.credential_requests` — the MCP server and the Slack bot cannot import each other, so a divergent copy would silently stop the button from dispatching. Slack also caps button text at 75 characters where Discord allows 80; the label builder takes the platform's limit.

**Click side.** The handler runs the same lifecycle checks as Discord's `interaction_check`, in the same order and with the same words: unknown token, cross-workspace defense, wrong requester, expired, already used — each answered with an ephemeral, never a modal. The repo kind additionally runs the shared-agent admin gate as a pre-filter, re-derived from primitives exactly as Discord's `credential_repo_bind` does. The click's `trigger_id` opens the modal directly — no loading-modal dance.

**Submissions.** The atomic single-use consume runs before every write, so a request produces at most one write regardless of resubmission or races:

- `env` commits the consume and the `agent_files` write in one transaction.
- `mcp` checks the daimon-mcp configuration before spending the request, then owes the agent attach after the vault write; partial states (token stored, server not attached) are reported truthfully.
- `skill_repo` verifies the token against the skill repo before storing, then binds, re-runs the import, and attaches the imported skills to the agent the request named — an import into the tenant library alone leaves the agent skill-less with a success message saying otherwise.
- `repo` re-runs the admin gate at the submit boundary, not just at click time — an admin at click may not be one at submit.

After the consume, the request message is edited in place to a `✓ Received` marker: a live-looking button invites a click that cannot succeed, and the ephemeral confirmation is invisible to everyone else in the thread.

Secret hygiene matches the Discord modals and the panel's paste form: values exist only in the modal input and the in-memory decision — never in a log line (env logs the key name; mcp/repo log a masked tail), an `action_id`, `private_metadata`, or any non-ephemeral message.

**Deliberately kept:** no admin gate for the env/mcp/skill_repo kinds (the documented requester-only trade in the MCP module), and `post_wizard`'s Slack guard is out of scope. Known limitation: the button posts at the channel's top level, never in a thread — a Slack thread is a (channel, ts) pair and the four request tools' shared `channel_id` contract carries no `thread_ts`; threading it means widening the cross-platform tool schema. The tools' docstrings are prompt context rendered on both platforms, so their Discord-specific wording is gone — the tool-schema snapshot diff is exactly that wording.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally
- [x] `uv run pyright` passes locally (strict mode)
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)

Note on pytest: the full suite runs 4579 passed, 2 failed locally — the two notebook-host uid/chown tests, which fail identically on `main` in this environment (macOS uid semantics) and touch nothing this branch changes. Not exercised live: the end-to-end Slack round trip (button post → click → modal → write) against a real workspace — coverage is transport-level fakes over the real SDK request/response path, plus real Postgres for every store interaction.

