### PR TITLE
fix(slack): reconcile every Slack tenant on worker boot

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -37,7 +37,7 @@ from daimon.adapters.discord.vision import (
 from daimon.core.config import Settings
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.defaults.provisioning import provision_tenant, reconcile_tenant_defaults
-from daimon.core.defaults.report import Action, ApplyReport
+from daimon.core.defaults.report import compose_failure_reason
 from daimon.core.errors import DaimonError
 from daimon.core.ma_identity import derive_tenant_uuid
 from daimon.core.ma_resolver import MAResolverMissError
@@ -190,24 +190,6 @@ def _build_snag_embed() -> discord.Embed:
         description="Setup hit a snag — still working on it. Mention me to nudge it along.",
         color=_EMBED_COLOR,
     )
-
-
-def _compose_failure_reason(report: ApplyReport) -> str | None:
-    """Compose a persisted reason from a report's failed outcomes only, one
-    line per failure naming the resource kind, name, and its recorded error.
-    Pure -- no I/O. Returns None when the report has no failures.
-
-    Composed ONLY from the outcome's own recorded fields -- never a raw
-    exception repr of a credentialed request -- so a provider secret or
-    request body can never land in this operator-visible column."""
-    failures = [
-        o
-        for o in (*report.agents, *report.environments, *report.skills, *report.system_config)
-        if o.action is Action.FAILED
-    ]
-    if not failures:
-        return None
-    return "\n".join(f"{o.kind} {o.name!r}: {o.error}" for o in failures)
 
 
 def _pick_post_channel(guild: discord.Guild) -> discord.abc.Messageable | None:
@@ -452,7 +434,7 @@ class DaimonBot(commands.Bot):
                 if not was_ready:
                     await self._post_to_guild(guild, _build_ready_embed())
             else:
-                reason = roster_failure_reason or _compose_failure_reason(report)
+                reason = roster_failure_reason or compose_failure_reason(report)
                 if was_ready:
                     # A previously-ready install stays ready: a transient reconcile
                     # failure must not take a working guild's turns offline. Record

--- a/packages/adapters/slack/daimon/adapters/slack/__main__.py
+++ b/packages/adapters/slack/daimon/adapters/slack/__main__.py
@@ -14,6 +14,7 @@ import sys
 
 import structlog
 from daimon.adapters.slack.app import SlackApp
+from daimon.adapters.slack.boot_sweep import run_boot_sweep
 from daimon.adapters.slack.runtime import build_runtime
 from daimon.core.config import load_settings
 from daimon.core.health import start_liveness_responder
@@ -80,6 +81,30 @@ async def main() -> None:
         log.info("starting_slack_listener", health_port=settings.slack.health_port)
         try:
             await client.connect()
+            # Boot-time reconcile sweep, in the background so a slow provider
+            # cannot delay mention handling. A crash is logged, never raised —
+            # the listener must outlive its sweep.
+            sweep_task: asyncio.Task[None] = asyncio.create_task(
+                run_boot_sweep(
+                    anthropic=runtime.anthropic,
+                    sessionmaker=runtime.sessionmaker,
+                    defaults_root=settings.defaults_root,
+                    deployment_default=runtime.deployment_default,
+                    public_url=(
+                        str(settings.mcp.public_url)
+                        if settings.mcp.public_url is not None
+                        else None
+                    ),
+                )
+            )
+            _bg_tasks.add(sweep_task)
+
+            def _on_sweep_done(task: asyncio.Task[None]) -> None:
+                _bg_tasks.discard(task)
+                if not task.cancelled() and task.exception() is not None:
+                    log.error("slack.boot_sweep_crashed", exc_info=task.exception())
+
+            sweep_task.add_done_callback(_on_sweep_done)
             await stop.wait()  # released by _shutdown after drain completes
         finally:
             health_server.close()

