### PR TITLE
fix(slack): answer the billing modal when a top-up checkout fails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,9 @@ DAIMON_ANTHROPIC__API_KEY=
 # === Billing (optional — Stripe top-ups) ===
 # 7-key flat env read by daimon.core.billing.load_billing_config.
 # No DAIMON_ prefix. Billing is disabled (not an error) when any is unset.
+# With billing disabled, /billing top-ups can't create a checkout. Credit
+# manually: insert a tenant_ledger row (delta_usd > 0, reason='topup', a
+# unique idempotency_key — its unique index makes a re-run a no-op).
 # STRIPE_SECRET_KEY=
 # STRIPE_WEBHOOK_SECRET=
 # STRIPE_PRICE_10_USD=

--- a/packages/adapters/slack/daimon/adapters/slack/billing_panel/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/billing_panel/actions.py
@@ -17,9 +17,12 @@ Pattern sequence for billing_topup block_action:
   4. get_or_create_platform_principal → account_id
   5. create_checkout(http_client, …) → url
   6. chat_postEphemeral with "<url|Complete payment>" link
+  7. On failure, views.update the open modal with a static "not configured" message
+     instead of leaving the dropdown silently dead
 
-Error boundary (S3): catches DaimonError | httpx.HTTPStatusError | SlackApiError
-at the handler level; logs + captures to Sentry. Never stripe.
+Error boundary (S3): catches DaimonError | httpx.HTTPStatusError | AssertionError |
+SlackApiError at the handler level; logs + captures to Sentry, then answers the open
+modal via views.update. Never stripe.
 """
 
 from __future__ import annotations
@@ -140,6 +143,8 @@ async def handle_topup_select(
     # channel comes from block_actions container (may be absent for modal actions)
     container: dict[str, Any] = payload.get("container") or {}
     channel: str = container.get("channel_id") or ""
+    view_info: dict[str, Any] = payload.get("view") or {}
+    view_id: str = str(view_info.get("id") or "")
 
     # Extract selected amount from the first action's selected_option value
     actions: list[dict[str, Any]] = payload.get("actions") or []
@@ -206,7 +211,7 @@ async def handle_topup_select(
             text=f"<{url}|Complete payment>",
         )
 
-    except (DaimonError, httpx.HTTPStatusError, SlackApiError) as exc:
+    except (DaimonError, httpx.HTTPStatusError, AssertionError, SlackApiError) as exc:
         log.error(
             "slack.billing_topup_failed",
             team_id=team_id,
@@ -214,3 +219,23 @@ async def handle_topup_select(
             exc_info=exc,
         )
         capture_exception_with_scope(exc)
+        await client.views_update(  # pyright: ignore[reportUnknownMemberType]
+            view_id=view_id,
+            view={
+                "type": "modal",
+                "title": {"type": "plain_text", "text": "Billing"},
+                "close": {"type": "plain_text", "text": "Close"},
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": (
+                                "Payments aren't configured for this workspace. "
+                                "Ask an operator about a manual credit top-up."
+                            ),
+                        },
+                    }
+                ],
+            },
+        )

--- a/packages/adapters/slack/tests/test_billing_checkout.py
+++ b/packages/adapters/slack/tests/test_billing_checkout.py
@@ -26,6 +26,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 import pytest_asyncio
+import yarl
 from aioresponses import aioresponses as AioResponsesMock
 from anthropic import AsyncAnthropic
 from cryptography.fernet import Fernet
@@ -101,6 +102,7 @@ def _build_admin_payload(*, amount: int) -> dict[str, Any]:
         "team": {"id": _TEAM_ID},
         "user": {"id": _USER_ID},
         "container": {"channel_id": _CHANNEL_ID},
+        "view": {"id": "V_BILLING_TEST", "hash": "H_BILLING_TEST"},
         "actions": [
             {
                 "action_id": "billing_topup",
@@ -397,6 +399,10 @@ async def test_handle_topup_select_non_admin_issues_no_checkout_post(
         )
 
     assert len(captured_checkout) == 0, "Non-admin must NOT trigger a checkout POST (fail-closed)"
+    views_update_key = ("POST", yarl.URL(_VIEWS_UPDATE_URL))
+    assert views_update_key not in mock.requests, (
+        "Non-admin refusal must stay silent — no views.update either"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -457,4 +463,109 @@ async def test_handle_topup_select_invalid_amount_issues_no_checkout_post(
 
     assert len(captured_checkout) == 0, (
         "Amount 999 (not in preset set) must NOT trigger a checkout POST (T-82-10)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: handle_topup_select — checkout route missing (no payment provider)
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_topup_select_updates_modal_when_checkout_route_is_missing(
+    runtime: SlackRuntime,
+) -> None:
+    """When /billing/checkout 404s, the open modal is updated with a visible message
+    instead of leaving the top-up select silently dead."""
+    from daimon.adapters.slack.billing_panel.actions import handle_topup_select
+
+    def checkout_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "Not Found"})
+
+    admin_users_info_payload = {
+        "ok": True,
+        "user": {
+            "id": _USER_ID,
+            "name": "admin_user",
+            "is_admin": True,
+            "is_owner": False,
+            "is_primary_owner": False,
+        },
+    }
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=admin_users_info_payload,
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            _VIEWS_UPDATE_URL,
+            payload={"ok": True, "view": {"id": "V_BILLING_TEST", "hash": "H_BILLING_TEST"}},
+            repeat=True,
+        )
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(checkout_handler))
+        await handle_topup_select(
+            runtime,
+            _build_admin_payload(amount=25),
+            _http_client=http_client,
+        )
+
+    views_update_key = ("POST", yarl.URL(_VIEWS_UPDATE_URL))
+    update_calls = mock.requests.get(views_update_key)
+    assert update_calls, "handle_topup_select must send a views.update when checkout 404s"
+    assert len(update_calls) == 1, "exactly one views.update must be sent on checkout failure"
+    body: dict[str, Any] = update_calls[0].kwargs["json"]
+    view_text = str(body["view"]["blocks"][0]["text"]["text"])
+    assert "aren't configured" in view_text, (
+        "views.update body must tell the operator payments aren't configured"
+    )
+    assert "manual credit top-up" in view_text, (
+        "views.update body must point the operator at a manual credit top-up"
+    )
+
+
+async def test_handle_topup_select_admin_success_sends_no_views_update(
+    runtime: SlackRuntime,
+) -> None:
+    """A successful checkout must not touch the modal — the ephemeral link is the
+    only response (mirroring it into the modal is out of scope)."""
+    from daimon.adapters.slack.billing_panel.actions import handle_topup_select
+
+    def checkout_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"url": _CHECKOUT_RESPONSE_URL})
+
+    admin_users_info_payload = {
+        "ok": True,
+        "user": {
+            "id": _USER_ID,
+            "name": "admin_user",
+            "is_admin": True,
+            "is_owner": False,
+            "is_primary_owner": False,
+        },
+    }
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            payload=admin_users_info_payload,
+            repeat=True,
+        )
+        mock.post(  # pyright: ignore[reportUnknownMemberType]
+            _POST_EPHEMERAL_URL,
+            payload={"ok": True, "message_ts": "1234.5678"},
+            repeat=True,
+        )
+
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(checkout_handler))
+        await handle_topup_select(
+            runtime,
+            _build_admin_payload(amount=25),
+            _http_client=http_client,
+        )
+
+    views_update_key = ("POST", yarl.URL(_VIEWS_UPDATE_URL))
+    assert views_update_key not in mock.requests, (
+        "a successful checkout must not send any views.update"
     )

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -231,6 +231,9 @@ def render_env_example() -> str:
     lines.append("# === Billing (optional — Stripe top-ups) ===")
     lines.append("# 7-key flat env read by daimon.core.billing.load_billing_config.")
     lines.append("# No DAIMON_ prefix. Billing is disabled (not an error) when any is unset.")
+    lines.append("# With billing disabled, /billing top-ups can't create a checkout. Credit")
+    lines.append("# manually: insert a tenant_ledger row (delta_usd > 0, reason='topup', a")
+    lines.append("# unique idempotency_key — its unique index makes a re-run a no-op).")
     for name in BILLING_FLAT_VARS:
         lines.append(f"# {name}=")
     lines.append("")


### PR DESCRIPTION
Addresses #103 — items **(1)** and **(3)**. Item (2) is deliberately not included.

@jchu96 you offered to PR (1) and (3); this got picked up on our side, so don't duplicate the work.

## The bug

`handle_topup_select` caught the checkout failure, logged it, captured it to Sentry, and returned. No `views.update`, no ephemeral — the operator picks an amount and the modal just sits there. Since the modal has no submit button by design, the dropdown reads as dead.

## The fix

A `views.update` on the already-open modal, inside the handler's **existing** except block:

> Payments aren't configured for this workspace. Ask an operator about a manual credit top-up.

The message is static by design — no `str(exc)`, no status code, no checkout or service URL. It renders to a workspace admin; the exception detail keeps going to structlog and Sentry.

Two failure shapes reach it:

1. **No payment provider.** `load_billing_config()` returns `None`, so `/billing/checkout` is never mounted, so the POST 404s and `raise_for_status()` raises `httpx.HTTPStatusError` — already in the except tuple.
2. **Unset public URL / JWT secret.** `create_checkout` asserts both are set and both settings are genuinely optional, so `AssertionError` was a second, separate silent no-op with the same symptom. Added to the same tuple rather than left behind.

Item (3) is three comment lines in the Stripe block of `.env.example`, recording the manual fallback operators have been reverse-engineering: a positive `tenant_ledger` row with `reason='topup'` and a unique idempotency key, whose unique index makes a re-run a no-op. Written in `scripts/generate_env_example.py` and regenerated, since that file is generated.

## Deliberately unchanged

The non-admin and invalid-amount branches `return` early, above the checkout call, and stay silent. A test pins that so nobody "fixes" it by accident. It does mean a non-admin still sees a dead dropdown — same defect class as #95, worth its own issue rather than smuggling it in here.

A second test pins that success sends **no** `views.update`, to keep a later author from drifting into item (2).

## Verification

`packages/adapters/slack` — 465 passed. `pyright` strict clean, `ruff`, `lint-imports` (6 contracts), and the `.env.example` staleness check all green.

**The modal itself needs human UAT — it is not automatable.** The Slack QA rig has three independent ceilings here: no Web API method invokes a slash command, so `/billing` can't be opened by a driver; no token can produce a `block_actions` payload, so neither the select nor this `views.update` is reachable; and a bot user can never be a workspace admin, so the admin/non-admin split has no automatable admin side. Checklist for a human:

1. Admin, tenant with no payment provider, `/billing` → pick any amount → expect the message above, not a dead dropdown.
2. Admin, tenant **with** Stripe → the ephemeral "Complete payment" link still posts and the modal is not replaced.
3. Non-admin → still silent, no checkout created (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)