### PR TITLE
feat(eval): add typed final-answer claims contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ whole team, in the thread — and hands back a notebook anyone can run.
 - CLI and MCP adapters sharing the same core turn pipeline
 - Tenant isolation enforced at the database `tenant_id` layer, so one shared
   Anthropic key can safely power every guild
+- Optional [typed final-answer claims](docs/typed-claims.md) let deployments
+  evaluate headline numbers without scraping formatted prose
 
 ## What you can ask it
 

--- a/docs/typed-claims.md
+++ b/docs/typed-claims.md
@@ -9,7 +9,7 @@ on presentation-sensitive regular expressions.
 Revenue was $7.57M for the period.
 
 ```claims
-[{"metric":"revenue","value":7571234,"unit":"usd","basis":"invoices","as_of":"2026-06-30","source":"semantic.revenue"}]
+[{"metric":"revenue","value":7571234,"unit":"usd","basis":"invoices","as_of":"2026-06-30","source":"invoices.total"}]
 ```
 ````
 
@@ -25,7 +25,9 @@ Unicode dashes and thin/non-breaking spaces are normalized, canonical units use
 a closed vocabulary, and formatted numeric strings are converted to exact
 decimals. Presentation-only keys are ignored.
 
-Renderers should call `strip_claims_blocks()` before showing an answer. The
-Slack adapter does this for every carrier, including malformed or non-trailing
-examples. Prose grading remains available for deployments that have not yet
-adopted typed claims.
+Core final and sealed-response extractors remove every carrier before returning
+human-facing text, including malformed or non-trailing examples. Discord,
+Slack, and headless consumers therefore share the same safe render boundary.
+Evaluation retains the raw answer separately for typed grading and audit.
+Prose grading remains available for deployments that have not yet adopted
+typed claims.

--- a/docs/typed-claims.md
+++ b/docs/typed-claims.md
@@ -1,0 +1,31 @@
+# Typed final-answer claims
+
+Deployments can ask an agent to append a machine-readable `claims` fence to
+its final answer. The prose remains the human-facing answer; the carrier gives
+evaluation code exact values, units, bases, dates, and sources without relying
+on presentation-sensitive regular expressions.
+
+````text
+Revenue was $7.57M for the period.
+
+```claims
+[{"metric":"revenue","value":7571234,"unit":"usd","basis":"invoices","as_of":"2026-06-30","source":"semantic.revenue"}]
+```
+````
+
+`daimon.core.claims_contract.render_claims_instruction()` generates the agent
+instruction from the same strict `Claim` model used by the parser. Deployments
+with a measure registry can pass it to the renderer and parser to reject
+unknown measure IDs; without one, lowercase registry-style IDs remain valid.
+
+`parse_claims_block()` treats only the final trailing fence as authoritative.
+Malformed JSON or an empty/non-list carrier rejects the block. Schema-invalid
+rows are reported independently so one bad row does not discard valid siblings.
+Unicode dashes and thin/non-breaking spaces are normalized, canonical units use
+a closed vocabulary, and formatted numeric strings are converted to exact
+decimals. Presentation-only keys are ignored.
+
+Renderers should call `strip_claims_blocks()` before showing an answer. The
+Slack adapter does this for every carrier, including malformed or non-trailing
+examples. Prose grading remains available for deployments that have not yet
+adopted typed claims.

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -34,6 +34,7 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
 from daimon.adapters.slack.blockkit import EmbedEvent, State, TurnPhase, to_blocks, update
 from daimon.adapters.slack.mrkdwn import escape_mrkdwn_preserving_mentions
 from daimon.adapters.slack.split import split_for_slack_safe
+from daimon.core.claims import strip_claims_blocks
 from daimon.core.pricing import MODEL_PRICING, cost_of, format_cost
 from daimon.core.turn.lifecycle import InterruptSource, ReconnectReason
 from daimon.core.turn.state import ToolUseBlock, TurnState, extract_final_response
@@ -245,7 +246,10 @@ class SlackTurnLifecycle:
         self._state = update(self._state, EmbedEvent(kind="done", label=""))
         self._apply_usage(state)
         try:
-            final_text = extract_final_response(state.content)
+            # Claims are a machine-readable carrier for evaluation and must not
+            # leak into the human-facing Slack answer. Strip every carrier,
+            # including malformed or non-trailing examples, before rendering.
+            final_text = strip_claims_blocks(extract_final_response(state.content))
             if not final_text:
                 # No final answer. A tool-only turn keeps the collapsed done
                 # footer; a truly empty turn (cancellation) shows "Turn

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -34,7 +34,6 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
 from daimon.adapters.slack.blockkit import EmbedEvent, State, TurnPhase, to_blocks, update
 from daimon.adapters.slack.mrkdwn import escape_mrkdwn_preserving_mentions
 from daimon.adapters.slack.split import split_for_slack_safe
