### PR TITLE
fix(slack): request the workspace's real page size instead of the capped one

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,8 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_SLACK__CLIENT_SECRET=
 # Maximum number of agent turns a single tenant (Slack workspace) may have in flight at once. Caps one noisy workspace from starving others on the shared Anthropic key.
 # DAIMON_SLACK__MAX_CONCURRENT_TURNS_PER_TENANT=3
+# Messages requested per conversations.replies call when replaying thread history. Slack clamps this per workspace: an app commercially distributed outside the Marketplace gets 15 whatever it asks for, an internal-app install gets the full page up to 1000, which is also the largest value Slack accepts. Raising it costs a clamped workspace nothing.
+# DAIMON_SLACK__HISTORY_PAGE_LIMIT=200
 # Port for the Slack process's liveness endpoint. Must not collide with the mcp process (8080), the discord process (8081), or the scheduler process (8082) — all process groups share one host.
 # DAIMON_SLACK__HEALTH_PORT=8083
 

--- a/docs/slack-app-manifest.yaml
+++ b/docs/slack-app-manifest.yaml
@@ -6,7 +6,14 @@
 # 3. Basic Information → App-Level Tokens → generate one with `connections:write`
 #    → DAIMON_SLACK__APP_TOKEN. Signing secret and OAuth client id/secret are on
 #    the same page → DAIMON_SLACK__SIGNING_SECRET / __CLIENT_ID / __CLIENT_SECRET.
-# 4. Manage Distribution → activate public distribution (the install flow needs it).
+# 4. Manage Distribution → activate public distribution ONLY if this deployment
+#    serves workspaces other than your own; the install flow in step 5 reaches
+#    your own workspace without it. Slack caps conversations.history and
+#    conversations.replies at 15 objects per call and one call per minute for
+#    apps distributed outside the Marketplace. A deployment that stays internal
+#    to one workspace is not capped: daimon requests 200 messages per page by
+#    default (DAIMON_SLACK__HISTORY_PAGE_LIMIT, up to 1000), and a capped
+#    workspace silently answers with 15.
 # 5. Visit https://DAIMON_HOST/oauth/slack/install and install to your workspace.
 #    The bot token is stored encrypted in daimon's database by that callback —
 #    there is no env var for it.

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -83,8 +83,9 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
         For threads use read_thread. Each platform takes only its own
         pagination parameter — the other is rejected. Discord: at most 200
-        messages per call; use before to fetch older messages. Slack: use
-        cursor to fetch the next page; at most 15 messages are returned.
+        messages per call; use before to fetch older messages. Slack: at most
+        999 per call, and some workspaces cap a single call at 15 whatever
+        limit is asked for; use cursor to fetch the next page.
         """
         auth = await _auth(ctx)
         # MCP clients often send "" for an optional param they mean to omit —
@@ -114,9 +115,10 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
         Discord: thread_id is the thread's channel id; use before for older messages.
         Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is rejected — Slack threads read one page of at most 15 messages
-        from the thread root, and has_more=true means the newest replies were
-        not returned.
+        before is rejected — Slack threads read one page of at most 999
+        messages from the thread root, some workspaces cap that page at 15
+        whatever limit is asked for, and has_more=true means the newest
+        replies were not returned.
         """
         auth = await _auth(ctx)
         before = before or None

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_client.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_client.py
@@ -41,9 +41,10 @@ def _build_retry_handlers() -> list[AsyncRetryHandler]:
     """Retry handlers for every AsyncWebClient built here.
 
     slack_sdk defaults to connection-error retries only, so a 429 reaches the
-    tool caller as a bare error. Slack caps non-Marketplace apps at one
-    ``conversations.history``/``conversations.replies`` call per minute, which
-    the model-facing read tools trip easily. Duplicated from the Slack
+    tool caller as a bare error. Slack caps apps commercially distributed
+    outside the Marketplace at one ``conversations.history``/
+    ``conversations.replies`` call per minute, which the model-facing read
+    tools trip easily. Duplicated from the Slack
     adapter's ``build_retry_handlers`` — adapters must not import each other.
     """
     return [*async_default_handlers(), AsyncRateLimitErrorRetryHandler()]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -50,11 +50,18 @@ from fastmcp.exceptions import ToolError
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
-# Slack's ceiling for non-Marketplace apps on conversations.history and
-# conversations.replies: at most 15 objects per call and one call per minute.
-# Larger limits are clamped server-side, so asking for more only misleads the
-# caller about how much of the channel or thread they were shown.
-_HISTORY_LIMIT_CAP = 15
+# Largest ``limit`` conversations.history accepts; conversations.replies takes
+# 1000 but one ceiling keeps both reads on the same bound. Above it Slack
+# answers ``invalid_limit`` rather than clamping, unlike the per-workspace
+# 15-object clamp, which it applies silently and reports through ``has_more``.
+_HISTORY_PAGE_CEILING = 999
+
+# Page size for the replies lookup that locates one message by ts.
+_MESSAGE_LOOKUP_PAGE = 200
+
+
+def _bounded_page(limit: int) -> int:
+    return max(1, min(limit, _HISTORY_PAGE_CEILING))
 
 
 def _reraise_mapped(err: SlackApiError, *, as_user: bool = False) -> ToolError:
