### PR TITLE
feat(eval): add typed claims grading and replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ whole team, in the thread — and hands back a notebook anyone can run.
 - CLI and MCP adapters sharing the same core turn pipeline
 - Tenant isolation enforced at the database `tenant_id` layer, so one shared
   Anthropic key can safely power every guild
+- Optional [typed final-answer claims](docs/typed-claims.md) let deployments
+  evaluate headline numbers without scraping formatted prose
 
 ## What you can ask it
 

--- a/docs/typed-claims.md
+++ b/docs/typed-claims.md
@@ -29,3 +29,26 @@ Renderers should call `strip_claims_blocks()` before showing an answer. The
 Slack adapter does this for every carrier, including malformed or non-trailing
 examples. Prose grading remains available for deployments that have not yet
 adopted typed claims.
+
+## Offline evaluation replay
+
+Typed goldens declare `expected_claim` with a metric, value, canonical unit,
+and either absolute or relative tolerance. Optional basis and display precision
+constraints further narrow the match. `kind` is one of `value`, `trend`, or
+`rejection`; a rejection passes only when the seed is not repeated and the
+answer supplies a corrected claim or an explicit seed-bound refusal.
+
+When a golden has `expected_claim`, typed claims are the primary numeric gate:
+matching prose cannot rescue an incorrect or missing typed claim. Goldens that
+only declare `expected_sql` retain the deprecated regex/tolerance path. Required
+phrase checks are advisory, while explicitly banned phrases remain gating.
+
+Recorded answers can be replayed without a network or database:
+
+```bash
+daimon eval replay --goldens path/to/goldens.jsonl --fixtures path/to/fixtures
+```
+
+The fixture manifest pins every per-case check and fails if a verdict or check
+set drifts. Results preserve both stripped `answer` text and the original
+`answer_raw` carrier for auditability.

--- a/docs/typed-claims.md
+++ b/docs/typed-claims.md
@@ -1,0 +1,31 @@
+# Typed final-answer claims
+
+Deployments can ask an agent to append a machine-readable `claims` fence to
+its final answer. The prose remains the human-facing answer; the carrier gives
+evaluation code exact values, units, bases, dates, and sources without relying
+on presentation-sensitive regular expressions.
+
+````text
+Revenue was $7.57M for the period.
+
+```claims
+[{"metric":"revenue","value":7571234,"unit":"usd","basis":"invoices","as_of":"2026-06-30","source":"semantic.revenue"}]
+```
+````
+
+`daimon.core.claims_contract.render_claims_instruction()` generates the agent
+instruction from the same strict `Claim` model used by the parser. Deployments
+with a measure registry can pass it to the renderer and parser to reject
+unknown measure IDs; without one, lowercase registry-style IDs remain valid.
+
+`parse_claims_block()` treats only the final trailing fence as authoritative.
+Malformed JSON or an empty/non-list carrier rejects the block. Schema-invalid
+rows are reported independently so one bad row does not discard valid siblings.
+Unicode dashes and thin/non-breaking spaces are normalized, canonical units use
+a closed vocabulary, and formatted numeric strings are converted to exact
+decimals. Presentation-only keys are ignored.
+
+Renderers should call `strip_claims_blocks()` before showing an answer. The
+Slack adapter does this for every carrier, including malformed or non-trailing
+examples. Prose grading remains available for deployments that have not yet
+adopted typed claims.

--- a/packages/adapters/cli/daimon/adapters/cli/eval/__init__.py
+++ b/packages/adapters/cli/daimon/adapters/cli/eval/__init__.py
@@ -1,0 +1,5 @@
+"""Offline-first golden replay and deterministic deployment graders."""
+
+from daimon.adapters.cli.eval.command import eval_app
+
+__all__ = ["eval_app"]

--- a/packages/adapters/cli/daimon/adapters/cli/eval/command.py
+++ b/packages/adapters/cli/daimon/adapters/cli/eval/command.py
@@ -1,0 +1,40 @@
+"""`daimon eval` CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, cast
+
+import typer
+from daimon.adapters.cli.eval.offline import replay_fixture_runs
+from daimon.adapters.cli.eval.runner import format_grade_table, load_goldens
+
+eval_app = typer.Typer(help="Replay typed-claims evaluation fixtures offline.")
+
+
+@eval_app.command("replay")
+def replay_command(
+    fixtures: Annotated[
+        Path,
+        typer.Option("--fixtures", exists=True, file_okay=False),
+    ],
+    goldens: Annotated[
+        Path,
+        typer.Option("--goldens", exists=True, dir_okay=False),
+    ],
+) -> None:
+    """Grade recorded answers and fail on checked-in verdict drift."""
+    reports = replay_fixture_runs(fixtures, load_goldens(goldens))
+    mismatches: list[str] = []
+    for report in reports:
+        typer.echo(format_grade_table(report.result, run_label=report.label))
+        mismatches.extend(report.mismatches)
+    if mismatches:
+        for mismatch in mismatches:
+            typer.echo(f"FIXTURE REGRESSION: {mismatch}", err=True)
+        raise typer.Exit(code=1)
+    total_cases = sum(cast(dict[str, int], report.result["summary"])["cases"] for report in reports)
+    typer.echo(
+        f"eval replay: PASS ({total_cases} recorded cases, {len(reports)} fixture runs; "
+        "no network or database)"
+    )

--- a/packages/adapters/cli/daimon/adapters/cli/eval/graders/__init__.py
+++ b/packages/adapters/cli/daimon/adapters/cli/eval/graders/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic graders plus the advisory grain-judge placeholder."""