-from daimon.core.claims import strip_claims_blocks
 from daimon.core.pricing import MODEL_PRICING, cost_of, format_cost
 from daimon.core.turn.lifecycle import InterruptSource, ReconnectReason
 from daimon.core.turn.state import ToolUseBlock, TurnState, extract_final_response
@@ -246,10 +245,7 @@ class SlackTurnLifecycle:
         self._state = update(self._state, EmbedEvent(kind="done", label=""))
         self._apply_usage(state)
         try:
-            # Claims are a machine-readable carrier for evaluation and must not
-            # leak into the human-facing Slack answer. Strip every carrier,
-            # including malformed or non-trailing examples, before rendering.
-            final_text = strip_claims_blocks(extract_final_response(state.content))
+            final_text = extract_final_response(state.content)
             if not final_text:
                 # No final answer. A tool-only turn keeps the collapsed done
                 # footer; a truly empty turn (cancellation) shows "Turn

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -322,7 +322,7 @@ async def test_terminal_success_strips_all_claims_fences(fake_slack_web_client: 
     answer = (
         'Example:\n```claims\n[{"metric":"example"}]\n```\n\n'
         "Supported total is 12 MW.\n"
-        '```claims\n[{"metric":"installed_mw","value":12}]\n```'
+        '```claims\n[{"metric":"invoice_total","value":12}]\n```'
     )
 
     await lc.on_terminal_success(TurnState(content=[TextBlock(kind="text", text=answer)]))

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -290,6 +290,50 @@ async def test_terminal_success_replaces_status_in_place(fake_slack_web_client: 
     assert not _has_actions_block(blocks), "cancel button must be removed on terminal success"
 
 
+async def test_terminal_success_strips_claims_carrier(fake_slack_web_client: Any) -> None:
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+    state = TurnState(
+        content=[
+            TextBlock(
+                kind="text",
+                text=(
+                    "Revenue was $10.08M.\n\n"
+                    "```claims\n"
+                    '[{"metric":"revenue","value":10080000,"unit":"usd",'
+                    '"basis":"invoices","as_of":null,"source":null}]\n'
+                    "```"
+                ),
+            )
+        ]
+    )
+
+    await lc.on_terminal_success(state)
+
+    rendered = _block_text(_last_update_blocks(fake_slack_web_client))
+    assert "Revenue was $10.08M." in rendered
+    assert "```claims" not in rendered
+    assert '"metric"' not in rendered
+
+
+async def test_terminal_success_strips_all_claims_fences(fake_slack_web_client: Any) -> None:
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+    answer = (
+        'Example:\n```claims\n[{"metric":"example"}]\n```\n\n'
+        "Supported total is 12 MW.\n"
+        '```claims\n[{"metric":"installed_mw","value":12}]\n```'
+    )
+
+    await lc.on_terminal_success(TurnState(content=[TextBlock(kind="text", text=answer)]))
+
+    rendered = _block_text(_last_update_blocks(fake_slack_web_client))
+    assert "Example:" in rendered
+    assert "Supported total is 12 MW." in rendered
+    assert "```claims" not in rendered
+    assert '"metric"' not in rendered
+
+
 async def test_terminal_success_overflow_posts_and_widens_final_ts(
     fake_slack_web_client: Any,
 ) -> None:

--- a/packages/core/daimon/core/claims.py
+++ b/packages/core/daimon/core/claims.py
@@ -44,8 +44,8 @@ def parse_claims_block(text: str, *, registry: MeasureRegistry | None = None) ->
     trailing carrier with malformed JSON, a non-list payload, or an empty list
     raises :class:`ClaimsBlockError`. Schema-invalid rows and, when configured,
     unknown registry IDs are omitted and reported individually while valid
-    siblings remain available to graders and renderers. Render consumers must
-    separately call :func:`strip_claims_blocks` to remove every fence.
+    siblings remain available to graders. Core human-response extractors remove
+    every carrier before handing text to renderers.
     """
     matches = list(_CLAIMS_FENCE.finditer(text))
     if not matches:

--- a/packages/core/daimon/core/claims.py
+++ b/packages/core/daimon/core/claims.py
@@ -1,0 +1,113 @@
+"""Strict machine-readable claims carried in an agent's final answer."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import cast
+
+from daimon.core.claims_contract import CLAIMS_FENCE_PATTERN, Claim, MeasureRegistry
+from pydantic import ValidationError
+
+_CLAIMS_FENCE = re.compile(CLAIMS_FENCE_PATTERN, re.DOTALL)
+
+
+class ClaimsBlockError(ValueError):
+    """The answer declared a claims carrier that failed strict validation."""
+
+
+@dataclass(frozen=True)
+class ClaimsExtraction:
+    """Parsed prose, accepted claims, and isolated per-row errors."""
+
+    prose: str
+    claims: list[Claim]
+    errors: tuple[str, ...] = ()
+
+
+def _format_claims_error(error: ValidationError) -> str:
+    detail = error.errors(include_url=False)[0]
+    if detail["type"] == "json_invalid":
+        return "claims: invalid JSON"
+    path = "claims"
+    for part in detail["loc"]:
+        path += f"[{part}]" if isinstance(part, int) else f".{part}"
+    message = str(detail["msg"]).removeprefix("Value error, ")
+    return f"{path}: {message}"
+
+
+def parse_claims_block(text: str, *, registry: MeasureRegistry | None = None) -> ClaimsExtraction:
+    """Parse the trailing carrier and isolate invalid rows.
+
+    Only the final trailing fence is the authoritative carrier. A declared
+    trailing carrier with malformed JSON, a non-list payload, or an empty list
+    raises :class:`ClaimsBlockError`. Schema-invalid rows and, when configured,
+    unknown registry IDs are omitted and reported individually while valid
+    siblings remain available to graders and renderers. Render consumers must
+    separately call :func:`strip_claims_blocks` to remove every fence.
+    """
+    matches = list(_CLAIMS_FENCE.finditer(text))
+    if not matches:
+        return ClaimsExtraction(text, [])
+    match = matches[-1]
+    if text[match.end() :].strip():
+        return ClaimsExtraction(text, [])
+    try:
+        payload = cast(object, json.loads(match.group("body")))
+    except json.JSONDecodeError as error:
+        raise ClaimsBlockError("claims: invalid JSON") from error
+    if not isinstance(payload, list):
+        raise ClaimsBlockError("claims: expected a JSON list")
+    if not payload:
+        raise ClaimsBlockError("claims block must contain at least one claim")
+
+    accepted: list[Claim] = []
+    errors: list[str] = []
+    registry_ids = registry.ids if registry is not None else None
+    for index, row in enumerate(cast(list[object], payload)):
+        try:
+            claim = Claim.model_validate(row)
+        except ValidationError as error:
+            detail = _format_claims_error(error)
+            errors.append(detail.replace("claims", f"claims[{index}]", 1))
+            continue
+        if registry_ids is not None and claim.metric not in registry_ids:
+            errors.append(f"claims[{index}].metric: unknown registered measure id {claim.metric!r}")
+            continue
+        accepted.append(claim)
+    return ClaimsExtraction(text[: match.start()].rstrip(), accepted, tuple(errors))
+
+
+def extract_claims_block(text: str) -> tuple[str, list[Claim]]:
+    """Backward-compatible strict extraction without registry membership checks."""
+    extraction = parse_claims_block(text)
+    if extraction.errors:
+        raise ClaimsBlockError(extraction.errors[0])
+    return extraction.prose, extraction.claims
+
+
+def strip_claims_blocks(text: str) -> str:
+    """Remove every claims fence from a render surface without validating it."""
+    return _CLAIMS_FENCE.sub("", text).rstrip()
+
+
+def claims_basis(claims: list[Claim]) -> str | None:
+    """Return ordered, de-duplicated bases for Slack provenance."""
+    bases = list(dict.fromkeys(claim.basis for claim in claims))
+    return " · ".join(bases) if bases else None
+
+
+def serialize_claims(claims: list[Claim]) -> list[dict[str, str | None]]:
+    """Return JSON-safe claim dictionaries without losing decimal precision."""
+    return [
+        {
+            "metric": claim.metric,
+            "value": str(claim.value),
+            "unit": claim.unit,
+            "basis": claim.basis,
+            "as_of": claim.as_of.isoformat() if claim.as_of is not None else None,
+            "source": claim.source,
+        }
+        for claim in claims
+    ]

--- a/packages/core/daimon/core/claims_contract.py
+++ b/packages/core/daimon/core/claims_contract.py
@@ -1,0 +1,283 @@
+"""Vendor-neutral contracts for machine-readable claims and measure registries."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+CLAIMS_FENCE_LANGUAGE = "claims"
+CLAIMS_FENCE_PATTERN = rf"```{re.escape(CLAIMS_FENCE_LANGUAGE)}\s*\n(?P<body>.*?)```"
+CLAIMS_INSTRUCTION_PLACEHOLDER = "{{DAIMON_CLAIMS_CONTRACT}}"
+MEASURE_REGISTRY_PLACEHOLDER = "{{DAIMON_MEASURE_REGISTRY}}"
+
+ALLOWED_CLAIM_UNITS = frozenset({"usd", "pct", "count", "days", "mw"})
+CLAIM_UNIT_ALIASES = {"$": "usd", "%": "pct"}
+
+_REGISTRY_ID = re.compile(r"[a-z][a-z0-9_.-]*\Z")
+_RELATION_COLUMN = re.compile(r"(?:[a-z_][a-z0-9_]*\.){2}[a-z_][a-z0-9_]*\Z")
+_DECIMAL_TEXT = re.compile(r"[+-]?(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d*)?|\.\d+)\Z")
+_NUMERIC_TOKEN = r"(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?"
+_NUMERIC_RANGE = re.compile(
+    rf"{_NUMERIC_TOKEN}\s*[-\u2010\u2011\u2012\u2013\u2014]\s*{_NUMERIC_TOKEN}"
+)
+_CLAIMS_TEXT_TRANSLATION = str.maketrans(
+    {
+        "\u2010": "-",
+        "\u2011": "-",
+        "\u2012": "-",
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2212": "-",
+        "\u00a0": " ",
+        "\u2009": " ",
+        "\u202f": " ",
+    }
+)
+
+
+def normalize_claims_text(value: str) -> str:
+    """Normalize contract-significant Unicode punctuation and spacing."""
+    return value.translate(_CLAIMS_TEXT_TRANSLATION)
+
+
+def normalize_numeric_grading_text(value: str, *, answer_regex: str | None) -> str:
+    """Normalize text while hiding range operands from scalar extraction.
+
+    A scalar golden must not read either endpoint of a displayed numeric range
+    as a standalone value. A range remains visible only when that golden's
+    answer regex spans the complete range. This numeric-only view does not
+    change the general text normalization used by phrase checks or claim dates.
+    """
+    normalized = normalize_claims_text(value)
+    explicit_spans = (
+        [
+            match.span()
+            for match in re.finditer(answer_regex, normalized, re.IGNORECASE | re.MULTILINE)
+        ]
+        if answer_regex is not None
+        else []
+    )
+    characters = list(normalized)
+    for numeric_range in _NUMERIC_RANGE.finditer(value):
+        start, end = numeric_range.span()
+        if any(
+            match_start <= start and match_end >= end for match_start, match_end in explicit_spans
+        ):
+            continue
+        for index in range(start, end):
+            if characters[index].isdigit() or characters[index] in ",.":
+                characters[index] = " "
+    return "".join(characters)
+
+
+@dataclass(frozen=True)
+class MeasureDefinition:
+    """One deployment-supplied measure exposed to a claims carrier."""
+
+    id: str
+    source: str
+    basis: str
+    unit: str
+    derivation: str | None = None
+    routing: str | None = None
+
+
+@dataclass(frozen=True)
+class MeasureRegistry:
+    """An immutable deployment-supplied set of registered measures."""
+
+    measures: tuple[MeasureDefinition, ...]
+
+    @property
+    def ids(self) -> frozenset[str]:
+        return frozenset(measure.id for measure in self.measures)
+
+
+def validate_measure_registry(registry: MeasureRegistry) -> None:
+    """Fail closed on malformed deployment registry data."""
+    ids = [measure.id for measure in registry.measures]
+    if not ids:
+        raise ValueError("measure registry must contain at least one measure")
+    if len(ids) != len(set(ids)):
+        raise ValueError("measure registry ids must be unique")
+    for measure in registry.measures:
+        if _REGISTRY_ID.fullmatch(measure.id) is None:
+            raise ValueError(f"invalid measure registry id: {measure.id!r}")
+        if _RELATION_COLUMN.fullmatch(measure.source) is None:
+            raise ValueError(
+                f"measure registry source must be relation.column: {measure.id}={measure.source}"
+            )
+        if not measure.basis.strip():
+            raise ValueError(f"measure registry source/basis must be non-empty: {measure.id}")
+        if measure.unit not in ALLOWED_CLAIM_UNITS:
+            raise ValueError(f"measure registry unit is not allowed: {measure.id}={measure.unit}")
+
+
+def normalize_claim_unit(value: str) -> str:
+    """Return the canonical claims unit for a textual unit."""
+    normalized = normalize_claims_text(value).strip().casefold()
+    return CLAIM_UNIT_ALIASES.get(normalized, normalized)
+
+
+class Claim(BaseModel):
+    """One registry-addressed numeric claim emitted by an agent."""
+
+    model_config = ConfigDict(extra="ignore", strict=True)
+
+    metric: str
+    value: Decimal
+    unit: str
+    basis: str
+    as_of: date | None
+    source: str | None
+
+    @field_validator("metric", mode="before")
+    @classmethod
+    def _normalize_metric(cls, value: object) -> object:
+        return normalize_claims_text(value).strip().casefold() if isinstance(value, str) else value
+
+    @field_validator("metric")
+    @classmethod
+    def _metric_is_registry_id(cls, value: str) -> str:
+        if _REGISTRY_ID.fullmatch(value) is None:
+            raise ValueError("metric must be a lowercase registry id")
+        return value
+
+    @field_validator("unit", mode="before")
+    @classmethod
+    def _normalize_unit(cls, value: object) -> object:
+        return normalize_claim_unit(value) if isinstance(value, str) else value
+
+    @field_validator("unit")
+    @classmethod
+    def _unit_is_allowed(cls, value: str) -> str:
+        if value not in ALLOWED_CLAIM_UNITS:
+            raise ValueError(f"{value} not allowed")
+        return value
+
+    @field_validator("basis", mode="before")
+    @classmethod
+    def _basis_is_present(cls, value: object) -> object:
+        if isinstance(value, str):
+            value = normalize_claims_text(value)
+        if not isinstance(value, str):
+            return value
+        if not value.strip() or value != value.strip():
+            raise ValueError("basis must be non-empty without surrounding whitespace")
+        return value
+
+    @field_validator("source", mode="before")
+    @classmethod
+    def _source_is_present_when_set(cls, value: object) -> object:
+        if isinstance(value, str):
+            value = normalize_claims_text(value)
+        if value is not None and not isinstance(value, str):
+            return value
+        if value is not None and (not value.strip() or value != value.strip()):
+            raise ValueError("source must be non-empty without surrounding whitespace")
+        return value
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _normalize_value(cls, value: object) -> object:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            normalized = Decimal(str(value))
+            if normalized.is_finite() and normalized == normalized.to_integral():
+                return Decimal(int(normalized))
+            return normalized
+        if not isinstance(value, str):
+            return value
+        normalized = normalize_claims_text(value).strip()
+        if normalized.startswith("$"):
+            normalized = normalized[1:].lstrip()
+        if _DECIMAL_TEXT.fullmatch(normalized) is None:
+            raise ValueError("value must be numeric")
+        try:
+            return Decimal(normalized.replace(",", ""))
+        except ArithmeticError as error:
+            raise ValueError("value must be numeric") from error
+
+    @field_validator("value")
+    @classmethod
+    def _value_is_finite(cls, value: Decimal) -> Decimal:
+        if not value.is_finite():
+            raise ValueError("value must be finite")
+        return value
+
+    @field_validator("as_of", mode="before")
+    @classmethod
+    def _normalize_as_of(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        normalized = normalize_claims_text(value)
+        try:
+            return date.fromisoformat(normalized)
+        except ValueError:
+            return normalized
+
+
+def render_claims_instruction(registry: MeasureRegistry | None = None) -> str:
+    """Generate the agent-facing instruction from the executable contract."""
+    fields = ", ".join(Claim.model_fields)
+    units = ", ".join(sorted(ALLOWED_CLAIM_UNITS))
+    aliases = ", ".join(
+        f"{source!r} to {target!r}" for source, target in sorted(CLAIM_UNIT_ALIASES.items())
+    )
+    metric_instruction = (
+        "Use one of the registered measure IDs; an unknown ID is rejected. "
+        if registry is not None
+        else "Use the registry measure id when one exists, otherwise a lowercase "
+        "registry-style descriptor. "
+    )
+    return (
+        "For every headline number, end the final answer with exactly one trailing "
+        f"`{CLAIMS_FENCE_LANGUAGE}` JSON fence containing a non-empty list of "
+        f"{{{fields}}}. Keep each headline number in the prose; the claims block "
+        f"supplements it. {metric_instruction}"
+        f"Emit canonical units only from this closed set: {units}. The parser normalizes "
+        f"{aliases}; do not rely on those aliases in generated output. Use null for unknown "
+        "as_of/source. If you emit another fenced payload, put the claims fence last."
+    )
+
+
+def render_measure_registry(registry: MeasureRegistry) -> str:
+    """Generate the complete agent-facing measure list from the typed registry."""
+    lines = [
+        "<!-- BEGIN GENERATED MEASURE REGISTRY -->",
+        "These are the complete registered measure IDs. Use the exact ID and canonical basis",
+        "in numeric claims; recompute from the named source at the answer's stated data cut.",
+    ]
+    for measure in registry.measures:
+        detail = (
+            f"- **{measure.id}** — source: `{measure.source}`; "
+            f"basis: `{measure.basis}`; unit: `{measure.unit}`."
+        )
+        if measure.derivation is not None:
+            detail += f" Derivation: {measure.derivation}."
+        if measure.routing is not None:
+            detail += f" Routing: {measure.routing}."
+        lines.append(detail)
+    lines.append("<!-- END GENERATED MEASURE REGISTRY -->")
+    return "\n".join(lines)
+
+
+def render_claims_placeholders(text: str, registry: MeasureRegistry | None = None) -> str:
+    """Expand authored claims placeholders from the executable contract."""
+    rendered = text.replace(CLAIMS_INSTRUCTION_PLACEHOLDER, render_claims_instruction(registry))
+    if MEASURE_REGISTRY_PLACEHOLDER not in rendered:
+        return rendered
+    if registry is None:
+        raise ValueError("measure registry placeholder requires a configured registry")
+    return rendered.replace(MEASURE_REGISTRY_PLACEHOLDER, render_measure_registry(registry))
+
+
+def missing_required_phrase_patterns(answer: str, patterns: list[str]) -> list[str]:
+    """Return the required regex patterns that do not match an answer."""
+    normalized = normalize_claims_text(answer)
+    return [pattern for pattern in patterns if re.search(pattern, normalized) is None]

--- a/packages/core/daimon/core/claims_contract.py
+++ b/packages/core/daimon/core/claims_contract.py
@@ -18,7 +18,7 @@ ALLOWED_CLAIM_UNITS = frozenset({"usd", "pct", "count", "days", "mw"})
 CLAIM_UNIT_ALIASES = {"$": "usd", "%": "pct"}
 
 _REGISTRY_ID = re.compile(r"[a-z][a-z0-9_.-]*\Z")
-_RELATION_COLUMN = re.compile(r"(?:[a-z_][a-z0-9_]*\.){2}[a-z_][a-z0-9_]*\Z")
+_RELATION_COLUMN = re.compile(r"(?:[a-z_][a-z0-9_]*\.)+[a-z_][a-z0-9_]*\Z")
 _DECIMAL_TEXT = re.compile(r"[+-]?(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d*)?|\.\d+)\Z")
 _NUMERIC_TOKEN = r"(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?"
 _NUMERIC_RANGE = re.compile(

--- a/packages/core/daimon/core/turn/state.py
+++ b/packages/core/daimon/core/turn/state.py
@@ -22,6 +22,7 @@ from anthropic.types.beta.sessions.beta_managed_agents_agent_tool_result_event i
 from anthropic.types.beta.sessions.beta_managed_agents_session_status_idle_event import (
     StopReason,
 )
+from daimon.core.claims import strip_claims_blocks
 from daimon.core.errors import TurnError
 
 
@@ -109,8 +110,10 @@ def extract_final_response(content: list[ContentBlock]) -> str:
         if isinstance(block, ToolUseBlock):
             last_tool_idx = i
 
-    return "".join(
-        block.text for block in content[last_tool_idx + 1 :] if isinstance(block, TextBlock)
+    return strip_claims_blocks(
+        "".join(
+            block.text for block in content[last_tool_idx + 1 :] if isinstance(block, TextBlock)
+        )
     )
 
 
@@ -132,8 +135,11 @@ def extract_sealed_responses(
         if isinstance(block, ToolUseBlock):
             last_tool_idx = i
 
-    return [
-        (i, block.text)
-        for i, block in enumerate(content[:last_tool_idx])
-        if isinstance(block, TextBlock) and len(block.text) >= min_chars
-    ]
+    responses: list[tuple[int, str]] = []
+    for i, block in enumerate(content[:last_tool_idx]):
+        if not isinstance(block, TextBlock) or len(block.text) < min_chars:
+            continue
+        text = strip_claims_blocks(block.text)
+        if text:
+            responses.append((i, text))
+    return responses

--- a/packages/core/tests/test_claims.py
+++ b/packages/core/tests/test_claims.py
@@ -1,0 +1,231 @@
+"""Machine-readable final-answer claims contract tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from daimon.core.claims import (
+    ClaimsBlockError,
+    extract_claims_block,
+    parse_claims_block,
+    serialize_claims,
+    strip_claims_blocks,
+)
+from daimon.core.claims_contract import (
+    CLAIMS_INSTRUCTION_PLACEHOLDER,
+    Claim,
+    MeasureDefinition,
+    MeasureRegistry,
+    normalize_claims_text,
+    normalize_numeric_grading_text,
+    render_claims_instruction,
+    render_claims_placeholders,
+    validate_measure_registry,
+)
+from pydantic import ValidationError
+
+
+def _claim_fence(rows: str) -> str:
+    return f"Answer prose.\n\n```claims\n{rows}\n```"
+
+
+def test_parse_claims_block_strips_and_validates_trailing_carrier() -> None:
+    extraction = parse_claims_block(
+        _claim_fence(
+            '[{"metric":"revenue","value":"$ 1,234.50","unit":"$",'
+            '"basis":"invoices","as_of":"2026-08-25","source":"ledger.revenue"}]'
+        )
+    )
+
+    assert extraction.prose == "Answer prose."
+    assert extraction.errors == ()
+    assert extraction.claims == [
+        Claim(
+            metric="revenue",
+            value=Decimal("1234.50"),
+            unit="usd",
+            basis="invoices",
+            as_of=date(2026, 8, 25),
+            source="ledger.revenue",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ("not-json", "claims: invalid JSON"),
+        ('{"metric":"revenue"}', "claims: expected a JSON list"),
+        ("[]", "claims block must contain at least one claim"),
+    ],
+)
+def test_parse_claims_block_rejects_invalid_carrier_shapes(payload: str, message: str) -> None:
+    with pytest.raises(ClaimsBlockError, match=message):
+        parse_claims_block(_claim_fence(payload))
+
+
+def test_claim_rows_isolate_invalid_siblings() -> None:
+    extraction = parse_claims_block(
+        _claim_fence(
+            "["
+            '{"metric":"bad metric","value":1,"unit":"usd","basis":"x",'
+            '"as_of":null,"source":null},'
+            '{"metric":"revenue","value":2,"unit":"usd","basis":"invoices",'
+            '"as_of":null,"source":null}'
+            "]"
+        )
+    )
+
+    assert [claim.metric for claim in extraction.claims] == ["revenue"]
+    assert extraction.errors == ("claims[0].metric: metric must be a lowercase registry id",)
+    with pytest.raises(ClaimsBlockError, match=r"claims\[0\]\.metric"):
+        extract_claims_block(
+            _claim_fence(
+                "["
+                '{"metric":"bad metric","value":1,"unit":"usd","basis":"x",'
+                '"as_of":null,"source":null},'
+                '{"metric":"revenue","value":2,"unit":"usd","basis":"invoices",'
+                '"as_of":null,"source":null}'
+                "]"
+            )
+        )
+
+
+def test_registry_membership_is_optional_and_isolated_per_row() -> None:
+    registry = MeasureRegistry(
+        (
+            MeasureDefinition(
+                id="revenue",
+                source="semantic.revenue.amount",
+                basis="invoices",
+                unit="usd",
+            ),
+        )
+    )
+    answer = _claim_fence(
+        "["
+        '{"metric":"unknown","value":1,"unit":"usd","basis":"x",'
+        '"as_of":null,"source":null},'
+        '{"metric":"revenue","value":2,"unit":"usd","basis":"invoices",'
+        '"as_of":null,"source":null}'
+        "]"
+    )
+
+    open_extraction = parse_claims_block(answer)
+    closed_extraction = parse_claims_block(answer, registry=registry)
+
+    assert [claim.metric for claim in open_extraction.claims] == ["unknown", "revenue"]
+    assert [claim.metric for claim in closed_extraction.claims] == ["revenue"]
+    assert "unknown registered measure id 'unknown'" in closed_extraction.errors[0]
+
+
+def test_non_trailing_fence_is_not_authoritative_but_all_fences_strip() -> None:
+    answer = _claim_fence('[{"metric":"example"}]') + "\n\nMore prose."
+
+    extraction = parse_claims_block(answer)
+
+    assert extraction.prose == answer
+    assert extraction.claims == []
+    assert strip_claims_blocks(answer) == "Answer prose.\n\n\n\nMore prose."
+
+
+def test_unicode_claim_normalization_covers_dashes_and_thin_spaces() -> None:
+    assert normalize_claims_text("2026\u201108\u201125\u2009USD") == "2026-08-25 USD"
+    claim = Claim.model_validate(
+        {
+            "metric": "REVENUE",
+            "value": "$\u202f1,234",
+            "unit": "$",
+            "basis": "service\u2013month",
+            "as_of": "2026\u201108\u201125",
+            "source": None,
+        }
+    )
+    assert claim.metric == "revenue"
+    assert claim.value == Decimal("1234")
+    assert claim.basis == "service-month"
+    assert claim.as_of == date(2026, 8, 25)
+
+
+def test_numeric_normalization_hides_range_endpoints_without_explicit_range_regex() -> None:
+    answer = "Expected range: 10\u201312 million; point estimate: 11."
+
+    scalar_view = normalize_numeric_grading_text(answer, answer_regex=None)
+    range_view = normalize_numeric_grading_text(answer, answer_regex=r"10-12")
+
+    assert "10" not in scalar_view and "12" not in scalar_view
+    assert "point estimate: 11" in scalar_view
+    assert "10-12" in range_view
+
+
+def test_claim_schema_is_strict_but_ignores_presentation_keys() -> None:
+    claim = Claim.model_validate(
+        {
+            "metric": "revenue",
+            "value": "1,234",
+            "unit": "usd",
+            "basis": "invoices",
+            "as_of": None,
+            "source": None,
+            "display": "$1.23k",
+        }
+    )
+    assert claim.value == Decimal("1234")
+    with pytest.raises(ValidationError):
+        Claim.model_validate(
+            {
+                "metric": "revenue",
+                "value": True,
+                "unit": "usd",
+                "basis": "invoices",
+                "as_of": None,
+                "source": None,
+            }
+        )
+
+
+def test_contract_generates_instruction_and_expands_placeholder() -> None:
+    instruction = render_claims_instruction()
+
+    assert "metric, value, unit, basis, as_of, source" in instruction
+    assert "usd" in instruction and "pct" in instruction
+    assert render_claims_placeholders(CLAIMS_INSTRUCTION_PLACEHOLDER) == instruction
+
+
+def test_measure_registry_validation_rejects_duplicate_or_malformed_definitions() -> None:
+    valid = MeasureDefinition(
+        id="revenue",
+        source="semantic.revenue.amount",
+        basis="invoices",
+        unit="usd",
+    )
+    validate_measure_registry(MeasureRegistry((valid,)))
+    with pytest.raises(ValueError, match="unique"):
+        validate_measure_registry(MeasureRegistry((valid, valid)))
+    with pytest.raises(ValueError, match="relation.column"):
+        validate_measure_registry(
+            MeasureRegistry(
+                (
+                    MeasureDefinition(
+                        id="revenue",
+                        source="revenue.amount",
+                        basis="invoices",
+                        unit="usd",
+                    ),
+                )
+            )
+        )
+
+
+def test_serialize_claims_preserves_decimal_precision() -> None:
+    claim = Claim(
+        metric="revenue",
+        value=Decimal("1.2300"),
+        unit="usd",
+        basis="invoices",
+        as_of=None,
+        source=None,
+    )
+    assert serialize_claims([claim])[0]["value"] == "1.2300"

--- a/packages/core/tests/test_claims.py
+++ b/packages/core/tests/test_claims.py
@@ -98,7 +98,7 @@ def test_registry_membership_is_optional_and_isolated_per_row() -> None:
         (
             MeasureDefinition(
                 id="revenue",
-                source="semantic.revenue.amount",
+                source="invoices.total",
                 basis="invoices",
                 unit="usd",
             ),
@@ -197,7 +197,7 @@ def test_contract_generates_instruction_and_expands_placeholder() -> None:
 def test_measure_registry_validation_rejects_duplicate_or_malformed_definitions() -> None:
     valid = MeasureDefinition(
         id="revenue",
-        source="semantic.revenue.amount",
+        source="invoices.total",
         basis="invoices",
         unit="usd",
     )
@@ -210,7 +210,7 @@ def test_measure_registry_validation_rejects_duplicate_or_malformed_definitions(
                 (
                     MeasureDefinition(
                         id="revenue",
-                        source="revenue.amount",
+                        source="revenue",
                         basis="invoices",
                         unit="usd",
                     ),

--- a/packages/core/tests/turn/test_state.py
+++ b/packages/core/tests/turn/test_state.py
@@ -133,6 +133,19 @@ class TestExtractFinalResponse:
         ]
         assert extract_final_response(content) == ""
 
+    def test_claims_carrier_is_removed_from_human_response(self) -> None:
+        content: list[ContentBlock] = [
+            TextBlock(
+                kind="text",
+                text=(
+                    "Invoice total is $10.\n\n```claims\n"
+                    '[{"metric":"invoice_total","value":10}]\n```'
+                ),
+            )
+        ]
+
+        assert extract_final_response(content) == "Invoice total is $10."
+
 
 class TestExtractSealedResponses:
     def test_long_text_followed_by_tool_is_returned_with_index(self) -> None:
@@ -181,3 +194,15 @@ class TestExtractSealedResponses:
 
     def test_empty_content_returns_empty_list(self) -> None:
         assert extract_sealed_responses([], min_chars=500) == []
+
+    def test_claims_carrier_is_removed_from_sealed_response(self) -> None:
+        prose = "Invoice details. " * 40
+        content: list[ContentBlock] = [
+            TextBlock(
+                kind="text",
+                text=(f'{prose}\n\n```claims\n[{{"metric":"invoice_total","value":10}}]\n```'),
+            ),
+            ToolUseBlock(kind="tool_use", id="tu_1", type="agent.tool_use", name="read", input={}),
+        ]
+
+        assert extract_sealed_responses(content, min_chars=500) == [(0, prose.rstrip())]


### PR DESCRIPTION
Add a vendor-neutral contract for machine-readable numeric claims in final answers, with a strict Pydantic schema, trailing-fence parser, per-row error isolation, normalization for formatted values and Unicode punctuation, and optional deployment-supplied measure membership checks.

Numeric evals currently recover values from formatted prose, which makes correctness sensitive to rounding, unit scale, number ordering, and wording. This first stack layer establishes one executable contract that also generates the agent-facing instruction, while preserving open registry-style metric IDs when a deployment does not provide a registry.

The Slack adapter strips every claims carrier before rendering, including malformed and non-trailing examples, so the machine-readable payload never leaks into the human-facing answer. The contract remains adapter-independent and includes no deployment-specific registry data.

This is Part 1/2 of #121. Part 2 adds claims-primary grading and offline replay fixtures on top of this branch.