### PR TITLE
fix(slack): bound the notification-text fallback so long answers survive chat.update

### DIFF
--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -45,6 +45,22 @@ log = structlog.get_logger()
 
 _DEBOUNCE_S = 5.0
 
+# Ceiling for the `text` notification fallback that accompanies `blocks`.
+# The rendered content lives in the blocks (a markdown block holds 11 800
+# safely); `text` only feeds notifications and previews. chat.update rejects
+# a message whose `text` is block-sized with msg_too_long even though
+# chat.postMessage accepts the identical payload — probed live 2026-08-24:
+# update with text=11 800 fails, text=4 000 passes, and the block length is
+# irrelevant to the error. Stay well under the observed pass point.
+_NOTIFICATION_TEXT_MAX = 3000
+
+
+def _notification_text(chunk: str) -> str:
+    """Bound a content chunk for use as the `text` notification fallback."""
+    if len(chunk) <= _NOTIFICATION_TEXT_MAX:
+        return chunk
+    return chunk[: _NOTIFICATION_TEXT_MAX - 1] + "…"
+
 
 def _map_sse_event(event: RawMessageStreamEvent) -> EmbedEvent | None:
     """Map a Managed Agents session SSE event to an EmbedEvent, or None if irrelevant."""
@@ -251,7 +267,7 @@ class SlackTurnLifecycle:
                 {"type": "markdown", "text": first_chunk},
                 *to_blocks(self._state, now=self._clock()),
             ]
-            await self._post_or_update(first_blocks, first_chunk)
+            await self._post_or_update(first_blocks, _notification_text(first_chunk))
             assert self._status_ts is not None  # narrowing — _post_or_update always sets it
             current_ts = self._status_ts
 
@@ -261,7 +277,7 @@ class SlackTurnLifecycle:
                     channel=self._channel,
                     thread_ts=self._thread_ts,
                     blocks=[{"type": "markdown", "text": chunk}],
-                    text=chunk,
+                    text=_notification_text(chunk),
                 )
                 current_ts = cast(str, resp["ts"])  # pyright: ignore[reportUnknownVariableType]
 

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -307,6 +307,49 @@ async def test_terminal_success_overflow_posts_and_widens_final_ts(
     assert lc.final_ts is not None, "final_ts must be set after overflow"
 
 
+async def test_terminal_success_bounds_notification_text_on_long_answers(
+    fake_slack_web_client: Any,
+) -> None:
+    """The `text` notification fallback stays bounded while blocks carry the full chunk.
+
+    chat.update rejects a message whose `text` is block-sized with msg_too_long
+    (probed live: update with text=11800 fails where chat.postMessage accepts the
+    identical payload), which lost a completed 28k-char answer entirely — the
+    status message stayed stuck at thinking with a dead cancel button. The
+    rendered content lives in the markdown block; `text` only feeds
+    notifications, so it must never grow with the answer.
+    """
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    long_text = "y" * 24000  # forces chunks at the 11800 block limit
+    state = TurnState(content=[TextBlock(kind="text", text=long_text)])
+    await lc.on_terminal_success(state)
+
+    update_calls = fake_slack_web_client.mock.requests.get(("POST", _UPDATE_URL), [])
+    assert update_calls, "the first chunk must replace the status message via chat.update"
+    update_body = update_calls[-1].kwargs["json"]
+    assert len(update_body["text"]) <= 3000, (
+        "chat.update's notification fallback must stay under the update text limit "
+        "(msg_too_long above ~4000)"
+    )
+    assert len(update_body["blocks"][0]["text"]) > 3000, (
+        "the markdown block must still carry the full first chunk — only the "
+        "notification fallback is bounded"
+    )
+
+    post_calls = fake_slack_web_client.mock.requests.get(("POST", _POST_URL), [])
+    overflow_bodies = [
+        c.kwargs["json"]
+        for c in post_calls
+        if c.kwargs.get("json", {}).get("blocks", [{}])[0].get("type") == "markdown"
+    ]
+    assert overflow_bodies, "overflow chunks must exist for a 24k answer"
+    assert all(len(b["text"]) <= 3000 for b in overflow_bodies), (
+        "overflow chunks' notification fallbacks must be bounded too"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Task 2: Terminal — collapse paths (tool-only / cancelled)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What broke

The first full Slack QA run asked for a >13k-char answer. The turn completed upstream (209s, 33 events, billed), then the final-answer `chat.update` came back `msg_too_long`, the `SlackApiError` escaped `on_terminal_success` into the mention boundary, and the answer was gone. User-visible state: the status message stuck at `🧠 thinking` with a 3m28s tool trail and a cancel button that the terminal `finally` had already deregistered — a dead button on a dead surface, indistinguishable from a hung bot.

## Root cause

`split_for_slack_safe` caps each **markdown block** at 11 800 chars, which is safe — but `on_terminal_success` also passed the same full chunk as the `text=` notification fallback. Slack's limits differ per method, probed live 2026-08-24 with a scratch channel:

| call | `text` length | result |
|---|---|---|
| chat.postMessage | 11 800 | ok |
| chat.update | 11 800 | **msg_too_long** |
| chat.update | 4 000 | ok |
| either, markdown block of 11 800 | (any short text) | ok |

So the block size was never the problem; `chat.update` rejects a block-sized `text` fallback that `chat.postMessage` accepts. Every short-answer turn passed because the fallback was short; only answers past ~4k in the first chunk died, and only on the update path (the status-message replacement — i.e. **every** long final answer).

## Fix

`text=` only feeds notifications and previews; the rendered content lives in the blocks. `_notification_text()` caps the fallback at 3 000 chars (well under the probed 4 000 pass point), applied to the terminal `chat.update` and, for consistency, to overflow `chat.postMessage` chunks.

## Testing

New test drives a 24k-char answer through the real SDK serialization (aioresponses transport) and asserts the update's `text` stays ≤3 000 while its markdown block still carries the full chunk, and that overflow chunks are bounded too. Verified failing with the fix reverted, passing with it. Slack shard: 463 passed; pyright 0 errors; ruff clean.

## Not in scope, worth a follow-up

Any `SlackApiError` inside the terminal flush still strands the status surface at a working state with a dead cancel button — this PR removes the one known trigger, not the failure mode. Filing separately.