### PR TITLE
fix(slack): repair the status message when the terminal flush fails

### DIFF
--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -27,6 +27,7 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import Any, cast
 
+import aiohttp
 import structlog
 from anthropic.types import RawMessageStreamEvent
 from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
@@ -35,6 +36,7 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
 from daimon.adapters.slack.blockkit import EmbedEvent, State, TurnPhase, to_blocks, update
 from daimon.adapters.slack.mrkdwn import escape_mrkdwn_preserving_mentions
 from daimon.adapters.slack.split import split_for_slack_safe
+from daimon.core.observability import capture_exception_with_scope
 from daimon.core.pricing import MODEL_PRICING, cost_of, format_cost
 from daimon.core.turn.lifecycle import InterruptSource, ReconnectReason
 from daimon.core.turn.state import ToolUseBlock, TurnState, extract_final_response
@@ -46,6 +48,13 @@ __all__ = ["SlackTurnLifecycle"]
 log = structlog.get_logger()
 
 _DEBOUNCE_S = 5.0
+
+# Everything a chat.postMessage/chat.update can raise. slack_sdk wraps ok:false
+# responses in SlackApiError but re-raises transport failures unwrapped
+# (async_internal_utils re-raises the original aiohttp/timeout error), so any
+# catch or suppress around a send must cover all three or the transport case
+# escapes.
+_SLACK_SEND_ERRORS = (SlackApiError, aiohttp.ClientError, asyncio.TimeoutError)
 
 # Ceiling for the `text` notification fallback that accompanies `blocks`.
 # The rendered content lives in the blocks (a markdown block holds 11 800
@@ -234,7 +243,7 @@ class SlackTurnLifecycle:
             "Turn cancelled.",
         )
 
-    async def _repair_terminal_flush(self) -> None:
+    async def _repair_terminal_flush(self, text: str) -> None:
         """Best-effort collapse of the status message after a failed terminal flush.
 
         Replaces whatever the last debounced flush wrote — phase title, tool
@@ -242,18 +251,16 @@ class SlackTurnLifecycle:
         is deregistered on every terminal path, so a status message left on the
         live surface shows a running turn with a dead cancel button forever.
         The repair can fail for the same reason as the flush (revoked token,
-        archived channel); there is nothing further to do then, so it is
-        suppressed rather than retried.
+        archived channel, network outage); there is nothing further to do then,
+        so it is suppressed rather than retried.
         """
         if self._status_ts is None:
             return