--- a/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
+++ b/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
@@ -1,0 +1,185 @@
+"""Boot-time reconcile sweep for Slack tenants.
+
+Discord tenants self-heal on every bot boot (``bot.py::on_ready``); Slack
+tenants were seeded at most once — the OAuth install callback provisions the
+DB rows only, and the first mention's resolver miss triggers a one-time
+reconcile — and then drifted forever: a ``defaults/`` edit (a prompt rewrite,
+a new seeded skill) never reached an existing Slack install. This module is
+the reconcile half of Discord's ``on_ready`` ported to the Slack worker:
+every registered, unarchived Slack tenant is reconciled against the shipped
+defaults on every boot, with bounded concurrency. An in-sync tenant costs
+provider reads and zero writes — the reconcile's per-resource fingerprint
+gate turns a hash match into a skip.
+
+Deliberately NOT ported from Discord's sweep:
+
+- guild permission checks and command-tree sync — Slack scopes and slash
+  commands are fixed by the app manifest, so there is nothing to probe or
+  register at boot;
+- provisioning installs that arrived while the worker was down — Slack
+  installs provision synchronously in the OAuth callback, so the tenant row
+  always exists before this sweep can run;
+- user-visible install/snag announcements — Slack has no "home channel" to
+  post into (the app can only speak where it was invited), and the OAuth
+  success page is the install-feedback surface. The sweep is silent; logs
+  are the operator surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+import anthropic as _anthropic
+import structlog
+from anthropic import AsyncAnthropic
+from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
+from daimon.core.defaults.provisioning import reconcile_tenant_defaults
+from daimon.core.defaults.report import compose_failure_reason
+from daimon.core.errors import DaimonError
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.tenants import list_tenants_by_platform, set_provision_status
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+log = structlog.get_logger()
+
+_SWEEP_CONCURRENCY = 2
+
+
+async def run_boot_sweep(
+    *,
+    anthropic: AsyncAnthropic,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    defaults_root: Path,
+    deployment_default: DeploymentDefault,
+    public_url: str | None,
+) -> None:
+    """Reconcile every registered, unarchived Slack tenant, bounded-concurrent.
+
+    Per-tenant failures are isolated: one tenant's provider or DB error is
+    logged and recorded on its row without stopping the rest of the sweep.
+    """
+    tenants = await list_tenants_by_platform(sessionmaker, platform="slack")
+    live = [t for t in tenants if t.archived_at is None]
+    if not live:
+        log.info("slack.boot_sweep_skipped", reason="no unarchived slack tenants")
+        return
+    log.info("slack.boot_sweep_started", tenants=len(live))
+    sem = asyncio.Semaphore(_SWEEP_CONCURRENCY)
+
+    async def _bounded(tenant_id: uuid.UUID, *, was_ready: bool) -> None:
+        async with sem:
+            await _seed_tenant_defaults(
+                anthropic=anthropic,
+                sessionmaker=sessionmaker,
+                defaults_root=defaults_root,
+                deployment_default=deployment_default,
+                public_url=public_url,
+                tenant_id=tenant_id,
+                was_ready=was_ready,
+            )
+
+    await asyncio.gather(*(_bounded(t.id, was_ready=t.provision_status == "ready") for t in live))
+    log.info("slack.boot_sweep_complete", tenants=len(live))
+
+
+async def _seed_tenant_defaults(
+    *,
+    anthropic: AsyncAnthropic,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    defaults_root: Path,
+    deployment_default: DeploymentDefault,
+    public_url: str | None,
+    tenant_id: uuid.UUID,
+    was_ready: bool,
+) -> None:
+    """Reconcile one tenant and own its status flip. Mirrors the Discord
+    ``_seed_tenant_defaults`` semantics, minus the guild embeds:
+
+    - success (report clean AND the deployment's default agent resolves on
+      MA): flip to ``ready`` and clear any stale failure reason;
+    - failure while ``was_ready``: the tenant STAYS ready — a transient
+      provider failure during a boot sweep must not take a working
+      workspace's turns offline; only the reason is recorded;
+    - failure while pending/failed: flip to ``failed`` with the reason.
+
+    The roster check exists because a non-failing ``ApplyReport`` alone does
+    not guarantee the configured default agent exists — ``config.yaml``'s
+    ``agent_name`` can drift from every spec under ``defaults_root/agents/``.
+    """
+    try:
+        report = await reconcile_tenant_defaults(
+            anthropic,
+            sessionmaker,
+            defaults_root,
+            tenant_id=tenant_id,
+            public_url=public_url,
+        )
+        seed_ok = not report.is_failure()
+        roster_failure_reason: str | None = None
+        if seed_ok:
+            agent_name = deployment_default.agent_name
+            if agent_name is None:
+                log.info("slack.boot_sweep_roster_check_skipped", tenant_id=str(tenant_id))
+            else:
+                default_agent = await find_agent_by_daimon_tag(
+                    anthropic, tenant_id=tenant_id, name=agent_name
+                )
+                if default_agent is None:
+                    seed_ok = False
+                    roster_failure_reason = (
+                        f"agent {agent_name!r}: default agent missing from roster after reconcile"
+                    )
+                    log.warning(
+                        "slack.boot_sweep_default_agent_missing",
+                        tenant_id=str(tenant_id),
+                        agent_name=agent_name,
+                    )
+        if seed_ok:
+            await set_provision_status(
+                sessionmaker, tenant_id=tenant_id, status="ready", clear_reason=True
+            )
+            log.info("slack.boot_sweep_tenant_ready", tenant_id=str(tenant_id))
+        else:
+            reason = roster_failure_reason or compose_failure_reason(report)
+            await _record_failure(
+                sessionmaker, tenant_id=tenant_id, reason=reason, was_ready=was_ready
+            )
+    except (DaimonError, _anthropic.APIError, SQLAlchemyError) as exc:
+        # Per-tenant supervisor boundary: one tenant's provider or DB error
+        # must not stop the sweep over its siblings.
+        log.warning("slack.boot_sweep_tenant_failed", tenant_id=str(tenant_id), error=str(exc))
+        await _record_failure(
+            sessionmaker,
+            tenant_id=tenant_id,
+            reason=f"{type(exc).__name__}: {exc}",
+            was_ready=was_ready,
+        )
+
+
+async def _record_failure(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: uuid.UUID,
+    reason: str | None,
+    was_ready: bool,
+) -> None:
+    """Best-effort failure flip. A ready tenant keeps its status (reason only);
+    a pending/failed one flips to ``failed``. A DB hiccup during the flip is
+    swallowed so the sweep continues — the next boot's sweep is the backstop."""
+    try:
+        if was_ready:
+            await set_provision_status(sessionmaker, tenant_id=tenant_id, reason=reason)
+            log.warning(
+                "slack.boot_sweep_reconcile_failed_ready_tenant",
+                tenant_id=str(tenant_id),
+                reason=reason,
+            )
+        else:
+            await set_provision_status(
+                sessionmaker, tenant_id=tenant_id, status="failed", reason=reason
+            )
+    except SQLAlchemyError:
+        log.exception("slack.boot_sweep_status_flip_failed", tenant_id=str(tenant_id))

