### PR TITLE
fix(slack): read one honest page of thread history and flag truncation

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -76,6 +76,8 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         """Read recent messages from a channel, oldest-first.
 
         For threads use read_thread.
+        Slack: at most 15 messages per call (the newest 15); older history is
+        not reachable from this tool.
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":
@@ -93,7 +95,8 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
         Discord: thread_id is the thread's channel id; use before for older messages.
         Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is ignored.
+        before is ignored. At most 15 messages per call, from the thread root;
+        has_more=true means the newest replies were not returned.
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -49,7 +49,11 @@ from fastmcp.exceptions import ToolError
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
-_HISTORY_LIMIT_CAP = 100
+# Slack's ceiling for non-Marketplace apps on conversations.history and
+# conversations.replies: at most 15 objects per call and one call per minute.
+# Larger limits are clamped server-side, so asking for more only misleads the
+# caller about how much of the channel or thread they were shown.
+_HISTORY_LIMIT_CAP = 15
 
 
 def _reraise_mapped(err: SlackApiError, *, as_user: bool = False) -> ToolError:

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2022,6 +2022,8 @@
         Read recent messages from a channel, oldest-first.
         
         For threads use read_thread.
+        Slack: at most 15 messages per call (the newest 15); older history is
+        not reachable from this tool.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2046,7 +2048,8 @@
         
         Discord: thread_id is the thread's channel id; use before for older messages.
         Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is ignored.
+        before is ignored. At most 15 messages per call, from the thread root;
+        has_more=true means the newest replies were not returned.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -1115,3 +1115,59 @@ async def test_list_channels_user_path_dm_destination_shows_public_private_and_i
     assert {r.id for r in rows} == {"C_PUB", "C_PRIV", "D_IM", "G_MPIM"}, (
         "DM destination should permit listing all private-ish entries too"
     )
+
+
+def _recorded_limit(m: aioresponses, path: str) -> str:
+    """The limit query param of the single recorded call to a Slack read method."""
+    limits = [
+        str(url.query["limit"])
+        for (method, url), _ in m.requests.items()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        if method == "GET" and url.path == path
+    ]
+    assert len(limits) == 1, f"expected one {path} call, saw {len(limits)}"
+    return limits[0]
+
+
+@pytest.mark.asyncio
+async def test_read_channel_clamps_limit_to_the_slack_page_cap(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A caller asking for 50 gets a request Slack will honour, not silently clamp.
+
+    Non-Marketplace apps receive at most 15 objects per conversations.history
+    call; the shared tool default of 50 is meaningful on Discord only.
+    """
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(_CONVERSATIONS_HISTORY, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
+        await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
+        limit = _recorded_limit(m, "/api/conversations.history")
+    assert limit == "15"
+
+
+@pytest.mark.asyncio
+async def test_read_thread_clamps_limit_to_the_slack_page_cap(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={"ok": True, "has_more": True, "messages": []},
+        )
+        result = await _slack_read_thread_impl(runtime, auth, thread_id="C1:1.0", limit=50)
+        limit = _recorded_limit(m, "/api/conversations.replies")
+    assert limit == "15"
+    assert result.has_more is True, "truncation must reach the caller"

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -1107,7 +1107,7 @@ class SlackApp:
         """Turn body: principal → MA session find-or-create → context build → turn → watermark.
 
         On first mention for a thread: creates a new MA session + ``thread_sessions``
-        row, replays full thread history via ``build_context_xml`` (limit 100).
+        row, replays thread history via ``build_context_xml`` (one Slack page).
         On follow-up mentions: reuses the existing MA session, replays only the
         delta since the watermark via ``build_delta_xml``.
 
@@ -1255,7 +1255,7 @@ class SlackApp:
         )
         author_id = str(event.get("user") or "")
         if not reused:
-            # First turn: replay full thread history (capped at 100 messages).
+            # First turn: replay thread history (one Slack page from the root).
             user_message = await build_context_xml(
                 web_client,
                 channel=channel,

--- a/packages/adapters/slack/daimon/adapters/slack/context.py
+++ b/packages/adapters/slack/daimon/adapters/slack/context.py
@@ -5,8 +5,14 @@ Builds XML context from a Slack thread's message history via
 responding in an existing thread.
 
 Mirrors ``packages/adapters/discord/daimon/adapters/discord/context.py``:
-- ``build_context_xml``: first-turn fetch, capped at 100 messages.
+- ``build_context_xml``: first-turn fetch, one page from the thread root.
 - ``build_delta_xml``: continuation fetch, delta since the watermark timestamp.
+
+Both fetch a single page. Slack caps non-Marketplace apps at
+``THREAD_PAGE_LIMIT`` objects per ``conversations.replies`` call and one call
+per minute, so paginating inside a turn is not viable; when Slack reports
+``has_more`` the block is marked ``truncated="true"`` so the model knows the
+window is partial.
 
 All message text is escaped via ``xml.sax.saxutils`` (T-80-XML mitigation).
 No try/except — exceptions propagate to the listener boundary.
@@ -20,6 +26,16 @@ from xml.sax.saxutils import escape, quoteattr
 from daimon.adapters.slack.attachments import ProxyUrlContext, build_proxy_url
 from daimon.adapters.slack.vision import SlackFile
 from slack_sdk.web.async_client import AsyncWebClient
+
+# Slack's ceiling for non-Marketplace apps on conversations.replies (both the
+# default and the maximum accepted value of ``limit``; larger values are clamped
+# server-side). Socket Mode apps cannot list on the Marketplace, so daimon is
+# always in this class.
+THREAD_PAGE_LIMIT = 15
+
+
+def _open_tag(name: str, *, truncated: bool) -> str:
+    return f'<{name} truncated="true">' if truncated else f"<{name}>"
 
 
 def _render_message(msg: dict[str, Any], *, proxy: ProxyUrlContext | None) -> list[str]:
@@ -79,26 +95,28 @@ async def build_context_xml(
 ) -> str:
     """Build XML context from thread history for the first turn.
 
-    Fetches up to 100 messages via ``conversations.replies`` (cap
-    mirroring Discord ``build_context_xml(limit=100)``).  Returns a string
-    with a ``<context>/<thread_history>`` block containing the replayed
-    messages followed by a ``<user_query>`` element.
+    Fetches one page of ``THREAD_PAGE_LIMIT`` messages via
+    ``conversations.replies``. Returns a string with a
+    ``<context>/<thread_history>`` block containing the replayed messages
+    followed by a ``<user_query>`` element.
 
-    Truncation note: ``conversations.replies`` with no cursor returns
-    the *first* page — the oldest 100 messages ascending from the thread root.
-    For threads longer than 100 messages the model does not see recent messages.
-    This is deliberate (mirrors Discord's 100-message cap) and avoids the
-    latency of full pagination on the first turn.
+    Window: ``conversations.replies`` always returns oldest-first from the
+    thread root, and ``oldest``/``latest`` only filter, so the newest window
+    cannot be requested in one call. A thread longer than one page therefore
+    replays the root and the first replies, and the block carries
+    ``truncated="true"`` so the model knows the recent tail is missing.
+    Discord's equivalent replays 100 messages; the gap is Slack's rate policy.
     """
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]
-        channel=channel, ts=thread_ts, limit=100
+        channel=channel, ts=thread_ts, limit=THREAD_PAGE_LIMIT
     )
     messages = cast(list[dict[str, Any]], resp["messages"])  # pyright: ignore[reportUnknownVariableType]
+    truncated = bool(resp.get("has_more"))  # pyright: ignore[reportUnknownMemberType]
 
     lines: list[str] = [
         "<context>",
         f"<channel platform={quoteattr('slack')} id={quoteattr(channel)}/>",
-        "<thread_history>",
+        _open_tag("thread_history", truncated=truncated),
     ]
     for msg in messages:
         lines.extend(_render_message(msg, proxy=proxy))
@@ -126,19 +144,24 @@ async def build_delta_xml(
     with ``oldest=watermark_ts, inclusive=False`` (mirroring Discord
     ``build_delta_xml``'s ``after_message_id`` path).  Returns a string with a
     ``<context>/<thread_delta>`` block and a ``<user_query>`` element.
+
+    One page of ``THREAD_PAGE_LIMIT`` messages, oldest-first from the
+    watermark; a delta longer than that is marked ``truncated="true"``.
     """
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]
         channel=channel,
         ts=thread_ts,
         oldest=watermark_ts,
         inclusive=False,
+        limit=THREAD_PAGE_LIMIT,
     )
     messages = cast(list[dict[str, Any]], resp["messages"])  # pyright: ignore[reportUnknownVariableType]