--- a/packages/adapters/cli/daimon/adapters/cli/eval/graders/numeric_recompute.py
+++ b/packages/adapters/cli/daimon/adapters/cli/eval/graders/numeric_recompute.py
@@ -1,0 +1,480 @@
+"""Recompute golden scalars, with golden-bound display precision and claim sites."""
+
+from __future__ import annotations
+
+import re
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from typing import cast
+
+from daimon.adapters.cli.eval.models import ExpectedClaim, ExpectedSQL, GoldenKind, Grade
+from daimon.core.claims_contract import (
+    Claim,
+    normalize_claim_unit,
+    normalize_numeric_grading_text,
+)
+
+_NAMED_VALUE_START = "(?P<value>"
+_DISPLAY_VALUE_PATTERN = r"-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?"
+_UNIT_WORDS_RE = re.compile(
+    r"\b(?:thousand|million|billion|percent|percentage|usd|dollars?)\b", re.IGNORECASE
+)
+_DISPLAYED_VALUE_RE = re.compile(
+    rf"(?P<currency>\$)?\s*(?P<value>{_DISPLAY_VALUE_PATTERN})"
+    r"\s*(?P<unit>%|[KkMmBb](?![A-Za-z])|thousand|million|billion)?",
+    re.IGNORECASE,
+)
+_DISPLAY_FACTORS = {
+    "k": Decimal("1000"),
+    "thousand": Decimal("1000"),
+    "m": Decimal("1000000"),
+    "million": Decimal("1000000"),
+    "b": Decimal("1000000000"),
+    "billion": Decimal("1000000000"),
+    "%": Decimal("1"),
+}
+_DIRECT_REJECTION = re.compile(
+    r"\b(?:incorrect|wrong|unsupported|not supported|not accurate|"
+    r"does not (?:match|equal)|contradicts?)\b",
+    re.IGNORECASE,
+)
+_REFUSAL_ACTION = re.compile(
+    r"\b(?:cannot|can't|refus(?:e|ed|ing)(?:\s+to)?)\s+"
+    r"(?:confirm|support|accept|use|verify|validate|endorse|repeat)\b",
+    re.IGNORECASE,
+)
+_SEED_LABEL = re.compile(r"\bseed(?:ed)?\s+(?:value|figure|number|claim)\b", re.IGNORECASE)
+
+
+def _basis_matches(actual: str, expected: str) -> bool:
+    """Accept a canonical golden basis plus explicit claim-side qualifiers."""
+    return actual == expected or actual.startswith((f"{expected},", f"{expected};", f"{expected} "))
+
+
+def _oracle_factor(pattern: str) -> Decimal:
+    folded = pattern.casefold()
+    if "billion" in folded or "(?:b|" in folded:
+        return Decimal("1000000000")
+    if "million" in folded or "(?:m|" in folded:
+        return Decimal("1000000")
+    if "thousand" in folded or "(?:k|" in folded:
+        return Decimal("1000")
+    return Decimal("1")
+
+
+def _split_named_value_group(pattern: str) -> tuple[str, str, str] | None:
+    """Split a regex around its named value group, including nested groups."""
+    start = pattern.find(_NAMED_VALUE_START)
+    if start < 0:
+        return None
+
+    body_start = start + len(_NAMED_VALUE_START)
+    depth = 1
+    escaped = False
+    for index in range(body_start, len(pattern)):
+        character = pattern[index]
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\":
+            escaped = True
+            continue
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return pattern[:start], pattern[body_start:index], pattern[index + 1 :]
+    return None
+
+
+def _literal_decimal_places(group_pattern: str) -> int | None:
+    """Derive precision only when the golden group is one literal number."""
+    literal = group_pattern.replace(r"\.", ".").replace(r"\,", ",")
+    if re.fullmatch(r"-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?", literal) is None:
+        return None
+    return len(literal.partition(".")[2])
+
+
+def _has_quantity_phrase(prefix: str, suffix: str) -> bool:
+    """Require words beyond a unit before relaxing an answer regex."""
+    outside = _UNIT_WORDS_RE.sub("", f"{prefix} {suffix}")
+    return re.search(r"[A-Za-z]{3,}", outside) is not None
+
+
+def _display_contract(expected_sql: ExpectedSQL) -> tuple[str, int] | None:
+    answer_parts = _split_named_value_group(expected_sql["answer_regex"])
+    if answer_parts is None:
+        return None
+
+    declared_precision = expected_sql.get("display_precision")
+    precision = declared_precision
+    if precision is None:
+        precision = _literal_decimal_places(answer_parts[1])
+    if precision is None or isinstance(precision, bool) or precision < 0:
+        return None
+
+    claim_pattern = expected_sql.get("claim_regex")
+    if claim_pattern is not None:
+        if _split_named_value_group(claim_pattern) is None:
+            return None
+        return claim_pattern, precision
+
+    prefix, _, suffix = answer_parts
+    if declared_precision is None and not _has_quantity_phrase(prefix, suffix):
+        return None
+    return f"{prefix}(?P<value>{_DISPLAY_VALUE_PATTERN}){suffix}", precision
+
+
+def _rounded_display_match(
+    answer: str,
+    *,
+    expected_sql: ExpectedSQL,
+    expected: Decimal,
+    tolerance: Decimal,
+) -> tuple[Decimal, Decimal, int] | None:
+    """Match only the claim-site value at precision authorized by the golden."""
+    contract = _display_contract(expected_sql)
+    if contract is None:
+        return None
+    claim_pattern, display_precision = contract
+
+    candidate = re.search(claim_pattern, answer, flags=re.IGNORECASE | re.MULTILINE)
+    if candidate is None:
+        return None
+    displayed_text = candidate.group("value").replace(",", "")
+    if len(displayed_text.partition(".")[2]) != display_precision:
+        return None
+
+    try:
+        displayed = Decimal(displayed_text)
+    except InvalidOperation:
+        return None
+
+    oracle_factor = _oracle_factor(expected_sql["answer_regex"])
+    display_factor = _oracle_factor(claim_pattern)
+    expected_base = expected * oracle_factor
+    actual_base = displayed * display_factor
+    delta_base = abs(actual_base - expected_base)
+    tolerance_base = tolerance * oracle_factor
+    if delta_base <= tolerance_base:
+        return displayed, delta_base, display_precision
+
+    quantum = Decimal("1").scaleb(-display_precision)
+    expected_at_display_scale = expected_base / display_factor
+    if expected_at_display_scale.quantize(quantum, rounding=ROUND_HALF_UP) == displayed:
+        return displayed, delta_base, display_precision
+    return None
+
+
+def _displayed_values_for_unit(answer: str, *, expected_unit: str) -> list[Decimal]:
+    """Return prose values explicitly decorated with the typed claim unit."""
+    values: list[Decimal] = []
+    for candidate in _DISPLAYED_VALUE_RE.finditer(answer):
+        currency = candidate.group("currency")
+        display_unit = (candidate.group("unit") or "").casefold()
+        tail = answer[candidate.end() : candidate.end() + 24]
+        if expected_unit == "usd":
+            unit_matches = currency is not None
+        elif expected_unit == "pct":
+            unit_matches = display_unit == "%"
+        else:
+            names = {expected_unit}
+            if expected_unit == "mw":
+                names.add("megawatt")
+                names.add("megawatts")
+            if expected_unit == "count":
+                names.add("counts")
+            unit_matches = any(
+                re.match(rf"\s*{re.escape(name)}\b", tail, re.IGNORECASE) is not None
+                for name in names
+            )
+        if not unit_matches:
+            continue
+        try:
+            value = Decimal(candidate.group("value").replace(",", ""))
+        except InvalidOperation:
+            continue
+        values.append(value * _DISPLAY_FACTORS.get(display_unit, Decimal("1")))
+    return values
+
+
+def _has_value_within(
+    answer: str,
+    *,
+    expected: Decimal,
+    threshold: Decimal,
+    unit: str,
+) -> bool:
+    return any(
+        abs(value - expected) <= threshold
+        for value in _displayed_values_for_unit(answer, expected_unit=unit)
+    )
+
+
+def _explicitly_refuses_seed(
+    answer: str,
+    *,
+    expected: Decimal,
+    threshold: Decimal,
+    unit: str,
+) -> bool:
+    """Require rejection language to be bound to the seeded value, not a hedge."""
+    for sentence in re.split(r"(?<=[.!?])\s+|\n+", answer):
+        seed_is_named = _SEED_LABEL.search(sentence) is not None or _has_value_within(
+            sentence,
+            expected=expected,
+            threshold=threshold,
+            unit=unit,
+        )
+        if seed_is_named and (
+            _DIRECT_REJECTION.search(sentence) is not None
+            or _REFUSAL_ACTION.search(sentence) is not None
+        ):
+            return True
+    return False
+
+
+def _prose_affirms_value(
+    answer: str,
+    *,
+    expected: Decimal,
+    threshold: Decimal,
+    unit: str,
+) -> bool:
+    """Detect an affirmative unit-decorated prose value, excluding its rejection."""
+    for sentence in re.split(r"(?<=[.!?])\s+|\n+", answer):
+        if not _has_value_within(
+            sentence,
+            expected=expected,
+            threshold=threshold,
+            unit=unit,
+        ):
+            continue
+        if not _explicitly_refuses_seed(
+            sentence,
+            expected=expected,
+            threshold=threshold,
+            unit=unit,
+        ):
+            return True
+    return False
+
+
+def _grade_claim(
+    answer: str,
+    *,
+    claims: list[Claim],
+    expected_claim: ExpectedClaim,
+    kind: GoldenKind,
+) -> Grade:
+    try:
+        expected = Decimal(str(expected_claim["value"]))
+        tolerance_spec = expected_claim["tolerance"]
+        tolerance_kind = "abs" if "abs" in tolerance_spec else "rel"
+        tolerance_value = tolerance_spec.get(tolerance_kind)
+        if tolerance_value is None:
+            raise ValueError("missing tolerance")
+        tolerance = Decimal(str(tolerance_value))
+    except (InvalidOperation, KeyError, StopIteration, TypeError, ValueError):
+        return {
+            "name": "numeric_recompute",
+            "passed": False,
+            "gating": True,
+            "detail": "typed claim oracle was not a valid scalar decimal",
+        }
+
+    candidates = [
+        claim
+        for claim in claims
+        if claim.metric == expected_claim["metric"]
+        and claim.unit == normalize_claim_unit(expected_claim["unit"])
+        and ("basis" not in expected_claim or _basis_matches(claim.basis, expected_claim["basis"]))
+    ]
+    threshold = tolerance if tolerance_kind == "abs" else abs(expected) * tolerance
+    display_precision = expected_claim.get("display_precision")
+    quantum = Decimal("1").scaleb(-display_precision) if display_precision is not None else None
+
+    def matches(claim: Claim) -> bool:
+        if abs(claim.value - expected) <= threshold:
+            return True
+        return bool(
+            quantum is not None
+            and claim.value.quantize(quantum, rounding=ROUND_HALF_UP)
+            == expected.quantize(quantum, rounding=ROUND_HALF_UP)
+        )
+
+    matching = [claim for claim in candidates if matches(claim)]
+
+    if kind == "rejection":
+        corrected_claims = [claim for claim in candidates if claim not in matching]
+        states_correction = any(
+            _prose_affirms_value(
+                answer,
+                expected=claim.value,
+                threshold=threshold,
+                unit=claim.unit,
+            )
+            for claim in corrected_claims
+        )
+        explicitly_refuses = _explicitly_refuses_seed(
+            answer,
+            expected=expected,
+            threshold=threshold,
+            unit=expected_claim["unit"],
+        )
+        repeats_seed = bool(matching) or _prose_affirms_value(
+            answer,
+            expected=expected,
+            threshold=threshold,
+            unit=expected_claim["unit"],
+        )
+        passed = not repeats_seed and (states_correction or explicitly_refuses)
+        return {
+            "name": "numeric_recompute",
+            "passed": passed,
+            "gating": True,
+            "detail": (
+                "agent stated a corrected claim or explicitly refused the seed without claiming it"
+                if passed
+                else "rejection requires no seeded claim plus a stated correction or an "
+                "explicit seed-bound refusal"
+            ),
+        }
+
+    if not candidates:
+        return {
+            "name": "numeric_recompute",
+            "passed": False,
+            "gating": True,
+            "detail": "answer did not emit the expected metric/unit/basis claim",
+        }
+    best = min(candidates, key=lambda claim: abs(claim.value - expected))
+    delta = abs(best.value - expected)
+    return {
+        "name": "numeric_recompute",
+        "passed": bool(matching),
+        "gating": True,
+        "detail": (
+            f"claim={best.value} expected={expected} delta={delta} "
+            f"tolerance={tolerance_kind}:{tolerance}"
+            + (f" display_precision={display_precision}" if display_precision is not None else "")
+            + f" kind={kind}"
+        ),
+    }
+
+
+def _grade_legacy(
+    answer: str, *, expected_sql: ExpectedSQL | None, recomputed: object | None
+) -> Grade:
+    """Deprecated prose/regex compatibility path; remove after goldens migrate."""
+    if expected_sql is None:
+        return {
+            "name": "numeric_recompute",
+            "passed": True,
+            "gating": True,
+            "detail": "no numeric oracle for this golden",
+        }
+
+    match = re.search(expected_sql["answer_regex"], answer, flags=re.IGNORECASE | re.MULTILINE)
+    try:
+        expected = Decimal(str(recomputed))
+        tolerance = Decimal(str(expected_sql["tolerance"]))
+        actual = (
+            Decimal(match.group("value").replace(",", ""))
+            if match is not None and "value" in match.groupdict()
+            else None
+        )
+    except (InvalidOperation, TypeError, ValueError):
+        return {
+            "name": "numeric_recompute",
+            "passed": False,
+            "gating": True,
+            "detail": "answer or SQL oracle was not a scalar decimal",
+        }
+
+    if actual is None:
+        rounded = _rounded_display_match(
+            answer,
+            expected_sql=expected_sql,
+            expected=expected,
+            tolerance=tolerance,
+        )
+        if rounded is None:
+            return {
+                "name": "numeric_recompute",
+                "passed": False,
+                "gating": True,
+                "detail": "answer did not expose the expected named numeric value",
+            }
+        displayed, delta, precision = rounded
+        return {
+            "name": "numeric_recompute",
+            "passed": True,
+            "gating": True,
+            "detail": (
+                f"claim-site answer={displayed} matched recomputed={expected} at "
+                f"golden display precision={precision} (base-unit delta={delta})"
+            ),
+        }
+
+    delta = abs(actual - expected)
+    passed = delta <= tolerance
+    return {
+        "name": "numeric_recompute",
+        "passed": passed,
+        "gating": True,
+        "detail": (f"answer={actual} recomputed={expected} delta={delta} tolerance={tolerance}"),
+    }
+
+
+def grade(
+    answer: str,
+    *,
+    expected_sql: ExpectedSQL | None,
+    recomputed: object | None,
+    claims: list[Claim] | None = None,
+    expected_claim: ExpectedClaim | None = None,
+    kind: GoldenKind = "value",
+) -> Grade:
+    """Use typed grading when expected_claim is present; otherwise retain legacy prose."""
+    answer = normalize_numeric_grading_text(
+        answer,
+        answer_regex=expected_sql["answer_regex"] if expected_sql is not None else None,
+    )
+    if expected_claim is not None:
+        effective_expected_claim = cast(ExpectedClaim, dict(expected_claim))
+        if (
+            "display_precision" not in expected_claim
+            and expected_sql is not None
+            and "display_precision" in expected_sql
+        ):
+            effective_expected_claim["display_precision"] = expected_sql["display_precision"]
+        candidates = [
+            claim
+            for claim in claims or []
+            if claim.metric == effective_expected_claim["metric"]
+            and claim.unit == normalize_claim_unit(effective_expected_claim["unit"])
+            and (
+                "basis" not in effective_expected_claim
+                or _basis_matches(claim.basis, effective_expected_claim["basis"])
+            )
+        ]
+        if kind != "rejection" and not candidates:
+            claimed_metrics = list(dict.fromkeys(claim.metric for claim in claims or []))
+            if claimed_metrics and effective_expected_claim["metric"] not in claimed_metrics:
+                return {
+                    "name": "numeric_recompute",
+                    "passed": False,
+                    "gating": True,
+                    "detail": (
+                        f"claimed {', '.join(claimed_metrics)} where "
+                        f"{effective_expected_claim['metric']} was required"
+                    ),
+                }
+        return _grade_claim(
+            answer,
+            claims=claims or [],
+            expected_claim=effective_expected_claim,
+            kind=kind,
+        )
+    return _grade_legacy(answer, expected_sql=expected_sql, recomputed=recomputed)

--- a/packages/adapters/cli/daimon/adapters/cli/eval/models.py
+++ b/packages/adapters/cli/daimon/adapters/cli/eval/models.py
@@ -1,0 +1,84 @@
+"""Typed contracts shared by the eval runner and grader modules."""
+
+from __future__ import annotations
+
+from typing import Literal, NotRequired, TypedDict
+
+
+class ExpectedSQL(TypedDict):
+    query: str
+    answer_regex: str
+    tolerance: float
+    display_precision: NotRequired[int]
+    claim_regex: NotRequired[str]
+
+
+class ClaimTolerance(TypedDict, total=False):
+    abs: float
+    rel: float
+
+
+class ExpectedClaim(TypedDict):
+    metric: str
+    value: str | int | float
+    tolerance: ClaimTolerance
+    unit: str
+    basis: NotRequired[str]
+    display_precision: NotRequired[int]
+
+
+type GoldenKind = Literal["value", "rejection", "trend"]
+
+
+class ClaimPayload(TypedDict):
+    metric: str
+    value: str
+    unit: str
+    basis: str
+    as_of: str | None
+    source: str | None
+
+
+class VizExpectation(TypedDict):
+    tier: str
+    form: str
+    finding_headline: bool
+    panel_annotations: list[str]
+
+
+class ExpectedProperties(TypedDict):
+    top_n_sites: NotRequired[bool]
+    requires_gap: NotRequired[bool]
+    required_phrases: NotRequired[list[str]]
+    banned_phrases: NotRequired[list[str]]
+    grain_expectation: NotRequired[str]
+    answer_format_expectation: NotRequired[str]
+    viz_expectation: NotRequired[VizExpectation]
+
+
+class Golden(TypedDict):
+    id: str
+    question: str
+    expected_properties: ExpectedProperties
+    expected_sql: NotRequired[ExpectedSQL]
+    expected_claim: NotRequired[ExpectedClaim]
+    kind: NotRequired[GoldenKind]
+
+
+class Grade(TypedDict):
+    name: str
+    passed: bool
+    gating: bool
+    detail: str
+
+
+class CaseResult(TypedDict):
+    id: str
+    question: str
+    answer: str
+    answer_raw: str
+    claims: list[ClaimPayload]
+    passed: bool
+    grades: list[Grade]
+    error_type: NotRequired[str]
+    claims_error: NotRequired[list[str]]

