### PR TITLE
feat(mcp): add a platform-neutral create_thread tool

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -17,6 +17,7 @@ from daimon.adapters.mcp.tools.discord import (
     ReadThreadResult,
     SearchResult,
     ThreadRow,
+    _create_thread_impl,  # pyright: ignore[reportPrivateUsage]
     _get_message_impl,  # pyright: ignore[reportPrivateUsage]
     _list_channels_impl,  # pyright: ignore[reportPrivateUsage]
     _list_threads_impl,  # pyright: ignore[reportPrivateUsage]
@@ -46,6 +47,7 @@ from daimon.adapters.mcp.tools.slack._search import (
     _slack_search_messages_impl,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.adapters.mcp.tools.slack._send import (
+    _slack_create_thread_impl,  # pyright: ignore[reportPrivateUsage]
     _slack_send_message_impl,  # pyright: ignore[reportPrivateUsage]
 )
 from fastmcp import Context, FastMCP
@@ -129,6 +131,42 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         if auth.platform == "slack":
             raise _slack_unsupported("list_threads")
         return await _list_threads_impl(runtime, auth, channel_id=channel_id)
+
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
+    async def create_thread(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        channel_id: str,
+        name: str,
+        content: str,
+    ) -> ThreadRow | SlackMessageRow:
+        """Create a new thread and post content as its first message.
+
+        ``content`` is required on both platforms and becomes the thread's
+        first message — Slack cannot open a thread without a root message,
+        and a Discord forum post is rejected by the API without a starter
+        message.
+
+        Discord: ``name`` is the thread's title (1-100 characters). On a text
+        channel this creates a PUBLIC thread; on a forum channel it creates a
+        post. ``name`` is ignored on Slack — Slack threads have no title.
+
+        Slack: posts ``content`` as a channel-root message and returns its
+        ``ts``. Combine that ``ts`` with ``channel_id`` to address the new
+        thread afterward: ``send_message`` and ``read_thread`` both take the
+        composite ``channel_id:ts`` form (e.g. if this call returns
+        ``ts="1717171717.123456"`` for channel ``C0123456789``, reply with
+        ``send_message(channel_id="C0123456789:1717171717.123456", ...)``).
+
+        Only create a thread when the user asked for one.
+        """
+        auth = await _auth(ctx)
+        if auth.platform == "slack":
+            return await _slack_create_thread_impl(
+                runtime, auth, channel_id=channel_id, content=content
+            )
+        return await _create_thread_impl(
+            runtime, auth, channel_id=channel_id, name=name, content=content
+        )
 
     @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def parse_link(  # pyright: ignore[reportUnusedFunction]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/__init__.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/__init__.py
@@ -1,5 +1,6 @@
 """Discord-action MCP tools: read_thread, read_channel, list_channels,
-list_threads, search_messages, parse_link, get_message, send_message.
+list_threads, search_messages, parse_link, get_message, send_message,
+create_thread.
 
 Mirrors ``tools/routines.py`` shape: each ``@mcp.tool`` closure delegates to a
 module-private ``_*_impl`` function that takes ``(runtime, auth, **kwargs)``.
@@ -84,6 +85,9 @@ from daimon.adapters.mcp.tools.discord._send import (
 )
 from daimon.adapters.mcp.tools.discord._send import (
     _send_message_impl as _send_message_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.discord._threads import (
+    _create_thread_impl as _create_thread_impl,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.adapters.mcp.tools.discord._wizard import (
     PostedWizard as PostedWizard,

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_threads.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_threads.py
@@ -1,0 +1,103 @@
+"""Discord thread-creation implementation.
+
+Provides: _create_thread_impl.
+
+Follows the locked sequence from ``_read.py``'s module docstring: validate
+inputs -> rest_client -> _resolve_member FIRST -> _resolve_channel ->
+_require_guild_channel -> permission check -> typed discord.py call -> map
+row. A freshly created thread reports message_count 0 and a last_activity
+derived from its own snowflake if built via the shared ``_to_thread_row``
+helper, so this module builds ``ThreadRow`` explicitly from the created
+thread and its starter message instead.
+"""
+
+from __future__ import annotations
+
+import discord
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.discord._client import (
+    _require_bot_token,  # pyright: ignore[reportPrivateUsage]
+    _require_discord_identity,  # pyright: ignore[reportPrivateUsage]
+    _require_guild_channel,  # pyright: ignore[reportPrivateUsage]
+    _require_guild_id,  # pyright: ignore[reportPrivateUsage]
+    _resolve_channel,  # pyright: ignore[reportPrivateUsage]
+    _resolve_member,  # pyright: ignore[reportPrivateUsage]
+    rest_client,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.discord._models import ThreadRow
+from daimon.adapters.mcp.tools.discord._visibility import (
+    _check_create_thread_permission,  # pyright: ignore[reportPrivateUsage]
+)
+from fastmcp.exceptions import ToolError
+
+_MAX_NAME_CHARS = 100
+
+
+def _validate_thread_name(name: str) -> str:
+    stripped = name.strip()
+    if not stripped:
+        raise ToolError("thread name must not be empty")
+    if len(stripped) > _MAX_NAME_CHARS:
+        raise ToolError(f"thread name must be at most {_MAX_NAME_CHARS} characters")
+    return stripped
+
+
+async def _create_thread_impl(  # pyright: ignore[reportUnusedFunction]
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    name: str,
+    content: str,
+) -> ThreadRow:
+    """Create a public thread on a text channel, or a post on a forum channel.
+
+    ``content`` is always posted as the thread's starter message. Text
+    channels get an explicit public thread (never Discord's private-thread
+    default); forum channels require a starter message to create a post at
+    all, so the same ``content`` parameter serves both shapes.
+    """
+    validated_name = _validate_thread_name(name)
+    _require_discord_identity(auth)
+    guild_id = _require_guild_id(auth)
+    token = _require_bot_token(runtime)
+
+    async with rest_client(token) as c:
+        _, member = await _resolve_member(c, guild_id, _require_discord_identity(auth))
+        raw_channel = await _resolve_channel(c, channel_id)
+        channel = _require_guild_channel(raw_channel, guild_id)
+
+        if isinstance(channel, discord.Thread):
+            raise ToolError("not a channel — create_thread takes a parent channel id")
+        if not isinstance(channel, (discord.TextChannel, discord.ForumChannel)):
+            raise ToolError("channel does not support threads")
+
+        _check_create_thread_permission(channel, member)
+
+        if isinstance(channel, discord.ForumChannel):
+            try:
+                thread, starter = await channel.create_thread(name=validated_name, content=content)
+            except discord.Forbidden as e:
+                raise ToolError(
+                    "daimon is missing the send_messages permission needed to post in this forum"
+                ) from e
+        else:
+            try:
+                thread = await channel.create_thread(
+                    name=validated_name, type=discord.ChannelType.public_thread
+                )
+                starter = await thread.send(content=content)
+            except discord.Forbidden as e:
+                raise ToolError(
+                    "daimon is missing the permission needed to create this thread"
+                ) from e
+
+        return ThreadRow(
+            id=str(thread.id),
+            name=thread.name,
+            parent_id=str(thread.parent_id),
+            archived=thread.archived,
+            message_count=1,
+            last_activity=starter.created_at.isoformat(),
+        )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_visibility.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_visibility.py
@@ -29,6 +29,29 @@ def _check_send_permission(  # pyright: ignore[reportUnusedFunction]
         raise ToolError("missing send_messages permission")
 
 
+def _check_create_thread_permission(  # pyright: ignore[reportUnusedFunction]
+    channel: discord.TextChannel | discord.ForumChannel, member: discord.Member
+) -> None:
+    """Discord gates thread creation differently by parent type. A forum post's
+    starter message IS the post, so only send_messages is required. A text
+    channel thread additionally needs send_messages_in_threads: the impl posts
+    the starter message into the new thread on the caller's behalf, so the
+    caller's reach into threads is what authorizes that."""
+    if member.guild_permissions.administrator:
+        return
+    perms = channel.permissions_for(member)
+    if not perms.view_channel:
+        raise ToolError("missing view_channel permission")
+    if isinstance(channel, discord.ForumChannel):
+        if not perms.send_messages:
+            raise ToolError("missing send_messages permission")
+        return
+    if not perms.create_public_threads:
+        raise ToolError("missing create_public_threads permission")
+    if not perms.send_messages_in_threads:
+        raise ToolError("missing send_messages_in_threads permission")
+
+
 async def _ensure_thread_parent_cached(  # pyright: ignore[reportUnusedFunction]
     thread: discord.Thread,
 ) -> discord.TextChannel | discord.ForumChannel:

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_send.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_send.py
@@ -1,5 +1,8 @@
 """Slack send_message implementation: post + composite thread targets.
 
+Also owns thread-root creation (``_slack_create_thread_impl``): posting a
+root message and returning its ``ts`` as the thread anchor.
+
 Bot-token only. Unlike the read tools, send never uses the caller's own
 xoxp token — there is no impersonation path and no hybrid client to fall
 back to; every post is authenticated as the workspace bot.
@@ -164,6 +167,49 @@ async def _slack_send_message_impl(  # pyright: ignore[reportUnusedFunction]  # 
 
     resp = await _post_message(
         client, channel_id=target_channel_id, content=content, thread_ts=thread_ts
+    )
+    message = cast(dict[str, Any], resp.get("message") or {})
+    response_thread_ts = message.get("thread_ts")
+    response_user_id = message.get("user")
+    return SlackMessageRow(
+        ts=str(resp["ts"]),
+        user_id=str(response_user_id) if response_user_id else None,
+        text=content,
+        thread_ts=str(response_thread_ts) if response_thread_ts else None,
+    )
+
+
+async def _slack_create_thread_impl(  # pyright: ignore[reportUnusedFunction]  # registered by tools/channels.py
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    content: str,
+) -> SlackMessageRow:
+    """Post a root message and return its ``ts`` as the thread anchor.
+
+    No ``name`` parameter — Slack threads have no title. A composite
+    ``channel_id:thread_ts`` target is refused: a thread root goes to a
+    channel, not into an existing thread (use send_message for a reply).
+    """
+    if len(content) > _MAX_CONTENT_CHARS:
+        raise ToolError(_OVER_LENGTH_MSG)
+
+    target_channel_id, thread_ts = _split_send_target(channel_id)
+    if thread_ts is not None:
+        raise ToolError(
+            "a thread root is posted to a channel, not into an existing thread — "
+            "use send_message with the composite channel_id:thread_ts form to reply "
+            "into an existing thread"
+        )
+    requester_id = _require_slack_identity(auth)
+    team_id = _require_team_id(auth)
+    client = await slack_web_client(runtime, team_id=team_id)
+
+    await _validate_channel_access(client, channel_id=target_channel_id, requester_id=requester_id)
+
+    resp = await _post_message(
+        client, channel_id=target_channel_id, content=content, thread_ts=None
     )
     message = cast(dict[str, Any], resp.get("message") or {})
     response_thread_ts = message.get("thread_ts")

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -1124,6 +1124,49 @@
         'type': 'object',
       }),
     }),
+    'create_thread': dict({
+      'description': '''
+        Create a new thread and post content as its first message.
+        
+        ``content`` is required on both platforms and becomes the thread's
+        first message — Slack cannot open a thread without a root message,
+        and a Discord forum post is rejected by the API without a starter
+        message.
+        
+        Discord: ``name`` is the thread's title (1-100 characters). On a text
+        channel this creates a PUBLIC thread; on a forum channel it creates a
+        post. ``name`` is ignored on Slack — Slack threads have no title.
+        
+        Slack: posts ``content`` as a channel-root message and returns its
+        ``ts``. Combine that ``ts`` with ``channel_id`` to address the new
+        thread afterward: ``send_message`` and ``read_thread`` both take the
+        composite ``channel_id:ts`` form (e.g. if this call returns
+        ``ts="1717171717.123456"`` for channel ``C0123456789``, reply with
+        ``send_message(channel_id="C0123456789:1717171717.123456", ...)``).
+        
+        Only create a thread when the user asked for one.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'channel_id': dict({
+            'type': 'string',
+          }),
+          'content': dict({
+            'type': 'string',
+          }),
+          'name': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'channel_id',
+          'name',
+          'content',
+        ]),
+        'type': 'object',
+      }),
+    }),
     'delete_notebook': dict({
       'description': '''
         Un-publish a notebook or blog you published (frees its host port).

--- a/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
+++ b/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
@@ -204,6 +204,7 @@ async def test_register_channel_tools_registers_shared_names() -> None:
         "parse_link",
         "send_message",
         "search_messages",
+        "create_thread",
     } <= tool_names, "all shared channel tool names must be registered once"
 
 
@@ -445,4 +446,83 @@ async def test_read_channel_discord_caller_routes_to_discord_impl_and_fails_on_m
     output_text = _output_text(call_result)
     assert "discord tools require DAIMON_DISCORD__BOT_TOKEN" in output_text, (
         f"Discord caller's read_channel must hit the Discord-side bot-token error; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_thread_slack_caller_routes_to_slack_impl_and_fails_on_missing_crypto(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A Slack-bound caller's create_thread call routes to the Slack impl.
+
+    With no DAIMON_CRYPTO__KEYS configured on the runtime, the Slack impl's
+    ``slack_web_client`` fails with a Slack-specific error the Discord impl
+    could never produce. Needs a linked PlatformPrincipal for the tenant's
+    platform since the Slack impl resolves identity before touching crypto.
+    """
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="slack-create-thread")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="slack",
+        external_id="U_SLACK_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="create_thread",
+        arguments={"channel_id": "C_TEST", "name": "t", "content": "hi"},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "slack tools require DAIMON_CRYPTO__KEYS" in output_text, (
+        f"Slack caller's create_thread must hit the Slack-only crypto-keys error; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_thread_discord_caller_routes_to_discord_impl_and_fails_on_missing_bot_token(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """The same registered create_thread tool routes a Discord-bound caller to
+    the Discord impl, producing the Discord-side bot-token error instead — the
+    asymmetry with the Slack test above pins the platform-based dispatch.
+
+    A valid name ("t") is passed: ``_create_thread_impl`` validates ``name``
+    before ``_require_bot_token``, so an empty/invalid name would surface the
+    name-validation error instead of the bot-token error this test pins.
+    """
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="discord-create-thread")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="U_DISCORD_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="create_thread",
+        arguments={"channel_id": "C_TEST", "name": "t", "content": "hi"},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "discord tools require DAIMON_DISCORD__BOT_TOKEN" in output_text, (
+        f"Discord caller's create_thread must hit the Discord-side bot-token error; got {output_text!r}"
     )

--- a/packages/adapters/mcp/tests/tools/test_discord_threads.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_threads.py
@@ -1,0 +1,527 @@
+"""Unit tests for Discord thread-creation implementation (_create_thread_impl).
+
+Each test calls the private ``_create_thread_impl`` directly with a hand-built
+``AuthIdentity`` and a transport-level patched ``discord.http.HTTPClient``.
+Inline route handlers and payload helpers per this file (no cross-test-file
+imports) so SDK-payload drift breaks the relevant test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import discord
+import discord.http
+import pytest
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.discord._threads import (
+    _create_thread_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    DiscordSettings,
+    Settings,
+)
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.domain import Role
+from fastmcp.exceptions import ToolError
+from pydantic import SecretStr
+
+# Load patch_discord_http directly from the sibling conftest.py by file path.
+_conftest_path = Path(__file__).parent / "conftest.py"
+_spec = importlib.util.spec_from_file_location("_tools_conftest", _conftest_path)
+assert _spec is not None and _spec.loader is not None
+_tools_conftest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_tools_conftest)
+patch_discord_http = _tools_conftest.patch_discord_http
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# Permission flag constants (Discord docs).
+# ---------------------------------------------------------------------------
+
+_VIEW_CHANNEL = 1 << 10
+_SEND_MESSAGES = 1 << 11
+_CREATE_PUBLIC_THREADS = 1 << 35
+_SEND_MESSAGES_IN_THREADS = 1 << 38
+
+# A real-looking snowflake (2026-ish), deliberately far from the tiny thread_id
+# ("444") used below, so a last_activity that used the thread's own snowflake
+# instead of the starter message's would produce a visibly different value.
+_STARTER_MESSAGE_ID = "1400000000000000000"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _runtime_with_discord_token() -> McpRuntime:
+    settings = Settings(
+        database=DatabaseSettings(url="postgresql+asyncpg://x/y"),  # pyright: ignore[reportArgumentType]
+        anthropic=AnthropicSettings(api_key=SecretStr("k")),
+        discord=DiscordSettings(bot_token=SecretStr("test-bot-token")),
+    )
+    return McpRuntime(
+        session_factory=MagicMock(),  # type: ignore[arg-type]
+        client=MagicMock(),  # type: ignore[arg-type]
+        settings=settings,
+        deployment_default=DeploymentDefault(),
+    )
+
+
+def _auth(*, external_id: str = "111", platform_user_id: str = "42") -> AuthIdentity:
+    return AuthIdentity(
+        account_id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+        role=Role.USER,
+        platform="discord",
+        external_id=external_id,
+        platform_user_id=platform_user_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Payload helpers (per-file, no cross-test-file imports)
+# ---------------------------------------------------------------------------
+
+
+def _guild_payload(*, guild_id: str = "111", owner_id: str = "1") -> dict[str, Any]:
+    return {
+        "id": guild_id,
+        "name": "test-guild",
+        "owner_id": owner_id,
+        "afk_timeout": 0,
+        "verification_level": 0,
+        "default_message_notifications": 0,
+        "explicit_content_filter": 0,
+        "roles": [],
+        "emojis": [],
+        "features": [],
+        "mfa_level": 0,
+        "system_channel_flags": 0,
+        "premium_tier": 0,
+        "preferred_locale": "en-US",
+        "nsfw_level": 0,
+        "premium_progress_bar_enabled": False,
+        "stickers": [],
+        "region": "us-east",
+    }
+
+
+def _everyone_role(guild_id: str, perms: int) -> dict[str, Any]:
+    return {
+        "id": guild_id,
+        "name": "@everyone",
+        "permissions": str(perms),
+        "position": 0,
+        "color": 0,
+        "hoist": False,
+        "managed": False,
+        "mentionable": False,
+        "flags": 0,
+    }
+
+
+def _member_payload(user_id: str = "42") -> dict[str, Any]:
+    return {
+        "user": {
+            "id": user_id,
+            "username": "caller",
+            "discriminator": "0001",
+            "global_name": "caller",
+            "avatar": None,
+            "bot": False,
+            "flags": 0,
+        },
+        "roles": [],
+        "joined_at": "2024-01-01T00:00:00+00:00",
+        "deaf": False,
+        "mute": False,
+        "flags": 0,
+    }
+
+
+def _text_channel_payload(
+    *,
+    channel_id: str = "222",
+    guild_id: str = "111",
+    permission_overwrites: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": channel_id,
+        "type": 0,
+        "guild_id": guild_id,
+        "name": "general",
+        "position": 0,
+        "permission_overwrites": permission_overwrites or [],
+        "nsfw": False,
+        "rate_limit_per_user": 0,
+        "parent_id": None,
+    }
+
+
+def _forum_channel_payload(
+    *,
+    channel_id: str = "333",
+    guild_id: str = "111",
+    permission_overwrites: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": channel_id,
+        "type": 15,
+        "guild_id": guild_id,
+        "name": "forum",
+        "position": 0,
+        "permission_overwrites": permission_overwrites or [],
+        "nsfw": False,
+        "rate_limit_per_user": 0,
+        "parent_id": None,
+    }
+
+
+def _voice_channel_payload(*, channel_id: str = "555", guild_id: str = "111") -> dict[str, Any]:
+    return {
+        "id": channel_id,
+        "type": 2,
+        "guild_id": guild_id,
+        "name": "voice",
+        "position": 0,
+        "permission_overwrites": [],
+        "bitrate": 64000,
+        "user_limit": 0,
+        "rate_limit_per_user": 0,
+        "parent_id": None,
+        "nsfw": False,
+        "rtc_region": None,
+        "video_quality_mode": 1,
+        "last_message_id": None,
+    }
+
+
+def _thread_payload(
+    *,
+    thread_id: str = "444",
+    parent_id: str = "222",
+    guild_id: str = "111",
+    name: str = "test-thread",
+    thread_type: int = 11,
+    archived: bool = False,
+    message_count: int = 0,
+    last_message_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": thread_id,
+        "parent_id": parent_id,
+        "owner_id": "1",
+        "name": name,
+        "type": thread_type,
+        "guild_id": guild_id,
+        "message_count": message_count,
+        "member_count": 1,
+        "thread_metadata": {
+            "archived": archived,
+            "auto_archive_duration": 1440,
+            "archive_timestamp": "2026-01-01T00:00:00+00:00",
+        },
+        "last_message_id": last_message_id,
+        "rate_limit_per_user": 0,
+    }
+
+
+def _author_payload(author_id: str = "1", *, bot: bool = True) -> dict[str, Any]:
+    return {
+        "id": author_id,
+        "username": "daimon",
+        "discriminator": "0001",
+        "global_name": "daimon",
+        "avatar": None,
+        "bot": bot,
+        "flags": 0,
+    }
+
+
+def _message_payload(
+    *,
+    message_id: str,
+    channel_id: str,
+    content: str = "hello",
+    timestamp: str = "2026-05-09T00:00:00+00:00",
+) -> dict[str, Any]:
+    return {
+        "id": message_id,
+        "channel_id": channel_id,
+        "author": _author_payload(),
+        "content": content,
+        "timestamp": timestamp,
+        "edited_timestamp": None,
+        "tts": False,
+        "mention_everyone": False,
+        "mentions": [],
+        "mention_roles": [],
+        "attachments": [],
+        "embeds": [],
+        "type": 0,
+        "pinned": False,
+        "flags": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Text channel: happy path + C-1 regression guard
+# ---------------------------------------------------------------------------
+
+
+async def test_create_thread_text_channel_happy_path_returns_thread_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text channel: creates the thread, posts the starter message, and returns
+    a ThreadRow with message_count=1 and last_activity from the starter
+    message — NOT 0, NOT the thread's own snowflake (the C-5 guard)."""
+
+    captured_create_kwargs: dict[str, Any] = {}
+
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [
+                _everyone_role(
+                    "111",
+                    _VIEW_CHANNEL | _CREATE_PUBLIC_THREADS | _SEND_MESSAGES_IN_THREADS,
+                )
+            ]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}" and route.method == "GET":
+            return _text_channel_payload(channel_id="222")
+        if route.path == "/channels/{channel_id}/threads" and route.method == "POST":
+            captured_create_kwargs.update(kwargs)
+            return _thread_payload(thread_id="444", parent_id="222", message_count=0)
+        if route.path == "/channels/{channel_id}/messages" and route.method == "POST":
+            assert route.channel_id == 444, "starter message must post into the new thread"
+            return _message_payload(
+                message_id=_STARTER_MESSAGE_ID,
+                channel_id="444",
+                content="hi there",
+            )
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    row = await _create_thread_impl(
+        _runtime_with_discord_token(),
+        _auth(),
+        channel_id="222",
+        name="my thread",
+        content="hi there",
+    )
+
+    assert row.id == "444", "row id must be the created thread's id"
+    assert row.name == "test-thread", "row name must be the created thread's name"
+    assert row.parent_id == "222", "row parent_id must be the text channel"
+    assert row.archived is False, "a freshly created thread must not be archived"
+    assert row.message_count == 1, "row must report the starter message (C-5 guard)"
+    expected_last_activity = discord.utils.snowflake_time(int(_STARTER_MESSAGE_ID)).isoformat()
+    assert row.last_activity == expected_last_activity, (
+        "last_activity must derive from the starter message's own snowflake, not 0 and not "
+        "the thread's own snowflake (C-5 guard)"
+    )
+    assert row.last_activity != discord.utils.snowflake_time(444).isoformat(), (
+        "last_activity must NOT be derived from the thread's own snowflake (C-5 guard)"
+    )
+    assert captured_create_kwargs["json"]["type"] == 11, (
+        "text-channel create must pass type=11 (public_thread) explicitly (C-1 guard)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forum channel: happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_create_thread_forum_channel_happy_path_returns_thread_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forum channel: a single POST carries the starter content and returns a
+    ThreadRow built from ThreadWithMessage.thread + .message."""
+
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}" and route.method == "GET":
+            return _forum_channel_payload(channel_id="333")
+        if route.path == "/channels/{channel_id}/threads" and route.method == "POST":
+            body = cast(dict[str, Any], kwargs["json"])
+            message_body = cast(dict[str, Any], body["message"])
+            assert message_body["content"] == "forum post body", (
+                "forum create must carry the starter content in the nested message payload"
+            )
+            thread_data = _thread_payload(
+                thread_id="446", parent_id="333", thread_type=11, message_count=1
+            )
+            thread_data["message"] = _message_payload(
+                message_id="446", channel_id="446", content="forum post body"
+            )
+            return thread_data
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    row = await _create_thread_impl(
+        _runtime_with_discord_token(),
+        _auth(),
+        channel_id="333",
+        name="forum post",
+        content="forum post body",
+    )
+
+    assert row.id == "446", "row id must be the created forum thread's id"
+    assert row.parent_id == "333", "row parent_id must be the forum channel"
+    assert row.message_count == 1, "forum starter message counts as the thread's first message"
+
+
+# ---------------------------------------------------------------------------
+# Rejections
+# ---------------------------------------------------------------------------
+
+
+async def test_create_thread_rejects_thread_as_parent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Passing a thread id as channel_id raises a named ToolError."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}" and route.method == "GET":
+            return _thread_payload(thread_id="444")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="not a channel"):
+        await _create_thread_impl(
+            _runtime_with_discord_token(), _auth(), channel_id="444", name="x", content="hi"
+        )
+
+
+async def test_create_thread_rejects_voice_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A voice channel (or any non-text, non-forum channel) is rejected."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}" and route.method == "GET":
+            return _voice_channel_payload(channel_id="555")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="channel does not support threads"):
+        await _create_thread_impl(
+            _runtime_with_discord_token(), _auth(), channel_id="555", name="x", content="hi"
+        )
+
+
+async def test_create_thread_denied_without_create_public_threads_before_any_create_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caller without create_public_threads on a text channel is denied by
+    Task 1's helper BEFORE any create request reaches the route handler."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}" and route.method == "GET":
+            return _text_channel_payload(channel_id="222")
+        if route.path == "/channels/{channel_id}/threads":
+            raise AssertionError("create-thread route must not be called without permission")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="missing create_public_threads permission"):
+        await _create_thread_impl(
+            _runtime_with_discord_token(), _auth(), channel_id="222", name="x", content="hi"
+        )
+
+
+async def test_create_thread_rejects_empty_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty (or whitespace-only) name is rejected before any I/O."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        raise AssertionError(f"no I/O expected, got {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="empty"):
+        await _create_thread_impl(
+            _runtime_with_discord_token(), _auth(), channel_id="222", name="   ", content="hi"
+        )
+
+
+async def test_create_thread_rejects_name_over_100_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A name over 100 characters is rejected, naming the 100-char cap."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        raise AssertionError(f"no I/O expected, got {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="100 characters"):
+        await _create_thread_impl(
+            _runtime_with_discord_token(),
+            _auth(),
+            channel_id="222",
+            name="x" * 101,
+            content="hi",
+        )
+
+
+async def test_create_thread_forbidden_from_create_maps_to_named_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A discord.Forbidden raised by the create call is mapped to a ToolError
+    naming daimon's own missing permission, chained from the original error."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [
+                _everyone_role(
+                    "111",
+                    _VIEW_CHANNEL | _CREATE_PUBLIC_THREADS | _SEND_MESSAGES_IN_THREADS,
+                )
+            ]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}" and route.method == "GET":
+            return _text_channel_payload(channel_id="222")
+        if route.path == "/channels/{channel_id}/threads" and route.method == "POST":
+            raise discord.Forbidden(MagicMock(status=403), {"message": "Missing Permissions"})
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="daimon") as exc_info:
+        await _create_thread_impl(
+            _runtime_with_discord_token(), _auth(), channel_id="222", name="x", content="hi"
+        )
+    assert isinstance(exc_info.value.__cause__, discord.Forbidden), (
+        "the ToolError must chain the original discord.Forbidden via `from err`"
+    )

--- a/packages/adapters/mcp/tests/tools/test_discord_visibility.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_visibility.py
@@ -22,7 +22,10 @@ from daimon.adapters.mcp.tools.discord._client import (
     _resolve_member,
     rest_client,
 )
-from daimon.adapters.mcp.tools.discord._visibility import _check_thread_view
+from daimon.adapters.mcp.tools.discord._visibility import (
+    _check_create_thread_permission,
+    _check_thread_view,
+)
 from daimon.core.config import (
     AnthropicSettings,
     DatabaseSettings,
@@ -51,6 +54,8 @@ pytestmark = pytest.mark.asyncio
 _VIEW_CHANNEL = 1 << 10  # 1024
 _SEND_MESSAGES = 1 << 11  # 2048
 _MANAGE_THREADS = 1 << 34
+_CREATE_PUBLIC_THREADS = 1 << 35
+_SEND_MESSAGES_IN_THREADS = 1 << 38
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +130,25 @@ def _text_channel_payload(
         "type": 0,
         "guild_id": guild_id,
         "name": "general",
+        "position": 0,
+        "permission_overwrites": permission_overwrites or [],
+        "nsfw": False,
+        "rate_limit_per_user": 0,
+        "parent_id": None,
+    }
+
+
+def _forum_channel_payload(
+    *,
+    channel_id: str = "333",
+    guild_id: str = "111",
+    permission_overwrites: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": channel_id,
+        "type": 15,
+        "guild_id": guild_id,
+        "name": "forum",
         "position": 0,
         "permission_overwrites": permission_overwrites or [],
         "nsfw": False,
@@ -208,6 +232,24 @@ async def _setup_thread_test(
             f"expected Thread, got {type(thread_raw).__name__}"
         )
         return c, thread_raw, member
+
+
+async def _setup_channel_test(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Any,
+    *,
+    channel_id: str,
+) -> tuple[discord.Client, discord.TextChannel | discord.ForumChannel, discord.Member]:
+    """Common plumbing for _check_create_thread_permission: patch HTTP, resolve
+    member + a text or forum channel, return (client, channel, member)."""
+    patch_discord_http(monkeypatch, handler)
+    async with rest_client("test-token") as c:
+        _, member = await _resolve_member(c, "111", "42")
+        channel_raw = await _resolve_channel(c, channel_id)
+        assert isinstance(channel_raw, (discord.TextChannel, discord.ForumChannel)), (
+            f"expected TextChannel or ForumChannel, got {type(channel_raw).__name__}"
+        )
+        return c, channel_raw, member
 
 
 # ---------------------------------------------------------------------------
@@ -441,3 +483,169 @@ async def test_admin_bypasses_all_checks(monkeypatch: pytest.MonkeyPatch) -> Non
 
     # Should pass without raising — admin bypasses everything
     await _check_thread_view(c, thread, member, "42")
+
+
+# ---------------------------------------------------------------------------
+# _check_create_thread_permission
+# ---------------------------------------------------------------------------
+
+
+async def test_create_thread_admin_bypasses_all_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Administrator short-circuits before any channel-side check."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", 1 << 3)]  # ADMINISTRATOR, no other perms
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload(channel_id="222")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    _c, channel, member = await _setup_channel_test(monkeypatch, handler, channel_id="222")
+
+    _check_create_thread_permission(channel, member)
+
+
+async def test_create_thread_text_channel_passes_with_full_permissions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text channel: view_channel + create_public_threads + send_messages_in_threads -> passes."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [
+                _everyone_role(
+                    "111",
+                    _VIEW_CHANNEL | _CREATE_PUBLIC_THREADS | _SEND_MESSAGES_IN_THREADS,
+                )
+            ]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload(channel_id="222")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    _c, channel, member = await _setup_channel_test(monkeypatch, handler, channel_id="222")
+
+    _check_create_thread_permission(channel, member)
+
+
+async def test_create_thread_text_channel_denied_without_view_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text channel: caller lacks view_channel -> ToolError."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", 0)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload(
+                channel_id="222",
+                permission_overwrites=[
+                    {"id": "111", "type": 0, "allow": "0", "deny": str(_VIEW_CHANNEL)}
+                ],
+            )
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    _c, channel, member = await _setup_channel_test(monkeypatch, handler, channel_id="222")
+
+    with pytest.raises(ToolError, match="missing view_channel permission"):
+        _check_create_thread_permission(channel, member)
+
+
+async def test_create_thread_text_channel_denied_without_create_public_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text channel: caller has view_channel but not create_public_threads -> ToolError."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload(channel_id="222")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    _c, channel, member = await _setup_channel_test(monkeypatch, handler, channel_id="222")
+
+    with pytest.raises(ToolError, match="missing create_public_threads permission"):
+        _check_create_thread_permission(channel, member)
+
+
+async def test_create_thread_text_channel_denied_without_send_messages_in_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text channel: view_channel + create_public_threads but not
+    send_messages_in_threads -> ToolError."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _CREATE_PUBLIC_THREADS)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload(channel_id="222")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    _c, channel, member = await _setup_channel_test(monkeypatch, handler, channel_id="222")
+
+    with pytest.raises(ToolError, match="missing send_messages_in_threads permission"):
+        _check_create_thread_permission(channel, member)
+
+
+async def test_create_thread_forum_channel_passes_without_create_public_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forum channel: view_channel + send_messages -> passes WITHOUT
+    create_public_threads (the C-2 regression guard)."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL | _SEND_MESSAGES)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _forum_channel_payload(channel_id="333")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    _c, channel, member = await _setup_channel_test(monkeypatch, handler, channel_id="333")
+
+    _check_create_thread_permission(channel, member)
+
+
+async def test_create_thread_forum_channel_denied_without_send_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forum channel: caller lacks send_messages -> ToolError."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _forum_channel_payload(channel_id="333")
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    _c, channel, member = await _setup_channel_test(monkeypatch, handler, channel_id="333")
+
+    with pytest.raises(ToolError, match="missing send_messages permission"):
+        _check_create_thread_permission(channel, member)

--- a/packages/adapters/mcp/tests/tools/test_slack_send.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_send.py
@@ -13,6 +13,7 @@ from cryptography.fernet import Fernet
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools.slack._send import (  # pyright: ignore[reportPrivateUsage]
+    _slack_create_thread_impl,
     _slack_send_message_impl,
 )
 from daimon.adapters.mcp.tools.slack._visibility import (
@@ -448,3 +449,96 @@ async def test_send_message_malformed_composite_target_raises_format_error_no_ap
                 runtime, auth, channel_id="C1:", content="hi", attachments=None, file_handles=None
             )
         assert m.requests == {}
+
+
+# ---------------------------------------------------------------------------
+# _slack_create_thread_impl
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_thread_happy_path_posts_root_message_no_thread_ts(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000010.000100"}
+        )
+        row = await _slack_create_thread_impl(
+            runtime, auth, channel_id="C1", content="new thread root"
+        )
+        body = _post_body(m)
+
+    assert row.ts == "1700000010.000100", "returned row must carry the posted ts"
+    assert row.text == "new thread root", "returned row's text must be the content as passed"
+    assert "thread_ts" not in body, "a thread-root post must not carry a thread_ts key"
+
+
+@pytest.mark.asyncio
+async def test_create_thread_composite_target_refused_before_any_api_call(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="thread root"):
+            await _slack_create_thread_impl(
+                runtime,
+                auth,
+                channel_id="C1:1717171717.123456",
+                content="a root",
+            )
+        assert m.requests == {}, "a composite target must cost zero Slack API calls"
+
+
+@pytest.mark.asyncio
+async def test_create_thread_over_12000_chars_refused_with_zero_api_calls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    content = "x" * 12_001
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="shorten"):
+            await _slack_create_thread_impl(runtime, auth, channel_id="C1", content=content)
+        assert m.requests == {}, "an over-length call must cost zero Slack API calls"
+
+
+@pytest.mark.asyncio
+async def test_create_thread_not_in_channel_from_post_yields_invite_instruction(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": False, "error": "not_in_channel"}
+        )
+        with pytest.raises(ToolError, match="/invite"):
+            await _slack_create_thread_impl(runtime, auth, channel_id="C1", content="hi")
+
+
+@pytest.mark.asyncio
+async def test_create_thread_channel_access_validated_before_posting(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C_PRIV", "name": "sekret", "is_private": True}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_MEMBERS, payload={"ok": True, "members": ["U_SOMEONE_ELSE"]}
+        )
+        with pytest.raises(ToolError, match=MISSING_ACCESS):
+            await _slack_create_thread_impl(runtime, auth, channel_id="C_PRIV", content="hi")
+        assert _POST_KEY not in m.requests, (
+            "the deny path must raise before ever reaching chat.postMessage"
+        )


### PR DESCRIPTION
## Summary

Adds `create_thread` to the channel tool surface in `tools/channels.py`, tagged `{"discord", "slack"}` like its seven siblings. Agents could read threads (`read_thread`, `list_threads`) and post into them, but had no way to open one.

```python
create_thread(channel_id: str, name: str, content: str) -> ThreadRow | SlackMessageRow
```

`content` is required on both platforms and becomes the thread's first message — Slack cannot open a thread without a root message, and a Discord forum post is rejected by the API without a starter.

**Discord** — `name` is the thread title (1–100 chars). On a text channel this creates a **public** thread; on a forum channel, a post.

**Slack** — Slack has no create-thread API; a thread exists only once something replies to a root message. So this posts `content` as a channel-root message and returns its `ts`. The caller composes that into the `channel_id:thread_ts` form `send_message` and `read_thread` already accept:

```
create_thread(channel_id="C0123456789", ...) -> ts="1717171717.123456"
send_message(channel_id="C0123456789:1717171717.123456", ...)
```

`name` is ignored on Slack — Slack threads have no title — and the docstring says so plainly.

## Notes for review

Three things worth a look, all covered by tests:

- **`type=public_thread` is passed explicitly.** discord.py's `TextChannel.create_thread` defaults to `ChannelType.private_thread` when `type is None`. Without the explicit argument we'd check `create_public_threads` and then create a private thread — a privilege mismatch. A test asserts `type: 11` on the captured request body.
- **The permission check branches on parent type.** Forum posts need only `send_messages` (the starter message *is* the post); text-channel threads need `create_public_threads` plus `send_messages_in_threads`, since the impl posts the starter into the thread afterward. A flat check would wrongly reject a legitimate forum poster.
- **`ThreadRow` is built explicitly, not via `_to_thread_row`.** A just-created thread reports `message_count=0` and has no `last_message_id`, so the shared mapper would report a thread with zero messages. The row is built from the thread plus its starter message; no SDK object is mutated to fake it.

Slack refuses a composite `channel_id:thread_ts` target before any HTTP call — Slack would otherwise silently post at the channel root instead of erroring.

New module `discord/_threads.py` rather than growing `_send.py`: `_read.py` is read-tools-only by its own docstring, and `_send.py` is already ~170 lines against the <200-line target.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally — 760 passed in `packages/adapters/mcp/tests/`
- [x] `uv run pyright` passes locally (strict mode) — 0 errors, 0 warnings
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts) — 6 kept, 0 broken

Tool schema snapshot regenerated single-process (`test_tool_schema_snapshot.py` documents why it must not run under `-n auto`); the diff is exactly one added `create_thread` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)