### PR TITLE
fix(core): fail fast on missing database migrations

### DIFF
--- a/apps/notebook-host/src/notebook_host/config.py
+++ b/apps/notebook-host/src/notebook_host/config.py
@@ -54,6 +54,13 @@ class Settings(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def _validate_marimo_port_range(self) -> Settings:
+        """Reject an inverted pool before startup reports it as exhausted."""
+        if self.marimo_port_start > self.marimo_port_end:
+            raise ValueError("marimo_port_start must not exceed marimo_port_end")
+        return self
+
     host_port: int = 8001
     marimo_port_start: int = 8100
     marimo_port_end: int = 8160

--- a/apps/notebook-host/tests/test_lifecycle.py
+++ b/apps/notebook-host/tests/test_lifecycle.py
@@ -70,6 +70,15 @@ def test_settings_env_override_applied(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def test_settings_rejects_an_inverted_marimo_port_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_START", "9001")
+    monkeypatch.setenv("DAIMON_NOTEBOOK__MARIMO_PORT_END", "9000")
+    from notebook_host.config import load_settings
+
+    with pytest.raises(ValidationError, match="marimo_port_start must not exceed"):
+        load_settings(_env_file=None)
+
+
 def test_resolved_blogs_file_defaults_to_data_dir_blogs_json() -> None:
     """blogs_file unset → resolved_blogs_file is data_dir / 'blogs.json'."""
     from notebook_host.config import load_settings

--- a/packages/adapters/cli/daimon/adapters/cli/commands/sessions.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/sessions.py
@@ -17,11 +17,14 @@ from daimon.adapters.cli.logging import configure_admin_logging
 from daimon.adapters.cli.output import emit_rows
 from daimon.adapters.cli.runtime import CliRuntime, build_runtime
 from daimon.adapters.cli.sessions_bootstrap import (
+    SessionBootstrapError,
     check_preconditions,
     resolve_agent_and_environment,
 )
 from daimon.adapters.cli.tenant import discover_tenant
 from daimon.core.config import load_settings
+from daimon.core.db import ensure_database_migrated
+from daimon.core.errors import DatabaseNotMigratedError
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.sessions import create_session
 from daimon.core.stores.identity import get_or_create_cli_principal
@@ -63,6 +66,10 @@ async def sessions_create(
     as_json: bool,
 ) -> None:
     configure_admin_logging()
+    try:
+        await ensure_database_migrated(rt.sessionmaker)
+    except DatabaseNotMigratedError as err:
+        raise SessionBootstrapError("db_not_migrated", str(err)) from err
     async with rt.sessionmaker() as db:
         tenant_id = await discover_tenant(db)
         await db.commit()

--- a/packages/adapters/cli/daimon/adapters/cli/sessions_bootstrap.py
+++ b/packages/adapters/cli/daimon/adapters/cli/sessions_bootstrap.py
@@ -10,7 +10,6 @@ import uuid
 from pathlib import Path
 from typing import Literal
 
-import asyncpg.exceptions  # type: ignore[reportMissingTypeStubs]
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import BetaEnvironment, BetaManagedAgentsAgent
 from daimon.core.defaults.provisioning import reconcile_tenant_defaults
@@ -28,7 +27,6 @@ from daimon.core.scope import (
     TenantScopeRef,
 )
 from daimon.core.stores.scoped_config_read import get_scope, resolve
-from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 BootstrapErrorKind = Literal[
@@ -57,15 +55,8 @@ async def check_preconditions(
     tenant_id: uuid.UUID,
     default: DeploymentDefault,
 ) -> None:
-    try:
-        async with sessionmaker() as s:
-            raw = await get_scope(s, scope=TenantScopeRef(tenant_id=tenant_id))
-    except (ProgrammingError, asyncpg.exceptions.UndefinedTableError) as err:
-        raise SessionBootstrapError(
-            "db_not_migrated",
-            "database not migrated.\n  run: uv run alembic upgrade head\n"
-            "  (with DAIMON_DATABASE_URL set to your target DB)",
-        ) from err
+    async with sessionmaker() as s:
+        raw = await get_scope(s, scope=TenantScopeRef(tenant_id=tenant_id))
     cfg = raw if isinstance(raw, TenantConfigRow) else None
     tenant_agent_name = cfg.agent_name if cfg is not None else None
     # A tenant is ready when an agent name resolves from EITHER an explicit

--- a/packages/adapters/cli/tests/test_sessions_bootstrap.py
+++ b/packages/adapters/cli/tests/test_sessions_bootstrap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -17,6 +18,7 @@ from daimon.core.scope import DeploymentDefault, TenantScopeRef, UserScopeRef
 from daimon.core.stores.scoped_config_write import set_fields
 from daimon.testing.factories import make_account, make_tenant
 from daimon.testing.ma import EMPTY_CLOUD_CONFIG, MARouter, build_stub_anthropic, list_response
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -91,6 +93,37 @@ def _make_client(
         router.add("GET", r"/v1/environments", lambda req, _m: list_response([]))
 
     return build_stub_anthropic(router.dispatch)
+
+
+@pytest.mark.asyncio
+async def test_sessions_create_maps_unmigrated_database_before_tenant_lookup() -> None:
+    from daimon.adapters.cli.commands.sessions import sessions_create
+
+    missing_table = ProgrammingError(
+        "SELECT 1 FROM tenants",
+        {},
+        RuntimeError("relation tenants does not exist"),
+    )
+    session = AsyncMock(spec=AsyncSession)
+    session.execute.side_effect = missing_table
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=False)
+    runtime = MagicMock()
+    runtime.sessionmaker.return_value = context
+
+    with pytest.raises(SessionBootstrapError) as exc_info:
+        await sessions_create(
+            rt=runtime,
+            console=MagicMock(),
+            agent_flag=None,
+            environment_flag=None,
+            as_json=False,
+        )
+
+    assert exc_info.value.kind == "db_not_migrated"
+    assert "uv run alembic upgrade head" in str(exc_info.value)
+    assert runtime.sessionmaker.call_count == 1, "tenant discovery must not run after preflight"
 
 
 @pytest.mark.asyncio

--- a/packages/adapters/discord/daimon/adapters/discord/__main__.py
+++ b/packages/adapters/discord/daimon/adapters/discord/__main__.py
@@ -11,6 +11,7 @@ import structlog
 from daimon.adapters.discord.bot import DaimonBot
 from daimon.adapters.discord.runtime import build_runtime
 from daimon.core.config import load_settings
+from daimon.core.db import ensure_database_migrated
 from daimon.core.health import start_liveness_responder
 from daimon.core.logging_setup import configure_log_level
 from daimon.core.observability import init_sentry
@@ -38,6 +39,7 @@ async def main() -> None:
         integrations=[AsyncioIntegration()],
     )
     async with build_runtime(settings) as runtime:
+        await ensure_database_migrated(runtime.sessionmaker)
         intents = discord.Intents.default()
         intents.message_content = True
         bot = DaimonBot(runtime=runtime, intents=intents)

--- a/packages/adapters/discord/tests/test_main.py
+++ b/packages/adapters/discord/tests/test_main.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from daimon.core.errors import DatabaseNotMigratedError
+
+
+@pytest.mark.asyncio
+async def test_main_checks_migrations_before_starting_the_bot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    main_module = importlib.import_module("daimon.adapters.discord.__main__")
+    settings = MagicMock()
+    settings.discord = MagicMock()
+    settings.sentry.dsn = None
+    sessionmaker = MagicMock()
+
+    @asynccontextmanager
+    async def runtime_context(_settings: object):
+        yield SimpleNamespace(sessionmaker=sessionmaker)
+
+    check = AsyncMock(side_effect=DatabaseNotMigratedError("database not migrated"))
+    bot = MagicMock()
+    monkeypatch.setattr(main_module, "load_settings", MagicMock(return_value=settings))
+    monkeypatch.setattr(main_module, "configure_log_level", MagicMock())
+    monkeypatch.setattr(main_module, "init_sentry", MagicMock())
+    monkeypatch.setattr(main_module, "build_runtime", runtime_context)
+    monkeypatch.setattr(main_module, "ensure_database_migrated", check)
+    monkeypatch.setattr(main_module, "DaimonBot", bot)
+
+    with pytest.raises(DatabaseNotMigratedError, match="database not migrated"):
+        await main_module.main()
+
+    check.assert_awaited_once_with(sessionmaker)
+    bot.assert_not_called()

--- a/packages/adapters/mcp/daimon/adapters/mcp/server.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/server.py
@@ -10,7 +10,8 @@ any collaborator the caller supplied.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 import httpx
@@ -56,7 +57,7 @@ from daimon.adapters.mcp.uploads import build_upload_route
 from daimon.adapters.mcp.webhooks import build_github_webhook, build_stripe_webhook
 from daimon.core.billing import BillingConfig, load_billing_config
 from daimon.core.config import Settings, load_settings
-from daimon.core.db import build_engine, build_session_factory
+from daimon.core.db import build_engine, build_session_factory, ensure_database_migrated
 from daimon.core.defaults.loader import parse_deployment_default
 from daimon.core.errors import BootstrapError
 from daimon.core.github_credentials import build_multifernet
@@ -68,7 +69,6 @@ from fastmcp.server.transforms import Visibility
 from fastmcp.server.transforms.search.base import serialize_tools_for_output_markdown
 from google import genai
 from sentry_sdk.integrations.starlette import StarletteIntegration
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -113,8 +113,7 @@ def _build_readyz(
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> Callable[[Request], Awaitable[PlainTextResponse]]:
     async def readyz(_req: Request) -> PlainTextResponse:
-        async with sessionmaker() as s:
-            await s.execute(text("SELECT 1"))
+        await ensure_database_migrated(sessionmaker)
         return PlainTextResponse("ready")
 
     return readyz
@@ -195,7 +194,12 @@ def create_mcp_app(
         # Stripe webhook route is only mounted when billing_config is not None (see below).
         effective_billing_config = load_billing_config()
 
-    mcp = FastMCP(name="daimon", auth=effective_auth)
+    @asynccontextmanager
+    async def _lifespan(_server: FastMCP[object]) -> AsyncIterator[dict[str, object]]:
+        await ensure_database_migrated(effective_sessionmaker)
+        yield {}
+
+    mcp = FastMCP(name="daimon", auth=effective_auth, lifespan=_lifespan)
     mcp.add_middleware(
         IdentityMiddleware(
             subject_resolver=effective_resolver,

--- a/packages/adapters/mcp/tests/test_server_lifespan.py
+++ b/packages/adapters/mcp/tests/test_server_lifespan.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from daimon.adapters.mcp import server
+from daimon.core.config import AnthropicSettings, DatabaseSettings, McpSettings, Settings
+from daimon.core.errors import DatabaseNotMigratedError
+from daimon.testing.ma import build_stub_anthropic
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from starlette.types import ASGIApp, Message
+
+
+def _settings() -> Settings:
+    return Settings(
+        database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+        anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+        mcp=McpSettings(
+            jwt_secret=SecretStr("a" * 32),
+            public_url=HttpUrl("https://x/mcp"),
+        ),
+    )
+
+
+def _app(sessionmaker: object) -> ASGIApp:
+    return server.create_mcp_app(
+        settings=_settings(),
+        sessionmaker=sessionmaker,  # type: ignore[arg-type]
+        auth=StaticTokenVerifier(tokens={}),
+        anthropic=build_stub_anthropic(),
+    )
+
+
+@asynccontextmanager
+async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
+    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
+    send_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await receive_queue.get()
+
+    async def send(message: Message) -> None:
+        await send_queue.put(message)
+
+    task = asyncio.create_task(app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send))
+    await receive_queue.put({"type": "lifespan.startup"})
+    startup = await send_queue.get()
+    assert startup["type"] == "lifespan.startup.complete", startup
+    try:
+        yield
+    finally:
+        await receive_queue.put({"type": "lifespan.shutdown"})
+        shutdown = await send_queue.get()
+        assert shutdown["type"] == "lifespan.shutdown.complete", shutdown
+        await task
+
+
+@pytest.mark.asyncio
+async def test_mcp_lifespan_runs_database_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    check = AsyncMock()
+    monkeypatch.setattr(server, "ensure_database_migrated", check)
+    sessionmaker = MagicMock()
+
+    async with _lifespan(_app(sessionmaker)):
+        pass
+
+    check.assert_awaited_once_with(sessionmaker)
+
+
+@pytest.mark.asyncio
+async def test_mcp_lifespan_surfaces_the_migration_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    check = AsyncMock(
+        side_effect=DatabaseNotMigratedError(
+            "database not migrated.\n  run: uv run alembic upgrade head"
+        )
+    )
+    monkeypatch.setattr(server, "ensure_database_migrated", check)
+    app = _app(MagicMock())
+    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
+    send_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await receive_queue.get()
+
+    async def send(message: Message) -> None:
+        await send_queue.put(message)
+
+    task = asyncio.create_task(app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send))
+    await receive_queue.put({"type": "lifespan.startup"})
+    startup = await send_queue.get()
+
+    assert startup["type"] == "lifespan.startup.failed", startup
+    assert "uv run alembic upgrade head" in startup["message"]
+    with contextlib.suppress(DatabaseNotMigratedError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_readyz_uses_the_schema_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    check = AsyncMock()
+    monkeypatch.setattr(server, "ensure_database_migrated", check)
+    sessionmaker = MagicMock()
+    app = _app(sessionmaker)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/readyz")
+
+    assert response.status_code == 200
+    assert response.text == "ready"
+    check.assert_awaited_once_with(sessionmaker)

--- a/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
+++ b/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
@@ -36,7 +36,7 @@ from daimon.adapters.scheduler.settings import SchedulerSettings
 from daimon.core.billing import BillingConfig, is_over_cap, load_billing_config
 from daimon.core.config import Settings, load_settings
 from daimon.core.constants import MA_MAX_RETRIES
-from daimon.core.db import build_engine, build_session_factory
+from daimon.core.db import build_engine, build_session_factory, ensure_database_migrated
 from daimon.core.defaults.loader import parse_deployment_default
 from daimon.core.defaults.provisioning import reconcile_tenant_defaults
 from daimon.core.github_credentials import build_multifernet
@@ -381,6 +381,12 @@ async def run(
 
     engine = _engine_override or build_engine(str(settings.database.url))
     sm = build_session_factory(engine)
+    try:
+        await ensure_database_migrated(sm)
+    except Exception:
+        if _engine_override is None:
+            await engine.dispose()
+        raise
 
     client = (
         await _anthropic_factory(settings)

--- a/packages/adapters/scheduler/tests/test_database_preflight.py
+++ b/packages/adapters/scheduler/tests/test_database_preflight.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from daimon.adapters.scheduler import main
+from daimon.core.errors import DatabaseNotMigratedError
+
+
+@pytest.mark.asyncio
+async def test_run_checks_migrations_before_external_clients_and_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = MagicMock()
+    settings.sentry.dsn = None
+    engine = MagicMock()
+    engine.dispose = AsyncMock()
+    sessionmaker = MagicMock()
+    check = AsyncMock(side_effect=DatabaseNotMigratedError("database not migrated"))
+    anthropic = MagicMock()
+    acquire_lock = AsyncMock()
+
+    monkeypatch.setattr(main, "load_settings", MagicMock(return_value=settings))
+    monkeypatch.setattr(main, "configure_log_level", MagicMock())
+    monkeypatch.setattr(main, "init_sentry", MagicMock())
+    monkeypatch.setattr(main, "SchedulerSettings", MagicMock())
+    monkeypatch.setattr(main, "_validate_mcp_settings", MagicMock())
+    monkeypatch.setattr(main, "build_engine", MagicMock(return_value=engine))
+    monkeypatch.setattr(main, "build_session_factory", MagicMock(return_value=sessionmaker))
+    monkeypatch.setattr(main, "ensure_database_migrated", check)
+    monkeypatch.setattr(main, "AsyncAnthropic", anthropic)
+    monkeypatch.setattr(main, "_acquire_advisory_lock", acquire_lock)
+
+    with pytest.raises(DatabaseNotMigratedError, match="database not migrated"):
+        await main.run([])
+
+    check.assert_awaited_once_with(sessionmaker)
+    engine.dispose.assert_awaited_once_with()
+    anthropic.assert_not_called()
+    acquire_lock.assert_not_awaited()

--- a/packages/adapters/slack/daimon/adapters/slack/__main__.py
+++ b/packages/adapters/slack/daimon/adapters/slack/__main__.py
@@ -17,6 +17,7 @@ from daimon.adapters.slack.app import SlackApp
 from daimon.adapters.slack.boot_sweep import run_boot_sweep
 from daimon.adapters.slack.runtime import build_runtime
 from daimon.core.config import load_settings
+from daimon.core.db import ensure_database_migrated
 from daimon.core.health import start_liveness_responder
 from daimon.core.logging_setup import configure_log_level
 from daimon.core.observability import init_sentry
@@ -52,6 +53,7 @@ async def main() -> None:
         integrations=[AsyncioIntegration()],
     )
     async with build_runtime(settings) as runtime:
+        await ensure_database_migrated(runtime.sessionmaker)
         app = SlackApp(runtime=runtime)
         client = SocketModeClient(
             app_token=settings.slack.app_token.get_secret_value(),

--- a/packages/adapters/slack/tests/test_main_preflight.py
+++ b/packages/adapters/slack/tests/test_main_preflight.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from daimon.core.errors import DatabaseNotMigratedError
+
+
+@pytest.mark.asyncio
+async def test_main_checks_migrations_before_connecting_socket_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    main_module = importlib.import_module("daimon.adapters.slack.__main__")
+    settings = MagicMock()
+    settings.slack = MagicMock()
+    settings.crypto.keys = [MagicMock()]
+    settings.sentry.dsn = None
+    sessionmaker = MagicMock()
+
+    @asynccontextmanager
+    async def runtime_context(_settings: object):
+        yield SimpleNamespace(sessionmaker=sessionmaker)
+
+    check = AsyncMock(side_effect=DatabaseNotMigratedError("database not migrated"))
+    slack_app = MagicMock()
+    socket_client = MagicMock()
+    monkeypatch.setattr(main_module, "load_settings", MagicMock(return_value=settings))
+    monkeypatch.setattr(main_module, "configure_log_level", MagicMock())
+    monkeypatch.setattr(main_module, "init_sentry", MagicMock())
+    monkeypatch.setattr(main_module, "build_runtime", runtime_context)
+    monkeypatch.setattr(main_module, "ensure_database_migrated", check)
+    monkeypatch.setattr(main_module, "SlackApp", slack_app)
+    monkeypatch.setattr(main_module, "SocketModeClient", socket_client)
+
+    with pytest.raises(DatabaseNotMigratedError, match="database not migrated"):
+        await main_module.main()
+
+    check.assert_awaited_once_with(sessionmaker)
+    slack_app.assert_not_called()
+    socket_client.assert_not_called()

--- a/packages/core/daimon/core/db.py
+++ b/packages/core/daimon/core/db.py
@@ -7,12 +7,39 @@ threads the `async_sessionmaker` into stores as an explicit parameter.
 
 from __future__ import annotations
 
+import asyncpg.exceptions  # type: ignore[reportMissingTypeStubs]
+from daimon.core.errors import DatabaseNotMigratedError
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+
+DATABASE_NOT_MIGRATED_MESSAGE = (
+    "database not migrated.\n"
+    "  run: uv run alembic upgrade head\n"
+    "  (with DAIMON_DATABASE_URL set to your target DB)"
+)
+
+
+async def ensure_database_migrated(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Fail fast with an actionable hint when the core schema is absent.
+
+    A connectivity-only ``SELECT 1`` succeeds against an empty database, so
+    probe a table created by daimon's initial migration instead. Connection,
+    authentication, and other operational failures deliberately propagate
+    unchanged; only an absent relation is translated into the migration hint.
+    """
+    try:
+        async with session_factory() as session:
+            await session.execute(text("SELECT 1 FROM tenants LIMIT 1"))
+    except (ProgrammingError, asyncpg.exceptions.UndefinedTableError) as err:
+        raise DatabaseNotMigratedError(DATABASE_NOT_MIGRATED_MESSAGE) from err
 
 
 def build_engine(url: str, *, echo: bool = False) -> AsyncEngine:

--- a/packages/core/daimon/core/errors.py
+++ b/packages/core/daimon/core/errors.py
@@ -86,6 +86,10 @@ class BootstrapError(DaimonError):
     """
 
 
+class DatabaseNotMigratedError(BootstrapError):
+    """The configured database is reachable but lacks the daimon schema."""
+
+
 class GitHubOAuthError(DaimonError):
     """Raised when GitHub returns an error payload from OAuth token exchange."""
 

--- a/packages/core/tests/test_db_preflight.py
+++ b/packages/core/tests/test_db_preflight.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import asyncpg.exceptions
+import pytest
+from daimon.core.db import ensure_database_migrated
+from daimon.core.errors import DatabaseNotMigratedError
+from sqlalchemy.exc import ProgrammingError
+
+
+class _Session:
+    def __init__(self, execute: Callable[[object], object]) -> None:
+        self._execute = execute
+
+    async def __aenter__(self) -> _Session:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def execute(self, statement: object) -> object:
+        result = self._execute(statement)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def _sessionmaker(execute: Callable[[object], object]) -> Any:
+    return lambda: _Session(execute)
+
+
+@pytest.mark.asyncio
+async def test_ensure_database_migrated_probes_a_core_table() -> None:
+    statements: list[str] = []
+
+    await ensure_database_migrated(
+        _sessionmaker(lambda statement: statements.append(str(statement)))
+    )
+
+    assert statements == ["SELECT 1 FROM tenants LIMIT 1"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        ProgrammingError("SELECT", {}, RuntimeError("relation does not exist")),
+        asyncpg.exceptions.UndefinedTableError("relation does not exist"),
+    ],
+)
+async def test_ensure_database_migrated_adds_the_operator_hint(error: BaseException) -> None:
+    with pytest.raises(DatabaseNotMigratedError, match="uv run alembic upgrade head") as exc_info:
+        await ensure_database_migrated(_sessionmaker(lambda _statement: error))
+
+    assert exc_info.value.__cause__ is error
+    assert "DAIMON_DATABASE_URL" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ensure_database_migrated_does_not_mask_other_database_failures() -> None:
+    error = RuntimeError("database unavailable")
+
+    with pytest.raises(RuntimeError, match="database unavailable") as exc_info:
+        await ensure_database_migrated(_sessionmaker(lambda _statement: error))
+
+    assert exc_info.value is error


### PR DESCRIPTION
## Summary

- move the existing unmigrated-database hint into a core schema preflight
- run the preflight before CLI tenant discovery and Discord, Slack, MCP, and scheduler startup work
- make MCP readiness schema-aware and add regression coverage for every boot path

## Testing

- [x] targeted pytest bundle (21 passed)
- [x] `uv run pyright`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run lint-imports`
- [ ] full `uv run pytest` (requires PostgreSQL, which was unavailable in this environment)

Fixes #4