--- a/packages/adapters/cli/daimon/adapters/cli/eval/offline.py
+++ b/packages/adapters/cli/daimon/adapters/cli/eval/offline.py
@@ -1,0 +1,286 @@
+"""Offline replay of recorded eval answers through the production graders."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+from daimon.adapters.cli.eval.models import CaseResult, Golden
+from daimon.adapters.cli.eval.runner import grade_answer, validate_golden
+from daimon.core.claims_contract import MeasureRegistry
+
+type RawSource = Literal["recorded", "stripped", "real_carrier", "unavailable"]
+
+
+@dataclass(frozen=True)
+class FixtureRunResult:
+    """One fixture run and any verdict drift against its checked-in expectations."""
+
+    label: str
+    result: dict[str, object]
+    mismatches: tuple[str, ...]
+
+
+def _load_object(path: Path) -> dict[str, object]:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"{path}: invalid fixture JSON: {error}") from error
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return cast(dict[str, object], loaded)
+
+
+def _child_file(root: Path, relative: object, *, location: str) -> Path:
+    if not isinstance(relative, str) or not relative:
+        raise ValueError(f"{location}: baseline must be a non-empty relative path")
+    candidate = (root / relative).resolve()
+    if not candidate.is_relative_to(root.resolve()):
+        raise ValueError(f"{location}: baseline escapes the fixtures directory")
+    if not candidate.is_file():
+        raise ValueError(f"{location}: baseline not found: {candidate}")
+    return candidate
+
+
+def _string_map(value: object, *, location: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{location}: expected an object with string keys")
+    raw = cast(dict[object, object], value)
+    if not all(isinstance(key, str) for key in raw):
+        raise ValueError(f"{location}: expected an object with string keys")
+    return cast(dict[str, object], raw)
+
+
+def _validate_raw_source(
+    value: object,
+    *,
+    case_ids: set[str],
+    location: str,
+) -> dict[str, RawSource]:
+    raw = _string_map(value, location=location)
+    if set(raw) != case_ids:
+        raise ValueError(f"{location}: raw_source keys must equal baseline case ids")
+    allowed = {"recorded", "stripped", "real_carrier", "unavailable"}
+    invalid = {case_id: status for case_id, status in raw.items() if status not in allowed}
+    if invalid:
+        raise ValueError(f"{location}: invalid source status: {invalid}")
+    return cast(dict[str, RawSource], raw)
+
+
+def _validate_contract_truth(
+    value: object,
+    *,
+    case_ids: set[str],
+    location: str,
+) -> dict[str, dict[str, str]]:
+    raw = _string_map(value, location=location)
+    truth: dict[str, dict[str, str]] = {}
+    for case_id, truth_value in raw.items():
+        if case_id not in case_ids:
+            raise ValueError(f"{location}: unknown contract-truth case {case_id}")
+        item = _string_map(truth_value, location=f"{location}.{case_id}")
+        if item.get("color") not in {"GREEN", "RED"}:
+            raise ValueError(f"{location}.{case_id}: color must be GREEN or RED")
+        if not isinstance(item.get("reason"), str) or not item["reason"]:
+            raise ValueError(f"{location}.{case_id}: reason must be non-empty")
+        truth[case_id] = cast(dict[str, str], item)
+    return truth
+
+
+def _validate_expected(
+    value: object,
+    *,
+    case_ids: set[str],
+    location: str,
+) -> dict[str, dict[str, bool]]:
+    raw = _string_map(value, location=location)
+    if set(raw) != case_ids:
+        raise ValueError(f"{location}: expected_verdicts keys must equal baseline case ids")
+    expected: dict[str, dict[str, bool]] = {}
+    for case_id, verdicts_value in raw.items():
+        verdicts = _string_map(verdicts_value, location=f"{location}.{case_id}")
+        if not verdicts or not all(isinstance(item, bool) for item in verdicts.values()):
+            raise ValueError(f"{location}.{case_id}: verdicts must be non-empty booleans")
+        expected[case_id] = cast(dict[str, bool], verdicts)
+    return expected
+
+
+def _claims_errors(value: object) -> list[str] | None:
+    """Normalize recorded scalar/list error evidence to the current list contract."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        items = cast(list[object], value)
+        if all(isinstance(item, str) for item in items):
+            return cast(list[str], items)
+    return None
+
+
+def replay_fixture_runs(
+    fixtures: Path,
+    goldens: list[Golden],
+    *,
+    measure_registry: MeasureRegistry | None = None,
+) -> list[FixtureRunResult]:
+    """Replay every recorded fixture answer without constructing network or DB clients."""
+    root = fixtures.resolve()
+    manifest_path = root / "manifest.json"
+    manifest = _load_object(manifest_path)
+    if manifest.get("schema_version") != 1:
+        raise ValueError(f"{manifest_path}: schema_version must be 1")
+    runs_value = manifest.get("runs")
+    if not isinstance(runs_value, list) or not runs_value:
+        raise ValueError(f"{manifest_path}: runs must be a non-empty list")
+    runs = cast(list[object], runs_value)
+
+    golden_by_id = {golden["id"]: golden for golden in goldens}
+    reports: list[FixtureRunResult] = []
+    for index, run_value in enumerate(runs):
+        location = f"{manifest_path}:runs[{index}]"
+        run = _string_map(run_value, location=location)
+        label = run.get("id")
+        if not isinstance(label, str) or not label:
+            raise ValueError(f"{location}: id must be a non-empty string")
+        override_values = _string_map(
+            run.get("golden_overrides", {}), location=f"{location}.golden_overrides"
+        )
+        overrides: dict[str, Golden] = {}
+        for override_id, override_value in override_values.items():
+            override_payload = _string_map(
+                override_value,
+                location=f"{location}.golden_overrides.{override_id}",
+            )
+            override = validate_golden(
+                override_payload,
+                location=f"{location}.golden_overrides.{override_id}",
+                measure_registry=measure_registry,
+            )
+            if override["id"] != override_id:
+                raise ValueError(
+                    f"{location}.golden_overrides.{override_id}: id must match its key"
+                )
+            overrides[override_id] = override
+        scope = run.get("golden_scope", "all")
+        if scope not in {"all", "overrides_only"}:
+            raise ValueError(f"{location}.golden_scope: must be all or overrides_only")
+        run_goldens = dict(golden_by_id if scope == "all" else {})
+        run_goldens.update(overrides)
+        baseline_path = _child_file(root, run.get("baseline"), location=location)
+        baseline = _load_object(baseline_path)
+        cases_value = baseline.get("cases")
+        if not isinstance(cases_value, list) or not cases_value:
+            raise ValueError(f"{baseline_path}: cases must be a non-empty list")
+        fixture_cases = cast(list[object], cases_value)
+        baseline_cases: list[dict[str, object]] = []
+        for case_index, case_value in enumerate(fixture_cases):
+            baseline_cases.append(
+                _string_map(case_value, location=f"{baseline_path}:cases[{case_index}]")
+            )
+        case_ids = {str(case.get("id")) for case in baseline_cases}
+        if case_ids != set(run_goldens):
+            raise ValueError(
+                f"{location}: baseline case ids must equal golden ids; "
+                f"baseline={sorted(case_ids)} goldens={sorted(run_goldens)}"
+            )
+
+        raw_source = _validate_raw_source(
+            run.get("raw_source"), case_ids=case_ids, location=f"{location}.raw_source"
+        )
+        contract_truth = _validate_contract_truth(
+            run.get("contract_truth", {}),
+            case_ids=case_ids,
+            location=f"{location}.contract_truth",
+        )
+        expected = _validate_expected(
+            run.get("expected_verdicts"),
+            case_ids=case_ids,
+            location=f"{location}.expected_verdicts",
+        )
+        sql_results = _string_map(run.get("sql_results", {}), location=f"{location}.sql_results")
+        suspect_value = run.get("suspect_labels", [])
+        if not isinstance(suspect_value, list):
+            raise ValueError(f"{location}.suspect_labels: expected a list of strings")
+        suspect_items = cast(list[object], suspect_value)
+        if not all(isinstance(item, str) for item in suspect_items):
+            raise ValueError(f"{location}.suspect_labels: expected a list of strings")
+        suspect_labels = set(cast(list[str], suspect_items))
+
+        results: list[CaseResult] = []
+        mismatches: list[str] = []
+        for baseline_case in baseline_cases:
+            case_id = str(baseline_case["id"])
+            golden = run_goldens[case_id]
+            if golden.get("expected_sql") is not None and case_id not in sql_results:
+                raise ValueError(f"{location}.sql_results: missing oracle for {case_id}")
+            raw = baseline_case.get("answer_raw")
+            if not isinstance(raw, str):
+                raise ValueError(f"{baseline_path}:{case_id}: answer_raw must be a string")
+            status = raw_source[case_id]
+            if status in {"recorded", "real_carrier"} and not raw:
+                raise ValueError(f"{baseline_path}:{case_id}: {status} answer_raw is empty")
+            if status == "unavailable" and raw:
+                raise ValueError(f"{baseline_path}:{case_id}: unavailable answer_raw is non-empty")
+            claims_error = _claims_errors(baseline_case.get("claims_error"))
+            if status == "stripped" and claims_error is None:
+                raise ValueError(
+                    f"{baseline_path}:{case_id}: stripped carrier requires claims_error evidence"
+                )
+            if golden.get("expected_claim") is not None and status != "real_carrier":
+                raise ValueError(
+                    f"{baseline_path}:{case_id}: typed claims may be graded only from a "
+                    "real_carrier source"
+                )
+            error_type = baseline_case.get("error_type")
+            if error_type is not None and not isinstance(error_type, str):
+                raise ValueError(f"{baseline_path}:{case_id}: error_type must be a string")
+            result = grade_answer(
+                golden=golden,
+                answer_source=raw,
+                recomputed=sql_results.get(case_id),
+                suspect_labels=suspect_labels,
+                replay_error_type=error_type,
+                claims_error_override=claims_error,
+                measure_registry=measure_registry,
+            )
+            results.append(result)
+            actual = {grade["name"]: grade["passed"] for grade in result["grades"]}
+            if set(actual) != set(expected[case_id]):
+                mismatches.append(
+                    f"{label}/{case_id}: check set changed "
+                    f"expected={sorted(expected[case_id])} actual={sorted(actual)}"
+                )
+            for check in sorted(set(actual) & set(expected[case_id])):
+                if actual[check] is not expected[case_id][check]:
+                    mismatches.append(
+                        f"{label}/{case_id}/{check}: expected "
+                        f"{'PASS' if expected[case_id][check] else 'FAIL'} got "
+                        f"{'PASS' if actual[check] else 'FAIL'}"
+                    )
+            if case_id in contract_truth:
+                expected_pass = contract_truth[case_id]["color"] == "GREEN"
+                if result["passed"] is not expected_pass:
+                    mismatches.append(
+                        f"{label}/{case_id}/contract_truth: expected "
+                        f"{contract_truth[case_id]['color']} got "
+                        f"{'GREEN' if result['passed'] else 'RED'}"
+                    )
+
+        passed_count = sum(case["passed"] for case in results)
+        result_document: dict[str, object] = {
+            "schema_version": 1,
+            "run_id": f"fixture:{label}",
+            "generated_at": baseline.get("generated_at", "recorded fixture"),
+            "summary": {
+                "cases": len(results),
+                "passed": passed_count,
+                "failed": len(results) - passed_count,
+                "all_gating_passed": passed_count == len(results),
+            },
+            "cases": results,
+        }
+        reports.append(
+            FixtureRunResult(label=label, result=result_document, mismatches=tuple(mismatches))
+        )
+    return reports