-        text = "⚠️ Something went wrong posting the answer."
-        with contextlib.suppress(SlackApiError):
-            await self._client.chat_update(  # pyright: ignore[reportUnknownMemberType]
-                channel=self._channel,
-                ts=self._status_ts,
-                blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": text}}],
-                text=text,
+        with contextlib.suppress(*_SLACK_SEND_ERRORS):
+            # The status_ts guard above pins _post_or_update to its update branch.
+            await self._post_or_update(
+                [{"type": "section", "text": {"type": "mrkdwn", "text": text}}],
+                text,
             )
 
     async def on_terminal_success(self, state: TurnState) -> None:
@@ -262,9 +269,11 @@ class SlackTurnLifecycle:
         If no final text (tool-only or cancelled), collapses to the done footer
         in place. Always deregisters the cancel Event in finally.
 
-        Does not re-raise on SlackApiError — the lifecycle boundary absorbs
-        render failures (same contract as on_terminal_failure). If the flush
-        fails before the status message is replaced, a best-effort repair
+        Does not re-raise on Slack send errors — the lifecycle boundary absorbs
+        render failures (same contract as on_terminal_failure), logging at
+        error level and capturing to Sentry since the swallowed exception is an
+        answer-delivery outage the listener boundary can no longer see. If the
+        flush fails before the status message is replaced, a best-effort repair
         collapses it to a failure notice; if it fails during overflow, the
         already-replaced answer is left standing. final_ts stays None on any
         flush failure so the caller's watermark cannot advance past content
@@ -280,6 +289,9 @@ class SlackTurnLifecycle:
         # content — past that point a repair would overwrite answer text the
         # user can already read, so the except branch skips it.
         surface_replaced = False
+        # A no-answer collapse (tool-only done footer, "Turn cancelled.") must
+        # not be repaired with copy that claims an answer existed.
+        repair_notice = "⚠️ Something went wrong finishing this turn."
         try:
             final_text = extract_final_response(state.content)
             if not final_text:
@@ -293,6 +305,7 @@ class SlackTurnLifecycle:
                 self.final_ts = self._status_ts
                 return
 
+            repair_notice = "⚠️ Something went wrong posting the answer."
             chunks = split_for_slack_safe(escape_mrkdwn_preserving_mentions(final_text))
             first_chunk = chunks[0]
             # First chunk + the cost/usage footer replace the status message
@@ -319,10 +332,14 @@ class SlackTurnLifecycle:
                 current_ts = cast(str, resp["ts"])  # pyright: ignore[reportUnknownVariableType]
 
             self.final_ts = current_ts
-        except SlackApiError:
-            log.warning("turn.terminal_success.flush_failed", exc_info=True)
+        except _SLACK_SEND_ERRORS as exc:
+            # error + Sentry, not warning: pre-repair this exception reached the
+            # listener boundary's log.error/capture path, and it means a billed
+            # turn whose answer the user never received.
+            log.error("turn.terminal_success.flush_failed", exc_info=True)
+            capture_exception_with_scope(exc)
             if not surface_replaced:
-                await self._repair_terminal_flush()
+                await self._repair_terminal_flush(repair_notice)
         finally:
             if self._status_ts is not None:
                 self._deregister(self._status_ts)
@@ -342,7 +359,7 @@ class SlackTurnLifecycle:
             self.final_ts = self._status_ts
         except Exception:  # noqa: BLE001
             log.warning("turn.terminal_failure.flush_failed", exc_info=True)
-            await self._repair_terminal_flush()
+            await self._repair_terminal_flush("⚠️ Something went wrong finishing this turn.")
         finally:
             if self._status_ts is not None:
                 self._deregister(self._status_ts)

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -20,6 +20,7 @@ Design decisions:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import time
 from collections.abc import Callable
@@ -37,6 +38,7 @@ from daimon.adapters.slack.split import split_for_slack_safe
 from daimon.core.pricing import MODEL_PRICING, cost_of, format_cost
 from daimon.core.turn.lifecycle import InterruptSource, ReconnectReason
 from daimon.core.turn.state import ToolUseBlock, TurnState, extract_final_response
+from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
 __all__ = ["SlackTurnLifecycle"]
@@ -232,11 +234,41 @@ class SlackTurnLifecycle:
             "Turn cancelled.",
         )
 
+    async def _repair_terminal_flush(self) -> None:
+        """Best-effort collapse of the status message after a failed terminal flush.
+
+        Replaces whatever the last debounced flush wrote — phase title, tool
+        trail, cancel actions — with a plain failure notice. The cancel Event
+        is deregistered on every terminal path, so a status message left on the
+        live surface shows a running turn with a dead cancel button forever.
+        The repair can fail for the same reason as the flush (revoked token,
+        archived channel); there is nothing further to do then, so it is
+        suppressed rather than retried.
+        """
+        if self._status_ts is None:
+            return
+        text = "⚠️ Something went wrong posting the answer."
+        with contextlib.suppress(SlackApiError):
+            await self._client.chat_update(  # pyright: ignore[reportUnknownMemberType]
+                channel=self._channel,
+                ts=self._status_ts,
+                blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": text}}],
+                text=text,
+            )
+
     async def on_terminal_success(self, state: TurnState) -> None:
         """Replace status message with final answer; post overflow chunks; widen final_ts.
 
         If no final text (tool-only or cancelled), collapses to the done footer
         in place. Always deregisters the cancel Event in finally.
+
+        Does not re-raise on SlackApiError — the lifecycle boundary absorbs
+        render failures (same contract as on_terminal_failure). If the flush
+        fails before the status message is replaced, a best-effort repair
+        collapses it to a failure notice; if it fails during overflow, the
+        already-replaced answer is left standing. final_ts stays None on any
+        flush failure so the caller's watermark cannot advance past content
+        the user never saw.
         """
         # Transition to the DONE phase BEFORE rendering so to_blocks emits the
         # terminal collapse (cost/usage footer, no cancel button) — matches the
@@ -244,6 +276,10 @@ class SlackTurnLifecycle:
         # running and the footer would never appear.
         self._state = update(self._state, EmbedEvent(kind="done", label=""))
         self._apply_usage(state)