@@ -240,7 +247,7 @@ async def _fetch_channel_history(
     client: AsyncWebClient, *, channel_id: str, limit: int, cursor: str | None
 ) -> SlackChannelResult:
     resp = await client.conversations_history(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-        channel=channel_id, limit=max(1, min(limit, _HISTORY_LIMIT_CAP)), cursor=cursor
+        channel=channel_id, limit=_bounded_page(limit), cursor=cursor
     )
     raw = cast(list[dict[str, Any]], resp["messages"])
     raw.reverse()  # Slack returns newest-first; tools return oldest-first
@@ -325,7 +332,7 @@ async def _fetch_thread_replies(
     client: AsyncWebClient, *, channel_id: str, thread_ts: str, limit: int
 ) -> SlackThreadResult:
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-        channel=channel_id, ts=thread_ts, limit=max(1, min(limit, _HISTORY_LIMIT_CAP))
+        channel=channel_id, ts=thread_ts, limit=_bounded_page(limit)
     )
     raw = cast(list[dict[str, Any]], resp["messages"])  # already oldest-first
     has_more = bool(resp.get("has_more"))
@@ -339,9 +346,7 @@ async def _fetch_thread_replies(
         if parent_ts and str(parent_ts) != thread_ts:
             result_thread_ts = str(parent_ts)
             resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-                channel=channel_id,
-                ts=result_thread_ts,
-                limit=max(1, min(limit, _HISTORY_LIMIT_CAP)),
+                channel=channel_id, ts=result_thread_ts, limit=_bounded_page(limit)
             )
             raw = cast(list[dict[str, Any]], resp["messages"])
             has_more = bool(resp.get("has_more"))
@@ -417,7 +422,7 @@ async def _fetch_single_message(
         # mapping (or an opaque raw SlackApiError).
         try:
             resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-                channel=channel_id, ts=message_id, limit=_HISTORY_LIMIT_CAP
+                channel=channel_id, ts=message_id, limit=_MESSAGE_LOOKUP_PAGE
             )
         except SlackApiError as err:
             error_code = _slack_error_code(err)

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2109,8 +2109,9 @@
         
         For threads use read_thread. Each platform takes only its own
         pagination parameter — the other is rejected. Discord: at most 200
-        messages per call; use before to fetch older messages. Slack: use
-        cursor to fetch the next page; at most 15 messages are returned.
+        messages per call; use before to fetch older messages. Slack: at most
+        999 per call, and some workspaces cap a single call at 15 whatever
+        limit is asked for; use cursor to fetch the next page.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2157,9 +2158,10 @@
         
         Discord: thread_id is the thread's channel id; use before for older messages.
         Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is rejected — Slack threads read one page of at most 15 messages
