### PR TITLE
Platform-tagged tool visibility + Slack permalinks in parse_link

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/middleware/mcp_identity.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/middleware/mcp_identity.py
@@ -181,6 +181,12 @@ class IdentityMiddleware(Middleware):
         await fastmcp_ctx.set_state("auth", identity, serializable=False)
         if is_admin:
             await enable_components(fastmcp_ctx, tags={"admin"})
+        # Enable the caller's platform tag (deny-by-default baselines live in
+        # server.py). A CLI token's platform="cli" matches no baseline tag,
+        # so this enable is a no-op for CLI — the intended outcome: CLI loses
+        # the discord/slack-tagged tools without any special-casing here.
+        if platform is not None:
+            await enable_components(fastmcp_ctx, tags={platform})
         # when agent_id is present (a verified
         # derived per-agent UUID), narrow the session to agent-chat-tagged
         # tools only. disable_components(match_all=True) then

--- a/packages/adapters/mcp/daimon/adapters/mcp/server.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/server.py
@@ -213,6 +213,8 @@ def create_mcp_app(
 
     mcp.add_transform(Visibility(False, tags={"admin"}))
     mcp.add_transform(Visibility(False, tags={"agent-chat"}))
+    mcp.add_transform(Visibility(False, tags={"discord"}))
+    mcp.add_transform(Visibility(False, tags={"slack"}))
     mcp.add_transform(
         AgentChatAwareBM25SearchTransform(
             max_results=5,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -857,7 +857,7 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
         For MCP servers that REQUIRE an auth token, do NOT collect the
         token in chat — direct the user to ``/agent-setup`` -> MCPs modal.
-        Tokens sent in chat end up in Discord channel history and MA's
+        Tokens sent in chat end up in channel history and MA's
         tenant-wide session event log; the modal flow is the only
         supported path for auth-required servers.
         """

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -29,8 +29,12 @@ from daimon.adapters.mcp.tools.discord import (
 from daimon.adapters.mcp.tools.slack._models import (
     SlackChannelRow,
     SlackMessageRow,
+    SlackParsedLink,
     SlackSearchResult,
     SlackThreadResult,
+)
+from daimon.adapters.mcp.tools.slack._parse_link import (
+    _slack_parse_link_impl,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.adapters.mcp.tools.slack._read import (
     _slack_get_message_impl,  # pyright: ignore[reportPrivateUsage]
@@ -126,23 +130,28 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             raise _slack_unsupported("list_threads")
         return await _list_threads_impl(runtime, auth, channel_id=channel_id)
 
-    @mcp.tool(tags={"discord"})  # pyright: ignore[reportArgumentType]
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def parse_link(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         url: str,
-    ) -> ParsedLink:
-        """Extract IDs from a Discord URL.
+    ) -> ParsedLink | SlackParsedLink:
+        """Extract IDs from a channel or message link.
 
-        Supports discord.com, ptb.discord.com, and canary.discord.com URLs.
-
-        After parsing:
+        Discord: supports discord.com, ptb.discord.com, and
+        canary.discord.com URLs.
         - If link_type is "channel": use read_channel(channel_id)
         - If link_type is "message_or_thread": try read_thread(thread_id) first;
           if read_thread fails, it is a message: use get_message(channel_id, message_id)
+
+        Slack: supports a workspace permalink
+        (.../archives/<channel>/p<digits>). Returns channel_id, the dotted
+        message ts, and thread_ts when the link is a reply. Try
+        read_thread(thread_id=f"{channel_id}:{thread_ts or message_ts}")
+        first; if that fails, use get_message(channel_id, message_ts).
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":
-            raise _slack_unsupported("parse_link")
+            return _slack_parse_link_impl(url)
         return _parse_link_impl(url, caller_guild_id=auth.external_id)
 
     @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -53,7 +53,7 @@ def _slack_unsupported(tool_name: str) -> ToolError:
 
 
 def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def list_channels(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
     ) -> list[ChannelRow] | list[SlackChannelRow]:
@@ -63,7 +63,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             return await _slack_list_channels_impl(runtime, auth)
         return await _list_channels_impl(runtime, auth)
 
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def read_channel(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         channel_id: str,
@@ -78,7 +78,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             return await _slack_read_channel_impl(runtime, auth, channel_id=channel_id, limit=limit)
         return await _read_channel_impl(runtime, auth, channel_id=channel_id, limit=limit)
 
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def read_thread(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         thread_id: str,
@@ -98,7 +98,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             runtime, auth, thread_id=thread_id, limit=limit, before=before
         )
 
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def get_message(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         channel_id: str,
@@ -112,7 +112,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             )
         return await _get_message_impl(runtime, auth, channel_id=channel_id, message_id=message_id)
 
-    @mcp.tool
+    @mcp.tool(tags={"discord"})  # pyright: ignore[reportArgumentType]
     async def list_threads(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         channel_id: str,
@@ -126,7 +126,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             raise _slack_unsupported("list_threads")
         return await _list_threads_impl(runtime, auth, channel_id=channel_id)
 
-    @mcp.tool
+    @mcp.tool(tags={"discord"})  # pyright: ignore[reportArgumentType]
     async def parse_link(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         url: str,
@@ -145,7 +145,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             raise _slack_unsupported("parse_link")
         return _parse_link_impl(url, caller_guild_id=auth.external_id)
 
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def send_message(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         channel_id: str,
@@ -209,7 +209,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     _VALID_AUTHOR_TYPES = frozenset({"user", "bot", "webhook"})
     _VALID_HAS = frozenset({"image", "video", "file", "sticker", "embed", "link", "poll", "sound"})
 
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def search_messages(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         content: str | None = None,
@@ -227,7 +227,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         scoped to channel_ids, total_results is the exact count for those
         channels (you must be able to view them; they are rejected before
         searching). Unscoped searches report only the visible rows — the
-        guild-wide count is withheld because it includes channels you cannot
+        server-wide count is withheld because it includes channels you cannot
         view. Slack: only content + limit are supported (other filters are
         Discord-only), and 1:1 DM hits are only returned in a DM with daimon.
         """

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -304,7 +304,7 @@ async def _request_repo_binding_impl(
 
 
 def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def request_env_credential(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
@@ -329,7 +329,7 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
             channel_id=channel_id,
         )
 
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def request_mcp_credential(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
@@ -365,7 +365,7 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
     # rather than a docstring paragraph because the docstring IS prompt
     # context: it is rendered into every model's tool list, where an internal
     # rationale is noise.
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def request_skill_repo_credential(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
@@ -401,7 +401,7 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
             channel_id=channel_id,
         )
 
-    @mcp.tool
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def request_repo_binding(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/github_app.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/github_app.py
@@ -74,7 +74,7 @@ async def _post_app_install_link_impl(
 
 
 def register_github_app_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
-    @mcp.tool
+    @mcp.tool(tags={"discord"})  # pyright: ignore[reportArgumentType]
     async def post_github_app_install_link(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         channel_id: str,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/propagation.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/propagation.py
@@ -221,12 +221,16 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         chosen scope is replaced (last-write-wins; an audit stamp is recorded by
         core).  Requires Manage Server (admin).
 
-        ``channel_id`` MUST be the parent channel's id — the one your context
-        gives as ``<channel role="parent_channel" id="...">``. Never pass the
-        current thread's id here. A turn always resolves its agent from the
-        parent channel, so a default written against a thread id is a scope
-        nothing ever reads: the write succeeds, this tool reports success, and
-        the channel keeps answering with the old agent.
+        Discord: ``channel_id`` MUST be the parent channel's id — the one
+        your context gives as
+        ``<channel platform="discord" id="..." role="parent_channel">``.
+        Never pass the current thread's id here. Slack: use the id from
+        ``<channel platform="slack" id="...">`` — Slack's context always
+        names the current channel, with no thread-vs-parent split. A turn
+        always resolves its agent from the parent channel, so a default
+        written against a thread id is a scope nothing ever reads: the write
+        succeeds, this tool reports success, and the channel keeps answering
+        with the old agent.
         """
         return await _set_agent_default_impl(runtime, await _auth(ctx), agent_name, channel_id)
 
@@ -241,10 +245,11 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         omit it to clear the workspace-wide default.  If the scope had no
         default the call is a no-op (idempotent).  Requires Manage Server (admin).
 
-        ``channel_id`` MUST be the parent channel's id
-        (``<channel role="parent_channel" id="...">``), never the current
-        thread's id — clearing a thread id is a silent no-op that leaves the
-        channel's real default in place.
+        Discord: ``channel_id`` MUST be the parent channel's id
+        (``<channel platform="discord" id="..." role="parent_channel">``),
+        never the current thread's id. Slack: use the id from
+        ``<channel platform="slack" id="...">``. Clearing a thread id is a
+        silent no-op that leaves the channel's real default in place.
         """
         return await _clear_agent_default_impl(runtime, await _auth(ctx), channel_id)
 
@@ -267,11 +272,13 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         Not admin-gated: this is a read of routing any member can already infer
         from a reply's footer.
 
-        ``channel_id`` MUST be the parent channel's id
-        (``<channel role="parent_channel" id="...">``), never the current
-        thread's id. Asking about a thread id reports that thread's own
-        (almost always empty) scope, which reads as a confident answer about
-        the channel and is not one — and if the same wrong id was just passed
-        to ``set_agent_default``, this tool will agree with it.
+        Discord: ``channel_id`` MUST be the parent channel's id
+        (``<channel platform="discord" id="..." role="parent_channel">``),
+        never the current thread's id. Slack: use the id from
+        ``<channel platform="slack" id="...">``. Asking about a thread id
+        reports that thread's own (almost always empty) scope, which reads
+        as a confident answer about the channel and is not one — and if the
+        same wrong id was just passed to ``set_agent_default``, this tool
+        will agree with it.
         """
         return await _explain_agent_resolution_impl(runtime, await _auth(ctx), channel_id)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/routines.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/routines.py
@@ -236,7 +236,7 @@ def register_routines_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         ``"research-bot"``). It is NOT:
 
         - a free-text description of the routine
-        - a Discord mention, tag fragment, or user handle
+        - a mention, tag fragment, or user handle
         - a routine label or trigger phrase
         - the name of a tool, MCP, or skill
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
@@ -45,3 +45,10 @@ class SlackSearchResult(BaseModel):
 
     matches: list[SlackSearchMatch]
     total: int
+
+
+class SlackParsedLink(BaseModel):
+    channel_id: str
+    message_ts: str  # dotted, e.g. "1717171717.123456"
+    thread_ts: str | None = None  # parent ts, when the link is a reply
+    hint: str

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_parse_link.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_parse_link.py
@@ -1,0 +1,75 @@
+"""Slack permalink parser (pure — no I/O).
+
+Parses a Slack message permalink
+(``https://<workspace>.slack.com/archives/<channel>/p<digits>``) into a
+channel id and dotted message ts, and — when the link carries
+``?thread_ts=...`` (a reply permalink) — the parent thread ts. Mirrors
+``tools/discord/_read.py``'s ``_parse_link_impl``: pure function, no
+client, no DB, no clock.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qs, urlsplit
+
+from daimon.adapters.mcp.tools.slack._models import SlackParsedLink
+from fastmcp.exceptions import ToolError
+
+_HOST_PATTERN = re.compile(r"^[a-z0-9-]+\.slack\.com$", re.IGNORECASE)
+_PATH_PATTERN = re.compile(r"^/archives/(?P<channel>[A-Za-z0-9]+)/p(?P<ts>\d+)$")
+
+# A p-value needs at least one digit before the inserted dot, or the
+# "seconds" half of the ts would be empty.
+_MIN_TS_DIGITS = 7
+
+_NOT_RECOGNIZED = "not a recognized slack message link"
+
+
+def _dotted_ts(digits: str) -> str:
+    return f"{digits[:-6]}.{digits[-6:]}"
+
+
+def _slack_parse_link_impl(url: str) -> SlackParsedLink:  # pyright: ignore[reportUnusedFunction]
+    """Parse a Slack permalink into structured components.
+
+    Pure function — no network calls. Routing hint references
+    read_thread/get_message.
+    """
+    parts = urlsplit(url)
+    if not _HOST_PATTERN.match(parts.netloc):
+        raise ToolError(_NOT_RECOGNIZED)
+    match = _PATH_PATTERN.match(parts.path)
+    if not match:
+        raise ToolError(_NOT_RECOGNIZED)
+
+    channel_id = match.group("channel")
+    digits = match.group("ts")
+    if len(digits) < _MIN_TS_DIGITS:
+        raise ToolError(_NOT_RECOGNIZED)
+    message_ts = _dotted_ts(digits)
+
+    query = parse_qs(parts.query)
+    thread_ts_values = query.get("thread_ts")
+    thread_ts = thread_ts_values[0] if thread_ts_values else None
+
+    if thread_ts is not None:
+        hint = (
+            f'try read_thread(thread_id="{channel_id}:{thread_ts}") — '
+            "this link is a reply, so the thread id is its parent ts, not "
+            "the message's own ts"
+        )
+    else:
+        hint = (
+            f'try read_thread(thread_id="{channel_id}:{message_ts}") first — '
+            "conversations.replies returns a valid one-message thread even "
+            "for a non-reply message; if that fails, it is a plain message: "
+            f'get_message(channel_id="{channel_id}", message_id="{message_ts}")'
+        )
+
+    return SlackParsedLink(
+        channel_id=channel_id,
+        message_ts=message_ts,
+        thread_ts=thread_ts,
+        hint=hint,
+    )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/wizard.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/wizard.py
@@ -110,7 +110,7 @@ async def _post_wizard_impl(
 
 
 def register_wizard_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
-    @mcp.tool
+    @mcp.tool(tags={"discord"})  # pyright: ignore[reportArgumentType]
     async def post_wizard(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         prompt: str,

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -1780,14 +1780,19 @@
     }),
     'parse_link': dict({
       'description': '''
-        Extract IDs from a Discord URL.
+        Extract IDs from a channel or message link.
         
-        Supports discord.com, ptb.discord.com, and canary.discord.com URLs.
-        
-        After parsing:
+        Discord: supports discord.com, ptb.discord.com, and
+        canary.discord.com URLs.
         - If link_type is "channel": use read_channel(channel_id)
         - If link_type is "message_or_thread": try read_thread(thread_id) first;
           if read_thread fails, it is a message: use get_message(channel_id, message_id)
+        
+        Slack: supports a workspace permalink
+        (.../archives/<channel>/p<digits>). Returns channel_id, the dotted
+        message ts, and thread_ts when the link is a reply. Try
+        read_thread(thread_id=f"{channel_id}:{thread_ts or message_ts}")
+        first; if that fails, use get_message(channel_id, message_ts).
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -53,7 +53,7 @@
         
         For MCP servers that REQUIRE an auth token, do NOT collect the
         token in chat — direct the user to ``/agent-setup`` -> MCPs modal.
-        Tokens sent in chat end up in Discord channel history and MA's
+        Tokens sent in chat end up in channel history and MA's
         tenant-wide session event log; the modal flow is the only
         supported path for auth-required servers.
       ''',
@@ -86,10 +86,11 @@
         omit it to clear the workspace-wide default.  If the scope had no
         default the call is a no-op (idempotent).  Requires Manage Server (admin).
         
-        ``channel_id`` MUST be the parent channel's id
-        (``<channel role="parent_channel" id="...">``), never the current
-        thread's id — clearing a thread id is a silent no-op that leaves the
-        channel's real default in place.
+        Discord: ``channel_id`` MUST be the parent channel's id
+        (``<channel platform="discord" id="..." role="parent_channel">``),
+        never the current thread's id. Slack: use the id from
+        ``<channel platform="slack" id="...">``. Clearing a thread id is a
+        silent no-op that leaves the channel's real default in place.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -1076,7 +1077,7 @@
         ``"research-bot"``). It is NOT:
         
         - a free-text description of the routine
-        - a Discord mention, tag fragment, or user handle
+        - a mention, tag fragment, or user handle
         - a routine label or trigger phrase
         - the name of a tool, MCP, or skill
         
@@ -1236,12 +1237,14 @@
         Not admin-gated: this is a read of routing any member can already infer
         from a reply's footer.
         
-        ``channel_id`` MUST be the parent channel's id
-        (``<channel role="parent_channel" id="...">``), never the current
-        thread's id. Asking about a thread id reports that thread's own
-        (almost always empty) scope, which reads as a confident answer about
-        the channel and is not one — and if the same wrong id was just passed
-        to ``set_agent_default``, this tool will agree with it.
+        Discord: ``channel_id`` MUST be the parent channel's id
+        (``<channel platform="discord" id="..." role="parent_channel">``),
+        never the current thread's id. Slack: use the id from
+        ``<channel platform="slack" id="...">``. Asking about a thread id
+        reports that thread's own (almost always empty) scope, which reads
+        as a confident answer about the channel and is not one — and if the
+        same wrong id was just passed to ``set_agent_default``, this tool
+        will agree with it.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2291,7 +2294,7 @@
         scoped to channel_ids, total_results is the exact count for those
         channels (you must be able to view them; they are rejected before
         searching). Unscoped searches report only the visible rows — the
-        guild-wide count is withheld because it includes channels you cannot
+        server-wide count is withheld because it includes channels you cannot
         view. Slack: only content + limit are supported (other filters are
         Discord-only), and 1:1 DM hits are only returned in a DM with daimon.
       ''',
@@ -2546,12 +2549,16 @@
         chosen scope is replaced (last-write-wins; an audit stamp is recorded by
         core).  Requires Manage Server (admin).
         
-        ``channel_id`` MUST be the parent channel's id — the one your context
-        gives as ``<channel role="parent_channel" id="...">``. Never pass the
-        current thread's id here. A turn always resolves its agent from the
-        parent channel, so a default written against a thread id is a scope
-        nothing ever reads: the write succeeds, this tool reports success, and
-        the channel keeps answering with the old agent.
+        Discord: ``channel_id`` MUST be the parent channel's id — the one
+        your context gives as
+        ``<channel platform="discord" id="..." role="parent_channel">``.
+        Never pass the current thread's id here. Slack: use the id from
+        ``<channel platform="slack" id="...">`` — Slack's context always
+        names the current channel, with no thread-vs-parent split. A turn
+        always resolves its agent from the parent channel, so a default
+        written against a thread id is a scope nothing ever reads: the write
+        succeeds, this tool reports success, and the channel keeps answering
+        with the old agent.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/test_middleware_identity.py
+++ b/packages/adapters/mcp/tests/test_middleware_identity.py
@@ -28,6 +28,7 @@ from daimon.adapters.mcp.middleware.mcp_identity import (
 from fastmcp import Client, FastMCP
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from fastmcp.server.context import Context
+from fastmcp.server.transforms import Visibility
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.types import ASGIApp, Message
 
@@ -1041,3 +1042,271 @@ async def test_internal_token_is_admin_claim_still_grants_admin(
         "an internal token (is_admin=True AND internal=True) must still grant admin "
         "(ADMIN-02 — CLI/scheduler/headless admin must not be stripped)"
     )
+
+
+# ---------------------------------------------------------------------------
+# platform-tagged visibility (re-derives a prior throwaway spike's findings —
+# see the tool-visibility quick-task RESEARCH.md; nothing here was ported
+# from committed source, since the spike was never committed)
+# ---------------------------------------------------------------------------
+
+
+async def _call_platform_tool(
+    app: ASGIApp, *, token: str, tool_name: str, arguments: dict[str, object]
+) -> dict[str, object]:
+    """Initialize an MCP HTTP session and call a tool; return the JSON-RPC result.
+
+    Duplicated locally rather than shared with test_channels_dispatch.py's
+    ``_call_tool`` — the testing guideline forbids sharing private setup
+    across test files.
+    """
+    headers = dict(_INIT_HEADERS)
+    headers["Authorization"] = f"Bearer {token}"
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        init_resp = await c.post("/mcp", json=_INIT_BODY, headers=headers)
+        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
+        session_id = init_resp.headers.get("mcp-session-id")
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+        body: dict[str, object] = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+        resp = await c.post("/mcp", json=body, headers=headers)
+        assert resp.status_code == 200, f"tools/call failed: {resp.text}"
+        result = _parse_jsonrpc_response(resp)
+    return result.get("result", result)  # type: ignore[return-value]
+
+
+def _make_platform_app(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    token_map: dict[str, dict[str, str]],
+) -> ASGIApp:
+    """Build a minimal FastMCP app with the discord/slack Visibility baselines.
+
+    Unlike ``_make_narrowing_app`` (no baseline transforms), this app carries
+    ``Visibility(False, tags={"discord"})`` and ``Visibility(False,
+    tags={"slack"})`` — the same deny-by-default baselines ``server.py``
+    registers — so a token's ``platform`` claim is what makes a
+    platform-tagged tool visible at all.
+
+    Tools:
+      - ``discord_tool`` tagged {"discord"}
+      - ``slack_tool`` tagged {"slack"}
+      - ``shared_tool`` tagged {"discord", "slack"}
+      - ``untagged_tool`` — no tags, always visible by default
+      - ``agent_tool`` tagged {"agent-chat"}
+    """
+    mcp = FastMCP(name="platform-test", auth=StaticTokenVerifier(tokens=token_map))
+    mcp.add_middleware(
+        IdentityMiddleware(
+            subject_resolver=production_subject_resolver,
+            tenant_resolver=production_tenant_resolver,
+            role_resolver=production_role_resolver,
+            agent_id_resolver=production_agent_id_resolver,
+            is_admin_resolver=production_is_admin_resolver,
+            internal_resolver=production_internal_resolver,
+            sessionmaker=sessionmaker,
+        )
+    )
+    mcp.add_transform(Visibility(False, tags={"discord"}))
+    mcp.add_transform(Visibility(False, tags={"slack"}))
+
+    @mcp.tool(tags={"discord"})  # pyright: ignore[reportArgumentType]
+    async def discord_tool() -> str:  # pyright: ignore[reportUnusedFunction]
+        return "discord"
+
+    @mcp.tool(tags={"slack"})  # pyright: ignore[reportArgumentType]
+    async def slack_tool() -> str:  # pyright: ignore[reportUnusedFunction]
+        return "slack"
+
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
+    async def shared_tool() -> str:  # pyright: ignore[reportUnusedFunction]
+        return "shared"
+
+    @mcp.tool
+    async def untagged_tool() -> str:  # pyright: ignore[reportUnusedFunction]
+        return "untagged"
+
+    @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
+    async def agent_tool() -> str:  # pyright: ignore[reportUnusedFunction]
+        return "agent"
+
+    return mcp.http_app()  # pyright: ignore[reportReturnType]
+
+
+async def test_platform_visibility_discord_token_sees_discord_and_shared_and_untagged(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    token = "discord-token"
+    token_map = {
+        token: {
+            "sub": str(uuid.uuid4()),
+            "tenant_id": str(uuid.uuid4()),
+            "role": "user",
+            "client_id": "test",
+            "platform": "discord",
+        }
+    }
+    app = _make_platform_app(sessionmaker, token_map)
+
+    tool_names = await _list_tools(app, token=token)
+
+    assert "discord_tool" in tool_names, "a discord caller must see discord-tagged tools"
+    assert "shared_tool" in tool_names, "a discord caller must see dual-tagged tools"
+    assert "untagged_tool" in tool_names, "an untagged tool must stay visible to every platform"
+    assert "slack_tool" not in tool_names, "a discord caller must not see slack-only tools"
+
+
+async def test_platform_visibility_slack_token_sees_slack_and_shared_and_untagged(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    token = "slack-token"
+    token_map = {
+        token: {
+            "sub": str(uuid.uuid4()),
+            "tenant_id": str(uuid.uuid4()),
+            "role": "user",
+            "client_id": "test",
+            "platform": "slack",
+        }
+    }
+    app = _make_platform_app(sessionmaker, token_map)
+
+    tool_names = await _list_tools(app, token=token)
+
+    assert "slack_tool" in tool_names, "a slack caller must see slack-tagged tools"
+    assert "shared_tool" in tool_names, "a slack caller must see dual-tagged tools"
+    assert "untagged_tool" in tool_names, "an untagged tool must stay visible to every platform"
+    assert "discord_tool" not in tool_names, "a slack caller must not see discord-only tools"
+
+
+async def test_platform_visibility_cli_token_sees_neither_platform_tag(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A CLI token's platform="cli" matches no baseline tag — CLI loses the
+    platform-tagged tools by construction, not by special-casing."""
+    token = "cli-token"
+    token_map = {
+        token: {
+            "sub": str(uuid.uuid4()),
+            "tenant_id": str(uuid.uuid4()),
+            "role": "user",
+            "client_id": "test",
+            "platform": "cli",
+        }
+    }
+    app = _make_platform_app(sessionmaker, token_map)
+
+    tool_names = await _list_tools(app, token=token)
+
+    assert "untagged_tool" in tool_names, "an untagged tool must stay visible to a cli caller"
+    assert "discord_tool" not in tool_names, "a cli caller must not see discord-only tools"
+    assert "slack_tool" not in tool_names, "a cli caller must not see slack-only tools"
+
+
+async def test_platform_visibility_slack_token_can_call_shared_tool(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A dual-tagged tool is callable when the middleware enabled only one of
+    its two tags — enabling {"slack"} is enough to clear a {"discord","slack"}
+    tool's Visibility(False, tags={...}) baseline on either tag alone."""
+    token = "slack-token"
+    token_map = {
+        token: {
+            "sub": str(uuid.uuid4()),
+            "tenant_id": str(uuid.uuid4()),
+            "role": "user",
+            "client_id": "test",
+            "platform": "slack",
+        }
+    }
+    app = _make_platform_app(sessionmaker, token_map)
+
+    result = await _call_platform_tool(app, token=token, tool_name="shared_tool", arguments={})
+
+    assert result.get("isError") is not True, f"shared_tool call must succeed; got {result!r}"
+
+
+async def test_platform_visibility_slack_token_calling_discord_tool_is_unknown_tool(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A slack caller directly calling a discord-only tool gets a generic
+    unknown-tool error, not any daimon gate copy — this is the error-UX
+    trade the decision to keep runtime gates was made against."""
+    token = "slack-token"
+    token_map = {
+        token: {
+            "sub": str(uuid.uuid4()),
+            "tenant_id": str(uuid.uuid4()),
+            "role": "user",
+            "client_id": "test",
+            "platform": "slack",
+        }
+    }
+    app = _make_platform_app(sessionmaker, token_map)
+
+    result = await _call_platform_tool(app, token=token, tool_name="discord_tool", arguments={})
+
+    assert result.get("isError") is True, (
+        f"a hidden tool must be uncallable, not just unlisted; got {result!r}"
+    )
+
+
+async def test_platform_visibility_agent_narrowing_overrides_platform_enable(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A discord token that ALSO carries a valid agent_id narrows to
+    agent-chat tools only — the platform enable must sit before
+    disable_components(match_all=True) so narrowing still wins."""
+    agent_id = uuid.uuid4()
+    token = "discord-agent-token"
+    token_map = {
+        token: {
+            "sub": str(uuid.uuid4()),
+            "tenant_id": str(uuid.uuid4()),
+            "role": "user",
+            "client_id": "test",
+            "platform": "discord",
+            "agent_id": str(agent_id),
+        }
+    }
+    app = _make_platform_app(sessionmaker, token_map)
+
+    tool_names = await _list_tools(app, token=token)
+
+    assert "agent_tool" in tool_names, "an agent-narrowed session must see agent-chat tools"
+    assert "discord_tool" not in tool_names, (
+        "agent-chat narrowing must override the earlier platform enable"
+    )
+    assert "shared_tool" not in tool_names, (
+        "agent-chat narrowing must override the earlier platform enable"
+    )
+
+
+async def test_platform_visibility_no_platform_claim_sees_neither_tag(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Fail-closed: a token with no platform claim at all enables neither
+    baseline tag — untagged_tool stays visible, discord_tool/slack_tool do
+    not."""
+    token = "no-platform-token"
+    token_map = {
+        token: {
+            "sub": str(uuid.uuid4()),
+            "tenant_id": str(uuid.uuid4()),
+            "role": "user",
+            "client_id": "test",
+            # No platform claim.
+        }
+    }
+    app = _make_platform_app(sessionmaker, token_map)
+
+    tool_names = await _list_tools(app, token=token)
+
+    assert "untagged_tool" in tool_names, "an untagged tool must stay visible with no platform"
+    assert "discord_tool" not in tool_names, "no platform claim must not enable discord tools"
+    assert "slack_tool" not in tool_names, "no platform claim must not enable slack tools"

--- a/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
+++ b/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
@@ -122,6 +122,30 @@ async def _call_tool(
     return result.get("result", result)  # type: ignore[return-value]
 
 
+async def _list_tool_names(app: ASGIApp, *, token: str) -> list[str]:
+    """Initialize an MCP HTTP session and call tools/list; return tool names."""
+    headers = dict(_INIT_HEADERS)
+    headers["Authorization"] = f"Bearer {token}"
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        init_resp = await c.post("/mcp", json=_INIT_BODY, headers=headers)
+        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
+        session_id = init_resp.headers.get("mcp-session-id")
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+        body: dict[str, object] = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {},
+        }
+        resp = await c.post("/mcp", json=body, headers=headers)
+        assert resp.status_code == 200, f"tools/list failed: {resp.text}"
+        result = _parse_jsonrpc_response(resp)
+    tools_payload = result.get("result", result)
+    return [t["name"] for t in tools_payload.get("tools", [])]  # type: ignore[union-attr]
+
+
 def _make_app(sessionmaker: async_sessionmaker[AsyncSession]) -> ASGIApp:
     return create_mcp_app(
         settings=Settings(
@@ -204,29 +228,41 @@ async def _seed_slack_bound_account(db_session: AsyncSession, *, workspace_id: s
         ("parse_link", {"url": "https://discord.com/channels/1/2"}),
     ],
 )
-async def test_slack_caller_calling_unsupported_tool_raises_own_name(
+async def test_slack_caller_tools_list_omits_discord_only_tool(
     db_session: AsyncSession,
     sessionmaker: async_sessionmaker[AsyncSession],
     tool_name: str,
     arguments: dict[str, object],
 ) -> None:
-    """A Slack caller invoking a Slack-unsupported registered tool gets a ToolError
-    naming that exact tool ("<tool_name> is not supported on Slack yet"), pinning
-    the per-site name literal in ``daimon.adapters.mcp.tools.channels``."""
+    """A Slack caller's tools/list no longer contains a discord-only-tagged
+    tool (see the tool-visibility quick task). Each tool's runtime gate
+    (channels.py's ``_slack_unsupported(...)`` branch) survives as
+    defense-in-depth against a transform regression, but a Slack caller can no
+    longer reach it through the registered surface at all: the tool is both
+    unlisted and uncallable, and a direct ``tools/call`` returns the
+    registry's own unknown-tool error, not the gate copy."""
     account_id = await _seed_slack_bound_account(
-        db_session, workspace_id=f"slack-unsupported-{tool_name}"
+        db_session, workspace_id=f"slack-hidden-{tool_name}"
     )
     token = mint_jwt(account_id=account_id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
     app = _make_app(sessionmaker)
 
+    tool_names = await _list_tool_names(app, token=token)
+
+    assert tool_name not in tool_names, (
+        f"{tool_name} is discord-only tagged; a Slack caller must not see it"
+    )
+
     call_result = await _call_tool(app, token=token, tool_name=tool_name, arguments=arguments)
 
     assert call_result.get("isError") is True, (
-        f"{tool_name} must raise a ToolError for a Slack caller; got {call_result!r}"
+        f"a hidden tool must be uncallable, not just unlisted; got {call_result!r}"
     )
     output_text = _output_text(call_result)
-    assert f"{tool_name} is not supported on Slack yet" in output_text, (
-        f"expected {tool_name}'s own name in the Slack-unsupported message; got {output_text!r}"
+    assert f"{tool_name} is not supported on Slack yet" not in output_text, (
+        "a Slack caller calling a hidden tool must hit the registry's unknown-tool "
+        f"error, not the runtime gate copy (unreachable through the registered "
+        f"surface); got {output_text!r}"
     )
 
 

--- a/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
+++ b/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
@@ -221,48 +221,76 @@ async def _seed_slack_bound_account(db_session: AsyncSession, *, workspace_id: s
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("tool_name", "arguments"),
-    [
-        ("list_threads", {"channel_id": "C_TEST"}),
-        ("parse_link", {"url": "https://discord.com/channels/1/2"}),
-    ],
-)
-async def test_slack_caller_tools_list_omits_discord_only_tool(
+async def test_slack_caller_tools_list_omits_list_threads(
     db_session: AsyncSession,
     sessionmaker: async_sessionmaker[AsyncSession],
-    tool_name: str,
-    arguments: dict[str, object],
 ) -> None:
-    """A Slack caller's tools/list no longer contains a discord-only-tagged
-    tool (see the tool-visibility quick task). Each tool's runtime gate
-    (channels.py's ``_slack_unsupported(...)`` branch) survives as
-    defense-in-depth against a transform regression, but a Slack caller can no
-    longer reach it through the registered surface at all: the tool is both
-    unlisted and uncallable, and a direct ``tools/call`` returns the
-    registry's own unknown-tool error, not the gate copy."""
-    account_id = await _seed_slack_bound_account(
-        db_session, workspace_id=f"slack-hidden-{tool_name}"
-    )
+    """A Slack caller's tools/list no longer contains list_threads (tagged
+    {"discord"} — see the tool-visibility quick task). ``parse_link`` is NOT
+    covered here any more: it is now dual-tagged {"discord","slack"} and
+    routes to a real Slack branch (see the dispatch test below). The tool's
+    runtime gate (channels.py's ``_slack_unsupported("list_threads")``
+    branch) survives as defense-in-depth against a transform regression, but
+    a Slack caller can no longer reach it through the registered surface at
+    all: the tool is both unlisted and uncallable, and a direct
+    ``tools/call`` returns the registry's own unknown-tool error, not the
+    gate copy."""
+    account_id = await _seed_slack_bound_account(db_session, workspace_id="slack-list-threads")
     token = mint_jwt(account_id=account_id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
     app = _make_app(sessionmaker)
 
     tool_names = await _list_tool_names(app, token=token)
 
-    assert tool_name not in tool_names, (
-        f"{tool_name} is discord-only tagged; a Slack caller must not see it"
+    assert "list_threads" not in tool_names, (
+        "list_threads is discord-only tagged; a Slack caller must not see it"
     )
 
-    call_result = await _call_tool(app, token=token, tool_name=tool_name, arguments=arguments)
+    call_result = await _call_tool(
+        app, token=token, tool_name="list_threads", arguments={"channel_id": "C_TEST"}
+    )
 
     assert call_result.get("isError") is True, (
         f"a hidden tool must be uncallable, not just unlisted; got {call_result!r}"
     )
     output_text = _output_text(call_result)
-    assert f"{tool_name} is not supported on Slack yet" not in output_text, (
+    assert "list_threads is not supported on Slack yet" not in output_text, (
         "a Slack caller calling a hidden tool must hit the registry's unknown-tool "
         f"error, not the runtime gate copy (unreachable through the registered "
         f"surface); got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_parse_link_slack_caller_routes_to_slack_branch(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A Slack-token caller reaches the Slack branch through the registered
+    parse_link tool: a Slack permalink in, a SlackParsedLink-shaped result
+    out (channel_id + message_ts, no guild_id)."""
+    account_id = await _seed_slack_bound_account(db_session, workspace_id="slack-parse-link")
+    token = mint_jwt(account_id=account_id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="parse_link",
+        arguments={"url": "https://acme.slack.com/archives/C0123456789/p1717171717000100"},
+    )
+
+    assert call_result.get("isError") is not True, (
+        f"a Slack caller's parse_link call must succeed; got {call_result!r}"
+    )
+    output_text = _output_text(call_result)
+    assert '"channel_id":"C0123456789"' in output_text.replace(" ", ""), (
+        f"the Slack branch's result must carry the parsed channel_id; got {output_text!r}"
+    )
+    assert '"message_ts":"1717171717.000100"' in output_text.replace(" ", ""), (
+        f"the Slack branch's result must carry the dotted message_ts; got {output_text!r}"
+    )
+    assert "guild_id" not in output_text, (
+        "a Slack parse_link result must not carry Discord's guild_id field"
     )
 
 

--- a/packages/adapters/mcp/tests/tools/test_slack_parse_link.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_parse_link.py
@@ -1,0 +1,98 @@
+"""Tests for the pure Slack permalink parser.
+
+Mirrors ``tests/tools/test_discord_read.py::TestParseLink`` in shape: no
+fixtures, no monkeypatch, no aioresponses, no DB — ``_slack_parse_link_impl``
+is pure, so importing it and calling it directly is the whole test.
+"""
+
+from __future__ import annotations
+
+import pytest
+from daimon.adapters.mcp.tools.slack._parse_link import (
+    _slack_parse_link_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from fastmcp.exceptions import ToolError
+
+
+class TestSlackParseLink:
+    def test_root_message_permalink(self) -> None:
+        result = _slack_parse_link_impl(
+            "https://acme.slack.com/archives/C0123456789/p1358546515000008"
+        )
+        assert result.channel_id == "C0123456789", "channel id must come from the path segment"
+        assert result.message_ts == "1358546515.000008", (
+            "the p-value's digits must be dotted before the last six digits"
+        )
+        assert result.thread_ts is None, "a root permalink carries no thread_ts"
+        assert "read_thread" in result.hint, "the hint must name read_thread"
+
+    def test_docs_example_is_malformed_test_the_rule_not_that_example(self) -> None:
+        """Slack's own published permalink example (p135854651500008, for the
+        ts 1358546515.000008) is missing a digit — 15 digits instead of 16.
+        This test pins the parser's actual rule (a dot before the last six
+        digits of whatever digit string is present), not that broken
+        example. A future reader must NOT "fix" the parser to reproduce
+        Slack's docs bug — the docs are wrong, not this test."""
+        result = _slack_parse_link_impl(
+            "https://acme.slack.com/archives/C0123456789/p135854651500008"
+        )
+        assert result.message_ts == "135854651.500008", (
+            "a dot inserted before the last six digits of the 15-digit p-value "
+            "is the mechanically-correct output of the parser's rule, even "
+            "though it does not match Slack's own (malformed) docs example"
+        )
+
+    def test_reply_permalink_thread_ts_is_already_dotted(self) -> None:
+        result = _slack_parse_link_impl(
+            "https://acme.slack.com/archives/C0123456789/p1717171717000200"
+            "?thread_ts=1717171717.000100&cid=C0123456789"
+        )
+        assert result.thread_ts == "1717171717.000100", (
+            "thread_ts arrives already dotted in the query string — no conversion"
+        )
+        assert result.message_ts == "1717171717.000200", (
+            "message_ts is still the converted p-value, distinct from thread_ts"
+        )
+        assert "C0123456789:1717171717.000100" in result.hint, (
+            "the hint's read_thread composite must use the PARENT ts (thread_ts), "
+            "not the reply's own message_ts"
+        )
+
+    def test_dm_permalink_parses_identically(self) -> None:
+        result = _slack_parse_link_impl(
+            "https://acme.slack.com/archives/D0123456789/p1717171717000100"
+        )
+        assert result.channel_id == "D0123456789", (
+            "a D-prefixed (DM) channel id needs no special-casing"
+        )
+        assert result.message_ts == "1717171717.000100"
+
+    def test_foreign_workspace_subdomain_parses_fine(self) -> None:
+        """The parser is workspace-agnostic; a wrong workspace fails downstream
+        at the read tool via map_slack_api_error, not here."""
+        result = _slack_parse_link_impl(
+            "https://other-workspace.slack.com/archives/C0123456789/p1717171717000100"
+        )
+        assert result.channel_id == "C0123456789"
+        assert result.message_ts == "1717171717.000100"
+
+    def test_non_slack_url_raises_tool_error(self) -> None:
+        with pytest.raises(ToolError, match="not a recognized slack"):
+            _slack_parse_link_impl("https://example.com/not-slack")
+
+    def test_no_archives_segment_raises_tool_error(self) -> None:
+        with pytest.raises(ToolError, match="not a recognized slack"):
+            _slack_parse_link_impl("https://acme.slack.com/messages/C0123456789/p1717171717000100")
+
+    def test_p_value_too_short_to_split_raises_tool_error(self) -> None:
+        with pytest.raises(ToolError, match="not a recognized slack"):
+            _slack_parse_link_impl("https://acme.slack.com/archives/C0123456789/p12345")
+
+    def test_root_permalink_hint_names_get_message_as_fallback(self) -> None:
+        result = _slack_parse_link_impl(
+            "https://acme.slack.com/archives/C0123456789/p1717171717000100"
+        )
+        assert "get_message" in result.hint, (
+            "a root permalink's hint must name get_message as the read_thread fallback, "
+            "mirroring Discord's ambiguity-tolerant hint"
+        )


### PR DESCRIPTION
Every MCP caller used to get the same tool list: Slack sessions saw `list_threads` and the wizard tools that only work on Discord, CLI sessions saw every channel tool, and each wrong call ended in a runtime refusal after the fact.

**Commit 1 — platform-tagged visibility.** Tools now carry platform tags — `{"discord"}` on the four Discord-only tools, `{"discord","slack"}` on the shared channel and credential tools — behind hidden-by-default visibility baselines. `IdentityMiddleware` enables the tag matching the caller's platform, inserted before agent-token narrowing so narrowed sessions stay narrow. Wrong-platform tools disappear from tools/list, tool search, and direct calls. The runtime platform gates stay as defense-in-depth. Six docstrings that described shared behavior in Discord vocabulary are rewritten platform-neutral, or split into explicit "Discord: … Slack: …" rules where the platforms genuinely differ. Seven characterization tests pin the matrix: dual-tag enable via a single tag, CLI callers fail closed, agent narrowing overrides the platform enable, and the exact unknown-tool error shape.

**Commit 2 — Slack permalinks in `parse_link`.** Pasting `https://<ws>.slack.com/archives/C…/p1717…` now resolves to the channel id and dotted message ts (dot inserted before the last six digits); a reply permalink returns the parent thread ts from its `?thread_ts=` query param. The parser is pure — no API calls — so foreign-workspace links parse fine and fail cleanly downstream. New `SlackParsedLink` return model; `parse_link` widens to both platforms. Nine parser tests, including one pinning that Slack's own docs example drops a digit — the parser follows the stated rule, not the example.

Each commit reverts independently. Full suite green (4633 passed); pyright, ruff, and import contracts clean.

https://claude.ai/code/session_01FNTXYv3pNSJV3QJ6jgaJTQ