+        # Flipped after the status message is successfully replaced with final
+        # content — past that point a repair would overwrite answer text the
+        # user can already read, so the except branch skips it.
+        surface_replaced = False
         try:
             final_text = extract_final_response(state.content)
             if not final_text:
@@ -268,6 +304,7 @@ class SlackTurnLifecycle:
                 *to_blocks(self._state, now=self._clock()),
             ]
             await self._post_or_update(first_blocks, _notification_text(first_chunk))
+            surface_replaced = True
             assert self._status_ts is not None  # narrowing — _post_or_update always sets it
             current_ts = self._status_ts
 
@@ -282,6 +319,10 @@ class SlackTurnLifecycle:
                 current_ts = cast(str, resp["ts"])  # pyright: ignore[reportUnknownVariableType]
 
             self.final_ts = current_ts
+        except SlackApiError:
+            log.warning("turn.terminal_success.flush_failed", exc_info=True)
+            if not surface_replaced:
+                await self._repair_terminal_flush()
         finally:
             if self._status_ts is not None:
                 self._deregister(self._status_ts)
@@ -301,6 +342,7 @@ class SlackTurnLifecycle:
             self.final_ts = self._status_ts
         except Exception:  # noqa: BLE001
             log.warning("turn.terminal_failure.flush_failed", exc_info=True)
+            await self._repair_terminal_flush()
         finally:
             if self._status_ts is not None:
                 self._deregister(self._status_ts)

--- a/packages/adapters/slack/tests/conftest.py
+++ b/packages/adapters/slack/tests/conftest.py
@@ -15,6 +15,15 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 _SLACK_API_BASE = "https://slack.com/api"
 
