### PR TITLE
fix(cli): accept Slack forms in config --scope

### DIFF
--- a/packages/adapters/cli/daimon/adapters/cli/commands/config.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/config.py
@@ -20,6 +20,7 @@ from daimon.core.scope import (
     TenantScopeRef,
     UserScopeRef,
 )
+from daimon.core.stores.domain import Platform
 from daimon.core.stores.identity import get_or_create_cli_principal
 from daimon.core.stores.scoped_config_read import get_scope, resolve
 from daimon.core.stores.scoped_config_write import (
@@ -63,6 +64,19 @@ def _validate_key(key: str) -> ConfigField:
     return result
 
 
+# Chat platforms addressable in a scope string. "cli" is deliberately absent:
+# the local CLI tenant is what the bare `tenant` / `channel:<id>` forms already
+# target, so a `tenant:cli/local` spelling would be a second name for it.
+_SCOPE_PLATFORMS: dict[str, Platform] = {"discord": "discord", "slack": "slack"}
+
+_SCOPE_HELP = (
+    "user, tenant, tenant:<platform>/<workspace_id>, channel:<channel_id>, "
+    "channel:<platform>/<workspace_id>/<channel_id> (platform: discord|slack; "
+    "a Discord workspace id is the guild id, a Slack one the team id), "
+    "deployment (read-only)"
+)
+
+
 def _parse_scope(
     raw: str,
     *,
@@ -74,10 +88,16 @@ def _parse_scope(
         return UserScopeRef(account_id=account_id)
     if raw == "tenant":
         return TenantScopeRef(tenant_id=tenant_id)
-    if raw.startswith("tenant:discord/"):
-        guild_id = raw[len("tenant:discord/") :]
-        return TenantScopeRef(
-            tenant_id=derive_tenant_uuid(platform="discord", workspace_id=guild_id)
+    if raw.startswith("tenant:"):
+        parts = raw[len("tenant:") :].split("/")
+        platform = _SCOPE_PLATFORMS.get(parts[0])
+        if len(parts) == 2 and platform is not None and parts[1]:
+            return TenantScopeRef(
+                tenant_id=derive_tenant_uuid(platform=platform, workspace_id=parts[1])
+            )
+        raise typer.BadParameter(
+            f"invalid tenant scope {raw!r}; expected tenant:<platform>/<workspace_id> "
+            f"(platform: {'|'.join(_SCOPE_PLATFORMS)})"
         )
     if raw.startswith("channel:"):
         rest = raw[len("channel:") :]
@@ -85,20 +105,18 @@ def _parse_scope(
             # bare channel:<channel_id> — local tenant
             return ChannelScopeRef(tenant_id=tenant_id, channel_id=rest)
         parts = rest.split("/")
-        if len(parts) == 3 and parts[0] == "discord":
-            # channel:discord/<guild_id>/<channel_id>
+        platform = _SCOPE_PLATFORMS.get(parts[0])
+        if len(parts) == 3 and platform is not None and parts[1] and parts[2]:
             return ChannelScopeRef(
-                tenant_id=derive_tenant_uuid(platform="discord", workspace_id=parts[1]),
+                tenant_id=derive_tenant_uuid(platform=platform, workspace_id=parts[1]),
                 channel_id=parts[2],
             )
         raise typer.BadParameter(
             f"invalid channel scope {raw!r}; expected channel:<channel_id> "
-            "or channel:discord/<guild_id>/<channel_id>"
+            "or channel:<platform>/<workspace_id>/<channel_id> "
+            f"(platform: {'|'.join(_SCOPE_PLATFORMS)})"
         )
-    raise typer.BadParameter(
-        "unknown scope; valid: user, tenant, tenant:discord/<guild_id>, "
-        "channel:<channel_id>, channel:discord/<guild_id>/<channel_id>, deployment (read-only)"
-    )
+    raise typer.BadParameter(f"unknown scope; valid: {_SCOPE_HELP}")
 
 
 # -- get -------------------------------------------------------------------
@@ -123,8 +141,7 @@ def config_get_command(
         str | None,
         typer.Option(
             "--scope",
-            help="Raw scope: user, tenant, tenant:discord/<guild_id>, channel:<channel_id>, "
-            "channel:discord/<guild_id>/<channel_id>, deployment (read-only)",
+            help=f"Raw scope: {_SCOPE_HELP}",
         ),
     ] = None,
     channel: Annotated[

--- a/packages/adapters/cli/tests/commands/test_config.py
+++ b/packages/adapters/cli/tests/commands/test_config.py
@@ -82,6 +82,40 @@ def test_parse_scope_channel_bad_discord_format_raises() -> None:
         _parse_scope("channel:discord/1234", tenant_id=uuid.uuid4(), account_id=uuid.uuid4())
 
 
+def test_parse_scope_tenant_slack() -> None:
+    tid = uuid.uuid4()
+    ref = _parse_scope("tenant:slack/T0TEST123", tenant_id=tid, account_id=uuid.uuid4())
+    assert isinstance(ref, TenantScopeRef), "tenant:slack/<team_id> must return TenantScopeRef"
+    assert ref.tenant_id == derive_tenant_uuid(platform="slack", workspace_id="T0TEST123"), (
+        "tenant_id must derive from (slack, team_id) — the same anchor the Slack adapter uses"
+    )
+
+
+def test_parse_scope_channel_slack() -> None:
+    tid = uuid.uuid4()
+    ref = _parse_scope("channel:slack/T0TEST123/C0CHAN9", tenant_id=tid, account_id=uuid.uuid4())
+    assert isinstance(ref, ChannelScopeRef), (
+        "channel:slack/<team_id>/<channel_id> must return ChannelScopeRef"
+    )
+    assert ref.channel_id == "C0CHAN9", "channel_id must be the last path segment"
+    assert ref.tenant_id == derive_tenant_uuid(platform="slack", workspace_id="T0TEST123"), (
+        "tenant_id must derive from the slack team, not the local CLI tenant"
+    )
+
+
+def test_parse_scope_unknown_platform_raises() -> None:
+    with pytest.raises(typer.BadParameter):
+        _parse_scope("tenant:teams/123", tenant_id=uuid.uuid4(), account_id=uuid.uuid4())
+    with pytest.raises(typer.BadParameter):
+        # "cli" is deliberately not scope-addressable — bare `tenant` already is the local tenant
+        _parse_scope("tenant:cli/local", tenant_id=uuid.uuid4(), account_id=uuid.uuid4())
+
+
+def test_parse_scope_tenant_missing_workspace_raises() -> None:
+    with pytest.raises(typer.BadParameter):
+        _parse_scope("tenant:slack/", tenant_id=uuid.uuid4(), account_id=uuid.uuid4())
+
+
 @pytest.mark.asyncio
 async def test_config_get_effective_shows_provenance(db_session: AsyncSession) -> None:
     tenant = await make_tenant(db_session)


### PR DESCRIPTION
## The gap

`config._parse_scope` accepted only `tenant:discord/<guild_id>` and `channel:discord/<guild_id>/<channel_id>`, with `derive_tenant_uuid(platform="discord", ...)` hardcoded at both sites. Setting a channel or tenant config default for a Slack install out of band was therefore impossible: the CLI is the only door (the in-product path is behind Slack's interaction ceiling — no token can produce a block_actions payload), so per-channel agent defaults on Slack could not be exercised or verified at all. #97 fixed the same class of hardcoding in `tenants` and the backfill commands; `config` was the remaining hold-out.

## Change

The scope grammar generalizes to `tenant:<platform>/<workspace_id>` and `channel:<platform>/<workspace_id>/<channel_id>` for `discord|slack`, resolving through the same `(platform, workspace_id)` uuid5 anchor the adapters use. Existing discord spellings parse identically. `cli` is deliberately not scope-addressable — bare `tenant` already names the local tenant, and a second spelling for the same row invites drift. Malformed platform or missing segments raise `BadParameter` naming the accepted grammar; the `--scope` help text derives from the same constant so it cannot go stale separately.

## Testing

New tests: slack tenant scope derives the slack tenant uuid, slack channel scope carries both derived tenant and channel id, unknown platform (`teams`) and `cli` both rejected, missing workspace segment rejected. Existing discord/bare/user cases unchanged and passing. CLI shard: 238 passed; pyright 0 errors.

Unblocks the Slack QA rig's scope-cascade scenario (per-channel default set via CLI, verified in-thread via `explain_agent_resolution`).