### PR TITLE
fix(adapters): log the per-tenant concurrency shed

### DIFF
--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -843,6 +843,17 @@ class DaimonBot(commands.Bot):
             cap = self.runtime.settings.discord.max_concurrent_turns_per_tenant
             count = self._inflight.get(tenant_id, 0)
             if not should_admit_turn(current_in_flight=count, cap=cap):
+                # Mirror of the Slack shed log — here the notice is a visible
+                # channel message, but the log keeps shed counts greppable
+                # across both adapters.
+                log.info(
+                    "turn.skipped.concurrency_shed",
+                    tenant_id=str(tenant_id),
+                    guild_id=str(message.guild.id) if message.guild else None,
+                    channel_id=str(message.channel.id),
+                    in_flight=count,
+                    cap=cap,
+                )
                 await message.channel.send(
                     "This server has too many chats in flight right now — try again in a moment."
                 )

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -863,6 +863,19 @@ class SlackApp:
         cap = self.runtime.settings.slack.max_concurrent_turns_per_tenant
         count = self._inflight.get(tenant_id, 0)
         if not should_admit_turn(current_in_flight=count, cap=cap):
+            # The rejection below is an ephemeral — it appears in no channel
+            # history and no API read. This log line is the ONLY server-side
+            # trace a shed turn leaves; without it a shed mention is
+            # indistinguishable from a dropped event.
+            log.info(
+                "turn.skipped.concurrency_shed",
+                tenant_id=str(tenant_id),
+                team_id=team_id,
+                channel_id=channel,
+                thread_id=thread_id,
+                in_flight=count,
+                cap=cap,
+            )
             await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
                 channel=channel,
                 user=str(event.get("user") or ""),

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import httpx
+import structlog.testing
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import (
     BetaManagedAgentsModelConfig,
@@ -1256,7 +1257,10 @@ async def test_orchestrate_tenant_cap_when_exhausted_sends_ephemeral_and_skips_t
         "text": "<@U_BOT> hello",
     }
 
-    with patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn:
+    with (
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        structlog.testing.capture_logs() as captured,
+    ):
         await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
             event,
             team_id=team_id,
@@ -1280,6 +1284,15 @@ async def test_orchestrate_tenant_cap_when_exhausted_sends_ephemeral_and_skips_t
 
     # Assert run_turn was NOT called.
     mock_run_turn.assert_not_called()  # pyright: ignore[reportUnknownMemberType]
+
+    # The ephemeral leaves no transcript or history trace, so this log line is
+    # the only server-side evidence a shed happened — its absence made a shed
+    # turn indistinguishable from a dropped event.
+    shed_logs = [c for c in captured if c.get("event") == "turn.skipped.concurrency_shed"]
+    assert len(shed_logs) == 1, "the concurrency shed must log exactly one skip event"
+    assert shed_logs[0]["in_flight"] == cap and shed_logs[0]["cap"] == cap, (
+        "the shed log must carry the in-flight count and cap for the operator"
+    )
 
 
 async def test_orchestrate_first_turn_when_channel_agent_propagated_resolves_channel_agent_tag(


### PR DESCRIPTION
Closes #100.

The Slack concurrency shed posts only a `chat.postEphemeral` — invisible in `conversations.history`/`conversations.replies` — and wrote no log line, making it the one admission outcome with zero server-side evidence (`turn.skipped.over_cap` belongs to the monthly usage gate, a different refusal). A shed mention read exactly like a dropped event, both to users debugging "the bot ignored me" and to automated post-deploy verification.

One `log.info("turn.skipped.concurrency_shed", tenant_id, team_id/guild_id, channel_id, thread_id, in_flight, cap)` before the notice, on both adapters — Discord's notice is a visible channel message so it was never blind there, but the mirror line keeps shed counts greppable across platforms with one event name.

The existing Slack over-cap test now also asserts the log event fires exactly once with the count and cap. 33 tests across both adapters pass; pyright/ruff clean via hooks.