### PR TITLE
feat(mcp): add session-scoped turn cancellation

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -19,6 +19,11 @@ Headless loop (primitives plus the bounded ``ask`` convenience tool):
   a session.
 - ``continue_turn`` sends a follow-up ``user.message``. Admission-gated,
   same as ``start_turn``.
+- ``cancel_turn`` cooperatively interrupts the active provider turn and waits
+  for observed terminal idle. An unconfirmed request returns
+  ``cancel_requested`` rather than claiming cancellation. It is owner-gated
+  but not admission-gated: stopping work must remain possible after a balance
+  or cap is reached.
 - ``get_session`` returns status/metadata (poll until idle). Read-only, not
   gated.
 - ``list_events`` returns the transcript; the caller reads the reply from the
@@ -60,6 +65,7 @@ from daimon.adapters.mcp.tools._pagination import Page
 from daimon.adapters.mcp.tools.sessions import SessionEventOut, SessionInfo
 from daimon.core.billing import BillingConfig
 from daimon.core.defaults.ma_index import find_environment_by_daimon_tag, list_agents_by_tenant
+from daimon.core.ma import cancel_turn as cancel_session_turn
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.scope import ScopeContext
 from daimon.core.sessions import create_session
@@ -71,11 +77,18 @@ from fastmcp.tools import ToolResult
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 
-from mcp.types import ImageContent, TextContent
+from mcp.types import ImageContent, TextContent, ToolAnnotations
 
 # Each transcript page costs two upstream calls (ownership retrieve + events
 # list), so an uncapped walk on a long session can outlast any client timeout.
 _MAX_EVENT_PAGES = 20
+
+_CANCEL_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+)
 
 
 class AgentDescription(BaseModel):
@@ -334,6 +347,25 @@ async def _continue_turn_impl(
     return {"handle": handle}
 
 
+async def _cancel_turn_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    session_id: str,
+) -> dict[str, str]:
+    """Owner-gated adapter boundary for the core cancellation primitive."""
+    await _verify_agent_owns_session(runtime, auth, session_id)
+    result = await cancel_session_turn(
+        runtime.client,
+        session_id=session_id,
+        requested_by=str(auth.account_id),
+    )
+    return {
+        "session_id": result.session_id,
+        "outcome": result.outcome,
+        "status": result.status,
+    }
+
+
 async def _list_sessions_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
@@ -573,7 +605,8 @@ def register_agent_chat_tools(
     caller's agent. ``ask`` composes the same primitives into one bounded
     hosted-client call and adds chart delivery after the session becomes idle.
     ``deliver_turn_charts`` provides the same delivery for clients that poll
-    and read the primitives themselves.
+    and read the primitives themselves. The scoped surface includes
+    ``cancel_turn`` alongside the existing session/event tools.
 
     ``list_sessions``/``get_session`` are registered as ``list_my_sessions``/
     ``get_my_session`` to avoid a name collision with the tenant-scoped
@@ -582,9 +615,11 @@ def register_agent_chat_tools(
 
     ``start_turn``, ``continue_turn``, and ``ask`` run the shared
     ``_check_admission`` gate (the same balance/cap checks the media tools run)
-    before creating a session or sending an event. The four read-only tools and
-    ``deliver_turn_charts`` stay on bare ``_auth``; the latter performs a
-    bounded artifact-store write when optional link delivery is configured.
+    before creating a session or sending an event. ``cancel_turn``, the four
+    read-only tools, and ``deliver_turn_charts`` stay on bare ``_auth`` so
+    cancellation remains available after a billing limit is reached; chart
+    delivery performs a bounded artifact-store write when optional link
+    delivery is configured.
     """
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
@@ -655,6 +690,22 @@ def register_agent_chat_tools(
             tool_name="continue_turn",
         )
         return await _continue_turn_impl(runtime, auth, handle, message)
+
+    @mcp.tool(  # pyright: ignore[reportArgumentType]
+        tags={"agent-chat"},
+        annotations=_CANCEL_ANNOTATIONS,
+    )
+    async def cancel_turn(ctx: Context, session_id: str) -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+        """Stop the active turn in a session owned by this caller's agent.
+        Cancellation is cooperative at the Managed Agents interrupt boundary,
+        so an in-flight tool operation may finish before the stop takes effect.
+        The call waits for observed terminal idle, leaves the session readable
+        and continuable, and is an idempotent no-op when the session is already
+        terminal. An unconfirmed timeout returns ``cancel_requested``. Charges
+        for completed ``span.model_request_end`` events stand; there is no
+        reserve or refund, and the cancel request itself adds no usage event.
+        """
+        return await _cancel_turn_impl(runtime, await _auth(ctx), session_id)
 
     @mcp.tool(tags={"agent-chat"}, name="get_my_session")  # pyright: ignore[reportArgumentType]
     async def get_my_session(ctx: Context, handle: str) -> SessionInfo:  # pyright: ignore[reportUnusedFunction]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -86,7 +86,7 @@ _MAX_EVENT_PAGES = 20
 _CANCEL_ANNOTATIONS = ToolAnnotations(
     readOnlyHint=False,
     destructiveHint=True,
-    idempotentHint=True,
+    idempotentHint=False,
     openWorldHint=False,
 )
 

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -99,6 +99,30 @@
         'type': 'object',
       }),
     }),
+    'cancel_turn': dict({
+      'description': '''
+        Stop the active turn in a session owned by this caller's agent.
+        Cancellation is cooperative at the Managed Agents interrupt boundary,
+        so an in-flight tool operation may finish before the stop takes effect.
+        The call waits for observed terminal idle, leaves the session readable
+        and continuable, and is an idempotent no-op when the session is already
+        terminal. An unconfirmed timeout returns ``cancel_requested``. Charges
+        for completed ``span.model_request_end`` events stand; there is no
+        reserve or refund, and the cancel request itself adds no usage event.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'session_id': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'session_id',
+        ]),
+        'type': 'object',
+      }),
+    }),
     'clear_agent_default': dict({
       'description': '''
         Remove the agent default from a channel or the whole workspace.

--- a/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
+++ b/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
@@ -338,7 +338,7 @@ async def test_agent_id_claim_session_discovers_agent_chat_and_self_edit_tools_o
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
     """A session narrowed to agent-chat-tagged tools (an agent_id claim)
-    discovers the eight agent-chat tools plus the eight self-edit/vault tools
+    discovers the nine agent-chat tools plus the eight self-edit/vault tools
     tagged in this plan, and none of the tenant-wide roster tools."""
     async with sessionmaker() as s, s.begin():
         tenant = await make_tenant(s, platform="discord", workspace_id="agent-chat-reachability")
@@ -357,6 +357,7 @@ async def test_agent_id_claim_session_discovers_agent_chat_and_self_edit_tools_o
         "list_my_sessions",
         "start_turn",
         "continue_turn",
+        "cancel_turn",
         "get_my_session",
         "list_events",
         "self_write_file",

--- a/packages/adapters/mcp/tests/test_tool_schema_snapshot.py
+++ b/packages/adapters/mcp/tests/test_tool_schema_snapshot.py
@@ -42,6 +42,7 @@ pytestmark = pytest.mark.asyncio
 # leaves a group unconfigured) — checked before the snapshot comparison so
 # that failure mode is loud rather than a quietly smaller snapshot.
 _MUST_CONTAIN = {
+    "cancel_turn",
     "create_environment",
     "send_message",
     "sync_skills",

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -45,6 +45,7 @@ from daimon.adapters.mcp.tools.agent_chat import (
     AskResult,
     _ask_impl,
     _ask_tool_result,
+    _cancel_turn_impl,
     _continue_turn_impl,
     _deliver_turn_charts_impl,
     _describe_agent_impl,
@@ -65,6 +66,7 @@ from daimon.testing.ma import (
     build_fake_anthropic,
     list_response,
     send_events_response,
+    sse_response,
 )
 from factories import make_ma_agent
 from fastmcp import FastMCP
@@ -345,6 +347,7 @@ async def test_narrowing_agent_id_claim_returns_only_agent_chat_tools() -> None:
         "start_turn",
         "continue_turn",
         "deliver_turn_charts",
+        "cancel_turn",
         "get_my_session",
         "list_events",
     }
@@ -432,6 +435,7 @@ async def test_narrowing_lists_agent_chat_tools_through_bm25_search_transform() 
         "start_turn",
         "continue_turn",
         "deliver_turn_charts",
+        "cancel_turn",
         "get_my_session",
         "list_events",
     }
@@ -1334,6 +1338,105 @@ async def test_continue_turn_raises_session_not_found_for_same_tenant_other_agen
         await _continue_turn_impl(runtime, auth, "ses_sibling", "hi")
 
 
+async def test_cancel_turn_stops_running_turn() -> None:
+    """The registered tool owner-checks, interrupts, and awaits terminal idle."""
+    sent_events: list[dict[str, Any]] = []
+    observed_statuses = iter(["running", "running", "running", "idle"])
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            200,
+            json=_make_fake_session(session_id="ses_running", status=next(observed_statuses)),
+        ),
+    )
+
+    def on_event_send(request: httpx.Request, _match: re.Match[str]) -> httpx.Response:
+        sent_events.extend(json.loads(request.content).get("events", []))
+        return send_events_response(data=[])
+
+    router.add("POST", r"/v1/sessions/([^/]+)/events", on_event_send)
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)/events/stream",
+        lambda _r, _m: sse_response([_make_idle_event()]),
+    )
+    runtime = _runtime(build_fake_anthropic(router.dispatch))
+    mcp = FastMCP(name="cancel-registration")
+    register_agent_chat_tools(mcp, runtime, billing_config=None)
+
+    tool = await mcp.get_tool("cancel_turn")
+    assert tool is not None, "cancel_turn must be registered in the agent-chat tool set"
+    assert tool.annotations is not None
+    assert tool.annotations.model_dump(exclude_none=True) == {
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    }
+
+    result = await _cancel_turn_impl(runtime, _auth(), "ses_running")
+
+    assert result == {
+        "session_id": "ses_running",
+        "outcome": "cancelled",
+        "status": "idle",
+    }
+    assert sent_events == [{"type": "user.interrupt"}]
+
+
+async def test_cancel_turn_idempotent_on_terminal() -> None:
+    """An already-idle turn returns distinctly without posting another interrupt."""
+    sent_requests: list[httpx.Request] = []
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            200,
+            json=_make_fake_session(session_id="ses_idle", status="idle"),
+        ),
+    )
+
+    def unexpected_send(request: httpx.Request, _match: re.Match[str]) -> httpx.Response:
+        sent_requests.append(request)
+        return send_events_response(data=[])
+
+    router.add("POST", r"/v1/sessions/([^/]+)/events", unexpected_send)
+    runtime = _runtime(build_fake_anthropic(router.dispatch))
+
+    result = await _cancel_turn_impl(runtime, _auth(), "ses_idle")
+
+    assert result == {
+        "session_id": "ses_idle",
+        "outcome": "already_terminal",
+        "status": "idle",
+    }
+    assert sent_requests == [], "terminal turns must not receive a duplicate interrupt"
+
+
+async def test_cancel_turn_rejects_same_tenant_sibling_agent_session() -> None:
+    """Cancellation preserves continue_turn's same-agent owner claim."""
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            200,
+            json=_make_fake_session(
+                session_id="ses_sibling_cancel",
+                agent_id="ag_sibling",
+                status="running",
+            ),
+        ),
+    )
+    runtime = _runtime(build_fake_anthropic(router.dispatch))
+
+    with pytest.raises(ToolError, match="session not found"):
+        await _cancel_turn_impl(runtime, _auth(), "ses_sibling_cancel")
+
+
 # ---------------------------------------------------------------------------
 # Test 4: Confused-deputy — no tool accepts an agent_id parameter
 # ---------------------------------------------------------------------------