+# Default ok payload for the POST-JSON chat methods. Exported so tests that
+# clear the defaults to stage failures can re-register the identical shape —
+# the ts value is load-bearing (tests assert on it as status_ts).
+CHAT_OK_PAYLOAD: dict[str, object] = {
+    "ok": True,
+    "ts": "1000000000.000001",
+    "channel": "C_TEST",
+}
+
 # Slack API methods that use POST with JSON body (params in body, not query string).
 # Exact URL match works for these since params are not in the URL.
 _SLACK_POST_JSON_METHODS: tuple[str, ...] = (
@@ -84,7 +93,7 @@ def _register_slack_defaults(mock: AioResponsesMock) -> None:
     for method in _SLACK_POST_JSON_METHODS:
         mock.post(  # pyright: ignore[reportUnknownMemberType]  # aioresponses url param is Pattern[Unknown]
             f"{_SLACK_API_BASE}/{method}",
-            payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
+            payload=CHAT_OK_PAYLOAD,
             repeat=True,
         )
     # views methods return a view object so handlers can read resp["view"]["id"].

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -18,6 +18,16 @@ Task 2 (terminal paths — replace-in-place, overflow, collapse, failure, deregi
   - registry deregister callback is invoked for status_ts in the terminal finally.
   - SlackTurnLifecycle satisfies the TurnLifecycle Protocol.
 
+Terminal flush failure — best-effort repair (#107):
+  - A failed answer-replace chat.update collapses the status to a plain failure
+    notice instead of leaving the live surface (phase, tool trail, dead cancel).
+  - A failed repair is swallowed — on_terminal_success never raises.
+  - A failed first post (no status message) attempts no repair.
+  - An overflow-post failure does NOT clobber the already-replaced answer.
+  - final_ts stays None on every flush failure so the watermark cannot advance
+    past an answer the user never saw.
+  - on_terminal_failure's own flush failure gets the same repair.
+
 Transport-level fake via aioresponses (guideline:testing) — transport-level fakes only.
 """
 
@@ -465,6 +475,202 @@ async def test_deregister_called_in_terminal_failure_finally(
 
     assert len(deregistered) == 1, "deregister must be called exactly once in failure path"
     assert deregistered[0] == "1000000000.000001", "deregistered ts must match status_ts"
+
+
+# ---------------------------------------------------------------------------
+# Terminal flush failure — best-effort repair (#107)
+# ---------------------------------------------------------------------------
+
+
+def _reset_slack_responses(fake: Any) -> None:
+    """Drop the fixture's repeat=True ok defaults so failures can be staged.
+
+    aioresponses matches in registration order, so the fixture's defaults
+    (registered first) would otherwise always win over per-test overrides.
+    """
+    fake.mock.clear()
+
+
+async def test_terminal_success_flush_failure_repairs_status_message(
+    fake_slack_web_client: Any,
+) -> None:
+    """A failed answer-replace chat.update collapses the status to a failure notice.
+
+    Without the repair the status message keeps whatever the last debounced
+    flush wrote — phase title, tool trail, cancel button — while the cancel
+    Event is deregistered in finally, so the turn looks alive forever with a
+    dead control.
+    """
+    _reset_slack_responses(fake_slack_web_client)
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
+        repeat=True,
+    )
+    # First chat.update (the answer replace) fails; the repair update succeeds.
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": False, "error": "msg_too_long"},
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": True, "ts": "1000000000.000001"},
+        repeat=True,
+    )
+    lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    state = TurnState(content=[TextBlock(kind="text", text="The answer is 42.")])
+    await lc.on_terminal_success(state)  # must not raise
+
+    assert _update_count(fake_slack_web_client) == 2, (
+        "the failed answer replace must be followed by exactly one repair chat.update"
+    )
+    blocks = _last_update_blocks(fake_slack_web_client)
+    assert "went wrong" in _block_text(blocks), (
+        "the repair must render a plain failure notice, not the live surface"
+    )
+    assert not _has_actions_block(blocks), "the repair must not keep the dead cancel button"
+    assert lc.final_ts is None, (
+        "final_ts must stay unset — the watermark must not advance past an answer "
+        "the user never saw"
+    )
+    assert deregistered == ["1000000000.000001"], (
+        "deregister must still run exactly once for status_ts"
+    )
+
+
+async def test_terminal_success_swallows_repair_failure(
+    fake_slack_web_client: Any,
+) -> None:
+    """When the repair chat.update fails for the same reason, nothing propagates."""
+    _reset_slack_responses(fake_slack_web_client)
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
+        repeat=True,
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": False, "error": "token_revoked"},
+        repeat=True,
+    )
+    lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    state = TurnState(content=[TextBlock(kind="text", text="Hello.")])
+    await lc.on_terminal_success(state)  # must not raise
+
+    assert _update_count(fake_slack_web_client) == 2, (
+        "exactly one repair attempt after the failed flush — no retry loop"
+    )
+    assert lc.final_ts is None, "final_ts must stay unset when nothing posted"
+    assert deregistered == ["1000000000.000001"], "deregister must still run in finally"
+
+
+async def test_terminal_success_first_post_failure_attempts_no_repair(
+    fake_slack_web_client: Any,
+) -> None:
+    """A turn reaching terminal with no status message has nothing to repair.
+
+    The terminal flush is the FIRST post (no prior SSE flush) and it fails:
+    status_ts is None, so there is no stranded message and no repair target.
+    """
+    _reset_slack_responses(fake_slack_web_client)
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload={"ok": False, "error": "channel_not_found"},
+        repeat=True,
+    )
+    lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+
+    state = TurnState(content=[TextBlock(kind="text", text="Hello.")])
+    await lc.on_terminal_success(state)  # must not raise
+
+    assert _update_count(fake_slack_web_client) == 0, (
+        "no chat.update may be attempted when no status message exists"
+    )
+    assert lc.final_ts is None, "final_ts must stay unset when nothing posted"
+    assert deregistered == [], "nothing was registered, so nothing to deregister"
+
+
+async def test_terminal_success_overflow_failure_keeps_replaced_answer(
+    fake_slack_web_client: Any,
+) -> None:
+    """An overflow-post failure must not clobber the already-replaced answer.
+
+    The first chunk landed via chat.update, so the status message shows real
+    answer text; repairing it to a failure notice would destroy content the
+    user can already read. final_ts still stays None so the watermark does not
+    advance past the missing tail.
+    """
+    _reset_slack_responses(fake_slack_web_client)
+    # Initial SSE flush posts fine; every later post (the overflow chunks) fails.
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload={"ok": False, "error": "ratelimited"},
+        repeat=True,
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": True, "ts": "1000000000.000001"},
+        repeat=True,
+    )
+    lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    long_text = "x" * 24000  # forces overflow chunks past the first update
+    state = TurnState(content=[TextBlock(kind="text", text=long_text)])
+    await lc.on_terminal_success(state)  # must not raise
+
+    assert _update_count(fake_slack_web_client) == 1, (
+        "the successful answer replace must stand — no repair update over it"
+    )
+    blocks = _last_update_blocks(fake_slack_web_client)
+    assert blocks[0]["type"] == "markdown" and "x" in blocks[0]["text"], (
+        "the status message must keep the first answer chunk"
+    )
+    assert lc.final_ts is None, "final_ts must stay unset when overflow chunks failed to post"
+    assert deregistered == ["1000000000.000001"], "deregister must still run in finally"
+
+
+async def test_terminal_failure_flush_failure_repairs_status_message(
+    fake_slack_web_client: Any,
+) -> None:
+    """on_terminal_failure's own flush failure gets the same repair treatment."""
+    _reset_slack_responses(fake_slack_web_client)
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
+        repeat=True,
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": False, "error": "msg_too_long"},
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": True, "ts": "1000000000.000001"},
+        repeat=True,
+    )
+    lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    await lc.on_terminal_failure(TurnState(), RuntimeError("upstream blew up"))
+
+    assert _update_count(fake_slack_web_client) == 2, (
+        "the failed error flush must be followed by exactly one repair chat.update"
+    )
+    blocks = _last_update_blocks(fake_slack_web_client)
+    assert "went wrong" in _block_text(blocks), (
+        "the repair must render a plain failure notice, not the live surface"
+    )
+    assert not _has_actions_block(blocks), "the repair must not keep the dead cancel button"
+    assert deregistered == ["1000000000.000001"], "deregister must still run in finally"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -27,6 +27,10 @@ Terminal flush failure — best-effort repair (#107):
   - final_ts stays None on every flush failure so the watermark cannot advance
     past an answer the user never saw.
   - on_terminal_failure's own flush failure gets the same repair.
+  - Transport errors (aiohttp, not SlackApiError) get the same repair, and
+    neither terminal hook raises when flush AND repair both hit them.
+  - A no-answer collapse is repaired with copy that does not claim an answer.
+  - The swallowed flush failure is captured to Sentry (answer-delivery outage).
 
 Transport-level fake via aioresponses (guideline:testing) — transport-level fakes only.
 """
@@ -39,10 +43,13 @@ import time
 import types
 from typing import Any
 
+import aiohttp
+import pytest
 import yarl
 from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
     BetaManagedAgentsSpanModelUsage,
 )
+from daimon.adapters.slack import lifecycle as lifecycle_mod
 from daimon.adapters.slack.lifecycle import SlackTurnLifecycle
 from daimon.core.pricing import MODEL_PRICING, cost_of, format_cost
 from daimon.core.turn.lifecycle import TurnLifecycle
@@ -52,6 +59,9 @@ from daimon.core.turn.state import (
     TurnState,
     UsageTotals,
 )
+from slack_sdk.errors import SlackApiError
+
+from .conftest import CHAT_OK_PAYLOAD
 
 # ---------------------------------------------------------------------------
 # URL constants for mock.requests inspection
@@ -491,6 +501,29 @@ def _reset_slack_responses(fake: Any) -> None:
     fake.mock.clear()
 
 
+def _stage_flush_failure_then_repair_ok(fake: Any, *, error: str) -> None:
+    """Posts succeed; the FIRST chat.update fails with ``error``; later updates succeed.
+
+    The shape shared by every repair test: the initial SSE flush posts fine,
+    the terminal flush's update raises, and the repair update lands.
+    """
+    _reset_slack_responses(fake)
+    fake.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload=CHAT_OK_PAYLOAD,
+        repeat=True,
+    )
+    fake.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": False, "error": error},
+    )
+    fake.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload=CHAT_OK_PAYLOAD,
+        repeat=True,
+    )
+
+
 async def test_terminal_success_flush_failure_repairs_status_message(
     fake_slack_web_client: Any,
 ) -> None:
@@ -501,22 +534,7 @@ async def test_terminal_success_flush_failure_repairs_status_message(
     Event is deregistered in finally, so the turn looks alive forever with a
     dead control.
     """
-    _reset_slack_responses(fake_slack_web_client)
-    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
-        str(_POST_URL),
-        payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
-        repeat=True,
-    )
-    # First chat.update (the answer replace) fails; the repair update succeeds.
-    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
-        str(_UPDATE_URL),
-        payload={"ok": False, "error": "msg_too_long"},
-    )
-    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
-        str(_UPDATE_URL),
-        payload={"ok": True, "ts": "1000000000.000001"},
-        repeat=True,
-    )
+    _stage_flush_failure_then_repair_ok(fake_slack_web_client, error="msg_too_long")
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
     await lc.on_sse_event(_thinking_event())
 