+    truncated = bool(resp.get("has_more"))  # pyright: ignore[reportUnknownMemberType]
 
     lines: list[str] = [
         "<context>",
         f"<channel platform={quoteattr('slack')} id={quoteattr(channel)}/>",
-        "<thread_delta>",
+        _open_tag("thread_delta", truncated=truncated),
     ]
     for msg in messages:
         lines.extend(_render_message(msg, proxy=proxy))

--- a/packages/adapters/slack/tests/test_context.py
+++ b/packages/adapters/slack/tests/test_context.py
@@ -26,30 +26,82 @@ def _make_client() -> AsyncWebClient:
     return AsyncWebClient(token="xoxb-test")
 
 
-async def test_build_context_xml_calls_conversations_replies_with_limit_100() -> None:
-    """build_context_xml should call conversations_replies with limit=100."""
+def _replies_request_params(mock: AioResponsesMock) -> dict[str, str]:
+    """Query params of the single recorded conversations.replies call."""
+    calls = [
+        dict(url.query)
+        for (method, url), _ in mock.requests.items()
+        if method == "GET" and url.path == "/api/conversations.replies"
+    ]
+    assert len(calls) == 1, f"expected one conversations.replies call, saw {len(calls)}"
+    return calls[0]
+
+
+def _fifteen_messages() -> list[dict[str, str]]:
+    return [{"user": "U1", "text": f"msg {i}", "ts": f"{100 + i}.0"} for i in range(15)]
+
+
+async def test_build_context_xml_requests_the_slack_page_cap() -> None:
+    """The first-turn replay asks for exactly the 15 messages Slack will return.
+
+    Non-Marketplace apps get at most 15 objects per conversations.replies call;
+    asking for more is silently clamped, so the request must state the real
+    ceiling rather than a number the API ignores.
+    """
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": _fifteen_messages(), "has_more": False},
+        )
+        client = _make_client()
+        xml = await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
+        params = _replies_request_params(mock)
+
+    assert params["limit"] == "15"
+    assert xml.count("<message ") == 15, "every returned message reaches the model"
+    assert "<thread_history>" in xml, "a complete window carries no truncation marker"
+
+
+async def test_build_context_xml_marks_thread_history_truncated_when_slack_has_more() -> None:
+    """A thread longer than one page tells the model the window is partial.
+
+    Slack returns the oldest page first and cannot serve the newest window in
+    one call, so the model must be told that recent messages are missing rather
+    than reading a stale head as the whole thread.
+    """
     with AioResponsesMock() as mock:
         mock.get(
             _REPLIES_PATTERN,
             payload={
                 "ok": True,
-                "messages": [
-                    {"user": "U123", "text": "hello", "ts": "99.0"},
-                ],
-                "has_more": False,
+                "messages": _fifteen_messages(),
+                "has_more": True,
+                "response_metadata": {"next_cursor": "bmV4dF90czoxMTUuMA=="},
             },
         )
         client = _make_client()
         xml = await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
 
