### PR TITLE
fix(mcp): harden read_channel pagination (stacked on #134)

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -110,11 +110,14 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
         Discord: thread_id is the thread's channel id; use before for older messages.
         Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is ignored. At most 15 messages per call, from the thread root;
-        has_more=true means the newest replies were not returned.
+        before is rejected — Slack threads read one page of at most 15 messages
+        from the thread root, and has_more=true means the newest replies were
+        not returned.
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":
+            if before is not None:
+                raise ToolError("before is Discord-only — slack read_thread has no pagination")
             return await _slack_read_thread_impl(runtime, auth, thread_id=thread_id, limit=limit)
         return await _read_thread_impl(
             runtime, auth, thread_id=thread_id, limit=limit, before=before

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -87,6 +87,10 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         cursor to fetch the next page; at most 15 messages are returned.
         """
         auth = await _auth(ctx)
+        # MCP clients often send "" for an optional param they mean to omit —
+        # treat it as absent, not as the wrong platform's cursor.
+        before = before or None
+        cursor = cursor or None
         if auth.platform == "slack":
             if before is not None:
                 raise ToolError("before is Discord-only — pass cursor to paginate on Slack")
@@ -115,6 +119,7 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         not returned.
         """
         auth = await _auth(ctx)
+        before = before or None
         if auth.platform == "slack":
             if before is not None:
                 raise ToolError("before is Discord-only — slack read_thread has no pagination")

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -81,14 +81,20 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     ) -> ReadChannelResult | SlackChannelResult:
         """Read channel messages, oldest-first, with pagination metadata.
 
-        For threads use read_thread. Discord: use before to fetch older messages.
-        Slack: use cursor to fetch the next page; at most 15 messages are returned.
+        For threads use read_thread. Each platform takes only its own
+        pagination parameter — the other is rejected. Discord: at most 200
+        messages per call; use before to fetch older messages. Slack: use
+        cursor to fetch the next page; at most 15 messages are returned.
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":
+            if before is not None:
+                raise ToolError("before is Discord-only — pass cursor to paginate on Slack")
             return await _slack_read_channel_impl(
                 runtime, auth, channel_id=channel_id, limit=limit, cursor=cursor
             )
+        if cursor is not None:
+            raise ToolError("cursor is Slack-only — pass before to paginate on Discord")
         return await _read_channel_impl(
             runtime, auth, channel_id=channel_id, limit=limit, before=before
         )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_read.py
@@ -54,10 +54,12 @@ _DISCORD_LINK_PATTERN = re.compile(
 def _before_object(before: str | None) -> discord.Object | None:
     if before is None:
         return None
-    try:
-        return discord.Object(id=int(before))
-    except ValueError as e:
-        raise ToolError("before must be a numeric discord message id") from e
+    # Stricter than int(): "1_000", " 42 ", "+7" all parse but name a
+    # different message than written, and a negative id reaches Discord as an
+    # unmapped 400.
+    if not (before.isascii() and before.isdecimal()):
+        raise ToolError("before must be a numeric discord message id")
+    return discord.Object(id=int(before))
 
 
 async def _history_page(

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_read.py
@@ -30,9 +30,9 @@ from daimon.adapters.mcp.tools.discord._models import (
     ChannelRow,  # pyright: ignore[reportPrivateUsage]
     MessageRow,  # pyright: ignore[reportPrivateUsage]
     ParsedLink,  # pyright: ignore[reportPrivateUsage]
-    ReadChannelResult,  # noqa: F811  # pyright: ignore[reportPrivateUsage,reportUnusedImport]
-    ReadThreadResult,  # noqa: F811  # pyright: ignore[reportPrivateUsage,reportUnusedImport]
-    ThreadRow,  # noqa: F811  # pyright: ignore[reportPrivateUsage,reportUnusedImport]
+    ReadChannelResult,  # pyright: ignore[reportPrivateUsage]
+    ReadThreadResult,  # pyright: ignore[reportPrivateUsage]
+    ThreadRow,  # pyright: ignore[reportPrivateUsage]
     _to_message_row,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.adapters.mcp.tools.discord._visibility import (
@@ -49,6 +49,36 @@ _DISCORD_LINK_PATTERN = re.compile(
     r"https?://(?:ptb\.|canary\.)?discord(?:app)?\.com/channels/"
     r"(\d+)/(\d+)(?:/(\d+))?"
 )
+
+
+def _before_object(before: str | None) -> discord.Object | None:
+    if before is None:
+        return None
+    try:
+        return discord.Object(id=int(before))
+    except ValueError as e:
+        raise ToolError("before must be a numeric discord message id") from e
+
+
+async def _history_page(
+    channel: discord.abc.Messageable, *, limit: int, before: str | None
+) -> tuple[list[MessageRow], str | None, str | None]:
+    """Fetch one history page; return oldest-first rows, cursor, and hint.
+
+    Discord's history API reports no has_more, so a full page is the only
+    signal that older history may exist. A channel holding exactly ``limit``
+    messages therefore still advertises a cursor; the follow-up read comes
+    back empty and ends the sweep.
+    """
+    page = [m async for m in channel.history(limit=limit, before=_before_object(before))]
+    rows = [_to_message_row(m) for m in reversed(page)]
+    next_before = str(page[-1].id) if len(page) == limit else None
+    hint = (
+        f"more messages available — pass before={next_before} to read older messages"
+        if next_before is not None
+        else None
+    )
+    return rows, next_before, hint
 
 
 # ---------------------------------------------------------------------------
@@ -85,15 +115,7 @@ async def _read_channel_impl(  # pyright: ignore[reportUnusedFunction]
         _check_view_permission(channel, member)
         if not isinstance(channel, discord.abc.Messageable):
             raise ToolError("channel does not support message history")
-        before_obj = discord.Object(id=int(before)) if before is not None else None
-        page = [m async for m in channel.history(limit=bounded_limit, before=before_obj)]
-        rows = [_to_message_row(m) for m in reversed(page)]
-        next_before = str(page[-1].id) if len(page) == bounded_limit else None
-        hint = (
-            f"more messages available — pass before={next_before} to read older messages"
-            if next_before is not None
-            else None
-        )
+        rows, next_before, hint = await _history_page(channel, limit=bounded_limit, before=before)
         return ReadChannelResult(rows=rows, next_before=next_before, hint=hint)
 
 
@@ -250,15 +272,7 @@ async def _read_thread_impl(  # pyright: ignore[reportUnusedFunction]
 
         await _check_thread_view(c, channel, member, _require_discord_identity(auth))
 
-        before_obj = discord.Object(id=int(before)) if before is not None else None
-        page = [m async for m in channel.history(limit=bounded_limit, before=before_obj)]
-        rows = [_to_message_row(m) for m in reversed(page)]
-        next_before = str(page[-1].id) if len(page) == bounded_limit else None
-        hint = (
-            f"more messages available — pass before={next_before} to read older messages"
-            if next_before is not None
-            else None
-        )
+        rows, next_before, hint = await _history_page(channel, limit=bounded_limit, before=before)
         return ReadThreadResult(rows=rows, next_before=next_before, hint=hint)
 
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_read.py
@@ -4,7 +4,7 @@ Provides: _read_channel_impl, _list_channels_impl, _get_message_impl,
 _parse_link_impl, _read_thread_impl, _list_threads_impl.
 
 Every impl follows the locked sequence:
-  gates -> bound limit -> rest_client -> _resolve_member FIRST ->
+  gates -> bound limit -> parse cursor -> rest_client -> _resolve_member FIRST ->
   _resolve_channel -> _require_guild_channel -> permission check ->
   typed discord.py call -> map rows.
 """
@@ -52,6 +52,8 @@ _DISCORD_LINK_PATTERN = re.compile(
 
 
 def _before_object(before: str | None) -> discord.Object | None:
+    """Parse a before cursor; call before any REST round-trip so a bad cursor
+    fails without spending rate-limited member/channel resolves."""
     if before is None:
         return None
     # Stricter than int(): "1_000", " 42 ", "+7" all parse but name a
@@ -59,11 +61,17 @@ def _before_object(before: str | None) -> discord.Object | None:
     # unmapped 400.
     if not (before.isascii() and before.isdecimal()):
         raise ToolError("before must be a numeric discord message id")
-    return discord.Object(id=int(before))
+    value = int(before)
+    # Snowflakes are unsigned 64-bit and never zero: out-of-range values are
+    # Discord's unmapped 400 again, and 0 returns an empty page that reads as
+    # exhausted history.
+    if not 0 < value < 1 << 64:
+        raise ToolError("before must be a numeric discord message id")
+    return discord.Object(id=value)
 
 
 async def _history_page(
-    channel: discord.abc.Messageable, *, limit: int, before: str | None
+    channel: discord.abc.Messageable, *, limit: int, before: discord.Object | None
 ) -> tuple[list[MessageRow], str | None, str | None]:
     """Fetch one history page; return oldest-first rows, cursor, and hint.
 
@@ -72,7 +80,7 @@ async def _history_page(
     messages therefore still advertises a cursor; the follow-up read comes
     back empty and ends the sweep.
     """
-    page = [m async for m in channel.history(limit=limit, before=_before_object(before))]
+    page = [m async for m in channel.history(limit=limit, before=before)]
     rows = [_to_message_row(m) for m in reversed(page)]
     next_before = str(page[-1].id) if len(page) == limit else None
     hint = (
@@ -105,6 +113,7 @@ async def _read_channel_impl(  # pyright: ignore[reportUnusedFunction]
     guild_id = _require_guild_id(auth)
     token = _require_bot_token(runtime)
     bounded_limit = max(1, min(limit, _MAX_HISTORY_LIMIT))
+    before_obj = _before_object(before)
 
     async with rest_client(token) as c:
         _, member = await _resolve_member(c, guild_id, _require_discord_identity(auth))
@@ -117,7 +126,9 @@ async def _read_channel_impl(  # pyright: ignore[reportUnusedFunction]
         _check_view_permission(channel, member)
         if not isinstance(channel, discord.abc.Messageable):
             raise ToolError("channel does not support message history")
-        rows, next_before, hint = await _history_page(channel, limit=bounded_limit, before=before)
+        rows, next_before, hint = await _history_page(
+            channel, limit=bounded_limit, before=before_obj
+        )
         return ReadChannelResult(rows=rows, next_before=next_before, hint=hint)
 
 
@@ -263,6 +274,7 @@ async def _read_thread_impl(  # pyright: ignore[reportUnusedFunction]
     guild_id = _require_guild_id(auth)
     token = _require_bot_token(runtime)
     bounded_limit = max(1, min(limit, _MAX_HISTORY_LIMIT))
+    before_obj = _before_object(before)
 
     async with rest_client(token) as c:
         _, member = await _resolve_member(c, guild_id, _require_discord_identity(auth))
@@ -274,7 +286,9 @@ async def _read_thread_impl(  # pyright: ignore[reportUnusedFunction]
 
         await _check_thread_view(c, channel, member, _require_discord_identity(auth))
 
-        rows, next_before, hint = await _history_page(channel, limit=bounded_limit, before=before)
+        rows, next_before, hint = await _history_page(
+            channel, limit=bounded_limit, before=before_obj
+        )
         return ReadThreadResult(rows=rows, next_before=next_before, hint=hint)
 
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -240,20 +240,23 @@ async def _fetch_channel_history(
     client: AsyncWebClient, *, channel_id: str, limit: int, cursor: str | None
 ) -> SlackChannelResult:
     resp = await client.conversations_history(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-        channel=channel_id, limit=min(limit, _HISTORY_LIMIT_CAP), cursor=cursor
+        channel=channel_id, limit=max(1, min(limit, _HISTORY_LIMIT_CAP)), cursor=cursor
     )
     raw = cast(list[dict[str, Any]], resp["messages"])
     raw.reverse()  # Slack returns newest-first; tools return oldest-first
     usernames = await _resolve_usernames(client, _author_ids(raw))
-    next_cursor = (
-        str(cast(dict[str, Any], resp.get("response_metadata") or {}).get("next_cursor") or "")
-        or None
-    )
-    hint = (
-        f"more messages available — pass cursor={next_cursor} to read older messages"
-        if next_cursor is not None
-        else None
-    )
+    # has_more is the authority on whether older history exists: Slack can
+    # send a next_cursor that only points past the end, and (rarely) report
+    # has_more without a cursor — say so rather than claim the sweep is done.
+    has_more = bool(resp.get("has_more"))
+    metadata = cast(dict[str, Any], resp.get("response_metadata") or {})
+    next_cursor = (str(metadata.get("next_cursor") or "") or None) if has_more else None
+    if next_cursor is not None:
+        hint = f"more messages available — pass cursor={next_cursor} to read older messages"
+    elif has_more:
+        hint = "more messages exist, but Slack returned no continuation cursor"
+    else:
+        hint = None
     return SlackChannelResult(
         messages=_to_message_rows(raw, usernames), next_cursor=next_cursor, hint=hint
     )
@@ -322,7 +325,7 @@ async def _fetch_thread_replies(
     client: AsyncWebClient, *, channel_id: str, thread_ts: str, limit: int
 ) -> SlackThreadResult:
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-        channel=channel_id, ts=thread_ts, limit=min(limit, _HISTORY_LIMIT_CAP)
+        channel=channel_id, ts=thread_ts, limit=max(1, min(limit, _HISTORY_LIMIT_CAP))
     )
     raw = cast(list[dict[str, Any]], resp["messages"])  # already oldest-first
     has_more = bool(resp.get("has_more"))
@@ -336,7 +339,9 @@ async def _fetch_thread_replies(
         if parent_ts and str(parent_ts) != thread_ts:
             result_thread_ts = str(parent_ts)
             resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-                channel=channel_id, ts=result_thread_ts, limit=min(limit, _HISTORY_LIMIT_CAP)
+                channel=channel_id,
+                ts=result_thread_ts,
+                limit=max(1, min(limit, _HISTORY_LIMIT_CAP)),
             )
             raw = cast(list[dict[str, Any]], resp["messages"])
             has_more = bool(resp.get("has_more"))

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_visibility.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_visibility.py
@@ -60,6 +60,8 @@ def map_slack_api_error(err: SlackApiError, *, as_user: bool = False) -> ToolErr
         return ToolError(MISSING_SCOPE_USER_MSG if as_user else MISSING_SCOPE_MSG)
     if error_code in ("channel_not_found", "not_in_channel"):
         return ToolError(MISSING_ACCESS)
+    if error_code == "invalid_cursor":
+        return ToolError("invalid or expired cursor — omit cursor to restart from the newest page")
     if error_code in ("token_revoked", "token_expired", "invalid_auth"):
         return ToolError(INVALID_AUTH_MSG)
     return None

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2114,8 +2114,9 @@
         
         Discord: thread_id is the thread's channel id; use before for older messages.
         Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is ignored. At most 15 messages per call, from the thread root;
-        has_more=true means the newest replies were not returned.
+        before is rejected — Slack threads read one page of at most 15 messages
+        from the thread root, and has_more=true means the newest replies were
+        not returned.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2064,8 +2064,10 @@
       'description': '''
         Read channel messages, oldest-first, with pagination metadata.
         
-        For threads use read_thread. Discord: use before to fetch older messages.
-        Slack: use cursor to fetch the next page; at most 15 messages are returned.
+        For threads use read_thread. Each platform takes only its own
+        pagination parameter — the other is rejected. Discord: at most 200
+        messages per call; use before to fetch older messages. Slack: use
+        cursor to fetch the next page; at most 15 messages are returned.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
+++ b/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
@@ -518,6 +518,40 @@ async def test_read_channel_discord_caller_rejects_slack_cursor_param(
 
 
 @pytest.mark.asyncio
+async def test_read_thread_slack_caller_rejects_discord_before_param(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A Slack caller passing before to read_thread gets a ToolError — Slack
+    threads have no pagination, so dropping it would replay page 1 as a sweep."""
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="slack-thread-before")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="slack",
+        external_id="U_SLACK_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="read_thread",
+        arguments={"thread_id": "C_TEST:1717171717.123456", "before": "1000"},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "before is Discord-only" in output_text, (
+        f"Slack caller's before param must be rejected, not dropped; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_thread_slack_caller_routes_to_slack_impl_and_fails_on_missing_crypto(
     db_session: AsyncSession,
     sessionmaker: async_sessionmaker[AsyncSession],

--- a/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
+++ b/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
@@ -450,6 +450,74 @@ async def test_read_channel_discord_caller_routes_to_discord_impl_and_fails_on_m
 
 
 @pytest.mark.asyncio
+async def test_read_channel_slack_caller_rejects_discord_before_param(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A Slack caller passing Discord's before param gets a ToolError, not a
+    silent first page — repeating page 1 reads as a completed sweep (#74)."""
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="slack-before-param")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="slack",
+        external_id="U_SLACK_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="read_channel",
+        arguments={"channel_id": "C_TEST", "before": "1000"},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "before is Discord-only" in output_text, (
+        f"Slack caller's before param must be rejected, not dropped; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_channel_discord_caller_rejects_slack_cursor_param(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A Discord caller passing Slack's cursor param gets a ToolError, not a
+    silent first page."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="discord-cursor-param")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="U_DISCORD_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="read_channel",
+        arguments={"channel_id": "C_TEST", "cursor": "CURSOR_1"},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "cursor is Slack-only" in output_text, (
+        f"Discord caller's cursor param must be rejected, not dropped; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_thread_slack_caller_routes_to_slack_impl_and_fails_on_missing_crypto(
     db_session: AsyncSession,
     sessionmaker: async_sessionmaker[AsyncSession],

--- a/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
+++ b/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
@@ -552,6 +552,112 @@ async def test_read_thread_slack_caller_rejects_discord_before_param(
 
 
 @pytest.mark.asyncio
+async def test_read_channel_slack_caller_treats_empty_pagination_params_as_absent(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """MCP clients often send "" for an optional param they mean to omit.
+
+    An empty before must not trip the Discord-only rejection, and an empty
+    cursor must not be forwarded to Slack — the call proceeds into the Slack
+    impl and fails on the missing crypto keys like any other routed call.
+    """
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="slack-empty-params")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="slack",
+        external_id="U_SLACK_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="read_channel",
+        arguments={"channel_id": "C_TEST", "before": "", "cursor": ""},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "slack tools require DAIMON_CRYPTO__KEYS" in output_text, (
+        f"empty pagination params must read as absent, not as misuse; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_channel_discord_caller_treats_empty_cursor_as_absent(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """An empty cursor from a Discord caller must not trip the Slack-only rejection."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="discord-empty-params")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="U_DISCORD_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="read_channel",
+        arguments={"channel_id": "C_TEST", "before": "", "cursor": ""},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "discord tools require DAIMON_DISCORD__BOT_TOKEN" in output_text, (
+        f"empty pagination params must read as absent, not as misuse; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_thread_slack_caller_treats_empty_before_as_absent(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """An empty before on read_thread must not trip the Discord-only rejection."""
+    tenant = await make_tenant(
+        db_session, platform="slack", workspace_id="slack-thread-empty-before"
+    )
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="slack",
+        external_id="U_SLACK_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="read_thread",
+        arguments={"thread_id": "C_TEST:1717171717.123456", "before": ""},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "slack tools require DAIMON_CRYPTO__KEYS" in output_text, (
+        f"an empty before must read as absent, not as misuse; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_thread_slack_caller_routes_to_slack_impl_and_fails_on_missing_crypto(
     db_session: AsyncSession,
     sessionmaker: async_sessionmaker[AsyncSession],

--- a/packages/adapters/mcp/tests/tools/test_discord_read.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_read.py
@@ -369,10 +369,16 @@ async def test_read_channel_passes_before_cursor(monkeypatch: pytest.MonkeyPatch
     assert result.hint is None, "a hint on the last page would send the caller in a loop"
 
 
+@pytest.mark.parametrize("before", ["not-an-id", "1_000", " 42 ", "+7", "-5", "١٢"])
 async def test_read_channel_rejects_non_numeric_before(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, before: str
 ) -> None:
-    """A malformed before value gets a ToolError, not a raw ValueError."""
+    """Anything but a plain decimal id gets a ToolError.
+
+    int() alone accepts "1_000" and " 42 " — which silently page from a
+    different message than written — and "-5", which Discord answers with an
+    unmapped 400.
+    """
 
     async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
         if route.path == "/guilds/{guild_id}":
@@ -388,7 +394,7 @@ async def test_read_channel_rejects_non_numeric_before(
     patch_discord_http(monkeypatch, handler)
     with pytest.raises(ToolError, match="before must be a numeric discord message id"):
         await _read_channel_impl(
-            _runtime_with_discord_token(), _auth(), channel_id="222", limit=50, before="not-an-id"
+            _runtime_with_discord_token(), _auth(), channel_id="222", limit=50, before=before
         )
 
 

--- a/packages/adapters/mcp/tests/tools/test_discord_read.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_read.py
@@ -365,6 +365,31 @@ async def test_read_channel_passes_before_cursor(monkeypatch: pytest.MonkeyPatch
     )
     assert [row.id for row in result.rows] == ["999"]
     assert str(seen_params.get("before")) == "1000"
+    assert result.next_before is None, "a short page means history is exhausted"
+    assert result.hint is None, "a hint on the last page would send the caller in a loop"
+
+
+async def test_read_channel_rejects_non_numeric_before(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed before value gets a ToolError, not a raw ValueError."""
+
+    async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
+        if route.path == "/guilds/{guild_id}":
+            return _guild_payload()
+        if route.path == "/guilds/{guild_id}/roles":
+            return [_everyone_role("111", _VIEW_CHANNEL)]
+        if route.path == "/guilds/{guild_id}/members/{member_id}":
+            return _member_payload()
+        if route.path == "/channels/{channel_id}":
+            return _text_channel_payload()
+        raise AssertionError(f"unexpected route {route.method} {route.path}")
+
+    patch_discord_http(monkeypatch, handler)
+    with pytest.raises(ToolError, match="before must be a numeric discord message id"):
+        await _read_channel_impl(
+            _runtime_with_discord_token(), _auth(), channel_id="222", limit=50, before="not-an-id"
+        )
 
 
 async def test_read_channel_bot_author_has_assistant_role(

--- a/packages/adapters/mcp/tests/tools/test_discord_read.py
+++ b/packages/adapters/mcp/tests/tools/test_discord_read.py
@@ -369,27 +369,26 @@ async def test_read_channel_passes_before_cursor(monkeypatch: pytest.MonkeyPatch
     assert result.hint is None, "a hint on the last page would send the caller in a loop"
 
 
-@pytest.mark.parametrize("before", ["not-an-id", "1_000", " 42 ", "+7", "-5", "١٢"])
+@pytest.mark.parametrize(
+    "before",
+    ["not-an-id", "1_000", " 42 ", "+7", "-5", "١٢", "0", "9999999999999999999999999"],
+)
 async def test_read_channel_rejects_non_numeric_before(
     monkeypatch: pytest.MonkeyPatch, before: str
 ) -> None:
-    """Anything but a plain decimal id gets a ToolError.
+    """Anything but an in-range decimal snowflake gets a ToolError, before any
+    REST call.
 
     int() alone accepts "1_000" and " 42 " — which silently page from a
     different message than written — and "-5", which Discord answers with an
-    unmapped 400.
+    unmapped 400. A 25-digit id is that same 400, and "0" returns an empty
+    page that reads as exhausted history.
     """
 
     async def handler(route: discord.http.Route, _kwargs: dict[str, Any]) -> Any:
-        if route.path == "/guilds/{guild_id}":
-            return _guild_payload()
-        if route.path == "/guilds/{guild_id}/roles":
-            return [_everyone_role("111", _VIEW_CHANNEL)]
-        if route.path == "/guilds/{guild_id}/members/{member_id}":
-            return _member_payload()
-        if route.path == "/channels/{channel_id}":
-            return _text_channel_payload()
-        raise AssertionError(f"unexpected route {route.method} {route.path}")
+        raise AssertionError(
+            f"a bad cursor must fail before any REST call; got {route.method} {route.path}"
+        )
 
     patch_discord_http(monkeypatch, handler)
     with pytest.raises(ToolError, match="before must be a numeric discord message id"):

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -1193,6 +1193,29 @@ async def test_read_channel_returns_and_uses_slack_cursor(
 
 
 @pytest.mark.asyncio
+async def test_read_channel_last_page_has_no_cursor_or_hint(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A response without response_metadata must not invent a continuation."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_HISTORY,
+            payload={"ok": True, "messages": [{"ts": "1", "text": "only"}]},
+        )
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
+    assert [row.text for row in result.messages] == ["only"]
+    assert result.next_cursor is None, "no response_metadata means the sweep is complete"
+    assert result.hint is None, "a hint on the last page would send the caller in a loop"
+
+
+@pytest.mark.asyncio
 async def test_read_thread_clamps_limit_to_the_slack_page_cap(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -1173,6 +1173,7 @@ async def test_read_channel_returns_and_uses_slack_cursor(
             _CONVERSATIONS_HISTORY,
             payload={
                 "ok": True,
+                "has_more": True,
                 "messages": [{"ts": "1", "text": "oldest"}],
                 "response_metadata": {"next_cursor": "CURSOR_3"},
             },
@@ -1213,6 +1214,103 @@ async def test_read_channel_last_page_has_no_cursor_or_hint(
     assert [row.text for row in result.messages] == ["only"]
     assert result.next_cursor is None, "no response_metadata means the sweep is complete"
     assert result.hint is None, "a hint on the last page would send the caller in a loop"
+
+
+@pytest.mark.asyncio
+async def test_read_channel_drops_cursor_when_has_more_is_false(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """has_more, not next_cursor, decides whether older history exists.
+
+    Slack can return a next_cursor that only points past the end; following it
+    costs a rate-limited call that comes back empty.
+    """
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_HISTORY,
+            payload={
+                "ok": True,
+                "has_more": False,
+                "messages": [{"ts": "1", "text": "only"}],
+                "response_metadata": {"next_cursor": "CURSOR_PAST_END"},
+            },
+        )
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
+    assert result.next_cursor is None, "has_more=false means the sweep is complete"
+    assert result.hint is None
+
+
+@pytest.mark.asyncio
+async def test_read_channel_flags_truncation_when_has_more_without_cursor(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """has_more with no cursor must still tell the caller the page is partial."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_HISTORY,
+            payload={"ok": True, "has_more": True, "messages": [{"ts": "1", "text": "head"}]},
+        )
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
+    assert result.next_cursor is None
+    assert result.hint is not None and "more messages exist" in result.hint, (
+        "a silently partial page is the truncation failure #74 exists to prevent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_channel_maps_invalid_cursor_to_tool_error(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A stale or malformed cursor gets a ToolError, not a raw SlackApiError."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_HISTORY,
+            payload={"ok": False, "error": "invalid_cursor"},
+        )
+        with pytest.raises(ToolError, match="invalid or expired cursor"):
+            await _slack_read_channel_impl(
+                runtime, auth, channel_id="C1", limit=50, cursor="CURSOR_STALE"
+            )
+
+
+@pytest.mark.asyncio
+async def test_read_channel_raises_limit_floor_to_one(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """limit=0 would come back from Slack as invalid_limit; clamp it like Discord does."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(_CONVERSATIONS_HISTORY, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
+        await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=0)
+        limit = _recorded_limit(m, "/api/conversations.history")
+    assert limit == "1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Stacked on #134 (this branch includes its commit; merging this PR lands both). Review follow-ups hardening the new `read_channel` pagination:

- Each platform accepts only its own pagination parameter. A Slack caller passing Discord's `before` (or a Discord caller passing `cursor`) previously got page one back with the param silently dropped — on Slack that repeats the same `next_cursor` and reads as a completed sweep, the exact failure #74 exists to prevent. The wrong param now raises a ToolError naming the right one.
- A non-numeric `before` (a Slack ts, or the literal `before=<id>` copied out of the hint text) raised a raw `ValueError`; it now maps to a ToolError like every other validation path. Applies to `read_thread` too, which had the same bare `int()`.
- The tool description states Discord's 200-per-call cap, which #74 called out as missing.
- The last-page contract is pinned on both platforms: a short Discord page and a Slack response without `response_metadata` must yield no cursor and no hint — previously a regression that always emitted a cursor would have passed the suite.

Not addressed here: the schema snapshot still pins tool inputs only (the `{rows, next_before, hint}` output shape is asserted at impl level, not in the snapshot), and Slack's one-call-per-minute pagination cost is not mentioned in the hint.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally (`packages/adapters/mcp`: 769 passed)
- [x] `uv run pyright` passes locally (strict mode)
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)
