### PR TITLE
fix(mcp): bound chart decode, transcript walks, and repeat-delivery spend

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/hosted_artifacts.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hosted_artifacts.py
@@ -28,9 +28,17 @@ _MAX_CHARTS = 5
 _MAX_IMAGE_BLOCKS = 3
 _MAX_IMAGE_EDGE = 1000
 _MAX_IMAGE_BLOCK_ENCODED_BYTES = 400 * 1024
+# Pillow's decompression-bomb *error* fires only above ~179M pixels; below
+# that a compact PNG can still decode to gigabytes of RGBA, so the byte cap
+# alone does not bound decode memory.
+_MAX_IMAGE_PIXELS = 25_000_000
 _MAX_SCANNED = 200
 _CLOCK_SLACK = dt.timedelta(seconds=30)
 _HOSTED_DELIVERY_TIMEOUT_SECONDS = 60.0
+# put_object runs in a thread asyncio.timeout cannot cancel; an upload that
+# starts near the deadline completes after the caller gave up and strands an
+# object nobody has a URL for. Don't start one that can't finish in time.
+_UPLOAD_DEADLINE_MARGIN_SECONDS = 10.0
 
 
 class ChartUrl(BaseModel):
@@ -112,6 +120,8 @@ def _bounded_image_block(content: bytes, content_type: str) -> ImageContent | No
         return None
 
     with Image.open(io.BytesIO(content)) as source:
+        if source.width * source.height > _MAX_IMAGE_PIXELS:
+            raise ValueError("artifact exceeds the per-chart pixel limit")
         source.load()
         image = source.copy()
 