@@ -1360,6 +1463,7 @@ async def test_agent_chat_tools_have_no_agent_id_parameter() -> None:
         "start_turn",
         "continue_turn",
         "deliver_turn_charts",
+        "cancel_turn",
         "get_my_session",
         "list_events",
     }

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -1372,7 +1372,7 @@ async def test_cancel_turn_stops_running_turn() -> None:
     assert tool.annotations.model_dump(exclude_none=True) == {
         "readOnlyHint": False,
         "destructiveHint": True,
-        "idempotentHint": True,
+        "idempotentHint": False,
         "openWorldHint": False,
     }
 

--- a/packages/core/daimon/core/ma.py
+++ b/packages/core/daimon/core/ma.py
@@ -2,16 +2,15 @@
 
 Per refinements §6, this module holds ONLY operations whose logic extends
 beyond one SDK call: full-history replay (for SSE reconnect rebuilds) and
-interrupt-with-ack-wait. Everything else (create/list/retrieve/archive on
-agents, environments, sessions) stays a direct SDK call in its call site;
+session-scoped turn cancellation. Everything else (create/list/retrieve/archive
+on agents, environments, sessions) stays a direct SDK call in its call site;
 no delegation layer to maintain.
 
 Design rules:
 - Free async functions; no class (no cross-call state to own).
 - `AsyncAnthropic` is injected by the caller. No module-level client.
 - Errors from the SDK (`anthropic.APIError` and subclasses) propagate
-  unchanged. The one exception: `send_interrupt_and_wait` converts its own
-  timeout — a purely local condition — into `TurnError(kind="interrupt_timeout")`.
+  unchanged unless a helper documents a local recovery path.
 """
 
 from __future__ import annotations
@@ -19,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Literal
 
@@ -54,12 +54,12 @@ class SessionDeletionReport:
 class CancelTurnResult:
     """Result of a session-scoped cancellation request.
 