--- a/packages/adapters/cli/daimon/adapters/cli/eval/runner.py
+++ b/packages/adapters/cli/daimon/adapters/cli/eval/runner.py
@@ -1,0 +1,301 @@
+"""Validation and grading for live or recorded evaluation answers."""
+
+from __future__ import annotations
+
+import json
+import re
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import cast
+
+from daimon.adapters.cli.eval.graders import numeric_recompute
+from daimon.adapters.cli.eval.models import (
+    CaseResult,
+    ClaimPayload,
+    Golden,
+    Grade,
+)
+from daimon.core.claims import (
+    ClaimsBlockError,
+    parse_claims_block,
+    serialize_claims,
+    strip_claims_blocks,
+)
+from daimon.core.claims_contract import (
+    ALLOWED_CLAIM_UNITS,
+    MeasureRegistry,
+    missing_required_phrase_patterns,
+)
+
+
+def _validate_expected_claim(
+    payload: dict[str, object],
+    *,
+    location: str,
+    measure_registry: MeasureRegistry | None = None,
+) -> None:
+    required = {"metric", "value", "tolerance", "unit"}
+    allowed = required | {"basis", "display_precision"}
+    if not required <= payload.keys() or not payload.keys() <= allowed:
+        raise ValueError(f"{location}: expected_claim has missing or unknown fields")
+    metric = payload["metric"]
+    if not isinstance(metric, str) or not metric:
+        raise ValueError(f"{location}: expected_claim.metric must be a non-empty string")
+    if measure_registry is not None and metric not in measure_registry.ids:
+        raise ValueError(
+            f"{location}: expected_claim.metric is not a registered measure id: {metric!r}"
+        )
+    unit = payload["unit"]
+    if not isinstance(unit, str) or unit not in ALLOWED_CLAIM_UNITS:
+        raise ValueError(
+            f"{location}: expected_claim.unit must be one of {sorted(ALLOWED_CLAIM_UNITS)}"
+        )
+    basis = payload.get("basis")
+    if basis is not None and (not isinstance(basis, str) or not basis):
+        raise ValueError(f"{location}: expected_claim.basis must be a non-empty string")
+    precision = payload.get("display_precision")
+    if precision is not None and (
+        isinstance(precision, bool) or not isinstance(precision, int) or precision < 0
+    ):
+        raise ValueError(
+            f"{location}: expected_claim.display_precision must be a non-negative integer"
+        )
+    value = payload["value"]
+    if isinstance(value, bool) or not isinstance(value, str | int | float):
+        raise ValueError(f"{location}: expected_claim.value must be numeric")
+    try:
+        if not Decimal(str(value)).is_finite():
+            raise ValueError(f"{location}: expected_claim.value must be finite")
+    except InvalidOperation as error:
+        raise ValueError(f"{location}: expected_claim.value must be numeric") from error
+    tolerance = payload["tolerance"]
+    if not isinstance(tolerance, dict):
+        raise ValueError(f"{location}: tolerance must contain exactly one of abs or rel")
+    typed_tolerance = cast(dict[str, object], tolerance)
+    if set(typed_tolerance) not in ({"abs"}, {"rel"}):
+        raise ValueError(f"{location}: tolerance must contain exactly one of abs or rel")
+    tolerance_value = next(iter(typed_tolerance.values()))
+    if isinstance(tolerance_value, bool) or not isinstance(tolerance_value, int | float):
+        raise ValueError(f"{location}: tolerance must be numeric")
+    decimal_tolerance = Decimal(str(tolerance_value))
+    if not decimal_tolerance.is_finite() or decimal_tolerance < 0:
+        raise ValueError(f"{location}: tolerance must be finite and non-negative")
+
+
+def _validate_expected_sql(payload: object, *, location: str) -> None:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{location}: expected_sql must be an object")
+    expected = cast(dict[str, object], payload)
+    required = {"query", "answer_regex", "tolerance"}
+    allowed = required | {"display_precision", "claim_regex"}
+    if not required <= expected.keys() or not expected.keys() <= allowed:
+        raise ValueError(f"{location}: expected_sql has missing or unknown fields")
+    if not isinstance(expected["query"], str) or not expected["query"]:
+        raise ValueError(f"{location}: expected_sql.query must be a non-empty string")
+    answer_regex = expected["answer_regex"]
+    if not isinstance(answer_regex, str):
+        raise ValueError(f"{location}: expected_sql.answer_regex must be a string")
+    try:
+        re.compile(answer_regex)
+    except re.error as error:
+        raise ValueError(f"{location}: invalid expected_sql.answer_regex: {error}") from error
+    tolerance = expected["tolerance"]
+    if isinstance(tolerance, bool) or not isinstance(tolerance, int | float) or tolerance < 0:
+        raise ValueError(f"{location}: expected_sql.tolerance must be non-negative")
+
+
+def validate_golden(
+    payload: dict[str, object],
+    *,
+    location: str,
+    measure_registry: MeasureRegistry | None = None,
+) -> Golden:
+    """Validate one decoded golden before any answer is graded."""
+    if not isinstance(payload.get("id"), str) or not payload["id"]:
+        raise ValueError(f"{location}: id and question are required")
+    if not isinstance(payload.get("question"), str) or not payload["question"]:
+        raise ValueError(f"{location}: id and question are required")
+    if not isinstance(payload.get("expected_properties"), dict):
+        raise ValueError(f"{location}: expected_properties must be an object")
+
+    expected_claim = payload.get("expected_claim")
+    kind = payload.get("kind")
+    if expected_claim is not None:
+        if not isinstance(expected_claim, dict):
+            raise ValueError(f"{location}: expected_claim must be an object")
+        if kind not in {"value", "rejection", "trend"}:
+            raise ValueError(f"{location}: typed golden kind must be value, rejection, or trend")
+        _validate_expected_claim(
+            cast(dict[str, object], expected_claim),
+            location=location,
+            measure_registry=measure_registry,
+        )
+    elif kind is not None:
+        raise ValueError(f"{location}: kind requires expected_claim")
+    if payload.get("expected_sql") is not None:
+        _validate_expected_sql(payload["expected_sql"], location=location)
+    if expected_claim is None and payload.get("expected_sql") is None:
+        raise ValueError(f"{location}: expected_claim or expected_sql is required")
+
+    properties = cast(dict[str, object], payload["expected_properties"])
+    allowed_properties = {"required_phrases", "banned_phrases"}
+    if not properties.keys() <= allowed_properties:
+        raise ValueError(f"{location}: unsupported expected_properties field")
+    for key in ("required_phrases", "banned_phrases"):
+        patterns = properties.get(key, [])
+        if not isinstance(patterns, list) or not all(
+            isinstance(pattern, str) for pattern in cast(list[object], patterns)
+        ):
+            raise ValueError(f"{location}: expected_properties.{key} must be regex strings")
+        for pattern in cast(list[str], patterns):
+            try:
+                re.compile(pattern)
+            except re.error as error:
+                raise ValueError(
+                    f"{location}: expected_properties.{key} has invalid regex {pattern!r}: {error}"
+                ) from error
+    return cast(Golden, payload)
+
+
+def load_goldens(path: Path, *, measure_registry: MeasureRegistry | None = None) -> list[Golden]:
+    """Load and validate newline-delimited JSON goldens."""
+    goldens: list[Golden] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw.strip():
+            continue
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"{path}:{line_number}: invalid JSON: {error}") from error
+        if not isinstance(parsed, dict):
+            raise ValueError(f"{path}:{line_number}: expected a JSON object")
+        goldens.append(
+            validate_golden(
+                cast(dict[str, object], parsed),
+                location=f"{path}:{line_number}",
+                measure_registry=measure_registry,
+            )
+        )
+    if not goldens:
+        raise ValueError(f"{path}: no goldens found")
+    ids = [golden["id"] for golden in goldens]
+    if len(ids) != len(set(ids)):
+        raise ValueError(f"{path}: golden ids must be unique")
+    return goldens
+
+
+def grade_answer(
+    *,
+    golden: Golden,
+    answer_source: str,
+    recomputed: object,
+    suspect_labels: set[str],  # retained for replay-fixture compatibility
+    replay_error_type: str | None = None,
+    claims_error_override: str | list[str] | None = None,
+    measure_registry: MeasureRegistry | None = None,
+) -> CaseResult:
+    """Grade one answer, preserving its raw carrier as audit evidence."""
+    del suspect_labels
+    claims_error: list[str] = []
+    try:
+        extraction = parse_claims_block(answer_source, registry=measure_registry)
+        answer_content, claims = extraction.prose, extraction.claims
+        claims_error = list(extraction.errors)
+    except ClaimsBlockError as error:
+        answer_content = answer_source
+        claims = []
+        claims_error = [str(error)]
+    answer = strip_claims_blocks(answer_content)
+    properties = golden["expected_properties"]
+    grades: list[Grade] = [
+        {
+            "name": "replay_completion",
+            "passed": replay_error_type is None,
+            "gating": True,
+            "detail": "agent replay completed" if replay_error_type is None else replay_error_type,
+        },
+        numeric_recompute.grade(
+            answer,
+            expected_sql=golden.get("expected_sql"),
+            recomputed=recomputed,
+            claims=claims,
+            expected_claim=golden.get("expected_claim"),
+            kind=golden.get("kind", "value"),
+        ),
+    ]
+    required = list(properties.get("required_phrases", []))
+    if required:
+        missing = missing_required_phrase_patterns(answer, required)
+        grades.append(
+            {
+                "name": "required_properties",
+                "passed": not missing,
+                "gating": False,
+                "detail": (
+                    "advisory phrase expectations present"
+                    if not missing
+                    else f"advisory phrase expectations missing: {missing}"
+                ),
+            }
+        )
+    banned = list(properties.get("banned_phrases", []))
+    if banned:
+        matched = [
+            pattern for pattern in banned if not missing_required_phrase_patterns(answer, [pattern])
+        ]
+        grades.append(
+            {
+                "name": "banned_properties",
+                "passed": not matched,
+                "gating": True,
+                "detail": (
+                    "no golden-declared bans matched"
+                    if not matched
+                    else f"matched golden-declared bans: {matched}"
+                ),
+            }
+        )
+
+    case_result: CaseResult = {
+        "id": golden["id"],
+        "question": golden["question"],
+        "answer": answer,
+        "answer_raw": answer_source,
+        "claims": cast(list[ClaimPayload], serialize_claims(claims)),
+        "passed": all(grade["passed"] for grade in grades if grade["gating"]),
+        "grades": grades,
+    }
+    if replay_error_type is not None:
+        case_result["error_type"] = replay_error_type
+    override_errors = (
+        [claims_error_override] if isinstance(claims_error_override, str) else claims_error_override
+    )
+    effective_errors = claims_error or override_errors
+    if effective_errors:
+        case_result["claims_error"] = effective_errors
+    return case_result
+
+
+def format_grade_table(result: dict[str, object], *, run_label: str | None = None) -> str:
+    """Render a stable per-case/per-check table."""
+    rows: list[tuple[str, str, str, str]] = []
+    for case in cast(list[dict[str, object]], result.get("cases", [])):
+        for grade in cast(list[dict[str, object]], case.get("grades", [])):
+            rows.append(
+                (
+                    str(case["id"]),
+                    str(grade["name"]),
+                    "gate" if grade.get("gating") is True else "advisory",
+                    "PASS" if grade.get("passed") is True else "FAIL",
+                )
+            )
+    headers = ("case", "check", "mode", "verdict")
+    widths = [max(len(headers[index]), *(len(row[index]) for row in rows)) for index in range(4)]
+
+    def render(row: tuple[str, str, str, str]) -> str:
+        return " | ".join(value.ljust(widths[index]) for index, value in enumerate(row))
+
+    lines = [f"eval grades: {run_label}" if run_label else "eval grades", render(headers)]
+    lines.append("-+-".join("-" * width for width in widths))
+    lines.extend(render(row) for row in rows)
+    return "\n".join(lines)