--- a/packages/adapters/slack/tests/test_boot_sweep.py
+++ b/packages/adapters/slack/tests/test_boot_sweep.py
@@ -1,0 +1,254 @@
+"""Tests for the Slack boot-time reconcile sweep.
+
+The sweep owns the tenant status flips: pending/failed tenants flip on the
+reconcile outcome, ready tenants are never demoted by a failed reconcile, and
+one tenant's provider error must not stop the sweep over its siblings.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import anthropic as _anthropic
+import httpx
+from anthropic.types.beta import BetaManagedAgentsAgent
+from daimon.adapters.slack.boot_sweep import run_boot_sweep
+from daimon.core.defaults.provisioning import provision_tenant
+from daimon.core.defaults.report import Action, ApplyReport, ResourceOutcome
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.tenants import get_tenant_liveness, set_provision_status
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+def _agent_matching_tenant(tenant_id: uuid.UUID, *, name: str) -> dict[str, object]:
+    return BetaManagedAgentsAgent(
+        id="ag_1",
+        type="agent",
+        name=name,
+        model={"id": "claude-opus-4-7"},
+        metadata={"daimon_tenant": str(tenant_id), "daimon_name": name},
+        description=None,
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    ).model_dump(mode="json")
+
+
+async def _provision_slack(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    workspace_id: str,
+    status: str | None = None,
+) -> uuid.UUID:
+    result = await provision_tenant(db_session_factory, platform="slack", workspace_id=workspace_id)
+    if status is not None:
+        await set_provision_status(db_session_factory, tenant_id=result.tenant_id, status=status)
+    return result.tenant_id
+
+
+async def _run_sweep(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    anthropic_client: _anthropic.AsyncAnthropic,
+    agent_name: str | None = "daimon",
+) -> None:
+    await run_boot_sweep(
+        anthropic=anthropic_client,
+        sessionmaker=db_session_factory,
+        defaults_root=Path("defaults"),
+        deployment_default=DeploymentDefault(agent_name=agent_name),
+        public_url=None,
+    )
+
+
+async def test_sweep_flips_pending_tenant_ready_when_reconcile_succeeds_and_agent_resolves(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = await _provision_slack(
+        db_session_factory, workspace_id="T-SWEEP-READY", status="pending"
+    )
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda req, _m: list_response([_agent_matching_tenant(tenant_id, name="daimon")]),
+    )
+    client = build_fake_anthropic(router.dispatch)
+
+    with patch(
+        "daimon.adapters.slack.boot_sweep.reconcile_tenant_defaults",
+        new_callable=AsyncMock,
+        return_value=ApplyReport(),
+    ) as reconcile:
+        await _run_sweep(db_session_factory, anthropic_client=client)
+
+    assert reconcile.await_count == 1, "the sweep must reconcile the one registered slack tenant"
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "ready", (
+        "a clean report with the default agent present on MA must flip pending to ready"
+    )
+
+
+async def test_sweep_keeps_ready_tenant_ready_when_reconcile_fails(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = await _provision_slack(db_session_factory, workspace_id="T-SWEEP-STAYS")
+    failing = ApplyReport()
+    failing.add(
+        ResourceOutcome(kind="skill", name="cli-auth", action=Action.FAILED, error="rate limited")
+    )
+
+    with patch(
+        "daimon.adapters.slack.boot_sweep.reconcile_tenant_defaults",
+        new_callable=AsyncMock,
+        return_value=failing,
+    ):
+        await _run_sweep(
+            db_session_factory,
+            anthropic_client=build_fake_anthropic(MARouter().dispatch),
+        )
+
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "ready", (
+        "a transient reconcile failure must not take a working workspace's turns offline"
+    )
+    assert tr.last_reconcile_error is not None and "cli-auth" in tr.last_reconcile_error, (
+        "the failure reason must be recorded for the operator even when status is kept"
+    )
+
+
+async def test_sweep_flips_pending_tenant_failed_when_reconcile_reports_failure(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = await _provision_slack(
+        db_session_factory, workspace_id="T-SWEEP-FAILS", status="pending"
+    )
+    failing = ApplyReport()
+    failing.add(ResourceOutcome(kind="agent", name="daimon", action=Action.FAILED, error="boom"))
+
+    with patch(
+        "daimon.adapters.slack.boot_sweep.reconcile_tenant_defaults",
+        new_callable=AsyncMock,
+        return_value=failing,
+    ):
+        await _run_sweep(
+            db_session_factory,
+            anthropic_client=build_fake_anthropic(MARouter().dispatch),
+        )
+
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "failed", (
+        "a pending tenant whose reconcile fails must flip to failed, not linger pending"
+    )
+
+
+async def test_sweep_flips_failed_when_default_agent_missing_from_ma(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id = await _provision_slack(
+        db_session_factory, workspace_id="T-SWEEP-ROSTER", status="pending"
+    )
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
+    client = build_fake_anthropic(router.dispatch)
+
+    with patch(
+        "daimon.adapters.slack.boot_sweep.reconcile_tenant_defaults",
+        new_callable=AsyncMock,
+        return_value=ApplyReport(),
+    ):
+        await _run_sweep(db_session_factory, anthropic_client=client)
+
+    tr = await get_tenant_liveness(db_session_factory, tenant_id)
+    assert tr is not None and tr.provision_status == "failed", (
+        "a clean report whose default agent is missing from the MA roster is not ready"
+    )
+    assert (
+        tr.last_reconcile_error is not None and "missing from roster" in tr.last_reconcile_error
+    ), "the roster miss must be recorded as the failure reason"
+
+
+async def test_sweep_skips_archived_and_foreign_platform_tenants(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    live_id = await _provision_slack(
+        db_session_factory, workspace_id="T-SWEEP-LIVE", status="pending"
+    )
+    archived_id = await _provision_slack(db_session_factory, workspace_id="T-SWEEP-ARCHIVED")
+    await set_provision_status(db_session_factory, tenant_id=archived_id, archive=True)
+    await provision_tenant(db_session_factory, platform="discord", workspace_id="123456")
+
+    seen: list[uuid.UUID] = []
+
+    async def _record(*args: object, tenant_id: uuid.UUID, **kwargs: object) -> ApplyReport:
+        seen.append(tenant_id)
+        return ApplyReport()
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda req, _m: list_response([_agent_matching_tenant(live_id, name="daimon")]),
+    )
+    with patch(
+        "daimon.adapters.slack.boot_sweep.reconcile_tenant_defaults",
+        side_effect=_record,
+    ):
+        await _run_sweep(db_session_factory, anthropic_client=build_fake_anthropic(router.dispatch))
+
+    assert seen == [live_id], (
+        "the sweep must reconcile exactly the unarchived slack tenants — never archived "
+        "ones and never other platforms'"
+    )
+
+
+async def test_sweep_isolates_one_tenants_provider_error(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    failing_id = await _provision_slack(
+        db_session_factory, workspace_id="T-SWEEP-ERR-A", status="pending"
+    )
+    healthy_id = await _provision_slack(
+        db_session_factory, workspace_id="T-SWEEP-ERR-B", status="pending"
+    )
+
+    async def _explode_first(*args: object, tenant_id: uuid.UUID, **kwargs: object) -> ApplyReport:
+        if tenant_id == failing_id:
+            raise _anthropic.APIConnectionError(request=httpx.Request("GET", "https://api"))
+        return ApplyReport()
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda req, _m: list_response([_agent_matching_tenant(healthy_id, name="daimon")]),
+    )
+    # Concurrency pinned to 1: the schema-per-test session factory binds every
+    # session to ONE asyncpg connection, so genuinely concurrent tenant seeds
+    # trip "another operation is in progress" — a fixture artifact, not a
+    # product behavior (production binds an engine pool). Serial order still
+    # proves the isolation contract: A raises, B must still be seeded.
+    with (
+        patch("daimon.adapters.slack.boot_sweep._SWEEP_CONCURRENCY", 1),
+        patch(
+            "daimon.adapters.slack.boot_sweep.reconcile_tenant_defaults",
+            side_effect=_explode_first,
+        ),
+    ):
+        await _run_sweep(db_session_factory, anthropic_client=build_fake_anthropic(router.dispatch))
+
+    failing_tr = await get_tenant_liveness(db_session_factory, failing_id)
+    healthy_tr = await get_tenant_liveness(db_session_factory, healthy_id)
+    assert failing_tr is not None and failing_tr.provision_status == "failed", (
+        "the tenant whose reconcile raised must be recorded failed, not left pending"
+    )
+    assert healthy_tr is not None and healthy_tr.provision_status == "ready", (
+        "a sibling tenant's provider error must not stop the rest of the sweep"
+    )

--- a/packages/core/daimon/core/defaults/report.py
+++ b/packages/core/daimon/core/defaults/report.py
@@ -63,6 +63,24 @@ class ApplyReport:
         )
 
 
+def compose_failure_reason(report: ApplyReport) -> str | None:
+    """Compose a persisted reason from a report's failed outcomes only, one
+    line per failure naming the resource kind, name, and its recorded error.
+    Pure -- no I/O. Returns None when the report has no failures.
+
+    Composed ONLY from the outcome's own recorded fields -- never a raw
+    exception repr of a credentialed request -- so a provider secret or
+    request body can never land in an operator-visible column."""
+    failures = [
+        o
+        for o in (*report.agents, *report.environments, *report.skills, *report.system_config)
+        if o.action is Action.FAILED
+    ]
+    if not failures:
+        return None
+    return "\n".join(f"{o.kind} {o.name!r}: {o.error}" for o in failures)
+
+
 VerificationStatus = Literal["in_sync", "diverged", "unverifiable"]
 
 


### PR DESCRIPTION
## The gap

Slack tenants were seeded at most once. The OAuth install callback provisions the DB rows only (`oauth_slack.py:646` — deliberately, per `provision_tenant`'s contract), and the tenant row's server default makes it born `ready`. The only thing that ever created its MA resources was the first mention's resolver miss (`admission.py:94` passes `reconcile_tenant_defaults` as the resolver's `apply_callable`), and nothing ever reconciled it again. Every subsequent `defaults/` edit — a prompt rewrite, a new seeded skill — never reached an existing Slack install, and the deploy pipeline's "verify deployed installs" step has been correctly flagging exactly this: a drifted Slack tenant that no code path could heal.

Discord installs self-heal on every bot boot (`bot.py::on_ready` reconciles every registered guild). Slack had no counterpart — this is the reconcile half of that sweep, ported.

## What it does

On Slack worker boot, after the Socket Mode connect, a background task reconciles every registered, unarchived Slack tenant against the shipped defaults, bounded at 2 concurrent (same cap as Discord's sweep). An in-sync tenant costs provider reads and zero writes — the reconcile's per-resource fingerprint gate turns a hash match into a skip.

Status semantics mirror Discord's exactly:

- clean report **and** the deployment's default agent resolves on MA → `ready`, stale failure reason cleared;
- failure while `ready` → stays `ready` (a transient provider failure during a boot sweep must not take a working workspace's turns offline); reason recorded for the operator;
- failure while `pending`/`failed` → `failed`, with the composed reason;
- per-tenant errors are isolated — one workspace's provider or DB error is recorded on its row and the sweep continues.

## Deliberately not ported from Discord's sweep

- **Permission checks and command-tree sync** — Slack scopes and slash commands are fixed by the app manifest; nothing to probe or register at boot.
- **Provisioning installs that arrived while the worker was down** — Slack installs provision synchronously in the OAuth callback, so the row always exists.
- **Install/snag announcements** — Slack has no home channel the app can post into uninvited, and the OAuth success page is the install-feedback surface. The sweep is silent; logs are the operator surface.

## Refactor rider

`_compose_failure_reason` moves from the Discord adapter into `daimon.core.defaults.report.compose_failure_reason`: it is a pure function of `ApplyReport`, both adapters now need it, and adapters must not import each other.

## Testing

Six behavioral tests against real Postgres, MA faked at the transport level (`MARouter` for the roster check), `reconcile_tenant_defaults` patched at the module seam — the same pattern as Discord's `test_bot_seed.py`:

- pending → ready on a clean report with the default agent on the roster
- ready stays ready on a failed report, reason recorded
- pending → failed on a failed report
- clean report but default agent missing from roster → failed (roster check)
- archived tenants and other platforms' tenants are never touched
- one tenant's `APIConnectionError` doesn't stop its sibling's seed

Full suite: 4593 passed, 4 skipped; `pyright` 0 errors; `ruff` clean; `lint-imports` 6/6 kept. The one local failure, `test_concurrent_consume_of_one_token_succeeds_exactly_once`, pre-exists on main (fails identically with this branch's changes stashed; came in with #99) and looks like the single-connection test fixture, not the store — flagged separately.