### PR TITLE
Slack send_message: post to channels and threads

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -41,6 +41,9 @@ from daimon.adapters.mcp.tools.slack._read import (
 from daimon.adapters.mcp.tools.slack._search import (
     _slack_search_messages_impl,  # pyright: ignore[reportPrivateUsage]
 )
+from daimon.adapters.mcp.tools.slack._send import (
+    _slack_send_message_impl,  # pyright: ignore[reportPrivateUsage]
+)
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 
@@ -149,12 +152,12 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         content: str,
         attachments: list[dict[str, str]] | None = None,
         file_handles: list[str] | None = None,
-    ) -> MessageRow:
-        """Post a message to a Discord channel.
+    ) -> MessageRow | SlackMessageRow:
+        """Post a message to a channel.
 
         For TEXT: only call this when the user explicitly asks you to send or
-        post something to Discord. Do NOT call it to share results, summaries,
-        or outputs unless the user specifically requested a Discord post.
+        post something to a channel. Do NOT call it to share results,
+        summaries, or outputs unless the user specifically requested a post.
         Deliver text output in your reply instead.
 
         For FILES that rule does not apply, because a reply cannot carry an
@@ -174,11 +177,26 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         To post a file you made in your sandbox, call
         ``create_file_upload_url`` first and PUT the bytes to the URL it
         returns — never base64 a file into a tool argument. Combined
-        cap of 10 attachments per message.
+        cap of 10 attachments per message. Both FILES paragraphs are
+        Discord-only for now — Slack file posting needs a scope this
+        install does not have.
+
+        Slack: ``channel_id`` may be ``channel_id:thread_ts`` (e.g.
+        ``C0123456789:1717171717.123456``) to post into a thread. Content is
+        sent as-is — nothing is escaped, so ``<@U…>`` mentions work — and is
+        capped at 12,000 characters. daimon must already be in the channel
+        (a member can run ``/invite @daimon``).
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":
-            raise _slack_unsupported("send_message")
+            return await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id=channel_id,
+                content=content,
+                attachments=attachments,
+                file_handles=file_handles,
+            )
         return await _send_message_impl(
             runtime,
             auth,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -301,10 +301,25 @@ async def _fetch_thread_replies(
     )
     raw = cast(list[dict[str, Any]], resp["messages"])  # already oldest-first
     has_more = bool(resp.get("has_more"))
+    result_thread_ts = thread_ts
+
+    # A reply's ts identifies its thread, matching how send treats a thread
+    # target: if the first message's own thread_ts differs from what was
+    # requested, the caller passed a reply's ts — refetch by the parent.
+    if raw:
+        parent_ts = raw[0].get("thread_ts")
+        if parent_ts and str(parent_ts) != thread_ts:
+            result_thread_ts = str(parent_ts)
+            resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
+                channel=channel_id, ts=result_thread_ts, limit=min(limit, _HISTORY_LIMIT_CAP)
+            )
+            raw = cast(list[dict[str, Any]], resp["messages"])
+            has_more = bool(resp.get("has_more"))
+
     usernames = await _resolve_usernames(client, _author_ids(raw))
     return SlackThreadResult(
         channel_id=channel_id,
-        thread_ts=thread_ts,
+        thread_ts=result_thread_ts,
         messages=_to_message_rows(raw, usernames),
         has_more=has_more,
     )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_send.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_send.py