@@ -156,10 +166,14 @@ async def _discover_chart_outputs(
     candidates: list[FileMetadata] = []
     async for item in anthropic.beta.files.list(
         scope_id=session_id,
+        limit=min(_MAX_SCANNED, 1000),
         betas=["managed-agents-2026-04-01"],
     ):
         candidates.append(item)
         if len(candidates) >= _MAX_SCANNED:
+            # The Files API documents no ordering, so the sort below only sees
+            # what fit under the cap; a >_MAX_SCANNED session may lose charts.
+            _log.warning("mcp.hosted_artifact.scan_truncated", scanned=_MAX_SCANNED)
             break
 
     candidates.sort(
@@ -191,8 +205,11 @@ async def _deliver_hosted_charts_impl(
     message: str,
     store: ArtifactStore | None = None,
     record_failure: Callable[..., None],
+    upload_deadline: float,
 ) -> HostedChartDelivery:
     """Embed charts by default and add URLs only when storage is configured."""
+    if settings is not None and store is None:
+        _log.warning("mcp.hosted_artifact.store_unconfigured")
     try:
         outputs = await _discover_chart_outputs(
             anthropic,
@@ -254,8 +271,21 @@ async def _deliver_hosted_charts_impl(
         if settings is None or store is None:
             continue
 
+        if asyncio.get_running_loop().time() > upload_deadline - _UPLOAD_DEADLINE_MARGIN_SECONDS:
+            record_failure(
+                stage="storage",
+                key=None,
+                exc=TimeoutError("upload skipped near the delivery deadline"),
+            )
+            continue
+
         try:
-            key = f"tenant/{tenant_id}/account/{account_id}/session/{session_id}/{filename}"
+            # file_id keeps the key unique per upload: a turn that rewrites
+            # chart.png must not repoint an earlier turn's still-live URL.
+            key = (
+                f"tenant/{tenant_id}/account/{account_id}/session/{session_id}/"
+                f"{_safe_filename(output.file_id)}/{filename}"
+            )
             stored = await store.upload_and_presign(
                 key=key,
                 content=content,
@@ -323,6 +353,7 @@ async def deliver_hosted_charts(
         )
 
     try:
+        upload_deadline = asyncio.get_running_loop().time() + _HOSTED_DELIVERY_TIMEOUT_SECONDS
         async with asyncio.timeout(_HOSTED_DELIVERY_TIMEOUT_SECONDS):
             result = await _deliver_hosted_charts_impl(
                 anthropic,
@@ -334,6 +365,7 @@ async def deliver_hosted_charts(
                 message=message,
                 store=store,
                 record_failure=record_failure,
+                upload_deadline=upload_deadline,
             )
     except TimeoutError as exc:
         record_failure(stage="timeout", key=None, exc=exc)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from time import monotonic
 from typing import Any, Literal
@@ -68,8 +69,13 @@ from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from mcp.types import ImageContent, TextContent
+
+# Each transcript page costs two upstream calls (ownership retrieve + events
+# list), so an uncapped walk on a long session can outlast any client timeout.
+_MAX_EVENT_PAGES = 20
 
 
 class AgentDescription(BaseModel):
@@ -92,17 +98,65 @@ class AskResult(BaseModel):
     handle: str
     message: str
     chart_urls: tuple[ChartUrl, ...] = ()
-    image_blocks: tuple[ImageContent, ...] = Field(default=(), exclude=True, repr=False)
+    # Excluded from dumps AND the JSON schema: image blocks travel as MCP
+    # content, never inside structured content, and advertising the field
+    # would point schema-reading clients at a value that never arrives.
+    image_blocks: SkipJsonSchema[tuple[ImageContent, ...]] = Field(
+        default=(), exclude=True, repr=False
+    )
 
 
-def _ask_tool_result(result: AskResult) -> AskResult | ToolResult:
-    """Add model-visible images while preserving the structured ask payload."""
-    if not result.chart_urls and not result.image_blocks:
-        return result
+def _ask_tool_result(result: AskResult) -> ToolResult:
+    """Give the model prose plus image blocks alongside the typed payload.
+
+    Built the same way with or without charts, so the caller sees one content
+    shape: prose text first, image blocks after, structured payload throughout.
+    """
     return ToolResult(
         content=[TextContent(type="text", text=result.message), *result.image_blocks],
         structured_content=result.model_dump(mode="json"),
     )
+
+
+class _DeliveryCache:
+    """Absorb hosted-client retry loops on ``deliver_turn_charts``.
+
+    A repeated call for the same completed turn re-downloads every chart from
+    the Files API and re-writes the artifact store on the operator's account,
+    unmetered — so one delivered result is held briefly per turn boundary.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_entries: int = 128,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        self._entries: OrderedDict[tuple[str, str], tuple[float, AskResult]] = OrderedDict()
+        self._max_entries = max_entries
+        self._clock = clock
+
+    def get(self, key: tuple[str, str]) -> AskResult | None:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        expires_at, result = entry
+        if self._clock() >= expires_at:
+            del self._entries[key]
+            return None
+        return result
+
+    def put(self, key: tuple[str, str], result: AskResult, *, ttl_seconds: float) -> None:
+        if ttl_seconds <= 0:
+            return
+        self._entries[key] = (self._clock() + ttl_seconds, result)
+        self._entries.move_to_end(key)
+        while len(self._entries) > self._max_entries:
+            self._entries.popitem(last=False)
+
+
+_DELIVERY_CACHE_TTL_SECONDS = 300.0
+_delivery_cache = _DeliveryCache()
 
 
 async def _resolve_environment_name(
@@ -386,7 +440,7 @@ async def _deliver_turn_charts_impl(
     page: str | None = None
     final_text: str | None = None
     turn_started_at: dt.datetime | None = None
-    while True:
+    for _ in range(_MAX_EVENT_PAGES):
         events = await _list_events_impl(runtime, auth, handle, page, 100, "desc")
         for event in events.items:
             if final_text is None:
@@ -404,6 +458,11 @@ async def _deliver_turn_charts_impl(
     if turn_started_at is None:
         raise ToolError(f"no completed turn boundary found for session {handle}")
 
+    cache_key = (handle, turn_started_at.isoformat())
+    cached = _delivery_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     delivery = await deliver_hosted_charts(
         runtime.client,
         settings=runtime.settings.artifacts,
@@ -414,12 +473,19 @@ async def _deliver_turn_charts_impl(
         message=final_text,
         store=runtime.artifact_store,
     )
-    return AskResult(
+    result = AskResult(
         handle=handle,
         message=delivery.message,
         chart_urls=delivery.chart_urls,
         image_blocks=delivery.image_blocks,
     )
+    ttl = _DELIVERY_CACHE_TTL_SECONDS
+    if result.chart_urls:
+        # A cached entry must never outlive its presigned links.
+        earliest = min(chart.expires_at for chart in result.chart_urls)
+        ttl = min(ttl, (earliest - dt.datetime.now(dt.UTC)).total_seconds())
+    _delivery_cache.put(cache_key, result, ttl_seconds=ttl)
+    return result
 
 
 async def _ask_impl(
@@ -441,7 +507,11 @@ async def _ask_impl(
 
     while True:
         current = await _get_session_impl(runtime, auth, handle)
-        if current.status not in {"idle", "rescheduling", "running"}:
+        # Only terminated is treated as terminal: the status value set is
+        # upstream-controlled (see SessionInfo.status), so an unmodeled
+        # transient status keeps polling until the deadline instead of
+        # failing a turn that admission already billed.
+        if current.status == "terminated":
             raise ToolError(
                 f"Daimon turn reached terminal status {current.status!r}; "
                 f"resume or inspect events with handle {handle}"
@@ -449,7 +519,7 @@ async def _ask_impl(
         if current.status == "idle":
             page: str | None = None
             final_text: str | None = None
-            while True:
+            for _ in range(_MAX_EVENT_PAGES):
                 events = await _list_events_impl(runtime, auth, handle, page, 100, "desc")
                 for event in events.items:
                     final_text = _agent_message_text(event)

--- a/packages/adapters/mcp/tests/test_hosted_artifacts.py
+++ b/packages/adapters/mcp/tests/test_hosted_artifacts.py
@@ -70,10 +70,12 @@ class _FilesTransport:
         self.files = files
         self.downloaded_ids: list[str] = []
         self.beta_headers: list[str] = []
+        self.list_params: list[dict[str, str]] = []
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
         if request.method == "GET" and request.url.path == "/v1/files":
             self.beta_headers.append(request.headers.get("anthropic-beta", ""))
+            self.list_params.append(dict(request.url.params))
             return httpx.Response(200, json={"data": list(self.files), "has_more": False})
         prefix = "/v1/files/"
         suffix = "/content"
@@ -158,7 +160,7 @@ async def test_configured_store_adds_presigned_link_and_structured_url() -> None
             store=store,
         )
 
-    key = "tenant/tenant-1/account/account-1/session/session-1/margin.png"
+    key = "tenant/tenant-1/account/account-1/session/session-1/file-1/margin.png"
     assert result.message == (
         "Analytical answer\n\n"
         f"Chart: [margin.png](https://bucket.example.test/{key}?signed=yes) — "
@@ -440,3 +442,147 @@ async def test_delivery_caps_each_turn_and_embeds_at_most_three_images() -> None
     assert len(result.image_blocks) == 3
     assert len(store.calls) == 4
     assert len(transport.downloaded_ids) == 4
+
+
+async def test_oversized_pixel_raster_is_dropped_not_decoded() -> None:
+    source = _png(width=200, height=100)
+    client, _transport = _client(source)
+    output = _ChartOutput(file_id="file-1", filename="huge.png", size_bytes=len(source))
+
+    with (
+        patch(
+            "daimon.adapters.mcp.hosted_artifacts._discover_chart_outputs",
+            new=AsyncMock(return_value=(output,)),
+        ),
+        patch("daimon.adapters.mcp.hosted_artifacts._MAX_IMAGE_PIXELS", 10_000),
+        patch("daimon.adapters.mcp.hosted_artifacts._log.warning") as warning,
+    ):
+        result = await deliver_hosted_charts(
+            client,
+            settings=None,
+            tenant_id="tenant-1",
+            account_id="account-1",
+            session_id="session-1",
+            turn_started_at=_NOW,
+            message="Answer survives",
+        )
+
+    assert result == HostedChartDelivery(message="Answer survives")
+    warning.assert_called_once()
+    assert warning.call_args.kwargs["stage"] == "embed"
+    assert warning.call_args.kwargs["error_type"] == "ValueError"
+
+
+async def test_same_filename_across_files_gets_distinct_object_keys() -> None:
+    client, _transport = _client()
+    store = FakeStore()
+    outputs = (
+        _ChartOutput(file_id="file-a", filename="chart.png", size_bytes=len(_PNG)),
+        _ChartOutput(file_id="file-b", filename="chart.png", size_bytes=len(_PNG)),
+    )
+
+    with patch(
+        "daimon.adapters.mcp.hosted_artifacts._discover_chart_outputs",
+        new=AsyncMock(return_value=outputs),
+    ):
+        await deliver_hosted_charts(
+            client,
+            settings=_settings(),
+            tenant_id="tenant-1",
+            account_id="account-1",
+            session_id="session-1",
+            turn_started_at=_NOW,
+            message="Answer",
+            store=store,
+        )
+
+    keys = [call["key"] for call in store.calls]
+    assert keys == [
+        "tenant/tenant-1/account/account-1/session/session-1/file-a/chart.png",
+        "tenant/tenant-1/account/account-1/session/session-1/file-b/chart.png",
+    ]
+
+
+async def test_upload_is_skipped_when_the_delivery_deadline_is_near() -> None:
+    client, _transport = _client()
+    store = FakeStore()
+    output = _ChartOutput(file_id="file-1", filename="chart.png", size_bytes=len(_PNG))
+
+    with (
+        patch(
+            "daimon.adapters.mcp.hosted_artifacts._discover_chart_outputs",
+            new=AsyncMock(return_value=(output,)),
+        ),
+        patch("daimon.adapters.mcp.hosted_artifacts._HOSTED_DELIVERY_TIMEOUT_SECONDS", 5.0),
+        patch("daimon.adapters.mcp.hosted_artifacts._UPLOAD_DEADLINE_MARGIN_SECONDS", 10.0),
+        patch("daimon.adapters.mcp.hosted_artifacts._log.warning") as warning,
+    ):
+        result = await deliver_hosted_charts(
+            client,
+            settings=_settings(),
+            tenant_id="tenant-1",
+            account_id="account-1",
+            session_id="session-1",
+            turn_started_at=_NOW,
+            message="Answer survives",
+            store=store,
+        )
+
+    assert store.calls == []
+    assert result.chart_urls == ()
+    assert len(result.image_blocks) == 1
+    warning.assert_called_once()
+    assert warning.call_args.kwargs["stage"] == "storage"
+    assert warning.call_args.kwargs["error_type"] == "TimeoutError"
+
+
+async def test_discovery_requests_full_pages_and_logs_scan_truncation() -> None:
+    files = tuple(
+        _file(f"file-{index}", f"chart-{index}.png", created_at=_NOW) for index in range(4)
+    )
+    client, transport = _client(files=files)
+
+    with (
+        patch("daimon.adapters.mcp.hosted_artifacts._MAX_SCANNED", 3),
+        patch("daimon.adapters.mcp.hosted_artifacts._log.warning") as warning,
+    ):
+        await deliver_hosted_charts(
+            client,
+            settings=None,
+            tenant_id="tenant-1",
+            account_id="account-1",
+            session_id="session-1",
+            turn_started_at=_NOW,
+            message="Answer",
+        )
+
+    assert transport.list_params[0]["limit"] == "3"
+    truncation_calls = [
+        call
+        for call in warning.call_args_list
+        if call.args and call.args[0] == "mcp.hosted_artifact.scan_truncated"
+    ]
+    assert len(truncation_calls) == 1
+    assert truncation_calls[0].kwargs["scanned"] == 3
+
+
+async def test_configured_settings_without_store_logs_once_and_still_embeds() -> None:
+    client, _transport = _client(
+        files=(_file("current", "current.png", created_at=_NOW),),
+    )
+
+    with patch("daimon.adapters.mcp.hosted_artifacts._log.warning") as warning:
+        result = await deliver_hosted_charts(
+            client,
+            settings=_settings(),
+            tenant_id="tenant-1",
+            account_id="account-1",
+            session_id="session-1",
+            turn_started_at=_NOW,
+            message="Answer",
+            store=None,
+        )
+
+    assert result.chart_urls == ()
+    assert len(result.image_blocks) == 1
+    warning.assert_called_once_with("mcp.hosted_artifact.store_unconfigured")

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -769,6 +769,149 @@ async def test_ask_tool_result_preserves_images_and_structured_urls() -> None:
     assert embed_only.content[1] == image
 
 
+async def test_ask_result_schema_omits_the_unserialized_image_blocks() -> None:
+    schema = AskResult.model_json_schema()
+
+    assert "image_blocks" not in schema["properties"], (
+        "image_blocks is excluded from every dump, so advertising it in the "
+        "output schema points clients at a field that never arrives"
+    )
+
+
+async def test_ask_tool_result_keeps_prose_shape_without_charts() -> None:
+    result = _ask_tool_result(AskResult(handle="ses_plain001", message="Plain answer"))
+
+    assert isinstance(result, ToolResult)
+    assert result.content[0].model_dump(by_alias=True, exclude_none=True) == {
+        "type": "text",
+        "text": "Plain answer",
+    }
+    assert result.structured_content is not None
+    assert result.structured_content["handle"] == "ses_plain001"
+
+
+async def test_ask_keeps_polling_through_an_unmodeled_transient_status() -> None:
+    runtime = MagicMock()
+    runtime.settings.artifacts = None
+    runtime.artifact_store = None
+    auth = _auth()
+    events = MagicMock(
+        items=[
+            MagicMock(
+                type="agent.message",
+                content=[{"type": "text", "text": "Final answer"}],
+            )
+        ],
+        next_page=None,
+    )
+
+    with (
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat._start_turn_impl",
+            new=AsyncMock(return_value={"handle": "ses_queued001"}),
+        ),
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat._get_session_impl",
+            new=AsyncMock(side_effect=[MagicMock(status="queued"), MagicMock(status="idle")]),
+        ),
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat._list_events_impl",
+            new=AsyncMock(return_value=events),
+        ),
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat.deliver_hosted_charts",
+            new=AsyncMock(return_value=HostedChartDelivery(message="Final answer")),
+        ),
+    ):
+        result = await _ask_impl(
+            runtime,
+            auth,
+            "Question",
+            sleep=AsyncMock(),
+            clock=lambda: 0.0,
+        )
+
+    assert result.message == "Final answer"
+
+
+async def test_deliver_turn_charts_bounds_the_transcript_walk() -> None:
+    runtime = MagicMock()
+    auth = _auth()
+    reply_at = dt.datetime(2026, 8, 25, 12, 20, tzinfo=dt.UTC)
+
+    def endless_page(*args: Any, **kwargs: Any) -> MagicMock:
+        del args, kwargs
+        return MagicMock(
+            items=[_timed_event("sevt_reply", "agent.message", reply_at, text="Answer")],
+            next_page="more",
+        )
+
+    with (
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat._get_session_impl",
+            new=AsyncMock(
+                return_value=MagicMock(
+                    status="idle",
+                    created_at=dt.datetime(2026, 8, 25, 12, 0, tzinfo=dt.UTC),
+                )
+            ),
+        ),
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat._list_events_impl",
+            new=AsyncMock(side_effect=endless_page),
+        ) as list_events,
+        patch("daimon.adapters.mcp.tools.agent_chat._MAX_EVENT_PAGES", 2),
+        pytest.raises(ToolError, match="no completed turn boundary"),
+    ):
+        await _deliver_turn_charts_impl(runtime, auth, "ses_endless001")
+
+    assert list_events.await_count == 2
+
+
+async def test_deliver_turn_charts_serves_repeat_calls_from_cache() -> None:
+    runtime = MagicMock()
+    runtime.settings.artifacts = None
+    runtime.artifact_store = None
+    auth = _auth()
+    reply_at = dt.datetime(2026, 8, 25, 12, 20, tzinfo=dt.UTC)
+    turn_started_at = dt.datetime(2026, 8, 25, 12, 10, tzinfo=dt.UTC)
+
+    def transcript(*args: Any, **kwargs: Any) -> MagicMock:
+        del args, kwargs
+        return MagicMock(
+            items=[
+                _timed_event("sevt_reply", "agent.message", reply_at, text="Final answer"),
+                _timed_event("sevt_turn_start", "user.message", turn_started_at),
+            ],
+            next_page=None,
+        )
+
+    with (
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat._get_session_impl",
+            new=AsyncMock(
+                return_value=MagicMock(
+                    status="idle",
+                    created_at=dt.datetime(2026, 8, 25, 12, 0, tzinfo=dt.UTC),
+                )
+            ),
+        ),
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat._list_events_impl",
+            new=AsyncMock(side_effect=transcript),
+        ),
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat.deliver_hosted_charts",
+            new=AsyncMock(return_value=HostedChartDelivery(message="Final answer")),
+        ) as deliver,
+    ):
+        first = await _deliver_turn_charts_impl(runtime, auth, "ses_retry001")
+        second = await _deliver_turn_charts_impl(runtime, auth, "ses_retry001")
+
+    assert first == second
+    deliver.assert_awaited_once()
+
+
 async def test_deliver_turn_charts_uses_newest_completed_turn_window() -> None:
     runtime = MagicMock()
     runtime.settings.artifacts = None


### PR DESCRIPTION
## Summary

Stacked on #129: the base branch here mirrors that PR's head (`6338ec4`), so this diff is only the follow-up commits; they fold into #129 once picked up there. No issue closes here — #129 carries the `Closes #119` (and #124 still needs adding there, per the thread).

- A compact PNG could decode to gigabytes: Pillow's decompression-bomb error fires only above ~179M pixels, so a 690 KB 13000x13000 chart cleared the 10 MB byte cap and peaked over 2 GB RSS in the embed thread (reproduced locally). Decodes refuse anything above 25M pixels before `load()`.
- Artifact object keys ended in the agent's filename, so a later turn rewriting `chart.png` repointed an earlier turn's still-live presigned URL, and two same-named files in one turn collapsed into one object. The file id is now part of the key.
- Uploads run in a thread `asyncio.timeout` cannot cancel; one started near the delivery deadline completed after the caller gave up, stranding an unreferenced object in the bucket. Uploads no longer start inside the final 10 s of the 60 s budget.
- File discovery paged at the SDK default of 20 and truncated at 200 candidates before sorting on an ordering the API does not document; it now requests full pages and logs `scan_truncated` when the cap drops candidates. Configured artifact settings with no constructed store log `store_unconfigured` instead of silently disabling URL delivery.
- The transcript walks in `ask` and `deliver_turn_charts` were unbounded, and each page costs an ownership retrieve plus an events list; both walks stop after 20 pages.
- `deliver_turn_charts` is ungated and unmetered, and every call re-downloaded each chart from the Files API and re-wrote the artifact store. A delivered result is cached in-process per turn boundary (at most 5 minutes, never longer than its presigned links live), so client retry loops stop multiplying operator-side spend.
- `ask` raised on any status outside `idle`/`rescheduling`/`running`, but the status value set is upstream-controlled. Only `terminated` is terminal; an unmodeled transient status keeps polling until the deadline instead of failing a turn admission already billed.
- `AskResult` advertised `image_blocks` in its output schema while excluding it from every dump. The field is out of the schema, and chartless and charted replies share one content shape: prose text first, image blocks after, structured payload throughout.

## Behaviour changes

- Every `ask`/`deliver_turn_charts` reply is a prose-first `ToolResult`; a chartless `ask` previously returned the serialized model as structured JSON only.
- A repeated `deliver_turn_charts` for the same completed turn within the cache window returns the earlier result without re-contacting the Files API or the bucket.
- Sessions deeper than 2000 events (20 pages) without a turn boundary now refuse with the existing `no completed turn boundary` error instead of walking the full transcript.

## Testing

- Twelve new tests, each watched failing first. The 2 GB decode was reproduced out-of-band with a real 13000x13000 PNG; CI pins the pixel gate via a patched cap instead.
- `uv run pytest`: 4670 passed, 6 skipped; the two notebook-host self-chown failures are the known macOS `PermissionError`s, byte-identical to the PR base.
- `uv run pyright` — 0 errors. `uv run ruff check .` and `ruff format --check .` clean. `uv run lint-imports` — 6 contracts kept.
- Tool schema snapshot unchanged (it covers input schemas; the `AskResult` output-schema change has direct assertions instead).
- Not tested live: everything on #129's outstanding human-UAT list (real bucket round-trip, hosted-client rendering) is unchanged by this branch.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally (two pre-existing macOS notebook-host failures, identical on base)
- [x] `uv run pyright` passes locally (strict mode)
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)