@@ -547,7 +565,7 @@ async def test_terminal_success_swallows_repair_failure(
     _reset_slack_responses(fake_slack_web_client)
     fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
         str(_POST_URL),
-        payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
+        payload=CHAT_OK_PAYLOAD,
         repeat=True,
     )
     fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
@@ -608,7 +626,7 @@ async def test_terminal_success_overflow_failure_keeps_replaced_answer(
     # Initial SSE flush posts fine; every later post (the overflow chunks) fails.
     fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
         str(_POST_URL),
-        payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
+        payload=CHAT_OK_PAYLOAD,
     )
     fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
         str(_POST_URL),
@@ -617,7 +635,7 @@ async def test_terminal_success_overflow_failure_keeps_replaced_answer(
     )
     fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
         str(_UPDATE_URL),
-        payload={"ok": True, "ts": "1000000000.000001"},
+        payload=CHAT_OK_PAYLOAD,
         repeat=True,
     )
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
@@ -642,21 +660,7 @@ async def test_terminal_failure_flush_failure_repairs_status_message(
     fake_slack_web_client: Any,
 ) -> None:
     """on_terminal_failure's own flush failure gets the same repair treatment."""
-    _reset_slack_responses(fake_slack_web_client)
-    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
-        str(_POST_URL),
-        payload={"ok": True, "ts": "1000000000.000001", "channel": "C_TEST"},
-        repeat=True,
-    )
-    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
-        str(_UPDATE_URL),
-        payload={"ok": False, "error": "msg_too_long"},
-    )
-    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
-        str(_UPDATE_URL),
-        payload={"ok": True, "ts": "1000000000.000001"},
-        repeat=True,
-    )
+    _stage_flush_failure_then_repair_ok(fake_slack_web_client, error="msg_too_long")
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
     await lc.on_sse_event(_thinking_event())
 