@@ -1,0 +1,176 @@
+"""Slack send_message implementation: post + composite thread targets.
+
+Bot-token only. Unlike the read tools, send never uses the caller's own
+xoxp token — there is no impersonation path and no hybrid client to fall
+back to; every post is authenticated as the workspace bot.
+
+Content is posted raw, with no entity escaping: send content is
+deliberately authored (by the agent or a routine), so `<@U…>` mentions,
+`<#C…>` channel links, and bold markers are meant to render, and escaping
+them would break that intent.
+
+A thread target is validated with `conversations.replies` before anything
+is posted. Slack accepts a `thread_ts` that does not exist, silently drops
+it, and posts the message at the channel root instead of erroring — so the
+post itself can never surface a bad thread target; only a pre-flight check
+can. The composite `channel_id:thread_ts` form is how a caller aims a reply
+at a specific thread.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.slack._client import (
+    _require_slack_identity,  # pyright: ignore[reportPrivateUsage]
+    _require_team_id,  # pyright: ignore[reportPrivateUsage]
+    slack_web_client,
+)
+from daimon.adapters.mcp.tools.slack._models import SlackMessageRow
+from daimon.adapters.mcp.tools.slack._visibility import (
+    check_channel_access,
+    map_slack_api_error,
+)
+from fastmcp.exceptions import ToolError
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.async_client import AsyncWebClient
+
+# Slack's {"type": "markdown"} block cap is 12,000 CHARACTERS (not bytes);
+# over it, chat.postMessage answers msg_too_long. Kept local to this module —
+# it is platform-specific and must not leak into core.
+_MAX_CONTENT_CHARS = 12_000
+
+# Duplicated from the Slack adapter's bounded notification-text fallback
+# (daimon.adapters.slack.lifecycle) — adapters must not import each other.
+_NOTIFICATION_TEXT_MAX = 3000
+
+_OVER_LENGTH_MSG = (
+    f"content is over Slack's {_MAX_CONTENT_CHARS:,}-character message limit — "
+    "shorten it, or send it in parts with several send_message calls "
+    "(thread replies work well for parts)"
+)
+_NOT_IN_CHANNEL_MSG = "daimon isn't in that channel — ask a member to /invite @daimon"
+_FILES_UNSUPPORTED_MSG = (
+    "file posting is not available on Slack yet — this workspace's bot token "
+    "has no files:write scope"
+)
+_THREAD_NOT_FOUND_MSG = "that thread does not exist — check the thread_ts and try again"
+
+
+def _split_send_target(channel_id: str) -> tuple[str, str | None]:
+    """Split a `channel_id` or `channel_id:thread_ts` composite target."""
+    target, sep, thread_ts = channel_id.partition(":")
+    if not sep:
+        return channel_id, None
+    if not target or not thread_ts:
+        raise ToolError(
+            "slack send targets have the form channel_id or channel_id:thread_ts "
+            "(e.g. C0123456789:1717171717.123456)"
+        )
+    return target, thread_ts
+
+
+def _notification_text(content: str) -> str:
+    """Bound content for use as the `text` notification fallback."""
+    if len(content) <= _NOTIFICATION_TEXT_MAX:
+        return content
+    return content[: _NOTIFICATION_TEXT_MAX - 1] + "…"
+
+
+def _slack_error_code(err: SlackApiError) -> str:
+    return str(err.response.get("error", ""))  # pyright: ignore[reportUnknownArgumentType, reportUnknownMemberType]  # slack_sdk response is dict-like
+
+
+async def _validate_channel_access(
+    client: AsyncWebClient, *, channel_id: str, requester_id: str
+) -> None:
+    try:
+        info = await client.conversations_info(channel=channel_id)  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
+        channel = cast(dict[str, Any], info["channel"])
+        await check_channel_access(client, channel=channel, user_id=requester_id)
+    except SlackApiError as err:
+        mapped = map_slack_api_error(err)
+        if mapped is None:
+            raise
+        raise mapped from err
+
+
+async def _validate_thread_target(
+    client: AsyncWebClient, *, channel_id: str, thread_ts: str
+) -> None:
+    try:
+        await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
+            channel=channel_id, ts=thread_ts, limit=1
+        )
+    except SlackApiError as err:
+        code = _slack_error_code(err)
+        if code in ("thread_not_found", "message_not_found"):
+            raise ToolError(_THREAD_NOT_FOUND_MSG) from err
+        mapped = map_slack_api_error(err)
+        if mapped is None:
+            raise
+        raise mapped from err
+
+
+async def _post_message(
+    client: AsyncWebClient, *, channel_id: str, content: str, thread_ts: str | None
+) -> dict[str, Any]:
+    post_kwargs: dict[str, Any] = {
+        "channel": channel_id,
+        "text": _notification_text(content),
+        "blocks": [{"type": "markdown", "text": content}],
+    }
+    if thread_ts is not None:
+        post_kwargs["thread_ts"] = thread_ts
+    try:
+        resp = await client.chat_postMessage(**post_kwargs)  # pyright: ignore[reportUnknownMemberType, reportArgumentType]  # slack_sdk **kwargs: Unknown
+    except SlackApiError as err:
+        code = _slack_error_code(err)
+        if code == "not_in_channel":
+            raise ToolError(_NOT_IN_CHANNEL_MSG) from err
+        if code == "msg_too_long":
+            raise ToolError(_OVER_LENGTH_MSG) from err
+        mapped = map_slack_api_error(err)
+        if mapped is None:
+            raise
+        raise mapped from err
+    return cast(dict[str, Any], resp.data)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]  # slack_sdk response is dict-like
+
+
+async def _slack_send_message_impl(  # pyright: ignore[reportUnusedFunction]  # registered by tools/channels.py
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    content: str,
+    attachments: list[dict[str, str]] | None,
+    file_handles: list[str] | None,
+) -> SlackMessageRow:
+    if attachments or file_handles:
+        raise ToolError(_FILES_UNSUPPORTED_MSG)
+    if len(content) > _MAX_CONTENT_CHARS:
+        raise ToolError(_OVER_LENGTH_MSG)
+
+    target_channel_id, thread_ts = _split_send_target(channel_id)
+    requester_id = _require_slack_identity(auth)
+    team_id = _require_team_id(auth)
+    client = await slack_web_client(runtime, team_id=team_id)
+
+    await _validate_channel_access(client, channel_id=target_channel_id, requester_id=requester_id)
+    if thread_ts is not None:
+        await _validate_thread_target(client, channel_id=target_channel_id, thread_ts=thread_ts)
+
+    resp = await _post_message(
+        client, channel_id=target_channel_id, content=content, thread_ts=thread_ts
+    )
+    message = cast(dict[str, Any], resp.get("message") or {})
+    response_thread_ts = message.get("thread_ts")
+    response_user_id = message.get("user")
+    return SlackMessageRow(
+        ts=str(resp["ts"]),
+        user_id=str(response_user_id) if response_user_id else None,
+        text=content,
+        thread_ts=str(response_thread_ts) if response_thread_ts else None,
+    )

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2455,11 +2455,11 @@
     }),
     'send_message': dict({
       'description': '''
-        Post a message to a Discord channel.
+        Post a message to a channel.
         
         For TEXT: only call this when the user explicitly asks you to send or
-        post something to Discord. Do NOT call it to share results, summaries,
-        or outputs unless the user specifically requested a Discord post.
+        post something to a channel. Do NOT call it to share results,
+        summaries, or outputs unless the user specifically requested a post.
         Deliver text output in your reply instead.
         
         For FILES that rule does not apply, because a reply cannot carry an
@@ -2479,7 +2479,15 @@
         To post a file you made in your sandbox, call
         ``create_file_upload_url`` first and PUT the bytes to the URL it
         returns — never base64 a file into a tool argument. Combined
-        cap of 10 attachments per message.
+        cap of 10 attachments per message. Both FILES paragraphs are
+        Discord-only for now — Slack file posting needs a scope this
+        install does not have.
+        
+        Slack: ``channel_id`` may be ``channel_id:thread_ts`` (e.g.
+        ``C0123456789:1717171717.123456``) to post into a thread. Content is
+        sent as-is — nothing is escaped, so ``<@U…>`` mentions work — and is
+        capped at 12,000 characters. daimon must already be in the channel
+        (a member can run ``/invite @daimon``).
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
+++ b/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
@@ -202,7 +202,6 @@ async def _seed_slack_bound_account(db_session: AsyncSession, *, workspace_id: s
     [
         ("list_threads", {"channel_id": "C_TEST"}),
         ("parse_link", {"url": "https://discord.com/channels/1/2"}),
-        ("send_message", {"channel_id": "C_TEST", "content": "hi"}),
     ],
 )
 async def test_slack_caller_calling_unsupported_tool_raises_own_name(
@@ -268,6 +267,49 @@ async def test_search_messages_slack_caller_no_longer_hits_unsupported_branch(
     )
     assert "slack tools require DAIMON_CRYPTO__KEYS" in output_text, (
         f"Slack caller's search_messages must hit the Slack-only crypto-keys error; "
+        f"got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_slack_caller_no_longer_hits_unsupported_branch(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """send_message used to be Slack-unsupported; it now routes to the Slack send
+    impl. With no DAIMON_CRYPTO__KEYS configured on the runtime, the Slack impl's
+    ``slack_web_client`` fails with a Slack-specific error the old "not supported
+    on Slack yet" branch could never produce — pinning that the dispatch now
+    reaches ``_slack_send_message_impl`` instead. Needs a linked PlatformPrincipal
+    (platform_user_id) since the send impl resolves slack identity before
+    touching crypto."""
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="slack-send-message")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="slack",
+        external_id="U_SLACK_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="send_message",
+        arguments={"channel_id": "C_TEST", "content": "hi"},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "send_message is not supported on Slack yet" not in output_text, (
+        "send_message must no longer hit the Slack-unsupported branch"
+    )
+    assert "slack tools require DAIMON_CRYPTO__KEYS" in output_text, (
+        f"Slack caller's send_message must hit the Slack-only crypto-keys error; "
         f"got {output_text!r}"
     )
 

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -376,6 +376,203 @@ async def test_read_thread_malformed_id_explains_format(
 
 
 @pytest.mark.asyncio
+async def test_read_thread_reply_ts_resolves_to_parent_thread(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A read_thread call given a reply's ts must return the whole parent
+    thread (oldest-first), not a one-message thread — the second
+    conversations.replies call answers with the full thread."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    reply_ts = "1.5"
+    parent_ts = "1.0"
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "has_more": False,
+                "messages": [
+                    {"ts": reply_ts, "user": "U_B", "text": "reply-only", "thread_ts": parent_ts}
+                ],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "has_more": False,
+                "messages": [
+                    {
+                        "ts": parent_ts,
+                        "user": "U_A",
+                        "text": "root",
+                        "thread_ts": parent_ts,
+                        "reply_count": 1,
+                    },
+                    {"ts": reply_ts, "user": "U_B", "text": "reply-only", "thread_ts": parent_ts},
+                ],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_B", "profile": {"display_name": "bob"}}},
+        )
+        result = await _slack_read_thread_impl(runtime, auth, thread_id=f"C1:{reply_ts}", limit=50)
+    assert result.thread_ts == parent_ts, "the result must report the parent ts, not the reply ts"
+    assert [msg.text for msg in result.messages] == ["root", "reply-only"], (
+        "a version that returns only the single reply must fail this assertion"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_thread_parent_ts_makes_exactly_one_replies_call(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Reading a thread by its own parent ts (the shipped case) must not
+    double every existing read with a second conversations.replies call."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    parent_ts = "1.0"
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "has_more": False,
+                "messages": [
+                    {
+                        "ts": parent_ts,
+                        "user": "U_A",
+                        "text": "root",
+                        "thread_ts": parent_ts,
+                        "reply_count": 1,
+                    },
+                    {"ts": "2.0", "user": "U_B", "text": "reply", "thread_ts": parent_ts},
+                ],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_B", "profile": {"display_name": "bob"}}},
+        )
+        result = await _slack_read_thread_impl(runtime, auth, thread_id=f"C1:{parent_ts}", limit=50)
+        replies_calls = [
+            reqs
+            for (method, url), reqs in m.requests.items()
+            if method == "GET" and "conversations.replies" in str(url)
+        ]
+    assert sum(len(reqs) for reqs in replies_calls) == 1, (
+        "reading a thread by its own parent ts must make exactly one conversations.replies call"
+    )
+    assert result.thread_ts == parent_ts
+
+
+@pytest.mark.asyncio
+async def test_read_thread_untreaded_message_returns_as_is_no_crash(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A ts with no thread_ts at all (an untreaded message fetched by ts) must
+    be returned as-is, with no second conversations.replies call and no crash."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    ts = "9.0"
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={"ok": True, "has_more": False, "messages": [{"ts": ts, "text": "lone"}]},
+        )
+        result = await _slack_read_thread_impl(runtime, auth, thread_id=f"C1:{ts}", limit=50)
+        replies_calls = [
+            reqs
+            for (method, url), reqs in m.requests.items()
+            if method == "GET" and "conversations.replies" in str(url)
+        ]
+    assert sum(len(reqs) for reqs in replies_calls) == 1
+    assert result.thread_ts == ts
+    assert [msg.text for msg in result.messages] == ["lone"]
+
+
+@pytest.mark.asyncio
+async def test_read_thread_reply_ts_resolves_to_parent_on_user_token_path(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """The user-token branch of _slack_read_thread_impl shares
+    _fetch_thread_replies, so the same reply-ts parent resolution applies."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    await _seed_user_token(runtime, committing_sessionmaker)
+    reply_ts = "1.5"
+    parent_ts = "1.0"
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "has_more": False,
+                "messages": [
+                    {"ts": reply_ts, "user": "U_B", "text": "reply-only", "thread_ts": parent_ts}
+                ],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "has_more": False,
+                "messages": [
+                    {
+                        "ts": parent_ts,
+                        "user": "U_A",
+                        "text": "root",
+                        "thread_ts": parent_ts,
+                        "reply_count": 1,
+                    },
+                    {"ts": reply_ts, "user": "U_B", "text": "reply-only", "thread_ts": parent_ts},
+                ],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_B", "profile": {"display_name": "bob"}}},
+        )
+        result = await _slack_read_thread_impl(runtime, auth, thread_id=f"C1:{reply_ts}", limit=50)
+    assert result.thread_ts == parent_ts
+    assert [msg.text for msg in result.messages] == ["root", "reply-only"]
+
+
+@pytest.mark.asyncio
 async def test_get_message_top_level_found_via_history(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/packages/adapters/mcp/tests/tools/test_slack_send.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_send.py
@@ -1,0 +1,450 @@
+"""Tests for tools/slack/_send.py — send_message implementation."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from aioresponses import aioresponses
+from anthropic import AsyncAnthropic
+from cryptography.fernet import Fernet
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.slack._send import (  # pyright: ignore[reportPrivateUsage]
+    _slack_send_message_impl,
+)
+from daimon.adapters.mcp.tools.slack._visibility import (
+    MISSING_ACCESS,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.config import (
+    AnthropicSettings,
+    CredentialsSettings,
+    CryptoSettings,
+    DatabaseSettings,
+    McpSettings,
+    Settings,
+)
+from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.domain import Role
+from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+from fastmcp.exceptions import ToolError
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from yarl import URL
+
+_CONVERSATIONS_INFO = re.compile(r"https://slack\.com/api/conversations\.info.*")
+_CONVERSATIONS_REPLIES = re.compile(r"https://slack\.com/api/conversations\.replies.*")
+_CONVERSATIONS_MEMBERS = re.compile(r"https://slack\.com/api/conversations\.members.*")
+_USERS_INFO = re.compile(r"https://slack\.com/api/users\.info.*")
+_CHAT_POST_MESSAGE = "https://slack.com/api/chat.postMessage"
+_POST_KEY = ("POST", URL(_CHAT_POST_MESSAGE))
+
+_FULL_MEMBER = {"ok": True, "user": {"id": "U_CALLER", "is_restricted": False}}
+
+
+def _auth(**overrides: object) -> AuthIdentity:
+    base: dict[str, object] = {
+        "account_id": uuid.uuid4(),
+        "tenant_id": uuid.uuid4(),
+        "role": Role.USER,
+        "platform": "slack",
+        "external_id": "T_TEST",
+        "platform_user_id": "U_CALLER",
+    }
+    base.update(overrides)
+    return AuthIdentity(**base)  # type: ignore[arg-type]  # test kwargs are shape-correct
+
+
+def _build_settings(*, fernet_key: SecretStr) -> Settings:
+    return Settings(
+        database=DatabaseSettings(
+            url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon"),
+        ),
+        anthropic=AnthropicSettings(
+            api_key=SecretStr("sk-test"),
+            base_url=HttpUrl("https://api.anthropic.com"),
+        ),
+        crypto=CryptoSettings(keys=(fernet_key,)),
+        credentials=CredentialsSettings(google_sa_json=None),
+        mcp=McpSettings(),
+        slack=None,
+    )
+
+
+async def _make_runtime(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> McpRuntime:
+    fernet_key = SecretStr(Fernet.generate_key().decode("ascii"))
+    fernet = build_multifernet((fernet_key.get_secret_value(),))
+    async with committing_sessionmaker() as session:
+        await upsert_slack_bot_token(
+            session, team_id="T_TEST", encrypted_token=encrypt_token(fernet, "xoxb-secret")
+        )
+        await session.commit()
+    return McpRuntime(
+        session_factory=committing_sessionmaker,
+        client=MagicMock(spec=AsyncAnthropic),
+        settings=_build_settings(fernet_key=fernet_key),
+        deployment_default=DeploymentDefault(),
+        fernet=fernet,
+    )
+
+
+def _mock_public_channel_access(m: aioresponses) -> None:
+    m.get(  # pyright: ignore[reportUnknownMemberType]
+        _CONVERSATIONS_INFO,
+        payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+    )
+    m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+
+
+def _post_body(m: aioresponses) -> dict[str, object]:
+    posts = m.requests[_POST_KEY]
+    return posts[0].kwargs["json"]  # type: ignore[no-any-return]
+
+
+@pytest.mark.asyncio
+async def test_send_message_channel_root_returns_row_and_posts_one_markdown_block(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000001.000100"}
+        )
+        row = await _slack_send_message_impl(
+            runtime,
+            auth,
+            channel_id="C1",
+            content="hello there",
+            attachments=None,
+            file_handles=None,
+        )
+        body = _post_body(m)
+
+    assert row.ts == "1700000001.000100", "returned row must carry the posted ts"
+    assert row.thread_ts is None, "a channel-root post must not carry a thread_ts"
+    blocks = body["blocks"]
+    assert isinstance(blocks, list) and len(blocks) == 1, "exactly one block must be posted"
+    assert blocks[0] == {"type": "markdown", "text": "hello there"}, (
+        "the markdown block text must be the content verbatim"
+    )
+    assert body["text"] == "hello there", "text fallback must be non-empty"
+    assert "thread_ts" not in body, "a channel-root post must not carry a thread_ts key"
+
+
+@pytest.mark.asyncio
+async def test_send_message_content_with_mentions_and_bold_is_not_escaped(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    content = "hey <@U123> **bold** thing"
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000002.000200"}
+        )
+        await _slack_send_message_impl(
+            runtime, auth, channel_id="C1", content=content, attachments=None, file_handles=None
+        )
+        body = _post_body(m)
+
+    blocks = body["blocks"]
+    assert isinstance(blocks, list)
+    assert blocks[0]["text"] == content, (
+        "entities the agent deliberately authored must reach Slack unescaped"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_long_content_bounds_notification_text_not_block_text(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    content = "x" * 3500
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000003.000300"}
+        )
+        await _slack_send_message_impl(
+            runtime, auth, channel_id="C1", content=content, attachments=None, file_handles=None
+        )
+        body = _post_body(m)
+
+    text = body["text"]
+    assert isinstance(text, str) and len(text) == 3000, (
+        "the text notification fallback must be bounded at 3000 chars"
+    )
+    blocks = body["blocks"]
+    assert isinstance(blocks, list)
+    assert blocks[0]["text"] == content, "the block text must carry the full, unbounded content"
+
+
+@pytest.mark.asyncio
+async def test_send_message_thread_composite_target_validates_then_posts_with_thread_ts(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    thread_ts = "1717171717.123456"
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={"ok": True, "messages": [{"ts": thread_ts, "user": "U_A", "text": "root"}]},
+        )
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE,
+            payload={
+                "ok": True,
+                "ts": "1700000004.000400",
+                "message": {"thread_ts": thread_ts, "user": "U_BOT"},
+            },
+        )
+        row = await _slack_send_message_impl(
+            runtime,
+            auth,
+            channel_id=f"C1:{thread_ts}",
+            content="a reply",
+            attachments=None,
+            file_handles=None,
+        )
+        body = _post_body(m)
+        replies_calls = [
+            reqs
+            for (method, url), reqs in m.requests.items()
+            if method == "GET" and "conversations.replies" in str(url)
+        ]
+
+    assert len(replies_calls) == 1 and len(replies_calls[0]) == 1, (
+        "conversations.replies must be called exactly once before the post"
+    )
+    assert body["thread_ts"] == thread_ts, "the post must carry the validated thread_ts"
+    assert row.thread_ts == thread_ts, (
+        "the returned row's thread_ts is whatever message.thread_ts the response gave"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_reply_ts_input_posts_as_given_row_reports_parent(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    reply_ts = "1717171717.999999"
+    parent_ts = "1717171717.123456"
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "messages": [{"ts": reply_ts, "thread_ts": parent_ts, "user": "U_A", "text": "r"}],
+            },
+        )
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE,
+            payload={
+                "ok": True,
+                "ts": "1700000005.000500",
+                "message": {"thread_ts": parent_ts, "user": "U_BOT"},
+            },
+        )
+        row = await _slack_send_message_impl(
+            runtime,
+            auth,
+            channel_id=f"C1:{reply_ts}",
+            content="a reply",
+            attachments=None,
+            file_handles=None,
+        )
+        body = _post_body(m)
+
+    assert body["thread_ts"] == reply_ts, "the post uses the ts as given, unnormalized"
+    assert row.thread_ts == parent_ts, (
+        "Slack normalizes; the row reports the parent from the response"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_nonexistent_thread_raises_before_any_post(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES, payload={"ok": False, "error": "thread_not_found"}
+        )
+        with pytest.raises(ToolError, match="thread"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1:1717171717.000000",
+                content="a reply",
+                attachments=None,
+                file_handles=None,
+            )
+        assert _POST_KEY not in m.requests, "chat.postMessage must never be called"
+
+
+@pytest.mark.asyncio
+async def test_send_message_im_channel_raises_missing_access_no_post(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO, payload={"ok": True, "channel": {"id": "D1", "is_im": True}}
+        )
+        with pytest.raises(ToolError, match=MISSING_ACCESS):
+            await _slack_send_message_impl(
+                runtime, auth, channel_id="D1", content="hi", attachments=None, file_handles=None
+            )
+        assert _POST_KEY not in m.requests
+
+
+@pytest.mark.asyncio
+async def test_send_message_private_channel_nonmember_raises_missing_access_no_post(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C_PRIV", "name": "sekret", "is_private": True}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_MEMBERS, payload={"ok": True, "members": ["U_SOMEONE_ELSE"]}
+        )
+        with pytest.raises(ToolError, match=MISSING_ACCESS):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C_PRIV",
+                content="hi",
+                attachments=None,
+                file_handles=None,
+            )
+        assert _POST_KEY not in m.requests
+
+
+@pytest.mark.asyncio
+async def test_send_message_not_in_channel_from_post_yields_invite_instruction(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": False, "error": "not_in_channel"}
+        )
+        with pytest.raises(ToolError, match="/invite") as exc_info:
+            await _slack_send_message_impl(
+                runtime, auth, channel_id="C1", content="hi", attachments=None, file_handles=None
+            )
+    assert MISSING_ACCESS not in str(exc_info.value), (
+        "not_in_channel on send must yield the invite instruction, not MISSING_ACCESS"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_msg_too_long_from_post_yields_over_length_guidance(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": False, "error": "msg_too_long"}
+        )
+        with pytest.raises(ToolError, match="shorten"):
+            await _slack_send_message_impl(
+                runtime, auth, channel_id="C1", content="hi", attachments=None, file_handles=None
+            )
+
+
+@pytest.mark.asyncio
+async def test_send_message_over_12000_chars_refused_with_zero_api_calls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    content = "x" * 12_001
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="shorten"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content=content,
+                attachments=None,
+                file_handles=None,
+            )
+        assert m.requests == {}, "an over-length call must cost zero Slack API calls"
+
+
+@pytest.mark.asyncio
+async def test_send_message_attachments_refused_naming_files_write_no_api_calls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="files:write"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content="hi",
+                attachments=[{"url": "https://example.com/f.png", "filename": "f.png"}],
+                file_handles=None,
+            )
+        assert m.requests == {}
+
+
+@pytest.mark.asyncio
+async def test_send_message_file_handles_refused_naming_files_write_no_api_calls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="files:write"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content="hi",
+                attachments=None,
+                file_handles=["handle_1"],
+            )
+        assert m.requests == {}
+
+
+@pytest.mark.asyncio
+async def test_send_message_malformed_composite_target_raises_format_error_no_api_calls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="channel_id:thread_ts"):
+            await _slack_send_message_impl(
+                runtime, auth, channel_id="C1:", content="hi", attachments=None, file_handles=None
+            )
+        assert m.requests == {}

--- a/packages/core/daimon/core/agent_guidance.py
+++ b/packages/core/daimon/core/agent_guidance.py
@@ -72,7 +72,7 @@ carrying the attachment. Do not report a file as sent on any weaker signal.
 
 ROUTINES RUN HEADLESS — the exception to the rule above. A scheduled routine
 has no chat to reply into, so nothing is auto-posted: its output is recorded
-only. To make a routine post to Discord it must explicitly call the
+only. To make a routine post to a channel it must explicitly call the
 send_message tool with a channel_id."""
 
 # The full sentinel-wrapped block. Re-applying detects this by sentinel and


### PR DESCRIPTION
`send_message` refused every Slack call, so a Slack routine's headless turn billed and then died with "not supported on Slack yet" — the output only visible in the routines panel. Interactive asks ("post this to #general") hit the same wall.

**Commit 1 — Slack send path** (`tools/slack/_send.py`, dispatched from `channels.py`):

- Posts as the bot, never a user token. Same authz as the Slack read tools: `conversations_info` → `check_channel_access` for the invoking user; DMs refused.
- Thread replies via a composite `channel_id:thread_ts` target, the same form `read_thread` already returns.
- Mandatory `conversations.replies` check before any threaded post. Probed live: `chat.postMessage` with an unknown `thread_ts` returns `ok:true`, silently drops the ts, and posts at the channel root — a routine with a stale ts would spam the channel while reporting success. Validation is the only defense.
- Content goes raw into a `{"type":"markdown"}` block (no entity escaping — it would break intentional `<@U…>` mentions), with a bounded `text=` notification fallback (#106 lesson).
- Guidance errors instead of raw API codes: `not_in_channel` → "ask a member to /invite @daimon" (first error every routine will hit — no `chat:write.public` scope), 12,000-char pre-flight (the markdown-block cap, measured live in characters, not bytes) → shorten or send in parts, attachments/files → refused naming the missing `files:write` scope.
- `send_message` docstring and the headless-routine guidance rewritten platform-neutral.

**Commit 2 — `read_thread` reply-ts normalization:** requesting a reply's ts used to return a one-message "thread"; it now resolves to the full parent thread, matching send's convention. Independent, reverts cleanly on its own.

Out of scope: scope additions (`chat:write.public`, `files:write` force workspace re-consent), auto-splitting long content, routine failure notifications.

20 new tests (`aioresponses` at the aiohttp transport, same pattern as the read tests), including: no API call ever fires on pre-flight refusals, and a bad thread target never reaches `chat.postMessage`. Full mcp suite green; pyright/ruff/lint-imports clean.

Fixes #110

https://claude.ai/code/session_01FNTXYv3pNSJV3QJ6jgaJTQ