-    ``cancelled`` means this call posted ``user.interrupt``, observed its idle
-    acknowledgement, and then re-retrieved an idle session. ``already_terminal``
-    is the idempotent no-op path, including a turn that completed between the
-    initial retrieve and the interrupt send. ``cancel_requested`` means the
-    interrupt was posted but terminal idle was not observed before the bounded
-    wait ended; callers must not present it as completed cancellation.
+    ``cancelled`` means this call posted ``user.interrupt`` and then
+    re-retrieved a terminal session (idle or terminated). ``already_terminal``
+    is the no-op path, including a turn that completed between the initial
+    retrieve and the interrupt send. ``cancel_requested`` means the interrupt
+    was posted but a terminal provider state was not observed before the
+    bounded wait ended; callers must not present it as completed cancellation.
     """
 
     session_id: str
@@ -124,8 +124,8 @@ _TERMINAL_STOP_REASONS: frozenset[str] = frozenset({"end_turn", "retries_exhaust
 # paused on a tool approval and the user cancels, the interrupt ack arrives as
 # `requires_action` idle (session is idle/paused, not running). Treating it as
 # terminal here is correct. Do NOT merge this into `_TERMINAL_STOP_REASONS` —
-# that constant lists only the variants `send_interrupt_and_wait` treats as
-# terminal. `terminal_stop_reason()` (below) is a separate, broader helper:
+# that constant lists only genuine completed-turn reasons. The interrupt wait
+# is intentionally broader. `terminal_stop_reason()` (below) is separate:
 # the interactive turn driver treats ANY `session.status_idle` (including
 # `requires_action`) as stream-terminal. No approval/resume loop is wired for
 # interactive surfaces — the driver finalizes a `requires_action` idle as an
@@ -139,51 +139,12 @@ def terminal_stop_reason(event: SessionEvent) -> str | None:
     """Return the ``stop_reason.type`` string for any ``session.status_idle`` event, else None.
 
     Callers decide which variants count as terminal. The turn driver treats any
-    non-None return as terminal; ``send_interrupt_and_wait`` only treats the
-    variants listed in ``_TERMINAL_STOP_REASONS`` as terminal.
+    non-None return as terminal; the cancellation wait accepts the variants in
+    ``_INTERRUPT_TERMINAL``.
     """
     if isinstance(event, BetaManagedAgentsSessionStatusIdleEvent):
         return event.stop_reason.type
     return None
-
-
-async def send_interrupt_and_wait(
-    anthropic: AsyncAnthropic,
-    *,
-    session_id: str,
-    timeout_s: float = 120.0,
-) -> None:
-    """Fire `user.interrupt` against `session_id` and block until MA reaches a
-    terminal idle or `timeout_s` elapses.
-
-    Per refinements §5 (interrupt UX):
-    - POST `user.interrupt`.
-    - Wait up to `timeout_s` (default 120s) for a `session.status_idle` whose
-      `stop_reason.type` is in `_INTERRUPT_TERMINAL` (`end_turn`,
-      `retries_exhausted`, or `requires_action`). `requires_action` IS treated
-      as terminal here — it means the session is idle/paused on a tool approval,
-      so the interrupt ack is valid and the cancel is complete.
-    - On timeout, raise `TurnError(kind="interrupt_timeout")`. The caller (turn
-      driver) converts the in-flight turn to a surfaced failure and tears down.
-
-    The caller owns rendering (`lifecycle.on_render("… interrupting")`). This
-    helper is pure I/O-and-wait.
-    """
-    await anthropic.beta.sessions.events.send(
-        session_id,
-        events=[{"type": "user.interrupt"}],
-    )
-
-    try:
-        await asyncio.wait_for(
-            _wait_for_interrupt_idle(anthropic, session_id=session_id, timeout_s=timeout_s),
-            timeout=timeout_s,
-        )
-    except TimeoutError as err:
-        raise TurnError(
-            kind="interrupt_timeout",
-            message=f"MA did not acknowledge interrupt within {timeout_s}s",
-        ) from err
 
 
 async def _wait_for_interrupt_idle(
@@ -287,28 +248,16 @@ async def cancel_turn(
             status=observed.status,
         )
 
-    try:
+    # Stream closure or timeout can race the provider reaching a terminal
+    # state. The authoritative retrieve below decides the outcome.
+    with suppress(TimeoutError, TurnError):
         await asyncio.wait_for(
             _wait_for_interrupt_idle(anthropic, session_id=session_id, timeout_s=timeout_s),
             timeout=timeout_s,
         )
-    except (TimeoutError, TurnError):
-        observed = await anthropic.beta.sessions.retrieve(session_id)
-        log.warning(
-            "turn.cancel.request_unconfirmed",
-            session_id=session_id,
-            requested_by=requested_by,
-            status=observed.status,
-            timeout_s=timeout_s,
-        )
-        return CancelTurnResult(
-            session_id=session_id,
-            outcome="cancel_requested",
-            status=observed.status,
-        )
 
     observed = await anthropic.beta.sessions.retrieve(session_id)
-    if observed.status != "idle":
+    if observed.status not in {"idle", "terminated"}:
         log.warning(
             "turn.cancel.request_unconfirmed",
             session_id=session_id,

--- a/packages/core/daimon/core/ma.py
+++ b/packages/core/daimon/core/ma.py
@@ -20,6 +20,7 @@ import asyncio
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Literal
 
 import structlog
 from anthropic import APIStatusError, AsyncAnthropic
@@ -47,6 +48,23 @@ class SessionDeletionReport:
     deleted: int = 0
     failed: int = 0
     upstream_error: bool = False
+
+
+@dataclass(frozen=True)
+class CancelTurnResult:
+    """Result of a session-scoped cancellation request.
+
+    ``cancelled`` means this call posted ``user.interrupt``, observed its idle
+    acknowledgement, and then re-retrieved an idle session. ``already_terminal``
+    is the idempotent no-op path, including a turn that completed between the
+    initial retrieve and the interrupt send. ``cancel_requested`` means the
+    interrupt was posted but terminal idle was not observed before the bounded
+    wait ended; callers must not present it as completed cancellation.
+    """
+
+    session_id: str
+    outcome: Literal["cancelled", "already_terminal", "cancel_requested"]
+    status: str
 
 
 # Local alias for SDK ergonomics — short import for call sites. No
@@ -156,25 +174,164 @@ async def send_interrupt_and_wait(
         events=[{"type": "user.interrupt"}],
     )
 
-    async def _wait_for_terminal_idle() -> None:
-        stream = await anthropic.beta.sessions.events.stream(session_id=session_id)
-        async for event in stream:
-            if not isinstance(event, BetaManagedAgentsSessionStatusIdleEvent):
-                continue
-            if event.stop_reason.type in _INTERRUPT_TERMINAL:
-                return
-        raise TurnError(
-            kind="interrupt_timeout",
-            message=f"MA SSE stream closed without terminal idle (timeout {timeout_s}s)",
-        )
-
     try:
-        await asyncio.wait_for(_wait_for_terminal_idle(), timeout=timeout_s)
+        await asyncio.wait_for(
+            _wait_for_interrupt_idle(anthropic, session_id=session_id, timeout_s=timeout_s),
+            timeout=timeout_s,
+        )
     except TimeoutError as err:
         raise TurnError(
             kind="interrupt_timeout",
             message=f"MA did not acknowledge interrupt within {timeout_s}s",
         ) from err
+
+
+async def _wait_for_interrupt_idle(
+    anthropic: AsyncAnthropic,
+    *,
+    session_id: str,
+    timeout_s: float,
+) -> None:
+    """Wait for a terminal idle event after an interrupt has been posted."""
+    stream = await anthropic.beta.sessions.events.stream(session_id=session_id)
+    async for event in stream:
+        if not isinstance(event, BetaManagedAgentsSessionStatusIdleEvent):
+            continue
+        if event.stop_reason.type in _INTERRUPT_TERMINAL:
+            return
+    raise TurnError(
+        kind="interrupt_timeout",
+        message=f"MA SSE stream closed without terminal idle (timeout {timeout_s}s)",
+    )
+
+
+async def cancel_turn(
+    anthropic: AsyncAnthropic,
+    *,
+    session_id: str,
+    requested_by: str,
+    timeout_s: float = 120.0,
+) -> CancelTurnResult:
+    """Cancel the active turn in ``session_id`` and await terminal idle.
+
+    Cancellation is cooperative at the Managed Agents interrupt boundary: an
+    in-flight provider/tool operation may finish before ``user.interrupt`` is
+    applied. The provider records that interrupt and a terminal
+    ``session.status_idle`` event, so transcript readers converge and the
+    session remains readable and continuable.
+
+    Idle and terminated sessions are terminal already, so cancellation is an
+    idempotent no-op. If the bounded acknowledgement wait ends first, the
+    result is ``cancel_requested`` and the session stays recoverable. Billing
+    remains event based: completed ``span.model_request_end`` charges stand;
+    no reserve or refund exists, and cancellation adds no usage event.
+    """
+    session = await anthropic.beta.sessions.retrieve(session_id)
+    if session.status == "idle" or session.status == "terminated":
+        log.info(
+            "turn.cancel.already_terminal",
+            session_id=session_id,
+            requested_by=requested_by,
+            status=session.status,
+        )
+        return CancelTurnResult(
+            session_id=session_id,
+            outcome="already_terminal",
+            status=session.status,
+        )
+
+    log.info(
+        "turn.cancel.requested",
+        session_id=session_id,
+        requested_by=requested_by,
+    )
+    try:
+        await anthropic.beta.sessions.events.send(
+            session_id,
+            events=[{"type": "user.interrupt"}],
+        )
+    except APIStatusError:
+        # Normal completion can win the retrieve-then-send race. Confirm that
+        # state before surfacing the provider's rejected interrupt.
+        observed = await anthropic.beta.sessions.retrieve(session_id)
+        if observed.status in {"idle", "terminated"}:
+            log.info(
+                "turn.cancel.already_terminal",
+                session_id=session_id,
+                requested_by=requested_by,
+                status=observed.status,
+                raced_interrupt=True,
+            )
+            return CancelTurnResult(
+                session_id=session_id,
+                outcome="already_terminal",
+                status=observed.status,
+            )
+        raise
+
+    # Close the retrieve-then-act race before opening another stream. If the
+    # original turn completed around the send, there may be no future idle
+    # event for a waiter to observe.
+    observed = await anthropic.beta.sessions.retrieve(session_id)
+    if observed.status in {"idle", "terminated"}:
+        log.info(
+            "turn.cancel.already_terminal",
+            session_id=session_id,
+            requested_by=requested_by,
+            status=observed.status,
+            raced_interrupt=True,
+        )
+        return CancelTurnResult(
+            session_id=session_id,
+            outcome="already_terminal",
+            status=observed.status,
+        )
+
+    try:
+        await asyncio.wait_for(
+            _wait_for_interrupt_idle(anthropic, session_id=session_id, timeout_s=timeout_s),
+            timeout=timeout_s,
+        )
+    except (TimeoutError, TurnError):
+        observed = await anthropic.beta.sessions.retrieve(session_id)
+        log.warning(
+            "turn.cancel.request_unconfirmed",
+            session_id=session_id,
+            requested_by=requested_by,
+            status=observed.status,
+            timeout_s=timeout_s,
+        )
+        return CancelTurnResult(
+            session_id=session_id,
+            outcome="cancel_requested",
+            status=observed.status,
+        )
+
+    observed = await anthropic.beta.sessions.retrieve(session_id)
+    if observed.status != "idle":
+        log.warning(
+            "turn.cancel.request_unconfirmed",
+            session_id=session_id,
+            requested_by=requested_by,
+            status=observed.status,
+            timeout_s=timeout_s,
+        )
+        return CancelTurnResult(
+            session_id=session_id,
+            outcome="cancel_requested",
+            status=observed.status,
+        )
+    log.info(
+        "turn.cancel.acknowledged",
+        session_id=session_id,
+        requested_by=requested_by,
+        status=observed.status,
+    )
+    return CancelTurnResult(
+        session_id=session_id,
+        outcome="cancelled",
+        status=observed.status,
+    )
 
 
 # HTTP status codes that indicate a stale-version conflict on agents.update.

--- a/packages/core/daimon/core/ma.py
+++ b/packages/core/daimon/core/ma.py
@@ -153,9 +153,11 @@ async def _wait_for_interrupt_idle(
     session_id: str,
     timeout_s: float,
 ) -> None:
-    """Wait for a terminal idle event after an interrupt has been posted."""
+    """Wait for a terminal idle or terminated event after an interrupt is posted."""
     stream = await anthropic.beta.sessions.events.stream(session_id=session_id)
     async for event in stream:
+        if event.type == "session.status_terminated":
+            return
         if not isinstance(event, BetaManagedAgentsSessionStatusIdleEvent):
             continue
         if event.stop_reason.type in _INTERRUPT_TERMINAL:

--- a/packages/core/daimon/core/turn/driver.py
+++ b/packages/core/daimon/core/turn/driver.py
@@ -59,7 +59,8 @@ from anthropic.types.beta.sessions import (
     BetaManagedAgentsUserMessageEventParams,
 )
 from daimon.core.errors import TurnError
-from daimon.core.ma import replay_events, send_interrupt_and_wait, terminal_stop_reason
+from daimon.core.ma import cancel_turn as cancel_session_turn
+from daimon.core.ma import replay_events, terminal_stop_reason
 from daimon.core.turn.approvals import build_confirmation_events, pending_confirmation_ids
 from daimon.core.turn.ceiling import ceiling_error, remaining_s
 from daimon.core.turn.lifecycle import ReconnectReason, TurnLifecycle
@@ -1053,18 +1054,29 @@ async def _handle_interrupt_in_consume(
     interrupt_timeout_s: float,
     renders_failed: int,
 ) -> TurnState:
-    """Normal-flow interrupt: post user.interrupt, wait for terminal idle,
-    route to on_terminal_success on ack or on_terminal_failure on timeout.
+    """Normal-flow interrupt through the shared session cancellation primitive.
+
+    Route to on_terminal_success only for an observed terminal outcome, or to
+    on_terminal_failure when the interrupt remains merely requested.
     """
     try:
-        await send_interrupt_and_wait(
+        result = await cancel_session_turn(
             anthropic,
             session_id=session_id,
+            requested_by="turn_driver",
             timeout_s=interrupt_timeout_s,
         )
+        if result.outcome != "already_terminal":
+            await lifecycle.on_interrupt_sent("cancel_event")
+        if result.outcome == "cancel_requested":
+            raise TurnError(
+                kind="interrupt_timeout",
+                message=(
+                    "MA did not confirm terminal idle after the interrupt request; "
+                    f"observed session status is {result.status!r}"
+                ),
+            )
     except TurnError as err:
-        # send_interrupt_and_wait raises TurnError(kind="interrupt_timeout")
-        # on its timeout; propagate through the on_terminal_failure path.
         log.warning(
             "turn.interrupt.timeout",
             session_id=session_id,
@@ -1082,9 +1094,12 @@ async def _handle_interrupt_in_consume(
         await lifecycle.on_terminal_failure(state_cell[0], err)
         return state_cell[0]
 
-    log.info("turn.interrupt.sent", session_id=session_id)
-    await lifecycle.on_interrupt_sent("cancel_event")
-    log.info("turn.interrupt.acked", session_id=session_id)
+    log.info(
+        "turn.interrupt.acked",
+        session_id=session_id,
+        outcome=result.outcome,
+        status=result.status,
+    )
     # Ack arrived -- partial state is "clean" (refinements §5).
     await render_once(state_cell[0])
     log.info(

--- a/packages/core/tests/test_ma.py
+++ b/packages/core/tests/test_ma.py
@@ -38,6 +38,7 @@ from daimon.core.ma import (
     _INTERRUPT_TERMINAL,
     _TERMINAL_STOP_REASONS,
     WORKSPACE_SENTINEL_AGENT_NAME,
+    cancel_turn,
     delete_entire_workspace_for_testing,
     delete_sessions_for_account,
     find_workspace_disposable_sentinel,
@@ -267,6 +268,116 @@ async def test_send_interrupt_and_wait_raises_turn_error_when_timeout_fires() ->
     assert "0.05" in exc_info.value.message or "timeout" in exc_info.value.message.lower(), (
         "message should indicate timeout duration for operator log context"
     )
+
+
+def _build_cancel_client(
+    *,
+    statuses: list[str],
+    stream_events: Sequence[BetaManagedAgentsSessionEvent] = (),
+) -> tuple[Any, list[dict[str, Any]], dict[str, int]]:
+    """Build a fake MA client whose retrieve status advances per call."""
+    remaining_statuses = list(statuses)
+    sent_events: list[dict[str, Any]] = []
+    calls = {"retrieve": 0, "stream": 0}
+    router = MARouter()
+
+    def handle_retrieve(request: httpx.Request, match: Any) -> httpx.Response:
+        calls["retrieve"] += 1
+        assert remaining_statuses, "test did not configure enough observed statuses"
+        session = _make_session("sesn_cancel", "agent_test", None)
+        payload = session.model_dump(mode="json")
+        payload["status"] = remaining_statuses.pop(0)
+        return httpx.Response(200, json=payload)
+
+    def handle_send(request: httpx.Request, match: Any) -> httpx.Response:
+        body: dict[str, Any] = json.loads(request.content)
+        sent_events.extend(body.get("events", []))
+        return httpx.Response(200, json={"data": None})
+
+    def handle_stream(request: httpx.Request, match: Any) -> httpx.Response:
+        calls["stream"] += 1
+        return sse_response([event.model_dump(mode="json") for event in stream_events])
+
+    router.add("GET", r"/v1/sessions/[^/]+", handle_retrieve)
+    router.add("POST", r"/v1/sessions/[^/]+/events", handle_send)
+    router.add("GET", r"/v1/sessions/[^/]+/events/stream", handle_stream)
+    return build_fake_anthropic(router.dispatch), sent_events, calls
+
+
+async def test_cancel_turn_happy_path_returns_observed_idle() -> None:
+    client, sent_events, calls = _build_cancel_client(
+        statuses=["running", "running", "idle"],
+        stream_events=[_idle("sevt_cancel_ack")],
+    )
+
+    result = await cancel_turn(
+        client,
+        session_id="sesn_cancel",
+        requested_by="test",
+        timeout_s=1.0,
+    )
+
+    assert result.outcome == "cancelled"
+    assert result.status == "idle"
+    assert calls == {"retrieve": 3, "stream": 1}, (
+        "cancelled requires a post-ack provider retrieve, not an asserted idle"
+    )
+    assert sent_events == [{"type": "user.interrupt"}]
+
+
+async def test_cancel_turn_timeout_returns_cancel_requested() -> None:
+    client, sent_events, calls = _build_cancel_client(
+        statuses=["running", "running", "running"],
+        stream_events=[_user_message("sevt_still_running", "still running")],
+    )
+
+    result = await cancel_turn(
+        client,
+        session_id="sesn_cancel",
+        requested_by="test",
+        timeout_s=0.05,
+    )
+
+    assert result.outcome == "cancel_requested", (
+        "an unacknowledged interrupt must never be reported as cancelled"
+    )
+    assert result.status == "running"
+    assert calls == {"retrieve": 3, "stream": 1}
+    assert sent_events == [{"type": "user.interrupt"}]
+
+
+async def test_cancel_turn_toctou_completion_returns_already_terminal() -> None:
+    client, sent_events, calls = _build_cancel_client(statuses=["running", "idle"])
+
+    result = await cancel_turn(
+        client,
+        session_id="sesn_cancel",
+        requested_by="test",
+        timeout_s=0.05,
+    )
+
+    assert result.outcome == "already_terminal"
+    assert result.status == "idle"
+    assert calls == {"retrieve": 2, "stream": 0}, (
+        "normal completion that wins the send race must not open a 120-second waiter"
+    )
+    assert sent_events == [{"type": "user.interrupt"}]
+
+
+async def test_cancel_turn_idempotent_on_terminal_session() -> None:
+    client, sent_events, calls = _build_cancel_client(statuses=["terminated"])
+
+    result = await cancel_turn(
+        client,
+        session_id="sesn_cancel",
+        requested_by="test",
+        timeout_s=0.05,
+    )
+
+    assert result.outcome == "already_terminal"
+    assert result.status == "terminated"
+    assert calls == {"retrieve": 1, "stream": 0}
+    assert sent_events == [], "terminal sessions must not receive user.interrupt"
 
 
 def test_terminal_stop_reason_returns_end_turn_on_idle_end_turn() -> None:

--- a/packages/core/tests/test_ma.py
+++ b/packages/core/tests/test_ma.py
@@ -43,7 +43,6 @@ from daimon.core.ma import (
     delete_sessions_for_account,
     find_workspace_disposable_sentinel,
     replay_events,
-    send_interrupt_and_wait,
     terminal_stop_reason,
     update_agent_with_version_retry,
 )
@@ -146,87 +145,15 @@ async def test_replay_events_raises_turn_error_when_paginator_stalls_past_timeou
     )
 
 
-async def test_send_interrupt_and_wait_sends_user_interrupt_when_invoked() -> None:
-    sent_events: list[dict[str, Any]] = []
-
-    router = MARouter()
-
-    def handle_send(request: httpx.Request, match: Any) -> httpx.Response:
-        body: dict[str, Any] = json.loads(request.content)
-        sent_events.extend(body.get("events", []))
-        return httpx.Response(200, json={"data": None})
-
-    def handle_stream(request: httpx.Request, match: Any) -> httpx.Response:
-        idle = _idle("sevt_1", stop="end_turn")
-        return sse_response([idle.model_dump(mode="json")])
-
-    router.add("POST", r"/v1/sessions/[^/]+/events", handle_send)
-    router.add("GET", r"/v1/sessions/[^/]+/events/stream", handle_stream)
-
-    client = build_fake_anthropic(router.dispatch)
-
-    await send_interrupt_and_wait(client, session_id="sesn_test", timeout_s=1.0)
-
-    assert len(sent_events) == 1, "must have sent exactly one event"
-    assert sent_events[0] == {"type": "user.interrupt"}, (
-        "SDK body carries a single `user.interrupt` event param"
-    )
-
-
-async def test_send_interrupt_and_wait_returns_when_terminal_idle_arrives() -> None:
-    router = MARouter()
-
-    def handle_send(request: httpx.Request, match: Any) -> httpx.Response:
-        return httpx.Response(200, json={"data": None})
-
-    def handle_stream(request: httpx.Request, match: Any) -> httpx.Response:
-        events = [
-            _user_message("sevt_a", "hi"),  # not a terminal
-            _idle("sevt_b", stop="end_turn"),  # terminal
-        ]
-        return sse_response([e.model_dump(mode="json") for e in events])
-
-    router.add("POST", r"/v1/sessions/[^/]+/events", handle_send)
-    router.add("GET", r"/v1/sessions/[^/]+/events/stream", handle_stream)
-    client = build_fake_anthropic(router.dispatch)
-
-    # Should not raise — idle arrives before timeout.
-    await send_interrupt_and_wait(client, session_id="sesn_test", timeout_s=1.0)
-
-
-async def test_send_interrupt_and_wait_treats_requires_action_as_terminal() -> None:
-    """`requires_action` means the session is idle (paused on tool approval) —
-    for interrupt purposes, this IS terminal. The cancel is complete: the turn
-    was running, user hit cancel, and MA confirmed idle (paused on a tool call
-    it will never execute now). Helper must return normally, not time out."""
-    router = MARouter()
-
-    def handle_send(request: httpx.Request, match: Any) -> httpx.Response:
-        return httpx.Response(200, json={"data": None})
-
-    def handle_stream(request: httpx.Request, match: Any) -> httpx.Response:
-        idle = _idle("sevt_a", stop="requires_action")
-        return sse_response([idle.model_dump(mode="json")])
-
-    router.add("POST", r"/v1/sessions/[^/]+/events", handle_send)
-    router.add("GET", r"/v1/sessions/[^/]+/events/stream", handle_stream)
-    client = build_fake_anthropic(router.dispatch)
-
-    # Should not raise — requires_action is now terminal for interrupt acks.
-    await send_interrupt_and_wait(client, session_id="sesn_test", timeout_s=1.0)
-
-
-def test_send_interrupt_and_wait_interrupt_terminal_is_superset_of_terminal_stop_reasons() -> None:
+def test_cancel_turn_interrupt_terminal_is_superset_of_terminal_stop_reasons() -> None:
     """_INTERRUPT_TERMINAL must be a strict superset of _TERMINAL_STOP_REASONS.
 
-    _TERMINAL_STOP_REASONS lists only the variants
-    `send_interrupt_and_wait` treats as terminal. `terminal_stop_reason()` (the
-    driver's broader helper) treats ANY status_idle, including requires_action,
-    as stream-terminal -- the driver has no approval/resume loop; it finalizes
-    requires_action as an actionable failure. _INTERRUPT_TERMINAL extends
-    _TERMINAL_STOP_REASONS with requires_action for the cancel-button path
-    only. This structural test ensures no one collapses the two constants
-    together.
+    The driver's broader helper treats ANY status_idle, including
+    requires_action, as stream-terminal -- the driver has no approval/resume
+    loop; it finalizes requires_action as an actionable failure.
+    _INTERRUPT_TERMINAL extends genuine completion reasons with
+    requires_action for the cancel path only. This structural test ensures no
+    one collapses the two constants together.
     """
     assert _TERMINAL_STOP_REASONS < _INTERRUPT_TERMINAL, (
         "_TERMINAL_STOP_REASONS must be a strict subset of _INTERRUPT_TERMINAL"
@@ -236,37 +163,6 @@ def test_send_interrupt_and_wait_interrupt_terminal_is_superset_of_terminal_stop
     )
     assert "requires_action" not in _TERMINAL_STOP_REASONS, (
         "_TERMINAL_STOP_REASONS must NOT include requires_action (driver approval loop)"
-    )
-
-
-async def test_send_interrupt_and_wait_raises_turn_error_when_timeout_fires() -> None:
-    # Stream yields only non-terminal events, then ends; helper must time out.
-    # Transport-level: response body ends after yielding non-terminal events.
-    # The SDK's stream parser closes the iterator when the body ends.
-    # Since run_turn breaks on status_idle before reaching end, but here we
-    # only yield non-terminals, the stream closes without a terminal idle —
-    # the asyncio.wait_for fires.
-    router = MARouter()
-
-    def handle_send(request: httpx.Request, match: Any) -> httpx.Response:
-        return httpx.Response(200, json={"data": None})
-
-    def handle_stream(request: httpx.Request, match: Any) -> httpx.Response:
-        non_terminal = _user_message("sevt_a", "still going")
-        return sse_response([non_terminal.model_dump(mode="json")])
-
-    router.add("POST", r"/v1/sessions/[^/]+/events", handle_send)
-    router.add("GET", r"/v1/sessions/[^/]+/events/stream", handle_stream)
-    client = build_fake_anthropic(router.dispatch)
-
-    with pytest.raises(TurnError) as exc_info:
-        await send_interrupt_and_wait(client, session_id="sesn_test", timeout_s=0.05)
-
-    assert exc_info.value.kind == "interrupt_timeout", (
-        "timeout path must surface as TurnError(kind='interrupt_timeout')"
-    )
-    assert "0.05" in exc_info.value.message or "timeout" in exc_info.value.message.lower(), (
-        "message should indicate timeout duration for operator log context"
     )
 
 
@@ -304,10 +200,14 @@ def _build_cancel_client(
     return build_fake_anthropic(router.dispatch), sent_events, calls
 
 
-async def test_cancel_turn_happy_path_returns_observed_idle() -> None:
+@pytest.mark.parametrize("stop_reason", ["end_turn", "retries_exhausted", "requires_action"])
+async def test_cancel_turn_happy_path_returns_observed_idle(stop_reason: str) -> None:
     client, sent_events, calls = _build_cancel_client(
         statuses=["running", "running", "idle"],
-        stream_events=[_idle("sevt_cancel_ack")],
+        stream_events=[
+            _user_message("sevt_still_running", "still running"),
+            _idle("sevt_cancel_ack", stop=stop_reason),
+        ],
     )
 
     result = await cancel_turn(
@@ -322,6 +222,44 @@ async def test_cancel_turn_happy_path_returns_observed_idle() -> None:
     assert calls == {"retrieve": 3, "stream": 1}, (
         "cancelled requires a post-ack provider retrieve, not an asserted idle"
     )
+    assert sent_events == [{"type": "user.interrupt"}]
+
+
+async def test_cancel_turn_post_ack_terminated_returns_cancelled() -> None:
+    client, sent_events, calls = _build_cancel_client(
+        statuses=["running", "running", "terminated"],
+        stream_events=[_idle("sevt_cancel_ack")],
+    )
+
+    result = await cancel_turn(
+        client,
+        session_id="sesn_cancel",
+        requested_by="test",
+        timeout_s=1.0,
+    )
+
+    assert result.outcome == "cancelled"
+    assert result.status == "terminated"
+    assert calls == {"retrieve": 3, "stream": 1}
+    assert sent_events == [{"type": "user.interrupt"}]
+
+
+async def test_cancel_turn_stream_closure_with_terminated_status_returns_cancelled() -> None:
+    client, sent_events, calls = _build_cancel_client(
+        statuses=["running", "running", "terminated"],
+        stream_events=[_user_message("sevt_still_running", "still running")],
+    )
+
+    result = await cancel_turn(
+        client,
+        session_id="sesn_cancel",
+        requested_by="test",
+        timeout_s=0.05,
+    )
+
+    assert result.outcome == "cancelled"
+    assert result.status == "terminated"
+    assert calls == {"retrieve": 3, "stream": 1}
     assert sent_events == [{"type": "user.interrupt"}]
 
 

--- a/packages/core/tests/test_ma.py
+++ b/packages/core/tests/test_ma.py
@@ -6,6 +6,7 @@ import re
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -26,6 +27,7 @@ from anthropic.types.beta.sessions import (
     BetaManagedAgentsSessionRequiresAction,
     BetaManagedAgentsSessionRetriesExhausted,
     BetaManagedAgentsSessionStatusIdleEvent,
+    BetaManagedAgentsSessionStatusTerminatedEvent,
     BetaManagedAgentsTextBlock,
     BetaManagedAgentsUserMessageEvent,
 )
@@ -38,6 +40,7 @@ from daimon.core.ma import (
     _INTERRUPT_TERMINAL,
     _TERMINAL_STOP_REASONS,
     WORKSPACE_SENTINEL_AGENT_NAME,
+    _wait_for_interrupt_idle,
     cancel_turn,
     delete_entire_workspace_for_testing,
     delete_sessions_for_account,
@@ -99,6 +102,21 @@ def _make_list_client(events: Sequence[BetaManagedAgentsSessionEvent]) -> Any:
 
     router.add("GET", r"/v1/sessions/[^/]+/events", handle_list)
     return build_fake_anthropic(router.dispatch)
+
+
+def _stream_client_yielding(events: Sequence[Any]) -> Any:
+    """Build a client whose session stream yields the supplied events."""
+    client = build_fake_anthropic(MARouter().dispatch)
+
+    async def _aiter() -> Any:
+        for event in events:
+            yield event
+
+    async def _stream(*, session_id: str) -> Any:
+        return _aiter()
+
+    client.beta.sessions.events.stream = _stream  # type: ignore[assignment]
+    return client
 
 
 async def test_replay_events_returns_all_events_in_order_when_paginator_yields_multiple() -> None:
@@ -166,10 +184,44 @@ def test_cancel_turn_interrupt_terminal_is_superset_of_terminal_stop_reasons() -
     )
 
 
+@pytest.mark.parametrize("stop_reason", ["end_turn", "retries_exhausted", "requires_action"])
+async def test_wait_for_interrupt_idle_returns_for_terminal_idle(stop_reason: str) -> None:
+    client = _stream_client_yielding(
+        [_user_message("sevt_running", "still running"), _idle("sevt_terminal", stop_reason)]
+    )
+
+    await _wait_for_interrupt_idle(client, session_id="sesn_cancel", timeout_s=1.0)
+
+
+async def test_wait_for_interrupt_idle_returns_for_session_terminated() -> None:
+    terminated = BetaManagedAgentsSessionStatusTerminatedEvent(
+        id="sevt_terminated",
+        type="session.status_terminated",
+        processed_at=datetime(2026, 4, 21, tzinfo=UTC),
+    )
+    client = _stream_client_yielding([terminated])
+
+    await _wait_for_interrupt_idle(client, session_id="sesn_cancel", timeout_s=1.0)
+
+
+async def test_wait_for_interrupt_idle_raises_for_non_terminal_idle() -> None:
+    # The current SDK union has no max_tokens variant, but the waiter must fail
+    # closed if MA adds or emits a non-terminal idle reason.
+    max_tokens = _idle("sevt_max_tokens")
+    object.__setattr__(max_tokens, "stop_reason", SimpleNamespace(type="max_tokens"))
+    client = _stream_client_yielding([max_tokens])
+
+    with pytest.raises(TurnError) as exc_info:
+        await _wait_for_interrupt_idle(client, session_id="sesn_cancel", timeout_s=1.0)
+
+    assert exc_info.value.kind == "interrupt_timeout"
+
+
 def _build_cancel_client(
     *,
     statuses: list[str],
     stream_events: Sequence[BetaManagedAgentsSessionEvent] = (),
+    send_status: int = 200,
 ) -> tuple[Any, list[dict[str, Any]], dict[str, int]]:
     """Build a fake MA client whose retrieve status advances per call."""
     remaining_statuses = list(statuses)
@@ -188,7 +240,15 @@ def _build_cancel_client(
     def handle_send(request: httpx.Request, match: Any) -> httpx.Response:
         body: dict[str, Any] = json.loads(request.content)
         sent_events.extend(body.get("events", []))
-        return httpx.Response(200, json={"data": None})
+        if send_status == 200:
+            return httpx.Response(200, json={"data": None})
+        return httpx.Response(
+            send_status,
+            json={
+                "type": "error",
+                "error": {"type": "api_error", "message": "interrupt send failed"},
+            },
+        )
 
     def handle_stream(request: httpx.Request, match: Any) -> httpx.Response:
         calls["stream"] += 1
@@ -197,7 +257,7 @@ def _build_cancel_client(
     router.add("GET", r"/v1/sessions/[^/]+", handle_retrieve)
     router.add("POST", r"/v1/sessions/[^/]+/events", handle_send)
     router.add("GET", r"/v1/sessions/[^/]+/events/stream", handle_stream)
-    return build_fake_anthropic(router.dispatch), sent_events, calls
+    return _build_no_retry_anthropic(router), sent_events, calls
 
 
 @pytest.mark.parametrize("stop_reason", ["end_turn", "retries_exhausted", "requires_action"])
@@ -263,7 +323,7 @@ async def test_cancel_turn_stream_closure_with_terminated_status_returns_cancell
     assert sent_events == [{"type": "user.interrupt"}]
 
 
-async def test_cancel_turn_timeout_returns_cancel_requested() -> None:
+async def test_cancel_turn_stream_closure_returns_cancel_requested() -> None:
     client, sent_events, calls = _build_cancel_client(
         statuses=["running", "running", "running"],
         stream_events=[_user_message("sevt_still_running", "still running")],
@@ -281,6 +341,44 @@ async def test_cancel_turn_timeout_returns_cancel_requested() -> None:
     )
     assert result.status == "running"
     assert calls == {"retrieve": 3, "stream": 1}
+    assert sent_events == [{"type": "user.interrupt"}]
+
+
+async def test_cancel_turn_send_conflict_reclassifies_terminal_race() -> None:
+    client, sent_events, calls = _build_cancel_client(
+        statuses=["running", "idle"],
+        send_status=409,
+    )
+
+    result = await cancel_turn(
+        client,
+        session_id="sesn_cancel",
+        requested_by="test",
+        timeout_s=0.05,
+    )
+
+    assert result.outcome == "already_terminal"
+    assert result.status == "idle"
+    assert calls == {"retrieve": 2, "stream": 0}
+    assert sent_events == [{"type": "user.interrupt"}]
+
+
+async def test_cancel_turn_send_server_error_propagates_for_running_session() -> None:
+    client, sent_events, calls = _build_cancel_client(
+        statuses=["running", "running"],
+        send_status=500,
+    )
+
+    with pytest.raises(APIStatusError) as exc_info:
+        await cancel_turn(
+            client,
+            session_id="sesn_cancel",
+            requested_by="test",
+            timeout_s=0.05,
+        )
+
+    assert exc_info.value.status_code == 500
+    assert calls == {"retrieve": 2, "stream": 0}
     assert sent_events == [{"type": "user.interrupt"}]
 
 
@@ -585,10 +683,9 @@ def _conflict_response() -> httpx.Response:
 def _build_no_retry_anthropic(router: MARouter) -> AsyncAnthropic:
     """Build an AsyncAnthropic with max_retries=0 backed by the given MARouter.
 
-    The SDK auto-retries 409 by default (max_retries=2). Tests for
-    update_agent_with_version_retry must disable SDK retries so the helper's
-    own retry logic is exercised in isolation — otherwise the SDK consumes
-    the first conflict internally before our code can inspect it.
+    The SDK auto-retries selected status errors by default (max_retries=2).
+    Tests for local status-error recovery must disable SDK retries so the
+    helper's own branch is exercised in isolation.
     """
     return AsyncAnthropic(
         api_key="test",

--- a/packages/core/tests/turn/test_driver.py
+++ b/packages/core/tests/turn/test_driver.py
@@ -583,6 +583,7 @@ async def test_interrupt_mid_consume_posts_user_interrupt_and_ends_clean_on_ack(
         [YieldEvent(pre), BlockForever()],
         [YieldEvent(make_status_idle(event_id="ack", stop_reason=make_end_turn()))],
     ]
+    fa.beta.sessions.retrieve_statuses = ["running", "running", "idle"]
     cancel = asyncio.Event()
     lc = RecordingLifecycle()
 
@@ -620,6 +621,7 @@ async def test_interrupt_mid_consume_timeout_surfaces_interrupt_timeout() -> Non
         [BlockForever()],
         [BlockForever()],  # ack-waiter never sees terminal idle
     ]
+    fa.beta.sessions.retrieve_statuses = ["running", "running", "running"]
     cancel = asyncio.Event()
     lc = RecordingLifecycle()
 

--- a/packages/core/tests/turn/test_driver_cancel.py
+++ b/packages/core/tests/turn/test_driver_cancel.py
@@ -224,6 +224,7 @@ async def test_interrupt_mid_consume_still_posts_user_interrupt_regression() -> 
         [BlockForever()],
         [YieldEvent(make_status_idle(event_id="ack", stop_reason=make_end_turn()))],
     ]
+    fa.beta.sessions.retrieve_statuses = ["running", "running", "idle"]
     cancel = asyncio.Event()
     lc = RecordingLifecycle()
 

--- a/packages/core/tests/turn/test_driver_hooks.py
+++ b/packages/core/tests/turn/test_driver_hooks.py
@@ -179,6 +179,7 @@ async def test_driver_calls_on_interrupt_sent_when_sigint() -> None:
         [YieldEvent(pre), BlockForever()],
         [YieldEvent(make_status_idle(event_id="ack", stop_reason=make_end_turn()))],
     ]
+    fa.beta.sessions.retrieve_statuses = ["running", "running", "idle"]
     cancel = asyncio.Event()
     lc = RecordingLifecycle()
 

--- a/packages/testing/daimon/testing/turn_fakes.py
+++ b/packages/testing/daimon/testing/turn_fakes.py
@@ -21,7 +21,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 import anthropic
 import httpx
@@ -128,6 +128,7 @@ StreamAction = (
     | RaiseReadTimeout
     | DelayThenYield
 )
+SessionStatus = Literal["rescheduling", "running", "idle", "terminated"]
 
 
 @dataclass
@@ -225,7 +226,7 @@ class _FakeEventList:
             yield e
 
 
-def _make_session(*, session_id: str, status: str) -> BetaManagedAgentsSession:
+def _make_session(*, session_id: str, status: SessionStatus) -> BetaManagedAgentsSession:
     """Build a real `BetaManagedAgentsSession` with fixed, obviously-fake
     values, via the SDK's own validated Pydantic construction -- see
     `guideline:testing`'s validated-construction rule for why unvalidated
@@ -234,7 +235,7 @@ def _make_session(*, session_id: str, status: str) -> BetaManagedAgentsSession:
     return BetaManagedAgentsSession(
         id=session_id,
         type="session",
-        status=status,  # pyright: ignore[reportArgumentType]
+        status=status,
         agent=BetaManagedAgentsSessionAgent(
             id="agent_fake",
             type="agent",
@@ -272,7 +273,7 @@ class FakeSessionsBeta:
     """
 
     events: FakeEventsResource = field(default_factory=FakeEventsResource)
-    retrieve_statuses: list[str] = field(default_factory=list[str])
+    retrieve_statuses: list[SessionStatus] = field(default_factory=list[SessionStatus])
     retrieve_calls: list[str] = field(default_factory=list[str])
     retrieve_raises: Exception | None = None
 


### PR DESCRIPTION
## Summary

Hosted agent-chat clients could start and observe a Managed Agents turn, but they had no session-level stop control. Slack already propagated its local Cancel event through the shared turn driver to a provider `user.interrupt`; an external client dropping its session handle, however, did not send an interrupt, so provider work could continue until completion or deadline and completed model-request usage remained billable.

This PR adds `daimon.core.ma.cancel_turn()` with three observed outcomes:

- `cancelled`: this call posted `user.interrupt` and a final retrieve observed `idle` or `terminated`.
- `already_terminal`: the session was already terminal, or normal completion won a retrieve/send race.
- `cancel_requested`: the interrupt was posted but a terminal provider state was not observed before the bounded wait ended.

The primitive retrieves before sending, posts one `user.interrupt`, handles both retrieve/send completion races, waits up to 120 seconds for terminal idle or terminated, and re-retrieves provider state before reporting success. A timeout or closed stream is not itself success.

The MCP `cancel_turn(session_id)` tool reuses the same derived-agent owner check as `continue_turn`. It deliberately bypasses the billing admission gate so a caller can stop work after reaching a balance or cap. The existing Slack Cancel path reaches the new primitive transitively through the shared turn driver, replacing the old core `send_interrupt_and_wait` helper.

Review hardening adds direct waiter coverage for `end_turn`, `retries_exhausted`, `requires_action`, and `session.status_terminated`, plus fail-closed coverage for a synthetic non-terminal `max_tokens` reason. Router tests cover the send-race `APIStatusError` branch: a 409 followed by terminal retrieval becomes `already_terminal`, while a 500 followed by a still-running retrieval propagates. The MCP annotation remains `idempotentHint=false` because a repeated call after an unconfirmed `cancel_requested` result may post another interrupt.

Cancellation remains cooperative at the Managed Agents boundary. An in-flight provider or tool operation may finish before the interrupt takes effect; completed `span.model_request_end` usage remains chargeable, cancellation emits no usage event, and there is no reserve/refund path. `test_cancel_turn_stream_closure_returns_cancel_requested` specifically pins finite SSE stream closure without a terminal event: when the authoritative final retrieve still reports `running`, Daimon does not claim cancellation. The driver's held-open stream test separately covers a real local timeout.

The existing session read and continuation APIs are unchanged, but real-provider interruption timing, transcript persistence, and continuation after cancellation still require hosted UAT.

CI run [32912391205](https://github.com/pymc-labs/daimon/actions/runs/32912391205) completed successfully at exact head `3d8161c69a49c7c8afb64ff912b424ccbf8e3ce4`: all eight executable jobs passed and the staging deploy job was skipped.

Closes #116

## Checklist

- [x] Tests added or updated for the cancellation behavior and race branches described above
- [x] `uv run pytest packages/core/tests/test_ma.py packages/core/tests/turn/ packages/adapters/mcp/tests/tools/test_agent_chat.py` — 183 passed, 3 dependency warnings
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run lint-imports` — 372 files / 1,589 dependencies analyzed; 6 contracts kept, 0 broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)