### PR TITLE
sync_skills summary claimed an attach it had not performed

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
@@ -86,6 +86,11 @@ class SkillSyncResult(BaseModel):
     The counts stayed permanently lopsided while the tool had no way to
     attach: ``attached_count`` was structurally 0 and the summary could only
     describe the gap it could not close. ``agent_name`` closes it.
+
+    ``attached_count`` is tenant-wide, not per-call: re-importing a skill that
+    some agent already mounts counts it, even with no ``agent_name``. Only
+    ``summary`` distinguishes "this call attached it" from "it was already
+    attached", so do not read the count as this call's effect.
     """
 
     source_url: str
@@ -308,20 +313,24 @@ async def _sync_impl(
             runtime, auth, agent_name=agent_name, skill_ids=registry_ids
         )
 
-    # Recounted AFTER any attach, so attached_count reflects this call's own
-    # effect rather than the state it observed on the way in.
+    # Recounted AFTER any attach so this call's own attach is included. Note the
+    # count is tenant-wide -- "of what I imported, how much is attached to some
+    # agent" -- so it can be non-zero on an import that attached nothing. The
+    # summary has to say which of the two it is, or the caller reads a re-import
+    # of already-attached skills as an attach it just performed.
     agents = await list_agents_by_tenant(runtime.client, tenant_id=auth.tenant_id)
     attached_ids = {skill.skill_id for agent in agents for skill in agent.skills}
     attached = registry_ids & attached_ids
 
-    summary = (
-        f"{len(registry_ids)} skill(s) imported into the workspace's shared skill "
-        f"library; {len(attached)} attached to an agent."
-        + (
-            attach_note
-            or " Importing and attaching are separate steps — pass agent_name to do both."
+    library = f"{len(registry_ids)} skill(s) imported into the workspace's shared skill library"
+    if agent_name is not None:
+        summary = f"{library}; {len(attached)} now attached to an agent." + attach_note
+    else:
+        summary = (
+            f"{library}. This call attached nothing: {len(attached)} of the "
+            f"{len(registry_ids)} are already attached to an agent. Pass agent_name "
+            "to import and attach in one step."
         )
-    )
     return SkillSyncResult(
         source_url=url,
         branch=branch,

--- a/packages/adapters/mcp/tests/tools/test_skills.py
+++ b/packages/adapters/mcp/tests/tools/test_skills.py
@@ -541,6 +541,13 @@ async def test_sync_impl_reports_one_attached_when_an_existing_agent_already_has
 
     assert result.registry_count == 1
     assert result.attached_count == 1, "the already-attached synced skill must be counted"
+    assert "attached nothing" in result.summary, (
+        "an import with no agent_name attaches nothing, so the summary must say so -- "
+        "the tenant-wide count alone reads as an attach this call performed"
+    )
+    assert "already attached" in result.summary, (
+        "the summary must attribute the count to prior state, not to this call"
+    )
 
 
 async def test_sync_impl_excludes_failed_outcome_from_both_counts(tmp_path: Path) -> None:
@@ -793,6 +800,9 @@ async def test_sync_impl_attaches_to_the_named_agent_and_preserves_its_existing_
         "attached_count must reflect this call's own attach, not the state it saw on the way in"
     )
     assert "agent" in result.summary, "the summary must name the agent it attached to"
+    assert "attached nothing" not in result.summary, (
+        "an attach did happen here, so the no-agent_name disclaimer must not fire"
+    )
 
 
 async def test_sync_impl_anonymous_404_names_the_credential_remedy() -> None:


### PR DESCRIPTION
Fixes #111 — though not in the direction that issue proposed. See below.

## The bug

An import-only sync (no `agent_name`) returned a summary that contradicted itself in one sentence:

> 5 skill(s) imported into the workspace's shared skill library; **5 attached to an agent.** Importing and attaching are separate steps — **pass agent_name to do both.**

Read the first clause and you conclude the call just modified an agent. Read the second and it didn't. Found on a real import whose five skills were already attached — it reported five attached, and nothing had been.

## The count is not the bug

#111 proposed making `attached_count` 0 when no `agent_name` is passed. That is wrong: the count is deliberately tenant-wide — *of the skills this call imported, how many are attached to some agent* — which is what the field's own docstring says, and `test_sync_impl_reports_one_attached_when_an_existing_agent_already_has_it` pins exactly that behaviour with no `agent_name` passed.

So the count genuinely cannot distinguish "I attached it" from "it was already attached". The wording has to.

## The fix

- With `agent_name`: "…; N **now attached** to an agent." plus the existing attach note.
- Without: "…. **This call attached nothing:** N of the M are already attached to an agent. Pass `agent_name` to import and attach in one step."

Also corrected two comments that stopped being true when `agent_name` was introduced: the recount comment claimed it "reflects this call's own effect", and the model docstring still said `attached_count` was structurally 0 on an import. Both now describe what the field counts, with an explicit warning not to read it as this call's effect.

## Tests

Extended the already-attached test to assert the disclaimer fires, and added the opposite guard to the attach test so a future change can't make the disclaimer unconditional and report "attached nothing" on a real attach.

Verified the regression test fails without the source change — the first version of the second test passed on unfixed code and was dropped rather than kept as decoration.

`pytest packages/adapters/mcp/tests/tools/test_skills.py` 22 passed; ruff, ruff-format and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)