### PR TITLE
Fix channel history pagination

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -14,6 +14,7 @@ from daimon.adapters.mcp.tools.discord import (
     ChannelRow,
     MessageRow,
     ParsedLink,
+    ReadChannelResult,
     ReadThreadResult,
     SearchResult,
     ThreadRow,
@@ -28,6 +29,7 @@ from daimon.adapters.mcp.tools.discord import (
     _send_message_impl,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.adapters.mcp.tools.slack._models import (
+    SlackChannelResult,
     SlackChannelRow,
     SlackMessageRow,
     SlackParsedLink,
@@ -74,17 +76,22 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         ctx: Context,
         channel_id: str,
         limit: int = 50,
-    ) -> list[MessageRow] | list[SlackMessageRow]:
-        """Read recent messages from a channel, oldest-first.
+        before: str | None = None,
+        cursor: str | None = None,
+    ) -> ReadChannelResult | SlackChannelResult:
+        """Read channel messages, oldest-first, with pagination metadata.
 
-        For threads use read_thread.
-        Slack: at most 15 messages per call (the newest 15); older history is
-        not reachable from this tool.
+        For threads use read_thread. Discord: use before to fetch older messages.
+        Slack: use cursor to fetch the next page; at most 15 messages are returned.
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":
-            return await _slack_read_channel_impl(runtime, auth, channel_id=channel_id, limit=limit)
-        return await _read_channel_impl(runtime, auth, channel_id=channel_id, limit=limit)
+            return await _slack_read_channel_impl(
+                runtime, auth, channel_id=channel_id, limit=limit, cursor=cursor
+            )
+        return await _read_channel_impl(
+            runtime, auth, channel_id=channel_id, limit=limit, before=before
+        )
 
     @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def read_thread(  # pyright: ignore[reportUnusedFunction]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/__init__.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/__init__.py
@@ -45,6 +45,9 @@ from daimon.adapters.mcp.tools.discord._models import (
     ParsedLink as ParsedLink,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.adapters.mcp.tools.discord._models import (
+    ReadChannelResult as ReadChannelResult,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.discord._models import (
     ReadThreadResult as ReadThreadResult,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.adapters.mcp.tools.discord._models import (

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_models.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_models.py
@@ -56,6 +56,12 @@ class ReadThreadResult(BaseModel):
     hint: str | None = None
 
 
+class ReadChannelResult(BaseModel):
+    rows: list[MessageRow]
+    next_before: str | None = None
+    hint: str | None = None
+
+
 class SearchResult(BaseModel):
     total_results: int
     showing: int

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_read.py
@@ -30,6 +30,7 @@ from daimon.adapters.mcp.tools.discord._models import (
     ChannelRow,  # pyright: ignore[reportPrivateUsage]
     MessageRow,  # pyright: ignore[reportPrivateUsage]
     ParsedLink,  # pyright: ignore[reportPrivateUsage]
+    ReadChannelResult,  # noqa: F811  # pyright: ignore[reportPrivateUsage,reportUnusedImport]
     ReadThreadResult,  # noqa: F811  # pyright: ignore[reportPrivateUsage,reportUnusedImport]
     ThreadRow,  # noqa: F811  # pyright: ignore[reportPrivateUsage,reportUnusedImport]
     _to_message_row,  # pyright: ignore[reportPrivateUsage]
@@ -61,8 +62,9 @@ async def _read_channel_impl(  # pyright: ignore[reportUnusedFunction]
     *,
     channel_id: str,
     limit: int = 50,
-) -> list[MessageRow]:
-    """Read recent messages from a channel, oldest-first.
+    before: str | None = None,
+) -> ReadChannelResult:
+    """Read channel messages, oldest-first, with before-cursor pagination.
 
     If the resolved channel is a thread, raises ToolError directing to
     read_thread (keeps parse_link routing unambiguous).
@@ -83,8 +85,16 @@ async def _read_channel_impl(  # pyright: ignore[reportUnusedFunction]
         _check_view_permission(channel, member)
         if not isinstance(channel, discord.abc.Messageable):
             raise ToolError("channel does not support message history")
-        page = [m async for m in channel.history(limit=bounded_limit)]
-        return [_to_message_row(m) for m in reversed(page)]
+        before_obj = discord.Object(id=int(before)) if before is not None else None
+        page = [m async for m in channel.history(limit=bounded_limit, before=before_obj)]
+        rows = [_to_message_row(m) for m in reversed(page)]
+        next_before = str(page[-1].id) if len(page) == bounded_limit else None
+        hint = (
+            f"more messages available — pass before={next_before} to read older messages"
+            if next_before is not None
+            else None
+        )
+        return ReadChannelResult(rows=rows, next_before=next_before, hint=hint)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
@@ -22,6 +22,12 @@ class SlackMessageRow(BaseModel):
     reply_count: int | None = None
 
 
+class SlackChannelResult(BaseModel):
+    messages: list[SlackMessageRow]
+    next_cursor: str | None = None
+    hint: str | None = None
+
+
 class SlackThreadResult(BaseModel):
     channel_id: str
     thread_ts: str

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -34,6 +34,7 @@ from daimon.adapters.mcp.tools.slack._leak_policy import (
     is_dm_destination,
 )
 from daimon.adapters.mcp.tools.slack._models import (
+    SlackChannelResult,
     SlackChannelRow,
     SlackMessageRow,
     SlackThreadResult,
@@ -236,20 +237,36 @@ async def _slack_list_channels_impl(  # pyright: ignore[reportUnusedFunction]  #
 
 
 async def _fetch_channel_history(
-    client: AsyncWebClient, *, channel_id: str, limit: int
-) -> list[SlackMessageRow]:
+    client: AsyncWebClient, *, channel_id: str, limit: int, cursor: str | None
+) -> SlackChannelResult:
     resp = await client.conversations_history(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-        channel=channel_id, limit=min(limit, _HISTORY_LIMIT_CAP)
+        channel=channel_id, limit=min(limit, _HISTORY_LIMIT_CAP), cursor=cursor
     )
     raw = cast(list[dict[str, Any]], resp["messages"])
     raw.reverse()  # Slack returns newest-first; tools return oldest-first
     usernames = await _resolve_usernames(client, _author_ids(raw))
-    return _to_message_rows(raw, usernames)
+    next_cursor = (
+        str(cast(dict[str, Any], resp.get("response_metadata") or {}).get("next_cursor") or "")
+        or None
+    )
+    hint = (
+        f"more messages available — pass cursor={next_cursor} to read older messages"
+        if next_cursor is not None
+        else None
+    )
+    return SlackChannelResult(
+        messages=_to_message_rows(raw, usernames), next_cursor=next_cursor, hint=hint
+    )
 
 
 async def _slack_read_channel_impl(  # pyright: ignore[reportUnusedFunction]  # registered by tools/channels.py
-    runtime: McpRuntime, auth: AuthIdentity, *, channel_id: str, limit: int
-) -> list[SlackMessageRow]:
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    limit: int,
+    cursor: str | None = None,
+) -> SlackChannelResult:
     user_id = _require_slack_identity(auth)
     team_id = _require_team_id(auth)
     rc = await slack_read_client(runtime, team_id=team_id, slack_user_id=user_id)
@@ -258,7 +275,9 @@ async def _slack_read_channel_impl(  # pyright: ignore[reportUnusedFunction]  # 
         try:
             channel = await _channel_info(rc.client, channel_id=channel_id)
             await _gate_user_source(runtime, auth, channel=channel)
-            return await _fetch_channel_history(rc.client, channel_id=channel_id, limit=limit)
+            return await _fetch_channel_history(
+                rc.client, channel_id=channel_id, limit=limit, cursor=cursor
+            )
         except SlackApiError as err:
             # Any not_in_channel from the user token (typically a public channel
             # the user never joined) falls back to the bot path, which
@@ -273,7 +292,9 @@ async def _slack_read_channel_impl(  # pyright: ignore[reportUnusedFunction]  # 
     try:
         channel = await _channel_info(bot_client, channel_id=channel_id)
         await check_channel_access(bot_client, channel=channel, user_id=user_id)
-        return await _fetch_channel_history(bot_client, channel_id=channel_id, limit=limit)
+        return await _fetch_channel_history(
+            bot_client, channel_id=channel_id, limit=limit, cursor=cursor
+        )
     except ToolError as terr:
         if rc.runs_as_user:
             raise  # user already has a token — a connect hint would be noise

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2062,17 +2062,38 @@
     }),
     'read_channel': dict({
       'description': '''
-        Read recent messages from a channel, oldest-first.
+        Read channel messages, oldest-first, with pagination metadata.
         
-        For threads use read_thread.
-        Slack: at most 15 messages per call (the newest 15); older history is
-        not reachable from this tool.
+        For threads use read_thread. Discord: use before to fetch older messages.
+        Slack: use cursor to fetch the next page; at most 15 messages are returned.
       ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
+          'before': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
           'channel_id': dict({
             'type': 'string',
+          }),
+          'cursor': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
           }),
           'limit': dict({
             'default': 50,

--- a/packages/adapters/mcp/tests/integration/test_discord_tools_live.py
+++ b/packages/adapters/mcp/tests/integration/test_discord_tools_live.py
@@ -134,13 +134,13 @@ async def test_read_channel_against_live_test_channel(
     bot_user_id = override or await _bot_user_id(token)
     auth = _make_auth(bot_user_id)
 
-    rows = await _read_channel_impl(
+    result = await _read_channel_impl(
         runtime,
         auth,
         channel_id=_TEST_CHANNEL_ID,
         limit=5,
     )
-    assert isinstance(rows, list), "read_channel must return a list"
+    assert isinstance(result.rows, list), "read_channel must return a message list"
 
 
 async def test_send_message_and_round_trip(
@@ -169,7 +169,7 @@ async def test_send_message_and_round_trip(
         channel_id=_TEST_CHANNEL_ID,
         limit=10,
     )
-    assert any(r.id == sent.id for r in recent), (
+    assert any(r.id == sent.id for r in recent.rows), (
         f"posted message {sent.id} must appear in read_channel"
     )
 

--- a/packages/adapters/mcp/tests/tools/test_discord_read.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_read.py
@@ -300,14 +300,71 @@ async def test_read_channel_happy_path_oldest_first(monkeypatch: pytest.MonkeyPa
         raise AssertionError(f"unexpected route {route.method} {route.path}")
 
     patch_discord_http(monkeypatch, handler)
-    rows = await _read_channel_impl(
+    result = await _read_channel_impl(
         _runtime_with_discord_token(), _auth(), channel_id="222", limit=50
     )
+    rows = result.rows
     assert len(rows) == 2, "read_channel should return both seeded messages"
     assert rows[0].id == "1001", "first row must be the older message (oldest-first)"
     assert rows[1].id == "1002", "second row must be the newer message"
     assert rows[0].author_username == "caller", "row must carry author_username"
     assert rows[0].role == "user", "non-bot author must have role 'user'"
+
+
+async def test_read_channel_full_page_returns_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """read_channel exposes a cursor instead of silently truncating a full page."""
+    limit = 3
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.path == "/channels/{channel_id}/messages":
+            return [
+                _message_payload(message_id="1003", channel_id="222"),
+                _message_payload(message_id="1002", channel_id="222"),
+                _message_payload(message_id="1001", channel_id="222"),
+            ]
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    result = await _read_channel_impl(
+        _runtime_with_discord_token(), _auth(), channel_id="222", limit=limit
+    )
+    assert [row.id for row in result.rows] == ["1001", "1002", "1003"]
+    assert result.next_before == "1001"
+    assert result.hint is not None and "before=1001" in result.hint
+
+
+async def test_read_channel_passes_before_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """read_channel forwards a continuation cursor to Discord history."""
+    seen_params: dict[str, Any] = {}
+
+    async def handler(route: discord.http.Route, kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        if route.path == "/channels/{channel_id}/messages":
+            seen_params.update(kwargs.get("params", {}))
+            return [_message_payload(message_id="999", channel_id="222")]
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    result = await _read_channel_impl(
+        _runtime_with_discord_token(), _auth(), channel_id="222", limit=50, before="1000"
+    )
+    assert [row.id for row in result.rows] == ["999"]
+    assert str(seen_params.get("before")) == "1000"
 
 
 async def test_read_channel_bot_author_has_assistant_role(
@@ -331,12 +388,12 @@ async def test_read_channel_bot_author_has_assistant_role(
         raise AssertionError(f"unexpected route {route.method} {route.path}")
 
     patch_discord_http(monkeypatch, handler)
-    rows = await _read_channel_impl(
+    result = await _read_channel_impl(
         _runtime_with_discord_token(), _auth(), channel_id="222", limit=50
     )
-    assert len(rows) == 1
-    assert rows[0].role == "assistant", "bot author must have role 'assistant'"
-    assert rows[0].author_username == "caller"
+    assert len(result.rows) == 1
+    assert result.rows[0].role == "assistant", "bot author must have role 'assistant'"
+    assert result.rows[0].author_username == "caller"
 
 
 async def test_read_channel_rejects_thread_id(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -173,7 +173,8 @@ async def test_read_channel_public_full_member_returns_oldest_first(
             _USERS_INFO,
             payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
         )
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
+    rows = result.messages
     assert [r.text for r in rows] == ["oldest", "mid", "newest"], (
         "read_channel must return oldest-first like the Discord tool"
     )
@@ -732,8 +733,8 @@ async def test_read_channel_user_path_private_same_channel_destination_returns_m
         )
         # No conversations.members mock registered: the user path never scans
         # membership, so an unregistered members URL would fail the test.
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="C_PRIV", limit=10)
-    assert [r.text for r in rows] == ["hi"], (
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C_PRIV", limit=10)
+    assert [r.text for r in result.messages] == ["hi"], (
         "user-token path should return the private channel's messages"
     )
 
@@ -760,8 +761,10 @@ async def test_read_channel_user_path_private_dm_destination_returns_messages(
             _USERS_INFO,
             payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
         )
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="C_PRIV", limit=10)
-    assert [r.text for r in rows] == ["hi"], "DM destination should always be an allowed audience"
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C_PRIV", limit=10)
+    assert [r.text for r in result.messages] == ["hi"], (
+        "DM destination should always be an allowed audience"
+    )
 
 
 @pytest.mark.asyncio
@@ -786,8 +789,8 @@ async def test_read_channel_user_path_private_cross_channel_destination_returns_
             _USERS_INFO,
             payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
         )
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="C_PRIV", limit=10)
-    assert [r.text for r in rows] == ["hi"], (
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C_PRIV", limit=10)
+    assert [r.text for r in result.messages] == ["hi"], (
         "a private channel the user can see is answerable from any destination"
     )
 
@@ -832,8 +835,8 @@ async def test_read_channel_user_path_mpim_source_channel_destination_returns_me
             _USERS_INFO,
             payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
         )
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="G_MPIM", limit=10)
-    assert [r.text for r in rows] == ["group dm"], (
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="G_MPIM", limit=10)
+    assert [r.text for r in result.messages] == ["group dm"], (
         "a group DM the user belongs to is answerable from any destination"
     )
 
@@ -860,8 +863,8 @@ async def test_read_channel_user_path_dm_source_dm_destination_returns_messages(
             _USERS_INFO,
             payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
         )
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="D_SRC", limit=10)
-    assert [r.text for r in rows] == ["hi"], "a DM read in a DM destination is allowed"
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="D_SRC", limit=10)
+    assert [r.text for r in result.messages] == ["hi"], "a DM read in a DM destination is allowed"
 
 
 @pytest.mark.asyncio
@@ -889,8 +892,10 @@ async def test_read_channel_user_path_public_channel_any_destination_returns_mes
             _USERS_INFO,
             payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
         )
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="C_PUB", limit=10)
-    assert [r.text for r in rows] == ["hi"], "public channels bypass the leak gate entirely"
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C_PUB", limit=10)
+    assert [r.text for r in result.messages] == ["hi"], (
+        "public channels bypass the leak gate entirely"
+    )
 
 
 @pytest.mark.asyncio
@@ -932,8 +937,8 @@ async def test_read_channel_user_path_public_not_in_channel_falls_back_to_bot_to
             _USERS_INFO,
             payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
         )
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="C_PUB", limit=10)
-    assert [r.text for r in rows] == ["bot-token hit"], (
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C_PUB", limit=10)
+    assert [r.text for r in result.messages] == ["bot-token hit"], (
         "not_in_channel on the user token must retry silently on the bot token"
     )
 
@@ -1003,8 +1008,8 @@ async def test_read_channel_user_path_im_source_dm_destination_returns_messages(
             _USERS_INFO,
             payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
         )
-        rows = await _slack_read_channel_impl(runtime, auth, channel_id="D_IM_SOURCE", limit=10)
-    assert [r.text for r in rows] == ["dm content"], (
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="D_IM_SOURCE", limit=10)
+    assert [r.text for r in result.messages] == ["dm content"], (
         "user-token path should serve an im the bot path would reject"
     )
 
@@ -1149,6 +1154,42 @@ async def test_read_channel_clamps_limit_to_the_slack_page_cap(
         await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
         limit = _recorded_limit(m, "/api/conversations.history")
     assert limit == "15"
+
+
+@pytest.mark.asyncio
+async def test_read_channel_returns_and_uses_slack_cursor(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Channel history exposes Slack's continuation cursor instead of truncating silently."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_HISTORY,
+            payload={
+                "ok": True,
+                "messages": [{"ts": "1", "text": "oldest"}],
+                "response_metadata": {"next_cursor": "CURSOR_3"},
+            },
+        )
+        result = await _slack_read_channel_impl(
+            runtime, auth, channel_id="C1", limit=50, cursor="CURSOR_2"
+        )
+        history_requests = [
+            url
+            for (method, url), _ in m.requests.items()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+            if method == "GET" and url.path == "/api/conversations.history"
+        ]
+    assert [row.text for row in result.messages] == ["oldest"]
+    assert result.next_cursor == "CURSOR_3"
+    assert result.hint is not None and "cursor=CURSOR_3" in result.hint
+    assert len(history_requests) == 1
+    assert str(history_requests[0].query["cursor"]) == "CURSOR_2"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- return page metadata from `read_channel` rather than silently truncating full Discord or Slack channel-history pages
- support Discord `before` continuations and Slack `cursor` continuations
- add regression coverage for full pages, continuation forwarding, and the model-facing MCP tool schema

## Validation
- `DAIMON_DATABASE__TEST_URL=... uv run pytest packages/adapters/mcp -q` (765 passed, 8 deselected)
- `uv run pyright`
- `uv run ruff check . && uv run ruff format --check .`
- `uv run lint-imports`

Closes #74