@@ -671,6 +675,116 @@ async def test_terminal_failure_flush_failure_repairs_status_message(
     )
     assert not _has_actions_block(blocks), "the repair must not keep the dead cancel button"
     assert deregistered == ["1000000000.000001"], "deregister must still run in finally"
+
+
+async def test_terminal_success_transport_error_repairs_and_does_not_raise(
+    fake_slack_web_client: Any,
+) -> None:
+    """A transport error during the answer replace gets the same repair as ok:false.
+
+    slack_sdk re-raises aiohttp errors unwrapped — they never become
+    SlackApiError — and the mention boundary's catch tuple does not include
+    them, so an escape here surfaces as an unhandled task error while the
+    status message stays stranded on the live surface.
+    """
+    _reset_slack_responses(fake_slack_web_client)
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload=CHAT_OK_PAYLOAD,
+        repeat=True,
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        exception=aiohttp.ClientConnectionError("network down"),
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload=CHAT_OK_PAYLOAD,
+        repeat=True,
+    )
+    lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    state = TurnState(content=[TextBlock(kind="text", text="Hello.")])
+    await lc.on_terminal_success(state)  # must not raise
+
+    blocks = _last_update_blocks(fake_slack_web_client)
+    assert "went wrong" in _block_text(blocks), (
+        "a transport error must produce the same repair notice as an ok:false response"
+    )
+    assert lc.final_ts is None, "final_ts must stay unset when the answer never posted"
+    assert deregistered == ["1000000000.000001"], "deregister must still run in finally"
+
+
+async def test_terminal_failure_transport_error_in_flush_and_repair_does_not_raise(
+    fake_slack_web_client: Any,
+) -> None:
+    """on_terminal_failure never raises, even when flush AND repair hit transport errors.
+
+    The driver awaits this hook unguarded on every failure path; an escape
+    aborts run_prepared_turn before its outcome bookkeeping.
+    """
+    _reset_slack_responses(fake_slack_web_client)
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_POST_URL),
+        payload=CHAT_OK_PAYLOAD,
+        repeat=True,
+    )
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        exception=aiohttp.ClientConnectionError("network down"),
+        repeat=True,
+    )
+    lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    await lc.on_terminal_failure(TurnState(), RuntimeError("upstream blew up"))
+
+    assert deregistered == ["1000000000.000001"], "deregister must still run in finally"
+
+
+async def test_terminal_success_cancelled_collapse_repair_does_not_claim_an_answer(
+    fake_slack_web_client: Any,
+) -> None:
+    """The repair after a failed 'Turn cancelled.' collapse must not mention an answer.
+
+    A user who cancelled their own turn would otherwise read
+    'Something went wrong posting the answer.' for a turn that produced none.
+    """
+    _stage_flush_failure_then_repair_ok(fake_slack_web_client, error="ratelimited")
+    lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    await lc.on_terminal_success(TurnState())  # empty content — cancelled path
+
+    text = _block_text(_last_update_blocks(fake_slack_web_client))
+    assert "went wrong" in text, "the failed collapse must still be repaired"
+    assert "answer" not in text, "a turn with no answer must not be described as one"
+    assert deregistered == ["1000000000.000001"], "deregister must still run in finally"
+
+
+async def test_terminal_success_flush_failure_reaches_sentry(
+    fake_slack_web_client: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A swallowed terminal-flush failure still produces an ops signal.
+
+    Before the repair existed, the exception reached the listener boundary's
+    log.error + capture_exception_with_scope. Absorbing it in the lifecycle
+    must not trade the stuck spinner for a silent answer-delivery outage —
+    a tenant can bill tokens on every turn while every answer is dropped.
+    """
+    captured: list[BaseException] = []
+    monkeypatch.setattr(lifecycle_mod, "capture_exception_with_scope", captured.append)
+    _stage_flush_failure_then_repair_ok(fake_slack_web_client, error="msg_too_long")
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+
+    state = TurnState(content=[TextBlock(kind="text", text="Hello.")])
+    await lc.on_terminal_success(state)
+
+    assert len(captured) == 1, "the flush failure must be captured exactly once"
+    assert isinstance(captured[0], SlackApiError), "the captured exception is the flush failure"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What breaks

#106 removed the one known trigger (`msg_too_long`) but left the failure mode open, per its own follow-up note — this closes #107. When any `chat.update`/`chat.postMessage` inside `on_terminal_success` raises `SlackApiError`, the exception escapes to the mention boundary and the status message is left exactly as the last debounced flush wrote it: phase title, tool trail, and a cancel button whose Event the terminal `finally` has already deregistered. The turn looks alive forever and Cancel silently does nothing. `on_terminal_failure` absorbs its own flush failures but strands the same surface.

## Fix

`on_terminal_success` now catches `SlackApiError` instead of re-raising — the same absorb contract `on_terminal_failure` already documents. On a failed flush, `_repair_terminal_flush` makes one best-effort `chat.update` collapsing the status message to "⚠️ Something went wrong posting the answer.", suppressed if it fails for the same root cause (revoked token, archived channel). The stuck spinner becomes a legible failure.

Two deliberate choices:

- The repair is skipped when the first answer chunk already replaced the status message and only an overflow post failed — repairing there would overwrite answer text the user can read. The truncation is logged, not painted over.
- `final_ts` stays `None` on any flush failure, including partial overflow, so `_orchestrate` never advances the thread watermark past content that did not post; the next turn's context re-reads it.

`on_terminal_failure`'s flush-failed branch gets the same repair call.

## Testing

Five new tests in `test_lifecycle.py`, transport-level via aioresponses like the rest of the file: failed answer-replace triggers exactly one repair update with no actions block; a failed repair is swallowed; a failed first post (no status message) attempts no repair; an overflow failure leaves the replaced answer standing; the failure-path flush gets the same repair. All written first and watched fail — the success-path ones on the propagating `SlackApiError`, the failure-path one on the missing repair.

Slack shard: 468 passed (DB-backed tests and 11 snapshots included); pyright 0 errors; ruff and import-linter clean. Not exercised against a live workspace.

## Adjacent work

#98 edits the same region of `on_terminal_success` (vote buttons on the final chunk) — no functional overlap, but whichever lands second will need a small rebase.