-        from the thread root, and has_more=true means the newest replies were
-        not returned.
+        before is rejected — Slack threads read one page of at most 999
+        messages from the thread root, some workspaces cap that page at 15
+        whatever limit is asked for, and has_more=true means the newest
+        replies were not returned.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -1134,13 +1134,15 @@ def _recorded_limit(m: aioresponses, path: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_read_channel_clamps_limit_to_the_slack_page_cap(
+async def test_read_channel_passes_the_requested_limit_through(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
-    """A caller asking for 50 gets a request Slack will honour, not silently clamp.
+    """A caller asking for 50 has 50 requested of Slack.
 
-    Non-Marketplace apps receive at most 15 objects per conversations.history
-    call; the shared tool default of 50 is meaningful on Discord only.
+    Slack clamps the value per workspace — 15 for an app commercially
+    distributed outside the Marketplace, the full page for an internal-app
+    install. Clamping in our own code would hold the second class to the
+    first's ceiling.
     """
     runtime = await _make_runtime(committing_sessionmaker)
     auth = _auth()
@@ -1153,7 +1155,7 @@ async def test_read_channel_clamps_limit_to_the_slack_page_cap(
         m.get(_CONVERSATIONS_HISTORY, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
         await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
         limit = _recorded_limit(m, "/api/conversations.history")
-    assert limit == "15"
+    assert limit == "50"
 
 
 @pytest.mark.asyncio
@@ -1314,7 +1316,44 @@ async def test_read_channel_raises_limit_floor_to_one(
 
 
 @pytest.mark.asyncio
-async def test_read_thread_clamps_limit_to_the_slack_page_cap(
+async def test_read_channel_caps_limit_at_the_slack_maximum(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Above 999 Slack answers invalid_limit instead of clamping, so we clamp there."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(_CONVERSATIONS_HISTORY, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
+        await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=5000)
+        limit = _recorded_limit(m, "/api/conversations.history")
+    assert limit == "999"
+
+
+@pytest.mark.asyncio
+async def test_read_thread_caps_limit_at_the_slack_maximum(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(_CONVERSATIONS_REPLIES, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
+        await _slack_read_thread_impl(runtime, auth, thread_id="C1:1.0", limit=5000)
+        limit = _recorded_limit(m, "/api/conversations.replies")
+    assert limit == "999"
+
+
+@pytest.mark.asyncio
+async def test_read_thread_passes_the_requested_limit_through(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
     runtime = await _make_runtime(committing_sessionmaker)
@@ -1331,5 +1370,5 @@ async def test_read_thread_clamps_limit_to_the_slack_page_cap(
         )
         result = await _slack_read_thread_impl(runtime, auth, thread_id="C1:1.0", limit=50)
         limit = _recorded_limit(m, "/api/conversations.replies")
-    assert limit == "15"
+    assert limit == "50"
     assert result.has_more is True, "truncation must reach the caller"

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -1035,6 +1035,7 @@ class SlackApp:
             "SlackApp._orchestrate requires slack settings (entrypoint validates at boot)"
         )
         cap = self.runtime.settings.slack.max_concurrent_turns_per_tenant
+        page_limit = self.runtime.settings.slack.history_page_limit
         count = self._inflight.get(tenant_id, 0)
         if not should_admit_turn(current_in_flight=count, cap=cap):
             # The rejection below is an ephemeral — it appears in no channel
@@ -1092,6 +1093,7 @@ class SlackApp:
                 tenant_id=tenant_id,
                 thread_id=thread_id,
                 team_id=team_id,
+                page_limit=page_limit,
                 files=_collect_files([event]),
             )
             # Drain loop: new events may arrive during the drain turn; they land
@@ -1138,6 +1140,7 @@ class SlackApp:
                             thread_id=thread_id,
                             content_override=_compose_queued_content(user_events),
                             team_id=team_id,
+                            page_limit=page_limit,
                             # Merge files from ALL of this author's queued events,
                             # in first-seen order — user_events[0] alone would
                             # silently drop files on their later mentions.
@@ -1190,6 +1193,7 @@ class SlackApp:
         tenant_id: uuid.UUID,
         thread_id: str,
         team_id: str,
+        page_limit: int,
         content_override: str | None = None,
         files: list[SlackFile] | None = None,
     ) -> None:
@@ -1468,6 +1472,7 @@ class SlackApp:
                     user_query=user_text,
                     author_id=author_id,
                     proxy=proxy_ctx,
+                    page_limit=page_limit,
                 )
             elif watermark is not None:
                 # Continuation: replay only messages since the last watermark.
@@ -1479,6 +1484,7 @@ class SlackApp:
                     user_query=user_text,
                     author_id=author_id,
                     proxy=proxy_ctx,
+                    page_limit=page_limit,
                 )
             else:
                 # Reused session with no watermark (prior turn's final_ts was None).
@@ -1542,6 +1548,7 @@ class SlackApp:
                     user_query=user_text,
                     author_id=author_id,
                     proxy=proxy_ctx,
+                    page_limit=page_limit,
                 )
                 if synthetic_prefix:
                     full_message = synthetic_prefix + "\n" + full_message

--- a/packages/adapters/slack/daimon/adapters/slack/context.py
+++ b/packages/adapters/slack/daimon/adapters/slack/context.py
@@ -8,9 +8,9 @@ Mirrors ``packages/adapters/discord/daimon/adapters/discord/context.py``:
 - ``build_context_xml``: first-turn fetch, one page from the thread root.
 - ``build_delta_xml``: continuation fetch, delta since the watermark timestamp.
 
-Both fetch a single page. Slack caps non-Marketplace apps at
-``THREAD_PAGE_LIMIT`` objects per ``conversations.replies`` call and one call
-per minute, so paginating inside a turn is not viable; when Slack reports
+Both fetch a single page. A workspace whose app is commercially distributed
+outside the Marketplace answers with at most 15 objects and allows one call per
+minute, so paginating inside a turn is not viable there; when Slack reports
 ``has_more`` the block is marked ``truncated="true"`` so the model knows the
 window is partial.
 
@@ -27,11 +27,13 @@ from daimon.adapters.slack.attachments import ProxyUrlContext, build_proxy_url
 from daimon.adapters.slack.vision import SlackFile
 from slack_sdk.web.async_client import AsyncWebClient
 
-# Slack's ceiling for non-Marketplace apps on conversations.replies (both the
-# default and the maximum accepted value of ``limit``; larger values are clamped
-# server-side). Socket Mode apps cannot list on the Marketplace, so daimon is
-# always in this class.
-THREAD_PAGE_LIMIT = 15
+# Messages requested per ``conversations.replies`` call. Slack clamps ``limit``
+# server-side rather than erroring: a workspace whose app is commercially
+# distributed outside the Marketplace returns 15 however much we ask for, an
+# internal-app install returns the full page. Asking for the real page size is
+# what lets the second class replay a deep thread; ``has_more`` reports which
+# class answered.
+DEFAULT_PAGE_LIMIT = 200
 
 
 def _open_tag(name: str, *, truncated: bool) -> str:
@@ -92,23 +94,24 @@ async def build_context_xml(
     user_query: str,
     author_id: str = "",
     proxy: ProxyUrlContext | None = None,
+    page_limit: int = DEFAULT_PAGE_LIMIT,
 ) -> str:
     """Build XML context from thread history for the first turn.
 
-    Fetches one page of ``THREAD_PAGE_LIMIT`` messages via
+    Fetches one page of ``page_limit`` messages via
     ``conversations.replies``. Returns a string with a
     ``<context>/<thread_history>`` block containing the replayed messages
     followed by a ``<user_query>`` element.
 
     Window: ``conversations.replies`` always returns oldest-first from the
     thread root, and ``oldest``/``latest`` only filter, so the newest window
-    cannot be requested in one call. A thread longer than one page therefore
-    replays the root and the first replies, and the block carries
-    ``truncated="true"`` so the model knows the recent tail is missing.
-    Discord's equivalent replays 100 messages; the gap is Slack's rate policy.
+    cannot be requested in one call. A thread longer than the page the
+    workspace grants therefore replays the root and the first replies, and the
+    block carries ``truncated="true"`` so the model knows the recent tail is
+    missing.
     """
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]
-        channel=channel, ts=thread_ts, limit=THREAD_PAGE_LIMIT
+        channel=channel, ts=thread_ts, limit=page_limit
     )
     messages = cast(list[dict[str, Any]], resp["messages"])  # pyright: ignore[reportUnknownVariableType]
     truncated = bool(resp.get("has_more"))  # pyright: ignore[reportUnknownMemberType]
@@ -137,6 +140,7 @@ async def build_delta_xml(
     user_query: str,
     author_id: str = "",
     proxy: ProxyUrlContext | None = None,
+    page_limit: int = DEFAULT_PAGE_LIMIT,
 ) -> str:
     """Build XML context for a continuation turn (delta since watermark).
 
@@ -145,15 +149,15 @@ async def build_delta_xml(
     ``build_delta_xml``'s ``after_message_id`` path).  Returns a string with a
     ``<context>/<thread_delta>`` block and a ``<user_query>`` element.
 
-    One page of ``THREAD_PAGE_LIMIT`` messages, oldest-first from the
-    watermark; a delta longer than that is marked ``truncated="true"``.
+    One page of ``page_limit`` messages, oldest-first from the watermark; a
+    delta longer than that is marked ``truncated="true"``.
     """
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]
         channel=channel,
         ts=thread_ts,
         oldest=watermark_ts,
         inclusive=False,
-        limit=THREAD_PAGE_LIMIT,
+        limit=page_limit,
     )
     messages = cast(list[dict[str, Any]], resp["messages"])  # pyright: ignore[reportUnknownVariableType]
     truncated = bool(resp.get("has_more"))  # pyright: ignore[reportUnknownMemberType]

--- a/packages/adapters/slack/daimon/adapters/slack/interactions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/interactions.py
@@ -24,11 +24,12 @@ def build_retry_handlers() -> list[AsyncRetryHandler]:
     """Retry handlers for every AsyncWebClient we construct.
 
     slack_sdk's default is connection-error retries only, so a 429 surfaces
-    immediately as ``SlackApiError``. Slack caps non-Marketplace apps at one
-    ``conversations.history``/``conversations.replies`` call per minute, and
-    the listener boundary posts nothing on failure, so an unretried 429 reads
-    as a dead bot. ``AsyncRateLimitErrorRetryHandler`` honours ``Retry-After``;
-    its default single retry is deliberate, since that wait can be 60s.
+    immediately as ``SlackApiError``. Slack caps apps commercially distributed
+    outside the Marketplace at one ``conversations.history``/
+    ``conversations.replies`` call per minute, and the listener boundary posts
+    nothing on failure, so an unretried 429 reads as a dead bot.
+    ``AsyncRateLimitErrorRetryHandler`` honours ``Retry-After``; its default
+    single retry is deliberate, since that wait can be 60s.
     """
     return [*async_default_handlers(), AsyncRateLimitErrorRetryHandler()]
 

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -28,7 +28,7 @@ import aiohttp
 import httpx
 import pytest
 import structlog.testing
-from anthropic import AsyncAnthropic
+from anthropic import AsyncAnthropic, NotFoundError
 from anthropic.types.beta import (
     BetaManagedAgentsModelConfig,
     BetaManagedAgentsSession,
@@ -40,7 +40,7 @@ from cryptography.fernet import Fernet
 from daimon.adapters.slack.app import SlackApp
 from daimon.adapters.slack.runtime import SlackRuntime, build_turn_deps
 from daimon.core.defaults.provisioning import provision_tenant
-from daimon.core.errors import DaimonError
+from daimon.core.errors import DaimonError, TurnError
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.ma_identity import derive_tenant_uuid
 from daimon.core.ma_resolver import new_resolver_cache
@@ -161,6 +161,7 @@ def _make_app(
     else:
         settings.crypto.keys = ()
     settings.slack.max_concurrent_turns_per_tenant = 3
+    settings.slack.history_page_limit = 200
 
     if sessionmaker is None:
         # Provide a factory that returns an AsyncMock context manager when
@@ -736,6 +737,7 @@ def _make_orchestrate_app(
     settings = MagicMock()
     settings.crypto.keys = (SecretStr(crypto_key),) if crypto_key is not None else ()
     settings.slack.max_concurrent_turns_per_tenant = max_concurrent_turns_per_tenant
+    settings.slack.history_page_limit = 200
     settings.mcp.public_url = None
     # app_root_url=None short-circuits _maybe_post_connect_nudge (Task 11) — these
     # orchestration tests don't exercise the connect-nudge flow.
@@ -1036,6 +1038,10 @@ async def test_orchestrate_continuation_when_live_session_exists_calls_build_del
         f"build_delta_xml must be called with watermark_ts={prior_watermark!r}, "
         f"got {call_kwargs.get('watermark_ts')!r}"
     )
+    assert call_kwargs.get("page_limit") == 200, (
+        "the configured page size must reach the replay call; hardcoding the "
+        "clamped ceiling denies unclamped workspaces their depth"
+    )
 
     # Assert watermark was updated in the DB.
     async with db_session_factory() as s:
@@ -1049,6 +1055,138 @@ async def test_orchestrate_continuation_when_live_session_exists_calls_build_del
     assert row is not None, "thread_sessions row must still exist"
     assert row.watermark_message_id != prior_watermark, (
         "watermark must be updated after the continuation turn"
+    )
+
+
+async def test_dead_session_reseed_requests_the_configured_page_size(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """The recovery re-seed replays history with the same page size as the first turn.
+
+    The setting is deliberately not 200 here: the reseed call falling back to
+    the module default would otherwise be indistinguishable from honouring it.
+    """
+    from daimon.core.stores.identity import get_or_create_platform_principal
+
+    team_id = "T_ORCH_80_RESEED"
+    channel = "C_TEST"
+    thread_ts = "9000000003.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    async with db_session_factory() as s:
+        principal = await get_or_create_platform_principal(
+            s, tenant_id=tenant_id, platform="slack", external_id="U_TEST_RESEED"
+        )
+        await create_thread_session(
+            s,
+            tenant_id=tenant_id,
+            platform="slack",
+            thread_id=thread_ts,
+            account_id=principal.account_id,
+            ma_session_id="sess-reseed-dead",
+            watermark_message_id=None,
+        )
+        await s.commit()
+
+    app, _ = _make_orchestrate_app(db_session_factory)
+    app.runtime.settings.slack.history_page_limit = 350
+
+    dead = TurnState(
+        error=TurnError(
+            kind="upstream",
+            message="session gone",
+            cause=NotFoundError(
+                "session gone",
+                response=httpx.Response(404, request=httpx.Request("POST", "https://ma.test")),
+                body=None,
+            ),
+        ),
+    )
+    outcomes = iter([dead, None])
+
+    async def _fake_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+        if (state := next(outcomes)) is not None:
+            return state
+        ok = TurnState(content=[TextBlock(kind="text", text="Recovered!")])
+        await lifecycle.on_terminal_success(ok)
+        return ok
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": "9000000003.000002",
+        "thread_ts": thread_ts,
+        "event_ts": "9000000003.000002",
+        "channel": channel,
+        "user": "U_TEST_RESEED",
+        "text": "<@U_BOT> still there?",
+    }
+
+    _now = datetime.now(UTC)
+    _fake_session = BetaManagedAgentsSession(
+        outcome_evaluations=[],
+        id="sess-reseed-fresh",
+        agent=BetaManagedAgentsSessionAgent(
+            id="agent_test_id",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at=_now,
+        environment_id="env_test_id",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=_now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+    )
+
+    with (
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+    ):
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env.return_value = "env_test_id"
+        mock_create_session.return_value = _fake_session
+        mock_run_turn.side_effect = _fake_run_turn
+
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            event,
+            team_id=team_id,
+            channel=channel,
+            event_ts="9000000003.000002",
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+        )
+
+    assert mock_run_turn.await_count == 2, "the dead session must be recovered exactly once"
+    requested = [
+        str(url.query["limit"])
+        for (method, url), _ in fake_slack_web_client.mock.requests.items()
+        if method == "GET" and url.path == "/api/conversations.replies"
+    ]
+    assert requested == ["350"], (
+        "the re-seed after recovery is the only history replay on a reused session, "
+        f"and it must carry the configured page size; saw {requested}"
     )
 
 
@@ -3614,6 +3752,7 @@ async def test_run_thread_turn_pump_phase_ceiling_renders_terminal_error_in_thre
             tenant_id=tenant_id,
             thread_id=thread_ts,
             team_id=team_id,
+            page_limit=200,
         )
 
     update_calls = [

--- a/packages/adapters/slack/tests/test_context.py
+++ b/packages/adapters/slack/tests/test_context.py
@@ -13,7 +13,12 @@ import re
 
 from aioresponses import aioresponses as AioResponsesMock
 from daimon.adapters.slack.attachments import ProxyUrlContext
-from daimon.adapters.slack.context import _render_message, build_context_xml, build_delta_xml
+from daimon.adapters.slack.context import (
+    DEFAULT_PAGE_LIMIT,
+    _render_message,
+    build_context_xml,
+    build_delta_xml,
+)
 from daimon.core.slack_file_token import verify_file_token
 from slack_sdk.web.async_client import AsyncWebClient
 
@@ -37,16 +42,34 @@ def _replies_request_params(mock: AioResponsesMock) -> dict[str, str]:
     return calls[0]
 
 
+def _messages(count: int) -> list[dict[str, str]]:
+    return [{"user": "U1", "text": f"msg {i}", "ts": f"{100 + i}.0"} for i in range(count)]
+
+
 def _fifteen_messages() -> list[dict[str, str]]:
-    return [{"user": "U1", "text": f"msg {i}", "ts": f"{100 + i}.0"} for i in range(15)]
+    return _messages(15)
 
 
-async def test_build_context_xml_requests_the_slack_page_cap() -> None:
-    """The first-turn replay asks for exactly the 15 messages Slack will return.
+def _clamped_to_fifteen(total: int) -> dict[str, object]:
+    """Response a capped workspace sends however large a limit it was asked for.
 
-    Non-Marketplace apps get at most 15 objects per conversations.replies call;
-    asking for more is silently clamped, so the request must state the real
-    ceiling rather than a number the API ignores.
+    Slack clamps ``limit`` server-side rather than erroring, which is why a
+    request for 100 returned 15 unnoticed before. Tests that echo back the
+    requested limit cannot tell the two workspace classes apart.
+    """
+    return {
+        "ok": True,
+        "messages": _messages(min(15, total)),
+        "has_more": total > 15,
+    }
+
+
+async def test_build_context_xml_requests_the_full_page_size() -> None:
+    """The first-turn replay asks for the page size the settings name.
+
+    Slack clamps the value server-side per workspace: a capped install gets 15
+    back whatever we ask for, an exempt one gets the full page. Hardcoding the
+    capped ceiling in the request denies exempt installs their depth.
     """
     with AioResponsesMock() as mock:
         mock.get(
@@ -54,12 +77,73 @@ async def test_build_context_xml_requests_the_slack_page_cap() -> None:
             payload={"ok": True, "messages": _fifteen_messages(), "has_more": False},
         )
         client = _make_client()
+        await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
+        params = _replies_request_params(mock)
+
+    assert params["limit"] == str(DEFAULT_PAGE_LIMIT)
+
+
+async def test_build_context_xml_requests_an_explicit_page_limit() -> None:
+    """A caller-supplied page size reaches the API call."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": _fifteen_messages(), "has_more": False},
+        )
+        client = _make_client()
+        await build_context_xml(
+            client, channel="C1", thread_ts="100.0", user_query="hi", page_limit=50
+        )
+        params = _replies_request_params(mock)
+
+    assert params["limit"] == "50"
+
+
+async def test_build_delta_xml_requests_the_full_page_size() -> None:
+    """The continuation delta asks for the same page size as the first turn."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": _fifteen_messages(), "has_more": False},
+        )
+        client = _make_client()
+        await build_delta_xml(
+            client, channel="C1", thread_ts="100.0", watermark_ts="99.0", user_query="hi"
+        )
+        params = _replies_request_params(mock)
+
+    assert params["limit"] == str(DEFAULT_PAGE_LIMIT)
+
+
+async def test_build_context_xml_replays_a_page_wider_than_the_capped_ceiling() -> None:
+    """An unclamped workspace replays everything Slack returns, not the first 15."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": _messages(40), "has_more": False},
+        )
+        client = _make_client()
+        xml = await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
+
+    assert xml.count("<message ") == 40, "every returned message reaches the model"
+    assert "<thread_history>" in xml, "a complete window carries no truncation marker"
+
+
+async def test_build_context_xml_flags_truncation_when_the_workspace_clamps() -> None:
+    """A capped workspace asked for a full page still reports a partial window.
+
+    The request states the full page size; the workspace returns 15 with
+    ``has_more``. The model must be told the tail is absent.
+    """
+    with AioResponsesMock() as mock:
+        mock.get(_REPLIES_PATTERN, payload=_clamped_to_fifteen(total=200))
+        client = _make_client()
         xml = await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
         params = _replies_request_params(mock)
 
-    assert params["limit"] == "15"
-    assert xml.count("<message ") == 15, "every returned message reaches the model"
-    assert "<thread_history>" in xml, "a complete window carries no truncation marker"
+    assert params["limit"] == str(DEFAULT_PAGE_LIMIT), "we asked for the full page"
+    assert xml.count("<message ") == 15, "the workspace clamped the response"
+    assert '<thread_history truncated="true">' in xml
 
 
 async def test_build_context_xml_marks_thread_history_truncated_when_slack_has_more() -> None:

--- a/packages/adapters/slack/tests/test_turn_context.py
+++ b/packages/adapters/slack/tests/test_turn_context.py
@@ -75,6 +75,7 @@ def _make_orchestrate_app(
     settings = MagicMock()
     settings.crypto.keys = ()
     settings.slack.max_concurrent_turns_per_tenant = 3
+    settings.slack.history_page_limit = 200
     settings.mcp.public_url = None
     # app_root_url=None short-circuits _maybe_post_connect_nudge (Task 11) — these
     # turn-context tests don't exercise the connect-nudge flow.

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -226,6 +226,19 @@ class SlackSettings(BaseModel):
             "starving others on the shared Anthropic key."
         ),
     )
+    history_page_limit: int = Field(
+        default=200,
+        ge=1,
+        le=1000,
+        description=(
+            "Messages requested per conversations.replies call when replaying "
+            "thread history. Slack clamps this per workspace: an app "
+            "commercially distributed outside the Marketplace gets 15 whatever "
+            "it asks for, an internal-app install gets the full page up to "
+            "1000, which is also the largest value Slack accepts. Raising it "
+            "costs a clamped workspace nothing."
+        ),
+    )
     health_port: int = Field(
         default=8083,
         description=(

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -575,3 +575,59 @@ def test_slack_settings_max_concurrent_turns_per_tenant_defaults_to_3(
     assert settings.slack.max_concurrent_turns_per_tenant == 3, (
         "max_concurrent_turns_per_tenant must default to 3 (STURN-06 per-tenant cap)"
     )
+
+
+def test_slack_settings_history_page_limit_defaults_to_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The requested conversations.replies page size defaults above the capped ceiling.
+
+    Slack clamps the value per workspace, so a default of 200 costs a capped
+    install nothing and gives an internal-app install the depth it is entitled
+    to.
+    """
+    monkeypatch.setenv("DAIMON_DATABASE__URL", "postgresql+asyncpg://u:p@h/d")
+    monkeypatch.setenv("DAIMON_ANTHROPIC__API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_SLACK__SIGNING_SECRET", "s" * 32)
+    monkeypatch.setenv("DAIMON_SLACK__APP_TOKEN", "xapp-test")
+    settings = load_settings(_env_file=None)
+    assert settings.slack is not None, "slack block must be present when DAIMON_SLACK__* are set"
+    assert settings.slack.history_page_limit == 200, (
+        "history_page_limit must default to 200 so unclamped workspaces replay deep threads"
+    )
+
+
+def test_slack_settings_history_page_limit_overrides_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator on an unclamped workspace can raise the page size to Slack's maximum."""
+    monkeypatch.setenv("DAIMON_DATABASE__URL", "postgresql+asyncpg://u:p@h/d")
+    monkeypatch.setenv("DAIMON_ANTHROPIC__API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_SLACK__SIGNING_SECRET", "s" * 32)
+    monkeypatch.setenv("DAIMON_SLACK__APP_TOKEN", "xapp-test")
+    monkeypatch.setenv("DAIMON_SLACK__HISTORY_PAGE_LIMIT", "1000")
+    settings = load_settings(_env_file=None)
+    assert settings.slack is not None
+    assert settings.slack.history_page_limit == 1000, (
+        "DAIMON_SLACK__HISTORY_PAGE_LIMIT must override the default page size"
+    )
+
+
+def test_slack_settings_history_page_limit_rejects_zero() -> None:
+    """A page size Slack would refuse fails at boot, not on the first mention.
+
+    conversations.replies answers ``invalid_limit`` for 0 and for anything above
+    1000, and the listener boundary posts nothing on failure, so an unbounded
+    field would turn a typo in .env into a workspace-wide silent bot.
+    """
+    from daimon.core.config import SlackSettings
+
+    with pytest.raises(ValidationError):
+        SlackSettings(signing_secret="s" * 32, app_token="xapp-test", history_page_limit=0)
+
+
+def test_slack_settings_history_page_limit_rejects_above_slack_maximum() -> None:
+    from daimon.core.config import SlackSettings
+
+    with pytest.raises(ValidationError):
+        SlackSettings(signing_secret="s" * 32, app_token="xapp-test", history_page_limit=1001)

--- a/tests/parity/drivers/slack_driver.py
+++ b/tests/parity/drivers/slack_driver.py
@@ -153,6 +153,7 @@ class SlackDriver:
         settings = MagicMock()
         settings.crypto.keys = (SecretStr(fernet_key),)
         settings.slack.max_concurrent_turns_per_tenant = 100
+        settings.slack.history_page_limit = 200
         settings.mcp.public_url = None
         settings.mcp.app_root_url = None
         settings.mcp.jwt_secret = None


### PR DESCRIPTION
Follow-up to #130

## What changes for users

A workspace whose daimon install is *not* commercially distributed replays up to 200 messages of thread history again, instead of 15. Nothing changes for a workspace that is distributed: Slack clamps the request to 15, `has_more` comes back true, and the block still opens as `<thread_history truncated="true">`.

`read_channel` and `read_thread` on Slack request the caller's `limit` rather than clamping it to 15 in our own code, so the tool default of 50 is honoured wherever the workspace allows it.

New setting `DAIMON_SLACK__HISTORY_PAGE_LIMIT` (default 200) for operators who want the full 1000-object page Slack allows internal apps.

## Why

#130 read Slack's May 2025 policy as covering every daimon install and hardcoded the penalised ceiling. The policy applies to apps **commercially distributed outside the Marketplace**; [internal customer-built apps keep 50+ requests per minute and 1000-object pages](https://docs.slack.dev/changelog/2025/05/29/rate-limit-changes-for-non-marketplace-apps/). daimon is self-hosted, so a deployment installed to its own workspace is in the exempt class — and `docs/slack-app-manifest.yaml` was pushing self-hosters out of it by telling everyone to activate public distribution, which only a multi-workspace deployment needs.

Slack clamps `limit` server-side rather than erroring — the reason a request for 100 returned 15 unnoticed for so long — so asking for the real page size needs no probe and no per-workspace config. Asking honestly *is* the probe: `has_more` reports which class answered.

## Behaviour change

Threads on unclamped workspaces replay deeper, so first-turn context grows for those installs. The `truncated="true"` marker, the delta page limit, and `has_more` on `read_thread` are all unchanged from #130.

## Testing

- Every new assertion was watched failing first.
- The context tests model both workspace classes: one fake returns the full page, another clamps to 15 with `has_more` however much is asked for. #130's bug survived review because the only fake echoed back whatever `limit` it was handed.
- 1344 tests pass locally; ruff, ruff-format, pyright, import-linter and the anti-pattern lint are clean. Tool schema snapshot regenerated single-process.
- Not tested: a live Slack workspace. Whether the pymc-labs install is itself clamped is still unmeasured — it is one `conversations.replies` call with `limit=100` against a thread of more than 15 replies.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally
- [x] `uv run pyright` passes locally (strict mode)
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)