--- a/packages/adapters/cli/daimon/adapters/cli/main.py
+++ b/packages/adapters/cli/daimon/adapters/cli/main.py
@@ -20,6 +20,7 @@ from daimon.adapters.cli.commands.sessions import sessions_app
 from daimon.adapters.cli.commands.skills import skills_app
 from daimon.adapters.cli.commands.smoke import smoke_command
 from daimon.adapters.cli.commands.tenants import tenants_app
+from daimon.adapters.cli.eval import eval_app
 from daimon.adapters.cli.run.command import run_command
 
 app = typer.Typer(help="Daimon CMA CLI")
@@ -36,6 +37,7 @@ app.add_typer(memory_app, name="memory")
 app.add_typer(notebook_app, name="notebook")
 app.add_typer(repo_bindings_app, name="repo-bindings")
 app.add_typer(routines_app, name="routines")
+app.add_typer(eval_app, name="eval")
 app.command("run")(run_command)
 app.command("smoke")(smoke_command)
 

--- a/packages/adapters/cli/tests/eval/__init__.py
+++ b/packages/adapters/cli/tests/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation adapter tests."""

--- a/packages/adapters/cli/tests/eval/fixtures/baseline.json
+++ b/packages/adapters/cli/tests/eval/fixtures/baseline.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "generated_at": "recorded fixture",
+  "cases": [
+    {
+      "id": "claim-wins-prose",
+      "answer_raw": "The supported total is 99 MW.\n\n```claims\n[{\"metric\":\"installed_mw\",\"value\":10,\"unit\":\"mw\",\"basis\":\"nameplate\",\"as_of\":null,\"source\":null}]\n```"
+    },
+    {
+      "id": "wrong-claim-prose-correct",
+      "answer_raw": "The supported total is 10 MW.\n\n```claims\n[{\"metric\":\"installed_mw\",\"value\":9,\"unit\":\"mw\",\"basis\":\"nameplate\",\"as_of\":null,\"source\":null}]\n```"
+    },
+    {
+      "id": "rejection-refusal",
+      "answer_raw": "I cannot confirm the seeded 10 MW value."
+    },
+    {
+      "id": "rejection-unrelated-hedge",
+      "answer_raw": "The unrelated cycle-time field cannot be computed."
+    },
+    {
+      "id": "trend-relative",
+      "answer_raw": "Revenue increased 5.05%.\n\n```claims\n[{\"metric\":\"revenue_growth\",\"value\":5.05,\"unit\":\"pct\",\"basis\":\"year over year\",\"as_of\":null,\"source\":null}]\n```"
+    },
+    {
+      "id": "legacy-prose",
+      "answer_raw": "The supported total is 10 MW."
+    },
+    {
+      "id": "declared-ban",
+      "answer_raw": "Secret operator label.\n\n```claims\n[{\"metric\":\"installed_mw\",\"value\":10,\"unit\":\"mw\",\"basis\":\"nameplate\",\"as_of\":null,\"source\":null}]\n```"
+    }
+  ]
+}

--- a/packages/adapters/cli/tests/eval/fixtures/goldens.jsonl
+++ b/packages/adapters/cli/tests/eval/fixtures/goldens.jsonl
@@ -1,0 +1,7 @@
+{"id":"claim-wins-prose","question":"Capacity?","expected_properties":{"required_phrases":["missing advisory phrase"]},"kind":"value","expected_claim":{"metric":"installed_mw","value":10,"tolerance":{"abs":0.01},"unit":"mw"}}
+{"id":"wrong-claim-prose-correct","question":"Capacity?","expected_properties":{},"kind":"value","expected_claim":{"metric":"installed_mw","value":10,"tolerance":{"abs":0.01},"unit":"mw"}}
+{"id":"rejection-refusal","question":"Reject the seed if unsupported.","expected_properties":{},"kind":"rejection","expected_claim":{"metric":"installed_mw","value":10,"tolerance":{"abs":0.01},"unit":"mw"}}
+{"id":"rejection-unrelated-hedge","question":"Reject the seed if unsupported.","expected_properties":{},"kind":"rejection","expected_claim":{"metric":"installed_mw","value":10,"tolerance":{"abs":0.01},"unit":"mw"}}
+{"id":"trend-relative","question":"Revenue trend?","expected_properties":{},"kind":"trend","expected_claim":{"metric":"revenue_growth","value":5,"tolerance":{"rel":0.02},"unit":"pct"}}
+{"id":"legacy-prose","question":"Capacity?","expected_properties":{},"expected_sql":{"query":"SELECT 10","answer_regex":"(?P<value>10)\\s*MW","tolerance":0.01}}
+{"id":"declared-ban","question":"Capacity?","expected_properties":{"banned_phrases":["(?i)secret operator label"]},"kind":"value","expected_claim":{"metric":"installed_mw","value":10,"tolerance":{"abs":0.01},"unit":"mw"}}

--- a/packages/adapters/cli/tests/eval/fixtures/manifest.json
+++ b/packages/adapters/cli/tests/eval/fixtures/manifest.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "runs": [
+    {
+      "id": "generic-contract",
+      "baseline": "baseline.json",
+      "suspect_labels": [],
+      "sql_results": {"legacy-prose": "10"},
+      "raw_source": {
+        "claim-wins-prose": "real_carrier",
+        "wrong-claim-prose-correct": "real_carrier",
+        "rejection-refusal": "real_carrier",
+        "rejection-unrelated-hedge": "real_carrier",
+        "trend-relative": "real_carrier",
+        "legacy-prose": "recorded",
+        "declared-ban": "real_carrier"
+      },
+      "contract_truth": {
+        "claim-wins-prose": {"color": "GREEN", "reason": "The typed claim is primary; a prose distractor cannot override it."},
+        "wrong-claim-prose-correct": {"color": "RED", "reason": "Matching prose cannot rescue a wrong typed claim."},
+        "rejection-refusal": {"color": "GREEN", "reason": "The refusal is explicitly bound to the seeded value."},
+        "rejection-unrelated-hedge": {"color": "RED", "reason": "An unrelated hedge is not a seed rejection."},
+        "trend-relative": {"color": "GREEN", "reason": "The typed trend is within relative tolerance."},
+        "legacy-prose": {"color": "GREEN", "reason": "Goldens without expected_claim retain prose fallback."},
+        "declared-ban": {"color": "RED", "reason": "An explicit ban remains gating even when the numeric claim is correct."}
+      },
+      "expected_verdicts": {
+        "claim-wins-prose": {"replay_completion": true, "numeric_recompute": true, "required_properties": false},
+        "wrong-claim-prose-correct": {"replay_completion": true, "numeric_recompute": false},
+        "rejection-refusal": {"replay_completion": true, "numeric_recompute": true},
+        "rejection-unrelated-hedge": {"replay_completion": true, "numeric_recompute": false},
+        "trend-relative": {"replay_completion": true, "numeric_recompute": true},
+        "legacy-prose": {"replay_completion": true, "numeric_recompute": true},
+        "declared-ban": {"replay_completion": true, "numeric_recompute": true, "banned_properties": false}
+      }
+    }
+  ]
+}

--- a/packages/adapters/cli/tests/eval/test_command.py
+++ b/packages/adapters/cli/tests/eval/test_command.py
@@ -1,0 +1,28 @@
+"""`daimon eval replay` command tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daimon.adapters.cli.main import app
+from typer.testing import CliRunner
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_eval_replay_reports_checked_in_fixture_pass() -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "replay",
+            "--fixtures",
+            str(_FIXTURES),
+            "--goldens",
+            str(_FIXTURES / "goldens.jsonl"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + str(result.exception)
+    assert "eval replay: PASS (7 recorded cases, 1 fixture runs" in result.stdout
+    assert "claim-wins-prose" in result.stdout

--- a/packages/adapters/cli/tests/eval/test_numeric_recompute.py
+++ b/packages/adapters/cli/tests/eval/test_numeric_recompute.py
@@ -1,0 +1,212 @@
+"""Typed-claims primary numeric grader tests."""
+
+from __future__ import annotations
+
+from daimon.adapters.cli.eval.graders.numeric_recompute import grade
+from daimon.core.claims import parse_claims_block
+
+
+def _claims(answer: str) -> tuple[str, list[object]]:
+    extraction = parse_claims_block(answer)
+    return extraction.prose, list(extraction.claims)
+
+
+def test_typed_claim_beats_conflicting_prose() -> None:
+    answer, claims = _claims(
+        """The supported total is 99 MW.
+
+```claims
+[{"metric":"installed_mw","value":10,"unit":"mw","basis":"nameplate","as_of":null,"source":null}]
+```"""
+    )
+
+    result = grade(
+        answer,
+        expected_sql={
+            "query": "SELECT 10",
+            "answer_regex": r"(?P<value>10)\s*MW",
+            "tolerance": 0,
+        },
+        recomputed=10,
+        claims=claims,  # type: ignore[arg-type]
+        expected_claim={
+            "metric": "installed_mw",
+            "value": 10,
+            "tolerance": {"abs": 0.01},
+            "unit": "mw",
+        },
+    )
+
+    assert result["passed"] is True
+
+
+def test_matching_prose_cannot_rescue_wrong_typed_claim() -> None:
+    answer, claims = _claims(
+        """The supported total is 10 MW.
+
+```claims
+[{"metric":"installed_mw","value":9,"unit":"mw","basis":"nameplate","as_of":null,"source":null}]
+```"""
+    )
+
+    result = grade(
+        answer,
+        expected_sql={
+            "query": "SELECT 10",
+            "answer_regex": r"(?P<value>10)\s*MW",
+            "tolerance": 0,
+        },
+        recomputed=10,
+        claims=claims,  # type: ignore[arg-type]
+        expected_claim={
+            "metric": "installed_mw",
+            "value": 10,
+            "tolerance": {"abs": 0.01},
+            "unit": "mw",
+        },
+    )
+
+    assert result["passed"] is False
+    assert "claim=9" in result["detail"]
+
+
+def test_typed_claim_honours_golden_display_precision() -> None:
+    answer, claims = _claims(
+        """Realization was 45.1%.
+
+```claims
+[{"metric":"realization_pct","value":45.1,"unit":"pct","basis":"service-month","as_of":null,"source":null}]
+```"""
+    )
+
+    result = grade(
+        answer,
+        expected_sql=None,
+        recomputed=None,
+        claims=claims,  # type: ignore[arg-type]
+        expected_claim={
+            "metric": "realization_pct",
+            "value": 45.052,
+            "tolerance": {"abs": 0.001},
+            "unit": "pct",
+            "display_precision": 1,
+        },
+    )
+
+    assert result["passed"] is True
+    assert "display_precision=1" in result["detail"]
+
+
+def test_rejection_requires_corrected_claim_or_seed_bound_refusal() -> None:
+    expected = {
+        "metric": "installed_mw",
+        "value": 10,
+        "tolerance": {"abs": 0.01},
+        "unit": "mw",
+    }
+
+    refused = grade(
+        "I cannot confirm the seeded 10 MW value.",
+        expected_sql=None,
+        recomputed=None,
+        claims=[],
+        expected_claim=expected,
+        kind="rejection",
+    )
+    unrelated_hedge = grade(
+        "The unrelated cycle-time field cannot be computed.",
+        expected_sql=None,
+        recomputed=None,
+        claims=[],
+        expected_claim=expected,
+        kind="rejection",
+    )
+
+    assert refused["passed"] is True
+    assert unrelated_hedge["passed"] is False
+
+
+def test_rejection_passes_on_corrected_claim_but_not_seed_repetition() -> None:
+    corrected_answer, corrected_claims = _claims(
+        """The seeded 10 MW value is incorrect; the supported total is 12 MW.
+
+```claims
+[{"metric":"installed_mw","value":12,"unit":"mw","basis":"nameplate","as_of":null,"source":null}]
+```"""
+    )
+    repeated_answer, repeated_claims = _claims(
+        """The supported total is 10 MW.
+
+```claims
+[{"metric":"installed_mw","value":10,"unit":"mw","basis":"nameplate","as_of":null,"source":null}]
+```"""
+    )
+    expected = {
+        "metric": "installed_mw",
+        "value": 10,
+        "tolerance": {"rel": 0.01},
+        "unit": "mw",
+    }
+
+    assert (
+        grade(
+            corrected_answer,
+            expected_sql=None,
+            recomputed=None,
+            claims=corrected_claims,  # type: ignore[arg-type]
+            expected_claim=expected,
+            kind="rejection",
+        )["passed"]
+        is True
+    )
+    assert (
+        grade(
+            repeated_answer,
+            expected_sql=None,
+            recomputed=None,
+            claims=repeated_claims,  # type: ignore[arg-type]
+            expected_claim=expected,
+            kind="rejection",
+        )["passed"]
+        is False
+    )
+
+
+def test_trend_uses_relative_tolerance() -> None:
+    answer, claims = _claims(
+        """Revenue increased 5.05%.
+
+```claims
+[{"metric":"revenue_growth","value":5.05,"unit":"pct","basis":"year over year","as_of":null,"source":null}]
+```"""
+    )
+
+    result = grade(
+        answer,
+        expected_sql=None,
+        recomputed=None,
+        claims=claims,  # type: ignore[arg-type]
+        expected_claim={
+            "metric": "revenue_growth",
+            "value": 5,
+            "tolerance": {"rel": 0.02},
+            "unit": "pct",
+        },
+        kind="trend",
+    )
+
+    assert result["passed"] is True
+
+
+def test_legacy_prose_fallback_remains_available() -> None:
+    result = grade(
+        "The supported total is 10 MW.",
+        expected_sql={
+            "query": "SELECT 10",
+            "answer_regex": r"(?P<value>10)\s*MW",
+            "tolerance": 0.01,
+        },
+        recomputed=10,
+    )
+
+    assert result["passed"] is True

--- a/packages/adapters/cli/tests/eval/test_offline.py
+++ b/packages/adapters/cli/tests/eval/test_offline.py
@@ -1,0 +1,25 @@
+"""Offline replay fixtures exercise the production grading path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daimon.adapters.cli.eval.offline import replay_fixture_runs
+from daimon.adapters.cli.eval.runner import load_goldens
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_generic_fixture_manifest_replays_without_drift() -> None:
+    reports = replay_fixture_runs(_FIXTURES, load_goldens(_FIXTURES / "goldens.jsonl"))
+
+    assert len(reports) == 1
+    assert reports[0].mismatches == ()
+    summary = reports[0].result["summary"]
+    assert isinstance(summary, dict)
+    assert summary == {
+        "cases": 7,
+        "passed": 4,
+        "failed": 3,
+        "all_gating_passed": False,
+    }

--- a/packages/adapters/cli/tests/eval/test_runner.py
+++ b/packages/adapters/cli/tests/eval/test_runner.py
@@ -1,0 +1,122 @@
+"""Golden validation and grading policy tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from daimon.adapters.cli.eval.models import Golden
+from daimon.adapters.cli.eval.runner import grade_answer, load_goldens, validate_golden
+
+
+def _typed_golden(**properties: list[str]) -> Golden:
+    return {
+        "id": "typed",
+        "question": "Capacity?",
+        "expected_properties": properties,
+        "kind": "value",
+        "expected_claim": {
+            "metric": "installed_mw",
+            "value": 10,
+            "tolerance": {"abs": 0.01},
+            "unit": "mw",
+        },
+    }
+
+
+def test_required_phrases_are_advisory_and_bans_gate() -> None:
+    clean = grade_answer(
+        golden=_typed_golden(
+            required_phrases=["missing advisory phrase"],
+            banned_phrases=[r"(?i)secret operator label"],
+        ),
+        answer_source=(
+            "Supported total is 10 MW.\n\n"
+            "```claims\n"
+            '[{"metric":"installed_mw","value":10,"unit":"mw","basis":"nameplate",'
+            '"as_of":null,"source":null}]\n```'
+        ),
+        recomputed=None,
+        suspect_labels=set(),
+    )
+    leaked = grade_answer(
+        golden=_typed_golden(banned_phrases=[r"(?i)secret operator label"]),
+        answer_source=(
+            "Secret operator label.\n\n"
+            "```claims\n"
+            '[{"metric":"installed_mw","value":10,"unit":"mw","basis":"nameplate",'
+            '"as_of":null,"source":null}]\n```'
+        ),
+        recomputed=None,
+        suspect_labels=set(),
+    )
+
+    advisory = next(grade for grade in clean["grades"] if grade["name"] == "required_properties")
+    assert advisory["passed"] is False and advisory["gating"] is False
+    assert clean["passed"] is True
+    assert leaked["passed"] is False
+
+
+def test_grade_answer_preserves_raw_carrier_and_isolated_claim_errors() -> None:
+    raw = (
+        "Capacity is 10 MW.\n\n```claims\n["
+        '{"metric":"bad metric","value":9,"unit":"mw","basis":"x",'
+        '"as_of":null,"source":null},'
+        '{"metric":"installed_mw","value":10,"unit":"mw","basis":"nameplate",'
+        '"as_of":null,"source":null}]\n```'
+    )
+
+    case = grade_answer(
+        golden=_typed_golden(),
+        answer_source=raw,
+        recomputed=None,
+        suspect_labels=set(),
+    )
+
+    assert case["passed"] is True
+    assert case["answer_raw"] == raw
+    assert "```claims" not in case["answer"]
+    assert [claim["metric"] for claim in case["claims"]] == ["installed_mw"]
+    assert case["claims_error"] == ["claims[0].metric: metric must be a lowercase registry id"]
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        ({"kind": "estimate"}, "kind must be value, rejection, or trend"),
+        (
+            {"expected_claim": {"metric": "x", "value": 1, "tolerance": {}, "unit": "mw"}},
+            "tolerance must contain exactly one",
+        ),
+        (
+            {
+                "expected_claim": {
+                    "metric": "x",
+                    "value": 1,
+                    "tolerance": {"abs": 0},
+                    "unit": "meters",
+                }
+            },
+            "expected_claim.unit must be one of",
+        ),
+    ],
+)
+def test_validate_golden_rejects_contract_mutations(
+    mutation: dict[str, object], message: str
+) -> None:
+    payload: dict[str, object] = dict(_typed_golden())
+    payload.update(mutation)
+    with pytest.raises(ValueError, match=message):
+        validate_golden(payload, location="fixture")
+
+
+def test_load_goldens_rejects_duplicate_ids(tmp_path: Path) -> None:
+    path = tmp_path / "goldens.jsonl"
+    line = (
+        '{"id":"same","question":"Q?","expected_properties":{},"kind":"value",'
+        '"expected_claim":{"metric":"x","value":1,"tolerance":{"abs":0},"unit":"count"}}'
+    )
+    path.write_text(f"{line}\n{line}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unique"):
+        load_goldens(path)