-    # The XML output should contain the channel element, thread_history block, and user_query
-    assert '<channel platform="slack" id="C1"/>' in xml, (
-        "should contain channel element with platform and channel id"
-    )
-    assert "<thread_history>" in xml, "should contain thread_history block"
-    assert "</thread_history>" in xml, "should close thread_history block"
-    assert "<user_query>" in xml, "should contain user_query element"
-    assert "hi" in xml, "user_query content should be in output"
+    assert '<thread_history truncated="true">' in xml
+    assert "<thread_history>" not in xml
+    assert "</thread_history>" in xml
+
+
+async def test_build_delta_xml_marks_thread_delta_truncated_when_slack_has_more() -> None:
+    """A continuation delta longer than one page is flagged the same way."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": _fifteen_messages(), "has_more": True},
+        )
+        client = _make_client()
+        xml = await build_delta_xml(
+            client, channel="C1", thread_ts="100.0", watermark_ts="99.0", user_query="hi"
+        )
+
+    assert '<thread_delta truncated="true">' in xml
+    assert "<thread_delta>" not in xml
+    assert "</thread_delta>" in xml
 
 
 async def test_build_context_xml_channel_is_first_child_of_context() -> None:


### PR DESCRIPTION
Addresses pymc-labs/daimon-private#67 (the read-cap items; the 429 retry items landed in #97).

## What changes for users

On a Slack thread longer than 15 messages, the first turn now tells the model its replay is partial. The `<thread_history>` (and continuation `<thread_delta>`) block opens as `<thread_history truncated="true">` whenever Slack reports `has_more`. Before, the model got the thread root plus the first 14 replies and treated that as the whole conversation.

`read_channel` and `read_thread` on Slack request 15 (the real ceiling) instead of 100, and their docstrings say so. `read_channel` returns the newest 15; `read_thread` returns from the root with `has_more` as before.

## Why

Slack's May 2025 policy caps non-Marketplace apps at 15 objects per `conversations.history`/`conversations.replies` call and one call per minute. daimon cannot leave that class (Socket Mode blocks a Marketplace listing; public distribution forfeits the internal-app exemption). Asking for 100 was silently clamped and the docstrings described behaviour that never happened.

`conversations.replies` is always oldest-first and `oldest`/`latest` only filter, so the newest window cannot be requested in one call, and paginating at 1 req/min inside a turn is not an option. The honest fix is to state the real page size and surface truncation.

## Behaviour change

The `<thread_history>` / `<thread_delta>` opening tag gains a `truncated="true"` attribute when the page is partial. The un-truncated tag is unchanged. Tool schema snapshot regenerated for the docstring edits.

## Testing

- New tests assert the request Slack actually receives (`limit=15`) and the `truncated` marker on `has_more`, replacing the test that asserted `limit=100` against a fake.
- Slack, MCP and parity suites pass locally (1302 tests); ruff, pyright, import-linter and the anti-pattern lint are clean.
- Not tested: a live Slack workspace. Whether the 1 req/min budget is tripped by a normal turn is still the open measurement noted in the issue.