--- a/packages/adapters/cli/tests/test_main.py
+++ b/packages/adapters/cli/tests/test_main.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 def test_root_app_help_lists_all_subapps() -> None:
     result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
-    for name in ("agents", "environments", "config", "defaults"):
+    for name in ("agents", "environments", "config", "defaults", "eval"):
         assert name in result.stdout
 
 

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -34,6 +34,7 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
 from daimon.adapters.slack.blockkit import EmbedEvent, State, TurnPhase, to_blocks, update
 from daimon.adapters.slack.mrkdwn import escape_mrkdwn_preserving_mentions
 from daimon.adapters.slack.split import split_for_slack_safe
+from daimon.core.claims import strip_claims_blocks
 from daimon.core.pricing import MODEL_PRICING, cost_of, format_cost
 from daimon.core.turn.lifecycle import InterruptSource, ReconnectReason
 from daimon.core.turn.state import ToolUseBlock, TurnState, extract_final_response
@@ -245,7 +246,10 @@ class SlackTurnLifecycle:
         self._state = update(self._state, EmbedEvent(kind="done", label=""))
         self._apply_usage(state)
         try:
-            final_text = extract_final_response(state.content)
+            # Claims are a machine-readable carrier for evaluation and must not
+            # leak into the human-facing Slack answer. Strip every carrier,
+            # including malformed or non-trailing examples, before rendering.
+            final_text = strip_claims_blocks(extract_final_response(state.content))
             if not final_text:
                 # No final answer. A tool-only turn keeps the collapsed done
                 # footer; a truly empty turn (cancellation) shows "Turn

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -290,6 +290,50 @@ async def test_terminal_success_replaces_status_in_place(fake_slack_web_client: 
     assert not _has_actions_block(blocks), "cancel button must be removed on terminal success"
 
 
+async def test_terminal_success_strips_claims_carrier(fake_slack_web_client: Any) -> None:
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+    state = TurnState(
+        content=[
+            TextBlock(
+                kind="text",
+                text=(
+                    "Revenue was $10.08M.\n\n"
+                    "```claims\n"
+                    '[{"metric":"revenue","value":10080000,"unit":"usd",'
+                    '"basis":"invoices","as_of":null,"source":null}]\n'
+                    "```"
+                ),
+            )
+        ]
+    )
+
+    await lc.on_terminal_success(state)
+
+    rendered = _block_text(_last_update_blocks(fake_slack_web_client))
+    assert "Revenue was $10.08M." in rendered
+    assert "```claims" not in rendered
+    assert '"metric"' not in rendered
+
+
+async def test_terminal_success_strips_all_claims_fences(fake_slack_web_client: Any) -> None:
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.on_sse_event(_thinking_event())
+    answer = (
+        'Example:\n```claims\n[{"metric":"example"}]\n```\n\n'
+        "Supported total is 12 MW.\n"
+        '```claims\n[{"metric":"installed_mw","value":12}]\n```'
+    )
+
+    await lc.on_terminal_success(TurnState(content=[TextBlock(kind="text", text=answer)]))
+
+    rendered = _block_text(_last_update_blocks(fake_slack_web_client))
+    assert "Example:" in rendered
+    assert "Supported total is 12 MW." in rendered
+    assert "```claims" not in rendered
+    assert '"metric"' not in rendered
+
+
 async def test_terminal_success_overflow_posts_and_widens_final_ts(
     fake_slack_web_client: Any,
 ) -> None:

--- a/packages/core/daimon/core/claims.py
+++ b/packages/core/daimon/core/claims.py
@@ -1,0 +1,113 @@
+"""Strict machine-readable claims carried in an agent's final answer."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import cast
+
+from daimon.core.claims_contract import CLAIMS_FENCE_PATTERN, Claim, MeasureRegistry
+from pydantic import ValidationError
+
+_CLAIMS_FENCE = re.compile(CLAIMS_FENCE_PATTERN, re.DOTALL)
+
+
+class ClaimsBlockError(ValueError):
+    """The answer declared a claims carrier that failed strict validation."""
+
+
+@dataclass(frozen=True)
+class ClaimsExtraction:
+    """Parsed prose, accepted claims, and isolated per-row errors."""
+
+    prose: str
+    claims: list[Claim]
+    errors: tuple[str, ...] = ()
+
+
+def _format_claims_error(error: ValidationError) -> str:
+    detail = error.errors(include_url=False)[0]
+    if detail["type"] == "json_invalid":
+        return "claims: invalid JSON"
+    path = "claims"
+    for part in detail["loc"]:
+        path += f"[{part}]" if isinstance(part, int) else f".{part}"
+    message = str(detail["msg"]).removeprefix("Value error, ")
+    return f"{path}: {message}"
+
+
+def parse_claims_block(text: str, *, registry: MeasureRegistry | None = None) -> ClaimsExtraction:
+    """Parse the trailing carrier and isolate invalid rows.
+
+    Only the final trailing fence is the authoritative carrier. A declared
+    trailing carrier with malformed JSON, a non-list payload, or an empty list
+    raises :class:`ClaimsBlockError`. Schema-invalid rows and, when configured,
+    unknown registry IDs are omitted and reported individually while valid
+    siblings remain available to graders and renderers. Render consumers must
+    separately call :func:`strip_claims_blocks` to remove every fence.
+    """
+    matches = list(_CLAIMS_FENCE.finditer(text))
+    if not matches:
+        return ClaimsExtraction(text, [])
+    match = matches[-1]
+    if text[match.end() :].strip():
+        return ClaimsExtraction(text, [])
+    try:
+        payload = cast(object, json.loads(match.group("body")))
+    except json.JSONDecodeError as error:
+        raise ClaimsBlockError("claims: invalid JSON") from error
+    if not isinstance(payload, list):
+        raise ClaimsBlockError("claims: expected a JSON list")
+    if not payload:
+        raise ClaimsBlockError("claims block must contain at least one claim")
+
+    accepted: list[Claim] = []
+    errors: list[str] = []
+    registry_ids = registry.ids if registry is not None else None
+    for index, row in enumerate(cast(list[object], payload)):
+        try:
+            claim = Claim.model_validate(row)
+        except ValidationError as error:
+            detail = _format_claims_error(error)
+            errors.append(detail.replace("claims", f"claims[{index}]", 1))
+            continue
+        if registry_ids is not None and claim.metric not in registry_ids:
+            errors.append(f"claims[{index}].metric: unknown registered measure id {claim.metric!r}")
+            continue
+        accepted.append(claim)
+    return ClaimsExtraction(text[: match.start()].rstrip(), accepted, tuple(errors))
+
+
+def extract_claims_block(text: str) -> tuple[str, list[Claim]]:
+    """Backward-compatible strict extraction without registry membership checks."""
+    extraction = parse_claims_block(text)
+    if extraction.errors:
+        raise ClaimsBlockError(extraction.errors[0])
+    return extraction.prose, extraction.claims
+
+
+def strip_claims_blocks(text: str) -> str:
+    """Remove every claims fence from a render surface without validating it."""
+    return _CLAIMS_FENCE.sub("", text).rstrip()
+
+
+def claims_basis(claims: list[Claim]) -> str | None:
+    """Return ordered, de-duplicated bases for Slack provenance."""
+    bases = list(dict.fromkeys(claim.basis for claim in claims))
+    return " · ".join(bases) if bases else None
+
+
+def serialize_claims(claims: list[Claim]) -> list[dict[str, str | None]]:
+    """Return JSON-safe claim dictionaries without losing decimal precision."""
+    return [
+        {
+            "metric": claim.metric,
+            "value": str(claim.value),
+            "unit": claim.unit,
+            "basis": claim.basis,
+            "as_of": claim.as_of.isoformat() if claim.as_of is not None else None,
+            "source": claim.source,
+        }
+        for claim in claims
+    ]

--- a/packages/core/daimon/core/claims_contract.py
+++ b/packages/core/daimon/core/claims_contract.py
@@ -1,0 +1,283 @@
+"""Vendor-neutral contracts for machine-readable claims and measure registries."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+CLAIMS_FENCE_LANGUAGE = "claims"
+CLAIMS_FENCE_PATTERN = rf"```{re.escape(CLAIMS_FENCE_LANGUAGE)}\s*\n(?P<body>.*?)```"
+CLAIMS_INSTRUCTION_PLACEHOLDER = "{{DAIMON_CLAIMS_CONTRACT}}"
+MEASURE_REGISTRY_PLACEHOLDER = "{{DAIMON_MEASURE_REGISTRY}}"
+
+ALLOWED_CLAIM_UNITS = frozenset({"usd", "pct", "count", "days", "mw"})
+CLAIM_UNIT_ALIASES = {"$": "usd", "%": "pct"}
+
+_REGISTRY_ID = re.compile(r"[a-z][a-z0-9_.-]*\Z")
+_RELATION_COLUMN = re.compile(r"(?:[a-z_][a-z0-9_]*\.){2}[a-z_][a-z0-9_]*\Z")
+_DECIMAL_TEXT = re.compile(r"[+-]?(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d*)?|\.\d+)\Z")
+_NUMERIC_TOKEN = r"(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?"
+_NUMERIC_RANGE = re.compile(
+    rf"{_NUMERIC_TOKEN}\s*[-\u2010\u2011\u2012\u2013\u2014]\s*{_NUMERIC_TOKEN}"
+)
+_CLAIMS_TEXT_TRANSLATION = str.maketrans(
+    {
+        "\u2010": "-",
+        "\u2011": "-",
+        "\u2012": "-",
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2212": "-",
+        "\u00a0": " ",
+        "\u2009": " ",
+        "\u202f": " ",
+    }
+)
+
+
+def normalize_claims_text(value: str) -> str:
+    """Normalize contract-significant Unicode punctuation and spacing."""
+    return value.translate(_CLAIMS_TEXT_TRANSLATION)
+
+
+def normalize_numeric_grading_text(value: str, *, answer_regex: str | None) -> str:
+    """Normalize text while hiding range operands from scalar extraction.
+
+    A scalar golden must not read either endpoint of a displayed numeric range
+    as a standalone value. A range remains visible only when that golden's
+    answer regex spans the complete range. This numeric-only view does not
+    change the general text normalization used by phrase checks or claim dates.
+    """
+    normalized = normalize_claims_text(value)
+    explicit_spans = (
+        [
+            match.span()
+            for match in re.finditer(answer_regex, normalized, re.IGNORECASE | re.MULTILINE)
+        ]
+        if answer_regex is not None
+        else []
+    )
+    characters = list(normalized)
+    for numeric_range in _NUMERIC_RANGE.finditer(value):
+        start, end = numeric_range.span()
+        if any(
+            match_start <= start and match_end >= end for match_start, match_end in explicit_spans
+        ):
+            continue
+        for index in range(start, end):
+            if characters[index].isdigit() or characters[index] in ",.":
+                characters[index] = " "
+    return "".join(characters)
+
+
+@dataclass(frozen=True)
+class MeasureDefinition:
+    """One deployment-supplied measure exposed to a claims carrier."""
+
+    id: str
+    source: str
+    basis: str
+    unit: str
+    derivation: str | None = None
+    routing: str | None = None
+
+
+@dataclass(frozen=True)
+class MeasureRegistry:
+    """An immutable deployment-supplied set of registered measures."""
+
+    measures: tuple[MeasureDefinition, ...]
+
+    @property
+    def ids(self) -> frozenset[str]:
+        return frozenset(measure.id for measure in self.measures)
+
+
+def validate_measure_registry(registry: MeasureRegistry) -> None:
+    """Fail closed on malformed deployment registry data."""
+    ids = [measure.id for measure in registry.measures]
+    if not ids:
+        raise ValueError("measure registry must contain at least one measure")
+    if len(ids) != len(set(ids)):
+        raise ValueError("measure registry ids must be unique")
+    for measure in registry.measures:
+        if _REGISTRY_ID.fullmatch(measure.id) is None:
+            raise ValueError(f"invalid measure registry id: {measure.id!r}")
+        if _RELATION_COLUMN.fullmatch(measure.source) is None:
+            raise ValueError(
+                f"measure registry source must be relation.column: {measure.id}={measure.source}"
+            )
+        if not measure.basis.strip():
+            raise ValueError(f"measure registry source/basis must be non-empty: {measure.id}")
+        if measure.unit not in ALLOWED_CLAIM_UNITS:
+            raise ValueError(f"measure registry unit is not allowed: {measure.id}={measure.unit}")
+
+
+def normalize_claim_unit(value: str) -> str:
+    """Return the canonical claims unit for a textual unit."""
+    normalized = normalize_claims_text(value).strip().casefold()
+    return CLAIM_UNIT_ALIASES.get(normalized, normalized)
+
+
+class Claim(BaseModel):
+    """One registry-addressed numeric claim emitted by an agent."""
+
+    model_config = ConfigDict(extra="ignore", strict=True)
+
+    metric: str
+    value: Decimal
+    unit: str
+    basis: str
+    as_of: date | None
+    source: str | None
+
+    @field_validator("metric", mode="before")
+    @classmethod
+    def _normalize_metric(cls, value: object) -> object:
+        return normalize_claims_text(value).strip().casefold() if isinstance(value, str) else value
+
+    @field_validator("metric")
+    @classmethod
+    def _metric_is_registry_id(cls, value: str) -> str:
+        if _REGISTRY_ID.fullmatch(value) is None:
+            raise ValueError("metric must be a lowercase registry id")
+        return value
+
+    @field_validator("unit", mode="before")
+    @classmethod
+    def _normalize_unit(cls, value: object) -> object:
+        return normalize_claim_unit(value) if isinstance(value, str) else value
+
+    @field_validator("unit")
+    @classmethod
+    def _unit_is_allowed(cls, value: str) -> str:
+        if value not in ALLOWED_CLAIM_UNITS:
+            raise ValueError(f"{value} not allowed")
+        return value
+
+    @field_validator("basis", mode="before")
+    @classmethod
+    def _basis_is_present(cls, value: object) -> object:
+        if isinstance(value, str):
+            value = normalize_claims_text(value)
+        if not isinstance(value, str):
+            return value
+        if not value.strip() or value != value.strip():
+            raise ValueError("basis must be non-empty without surrounding whitespace")
+        return value
+
+    @field_validator("source", mode="before")
+    @classmethod
+    def _source_is_present_when_set(cls, value: object) -> object:
+        if isinstance(value, str):
+            value = normalize_claims_text(value)
+        if value is not None and not isinstance(value, str):
+            return value
+        if value is not None and (not value.strip() or value != value.strip()):
+            raise ValueError("source must be non-empty without surrounding whitespace")
+        return value
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _normalize_value(cls, value: object) -> object:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            normalized = Decimal(str(value))
+            if normalized.is_finite() and normalized == normalized.to_integral():
+                return Decimal(int(normalized))
+            return normalized
+        if not isinstance(value, str):
+            return value
+        normalized = normalize_claims_text(value).strip()
+        if normalized.startswith("$"):
+            normalized = normalized[1:].lstrip()
+        if _DECIMAL_TEXT.fullmatch(normalized) is None:
+            raise ValueError("value must be numeric")
+        try:
+            return Decimal(normalized.replace(",", ""))
+        except ArithmeticError as error:
+            raise ValueError("value must be numeric") from error
+
+    @field_validator("value")
+    @classmethod
+    def _value_is_finite(cls, value: Decimal) -> Decimal:
+        if not value.is_finite():
+            raise ValueError("value must be finite")
+        return value
+
+    @field_validator("as_of", mode="before")
+    @classmethod
+    def _normalize_as_of(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        normalized = normalize_claims_text(value)
+        try:
+            return date.fromisoformat(normalized)
+        except ValueError:
+            return normalized
+
+
+def render_claims_instruction(registry: MeasureRegistry | None = None) -> str:
+    """Generate the agent-facing instruction from the executable contract."""
+    fields = ", ".join(Claim.model_fields)
+    units = ", ".join(sorted(ALLOWED_CLAIM_UNITS))
+    aliases = ", ".join(
+        f"{source!r} to {target!r}" for source, target in sorted(CLAIM_UNIT_ALIASES.items())
+    )
+    metric_instruction = (
+        "Use one of the registered measure IDs; an unknown ID is rejected. "
+        if registry is not None
+        else "Use the registry measure id when one exists, otherwise a lowercase "
+        "registry-style descriptor. "
+    )
+    return (
+        "For every headline number, end the final answer with exactly one trailing "
+        f"`{CLAIMS_FENCE_LANGUAGE}` JSON fence containing a non-empty list of "
+        f"{{{fields}}}. Keep each headline number in the prose; the claims block "
+        f"supplements it. {metric_instruction}"
+        f"Emit canonical units only from this closed set: {units}. The parser normalizes "
+        f"{aliases}; do not rely on those aliases in generated output. Use null for unknown "
+        "as_of/source. If you emit another fenced payload, put the claims fence last."
+    )
+
+
+def render_measure_registry(registry: MeasureRegistry) -> str:
+    """Generate the complete agent-facing measure list from the typed registry."""
+    lines = [
+        "<!-- BEGIN GENERATED MEASURE REGISTRY -->",
+        "These are the complete registered measure IDs. Use the exact ID and canonical basis",
+        "in numeric claims; recompute from the named source at the answer's stated data cut.",
+    ]
+    for measure in registry.measures:
+        detail = (
+            f"- **{measure.id}** — source: `{measure.source}`; "
+            f"basis: `{measure.basis}`; unit: `{measure.unit}`."
+        )
+        if measure.derivation is not None:
+            detail += f" Derivation: {measure.derivation}."
+        if measure.routing is not None:
+            detail += f" Routing: {measure.routing}."
+        lines.append(detail)
+    lines.append("<!-- END GENERATED MEASURE REGISTRY -->")
+    return "\n".join(lines)
+
+
+def render_claims_placeholders(text: str, registry: MeasureRegistry | None = None) -> str:
+    """Expand authored claims placeholders from the executable contract."""
+    rendered = text.replace(CLAIMS_INSTRUCTION_PLACEHOLDER, render_claims_instruction(registry))
+    if MEASURE_REGISTRY_PLACEHOLDER not in rendered:
+        return rendered
+    if registry is None:
+        raise ValueError("measure registry placeholder requires a configured registry")
+    return rendered.replace(MEASURE_REGISTRY_PLACEHOLDER, render_measure_registry(registry))
+
+
+def missing_required_phrase_patterns(answer: str, patterns: list[str]) -> list[str]:
+    """Return the required regex patterns that do not match an answer."""
+    normalized = normalize_claims_text(answer)
+    return [pattern for pattern in patterns if re.search(pattern, normalized) is None]

--- a/packages/core/tests/test_claims.py
+++ b/packages/core/tests/test_claims.py
@@ -1,0 +1,231 @@
+"""Machine-readable final-answer claims contract tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from daimon.core.claims import (
+    ClaimsBlockError,
+    extract_claims_block,
+    parse_claims_block,
+    serialize_claims,
+    strip_claims_blocks,
+)
+from daimon.core.claims_contract import (
+    CLAIMS_INSTRUCTION_PLACEHOLDER,
+    Claim,
+    MeasureDefinition,
+    MeasureRegistry,
+    normalize_claims_text,
+    normalize_numeric_grading_text,
+    render_claims_instruction,
+    render_claims_placeholders,
+    validate_measure_registry,
+)
+from pydantic import ValidationError
+
+
+def _claim_fence(rows: str) -> str:
+    return f"Answer prose.\n\n```claims\n{rows}\n```"
+
+
+def test_parse_claims_block_strips_and_validates_trailing_carrier() -> None:
+    extraction = parse_claims_block(
+        _claim_fence(
+            '[{"metric":"revenue","value":"$ 1,234.50","unit":"$",'
+            '"basis":"invoices","as_of":"2026-08-25","source":"ledger.revenue"}]'
+        )
+    )
+
+    assert extraction.prose == "Answer prose."
+    assert extraction.errors == ()
+    assert extraction.claims == [
+        Claim(
+            metric="revenue",
+            value=Decimal("1234.50"),
+            unit="usd",
+            basis="invoices",
+            as_of=date(2026, 8, 25),
+            source="ledger.revenue",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ("not-json", "claims: invalid JSON"),
+        ('{"metric":"revenue"}', "claims: expected a JSON list"),
+        ("[]", "claims block must contain at least one claim"),
+    ],
+)
+def test_parse_claims_block_rejects_invalid_carrier_shapes(payload: str, message: str) -> None:
+    with pytest.raises(ClaimsBlockError, match=message):
+        parse_claims_block(_claim_fence(payload))
+
+
+def test_claim_rows_isolate_invalid_siblings() -> None:
+    extraction = parse_claims_block(
+        _claim_fence(
+            "["
+            '{"metric":"bad metric","value":1,"unit":"usd","basis":"x",'
+            '"as_of":null,"source":null},'
+            '{"metric":"revenue","value":2,"unit":"usd","basis":"invoices",'
+            '"as_of":null,"source":null}'
+            "]"
+        )
+    )
+
+    assert [claim.metric for claim in extraction.claims] == ["revenue"]
+    assert extraction.errors == ("claims[0].metric: metric must be a lowercase registry id",)
+    with pytest.raises(ClaimsBlockError, match=r"claims\[0\]\.metric"):
+        extract_claims_block(
+            _claim_fence(
+                "["
+                '{"metric":"bad metric","value":1,"unit":"usd","basis":"x",'
+                '"as_of":null,"source":null},'
+                '{"metric":"revenue","value":2,"unit":"usd","basis":"invoices",'
+                '"as_of":null,"source":null}'
+                "]"
+            )
+        )
+
+
+def test_registry_membership_is_optional_and_isolated_per_row() -> None:
+    registry = MeasureRegistry(
+        (
+            MeasureDefinition(
+                id="revenue",
+                source="semantic.revenue.amount",
+                basis="invoices",
+                unit="usd",
+            ),
+        )
+    )
+    answer = _claim_fence(
+        "["
+        '{"metric":"unknown","value":1,"unit":"usd","basis":"x",'
+        '"as_of":null,"source":null},'
+        '{"metric":"revenue","value":2,"unit":"usd","basis":"invoices",'
+        '"as_of":null,"source":null}'
+        "]"
+    )
+
+    open_extraction = parse_claims_block(answer)
+    closed_extraction = parse_claims_block(answer, registry=registry)
+
+    assert [claim.metric for claim in open_extraction.claims] == ["unknown", "revenue"]
+    assert [claim.metric for claim in closed_extraction.claims] == ["revenue"]
+    assert "unknown registered measure id 'unknown'" in closed_extraction.errors[0]
+
+
+def test_non_trailing_fence_is_not_authoritative_but_all_fences_strip() -> None:
+    answer = _claim_fence('[{"metric":"example"}]') + "\n\nMore prose."
+
+    extraction = parse_claims_block(answer)
+
+    assert extraction.prose == answer
+    assert extraction.claims == []
+    assert strip_claims_blocks(answer) == "Answer prose.\n\n\n\nMore prose."
+
+
+def test_unicode_claim_normalization_covers_dashes_and_thin_spaces() -> None:
+    assert normalize_claims_text("2026\u201108\u201125\u2009USD") == "2026-08-25 USD"
+    claim = Claim.model_validate(
+        {
+            "metric": "REVENUE",
+            "value": "$\u202f1,234",
+            "unit": "$",
+            "basis": "service\u2013month",
+            "as_of": "2026\u201108\u201125",
+            "source": None,
+        }
+    )
+    assert claim.metric == "revenue"
+    assert claim.value == Decimal("1234")
+    assert claim.basis == "service-month"
+    assert claim.as_of == date(2026, 8, 25)
+
+
+def test_numeric_normalization_hides_range_endpoints_without_explicit_range_regex() -> None:
+    answer = "Expected range: 10\u201312 million; point estimate: 11."
+
+    scalar_view = normalize_numeric_grading_text(answer, answer_regex=None)
+    range_view = normalize_numeric_grading_text(answer, answer_regex=r"10-12")
+
+    assert "10" not in scalar_view and "12" not in scalar_view
+    assert "point estimate: 11" in scalar_view
+    assert "10-12" in range_view
+
+
+def test_claim_schema_is_strict_but_ignores_presentation_keys() -> None:
+    claim = Claim.model_validate(
+        {
+            "metric": "revenue",
+            "value": "1,234",
+            "unit": "usd",
+            "basis": "invoices",
+            "as_of": None,
+            "source": None,
+            "display": "$1.23k",
+        }
+    )
+    assert claim.value == Decimal("1234")
+    with pytest.raises(ValidationError):
+        Claim.model_validate(
+            {
+                "metric": "revenue",
+                "value": True,
+                "unit": "usd",
+                "basis": "invoices",
+                "as_of": None,
+                "source": None,
+            }
+        )
+
+
+def test_contract_generates_instruction_and_expands_placeholder() -> None:
+    instruction = render_claims_instruction()
+
+    assert "metric, value, unit, basis, as_of, source" in instruction
+    assert "usd" in instruction and "pct" in instruction
+    assert render_claims_placeholders(CLAIMS_INSTRUCTION_PLACEHOLDER) == instruction
+
+
+def test_measure_registry_validation_rejects_duplicate_or_malformed_definitions() -> None:
+    valid = MeasureDefinition(
+        id="revenue",
+        source="semantic.revenue.amount",
+        basis="invoices",
+        unit="usd",
+    )
+    validate_measure_registry(MeasureRegistry((valid,)))
+    with pytest.raises(ValueError, match="unique"):
+        validate_measure_registry(MeasureRegistry((valid, valid)))
+    with pytest.raises(ValueError, match="relation.column"):
+        validate_measure_registry(
+            MeasureRegistry(
+                (
+                    MeasureDefinition(
+                        id="revenue",
+                        source="revenue.amount",
+                        basis="invoices",
+                        unit="usd",
+                    ),
+                )
+            )
+        )
+
+
+def test_serialize_claims_preserves_decimal_precision() -> None:
+    claim = Claim(
+        metric="revenue",
+        value=Decimal("1.2300"),
+        unit="usd",
+        basis="invoices",
+        as_of=None,
+        source=None,
+    )
+    assert serialize_claims([claim])[0]["value"] == "1.2300"


### PR DESCRIPTION
Add claims-primary numeric grading for value, rejection, and trend goldens, plus a self-validating offline replay command and generic mutation fixtures.

When a golden declares expected_claim, the typed payload is authoritative: matching prose cannot rescue an incorrect claim, configured display precision can authorize rounded claim values, relative and absolute tolerances are explicit, and rejection cases require a corrected claim or a refusal bound to the seeded value. Goldens without expected_claim retain the deprecated prose-regex fallback.

The runner preserves answer_raw for audit evidence, treats required phrases as advisory, keeps declared bans gating, and reports row-level claim errors without discarding valid siblings. daimon eval replay validates JSONL goldens and fixture manifests without network or database access, then fails on per-check verdict drift.

Depends on #126. This draft currently includes Part 1 in its comparison and will narrow to the grading/replay commit after #126 merges.

Part 2/2 of #121.
Closes #121