### PR TITLE
fix(slack): five authorization and turn-isolation fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,8 +61,6 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_SLACK__MAX_CONCURRENT_TURNS_PER_TENANT=3
 # Port for the Slack process's liveness endpoint. Must not collide with the mcp process (8080), the discord process (8081), or the scheduler process (8082) — all process groups share one host.
 # DAIMON_SLACK__HEALTH_PORT=8083
-# Testing-only flag: when True, treats every Slack user as a workspace admin, bypassing the normal admin lookup, so a non-admin tester can exercise agent CRUD on a test deployment. Must stay unset in production.
-# DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN=False
 
 # === GitHub (optional) ===
 # OAuth scopes requested when a GitHub token-broker flow is used. Not consulted for GitHub App or PAT authentication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- **`DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN`** — the Slack testing-only admin bypass.
+  It made the admin check return true before `users.info` was ever called,
+  opening every Slack admin gate for every member of every install on the
+  deployment. Settings ignores unknown keys, so a deployment still setting it
+  boots normally: the variable is dropped and the gates begin enforcing. Remove
+  it from your environment, and promote a real workspace admin for any account
+  that relied on it.
+
+### Security
+
+- Slack mentions queued behind an in-flight turn are now partitioned by author,
+  one turn per caller. Previously the whole queue was coalesced into a single
+  turn run as the first queued author, so a second member's instructions
+  executed inside the first member's session, under their credentials and
+  visibility, billed to them.
+- `tokens_revoked` no longer tears down the install unless the event names the
+  bot token. Slack also emits it when a single member revokes their own user
+  token, which meant one member disconnecting could uninstall the app for the
+  entire workspace.
+- Agents seeded from `defaults/` can no longer be deleted. Both adapters refuse
+  server-side before archiving; the Discord panel's disabled button was
+  client-side only, and the Slack panel offered deletion outright.
+- Reading a routine's last run output now requires the same authority as
+  pausing or deleting it (workspace admin, or the routine's creator).
+
 ## [0.1.0] - 2026-07-15
 
 Initial public release.

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/write.py
@@ -484,6 +484,15 @@ async def delete_agent(runtime: DiscordRuntime, *, tenant_id: uuid.UUID, name: s
     agent = await find_agent_by_daimon_tag(runtime.anthropic, tenant_id=tenant_id, name=name)
     if agent is None:
         raise DaimonError(f"No agent named **{name}** found.")
+    if agent.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
+        # Server-side refusal. The panel disables Delete for a seeded agent
+        # (is_system on the roster entry), but a stale or re-fired view
+        # interaction reaches this function anyway — and archiving here would
+        # take the deployment's built-in agent and its memory store with it.
+        raise DaimonError(
+            f"**{name}** is a built-in agent and cannot be deleted. "
+            "Fork it first, then delete the fork."
+        )
     await runtime.anthropic.beta.agents.archive(agent.id)
     await agent_lifecycle.archive_memory_store_best_effort(
         anthropic=runtime.anthropic,

--- a/packages/adapters/discord/tests/agent_setup/test_delete_agent_memory.py
+++ b/packages/adapters/discord/tests/agent_setup/test_delete_agent_memory.py
@@ -9,8 +9,11 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from anthropic.types.beta import BetaManagedAgentsAgent
+from anthropic.types.beta.beta_managed_agents_model_config import BetaManagedAgentsModelConfig
 from daimon.adapters.discord.agent_setup.write import delete_agent
 from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.errors import DaimonError
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.scope import ChannelScopeRef
 from daimon.core.stores.agent_memory_stores import (
@@ -239,3 +242,112 @@ async def test_delete_agent_leaves_scope_rows_naming_another_agent_untouched(
         assert survivor.agent_name == "keeper", (
             "a channel row naming a different agent must keep its agent_name"
         )
+
+
+# ---------------------------------------------------------------------------
+# delete_agent — server-side refusal for defaults-managed ("system") agents
+# ---------------------------------------------------------------------------
+
+
+def _make_recording_archive_handler(
+    archived_ids: list[str],
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Archive handler that records which agent ids MA was actually asked to archive.
+
+    Lets a test assert the guard fired *before* the archive call, not merely
+    that `delete_agent` raised.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        m = re.fullmatch(r"/v1/agents/(?P<id>[^/]+)/archive", request.url.path)
+        if request.method != "POST" or not m:
+            raise NotHandled
+        archived_ids.append(m.group("id"))
+        now = datetime.now(UTC)
+        return httpx.Response(
+            200,
+            json=BetaManagedAgentsAgent(
+                id=m.group("id"),
+                type="agent",
+                name="doomed",
+                model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6"),
+                metadata={},
+                description=None,
+                archived_at=now,
+                created_at=now,
+                updated_at=now,
+                version=2,
+                mcp_servers=[],
+                skills=[],
+                tools=[],
+                system=None,
+            ).model_dump(mode="json"),
+        )
+
+    return handler
+
+
+async def test_delete_agent_refuses_defaults_managed_agent(db_session, db_session_factory) -> None:
+    """The panel disables Delete for a seeded agent — the server must refuse too.
+
+    A stale or re-fired view interaction reaches `delete_agent` directly, and
+    the archive would take the deployment's built-in agent and its memory store
+    with it.
+    """
+    tenant = await make_tenant(db_session)
+    archived_ids: list[str] = []
+    client = build_fake_anthropic(
+        combine_handlers(
+            _make_recording_archive_handler(archived_ids),
+            make_fake_memory_store_handler(FakeMemoryStoreState()),
+            make_fake_ma_handler(),
+        )
+    )
+    await client.beta.agents.create(
+        name="daimon",
+        model="claude-sonnet-4-6",
+        metadata={
+            "daimon_tenant": str(tenant.id),
+            "daimon_name": "daimon",
+            "daimon_managed": "true",
+        },
+    )
+
+    runtime = MagicMock(spec=DiscordRuntime)
+    runtime.anthropic = client
+    runtime.sessionmaker = db_session_factory
+
+    with pytest.raises(DaimonError, match="built-in agent"):
+        await delete_agent(runtime, tenant_id=tenant.id, name="daimon")
+
+    assert archived_ids == [], (
+        "delete_agent must refuse a daimon_managed agent before calling agents.archive"
+    )
+
+
+async def test_delete_agent_still_archives_unmanaged_agent(db_session, db_session_factory) -> None:
+    """The managed guard must not over-block: user forks still delete normally."""
+    tenant = await make_tenant(db_session)
+    archived_ids: list[str] = []
+    client = build_fake_anthropic(
+        combine_handlers(
+            _make_recording_archive_handler(archived_ids),
+            make_fake_memory_store_handler(FakeMemoryStoreState()),
+            make_fake_ma_handler(),
+        )
+    )
+    agent = await client.beta.agents.create(
+        name="my-fork",
+        model="claude-sonnet-4-6",
+        metadata={"daimon_tenant": str(tenant.id), "daimon_name": "my-fork"},
+    )
+
+    runtime = MagicMock(spec=DiscordRuntime)
+    runtime.anthropic = client
+    runtime.sessionmaker = db_session_factory
+
+    await delete_agent(runtime, tenant_id=tenant.id, name="my-fork")
+
+    assert archived_ids == [agent.id], (
+        "an agent without the daimon_managed marker must still be archived"
+    )

--- a/packages/adapters/slack/daimon/adapters/slack/admin.py
+++ b/packages/adapters/slack/daimon/adapters/slack/admin.py
@@ -11,24 +11,13 @@ The caller resolves once per interaction; no cross-interaction cache.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import structlog
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
-if TYPE_CHECKING:
-    from daimon.adapters.slack.runtime import SlackRuntime
-
 log = structlog.get_logger()
-
-
-def _dev_allow_all_admin(  # pyright: ignore[reportUnusedFunction]  # used cross-module by every run_* call site
-    runtime: SlackRuntime,
-) -> bool:
-    """Read the testing-only admin-gate override from settings (default False)."""
-    slack = runtime.settings.slack
-    return slack is not None and slack.dev_allow_all_admin
 
 
 def _is_admin_signal(user: dict[str, Any]) -> bool:
@@ -40,9 +29,7 @@ def _is_admin_signal(user: dict[str, Any]) -> bool:
     return bool(user.get("is_admin") or user.get("is_owner") or user.get("is_primary_owner"))
 
 
-async def resolve_is_admin(
-    client: AsyncWebClient, *, user_id: str, dev_allow_all: bool = False
-) -> bool:
+async def resolve_is_admin(client: AsyncWebClient, *, user_id: str) -> bool:
     """Return True if the Slack user is a workspace admin, fail-closed.
 
     Calls ``users.info`` via the injected per-event client; never caches the
@@ -53,19 +40,11 @@ async def resolve_is_admin(
     Args:
         client:  Per-event ``AsyncWebClient`` (injected; never cached).
         user_id: Slack user ID from the verified Socket Mode payload.
-        dev_allow_all: Testing-only escape hatch (env
-            ``DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN``). When ``True``, every user is
-            treated as admin and ``users.info`` is skipped entirely — so the
-            gate opens even on a workspace where the bot lacks ``users:read``.
-            Defaults ``False``; production deployments must leave it unset.
 
     Returns:
         ``True`` if the user is a workspace admin, owner, or primary owner;
         ``False`` otherwise, including on ``users.info`` failure.
     """
-    if dev_allow_all:
-        log.warning("slack.is_admin.dev_allow_all", user=user_id)
-        return True
     try:
         resp = await client.users_info(user=user_id)  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
     except SlackApiError as exc:

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
@@ -61,10 +61,7 @@ import anthropic
 import jwt as pyjwt
 import structlog
 from cryptography.fernet import InvalidToken
-from daimon.adapters.slack.admin import (
-    _dev_allow_all_admin,  # pyright: ignore[reportPrivateUsage]
-    resolve_is_admin,
-)
+from daimon.adapters.slack.admin import resolve_is_admin
 from daimon.adapters.slack.agent_setup import gate
 from daimon.adapters.slack.agent_setup.read import (
     load_agent_channel_ids,
@@ -363,9 +360,7 @@ async def handle_agent_setup_command(runtime: SlackRuntime, payload: dict[str, A
 
         # Slow path (off the 3s window): resolve tenant + is_admin + fetch roster.
         tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
-        is_admin = await resolve_is_admin(
-            client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-        )
+        is_admin = await resolve_is_admin(client, user_id=user_id)
 
         async with runtime.sessionmaker() as session:
             entries, over_cap = await load_tenant_roster(
@@ -470,9 +465,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     channel_id=channel_id,
                 )
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             # Stale check — if the chosen agent is not in the fresh roster, re-render warning.
             agent_exists = any(e.agent_name == chosen for e in entries)
@@ -512,9 +505,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             if not agent_name_for_tab:
                 return
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             # Stale check before fetching section data.
             agents_check = await list_agents_by_tenant(runtime.anthropic, tenant_id=tenant_id)
@@ -580,9 +571,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             if not agent_name_for_edit:
                 return
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             # Stale check.
             agents_check = await list_agents_by_tenant(runtime.anthropic, tenant_id=tenant_id)
@@ -641,9 +630,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
         # Delete (archive) — MUTATION: re-resolve is_admin (T-83-10)
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__delete":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
             if not is_admin:
                 await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
                     channel=channel_id or user_id,
@@ -700,9 +687,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
         # Scope: whole workspace — MUTATION: re-resolve is_admin (T-83-10)
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__scope:workspace":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
             if not is_admin:
                 await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
                     channel=channel_id or user_id,
@@ -770,9 +755,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
         # Scope: this channel — MUTATION: re-resolve is_admin (T-83-10)
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__scope:channel":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
             if not is_admin:
                 await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
                     channel=channel_id or user_id,
@@ -843,9 +826,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
         # Scope: clear — MUTATION: re-resolve is_admin (T-83-10)
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__scope:clear":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
             if not is_admin:
                 await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
                     channel=channel_id or user_id,
@@ -913,9 +894,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
         # currently reachable. Re-resolves via the shared gate post-ack.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__remove_skill":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             skill_to_remove: str = action.get("selected_option", {}).get("value") or ""
             if not skill_to_remove or skill_to_remove == "__none__":
@@ -932,7 +911,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 agent_name=agent_name_for_remove,
                 channel_id=channel_id,
                 user_id=user_id,
-                dev_allow_all=_dev_allow_all_admin(runtime),
             ):
                 return
 
@@ -1002,9 +980,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
         # is currently reachable. Re-resolves via the shared gate post-ack.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__remove_mcp":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             mcp_to_remove: str = action.get("selected_option", {}).get("value") or ""
             if not mcp_to_remove or mcp_to_remove == "__none__":
@@ -1021,7 +997,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 agent_name=agent_name_for_remove,
                 channel_id=channel_id,
                 user_id=user_id,
-                dev_allow_all=_dev_allow_all_admin(runtime),
             ):
                 return
 
@@ -1093,9 +1068,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
         # only the L1 stale fallback and the L2 re-render's build_l2_view kwargs.
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__remove_secret":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             secret_key_to_remove: str = action.get("selected_option", {}).get("value") or ""
             if not secret_key_to_remove or secret_key_to_remove == "__none__":
@@ -1112,7 +1085,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 agent_name=agent_name_for_remove,
                 channel_id=channel_id,
                 user_id=user_id,
-                dev_allow_all=_dev_allow_all_admin(runtime),
             ):
                 return
 
@@ -1179,9 +1151,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
         # JWT: never logged, jti only (T-83-11).
         # -----------------------------------------------------------------------
         elif action_id == "agent_setup__connect_mcp":
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
             if not is_admin:
                 await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
                     channel=channel_id or user_id,
@@ -1292,9 +1262,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             if not fork_source:
                 return
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             # Stale check (T-83-21): verify source agent still exists.
             ma_agent = await find_agent_by_daimon_tag(
@@ -1333,9 +1301,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             if not agent_name_for_edit:
                 return
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             if await gate.refuse_if_reachable_and_not_admin(
                 runtime,
@@ -1344,7 +1310,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 agent_name=agent_name_for_edit,
                 channel_id=channel_id,
                 user_id=user_id,
-                dev_allow_all=_dev_allow_all_admin(runtime),
             ):
                 return
 
@@ -1406,13 +1371,10 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 agent_name=agent_name_for_repo,
                 channel_id=channel_id,
                 user_id=user_id,
-                dev_allow_all=_dev_allow_all_admin(runtime),
             ):
                 return
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             # Stale check (T-83-21).
             ma_agent = await find_agent_by_daimon_tag(
@@ -1451,9 +1413,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             if not agent_name_for_skill:
                 return
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             if await gate.refuse_if_reachable_and_not_admin(
                 runtime,
@@ -1462,7 +1422,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 agent_name=agent_name_for_skill,
                 channel_id=channel_id,
                 user_id=user_id,
-                dev_allow_all=_dev_allow_all_admin(runtime),
             ):
                 return
 
@@ -1503,9 +1462,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             if not agent_name_for_mcp:
                 return
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             if await gate.refuse_if_reachable_and_not_admin(
                 runtime,
@@ -1514,7 +1471,6 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                 agent_name=agent_name_for_mcp,
                 channel_id=channel_id,
                 user_id=user_id,
-                dev_allow_all=_dev_allow_all_admin(runtime),
             ):
                 return
 
@@ -1557,9 +1513,7 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
             if not agent_name_for_secrets:
                 return
 
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(client, user_id=user_id)
 
             # Stale check (T-83-21).
             ma_agent = await find_agent_by_daimon_tag(

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
@@ -42,7 +42,10 @@ decided post-ack, server-side, never trusted from the rendered view):
     workspace default) — an unreachable agent has no live gate to defend.
   - Admin-only unconditionally, unchanged: delete, the three scope:* branches,
     connect_mcp (mints a bearer token; token issuance stays outside what
-    this phase opens).
+    this phase opens). Delete carries one refusal above the admin check as
+    well: the deployment's built-in agent is never deletable, admins included,
+    and that refusal is posted as an ephemeral rather than raised, so the
+    click does not look like a no-op.
   - JWT values for connect-mcp: never logged, last4/presence only.
   - Stale agent: re-fetch tolerates missing agent → no write, re-render L1 with
     warning notice.
@@ -103,7 +106,7 @@ from daimon.core.defaults.ma_index import (
     find_agent_by_daimon_tag,
     list_agents_by_tenant,
 )
-from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME
+from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED, MA_METADATA_KEY_NAME
 from daimon.core.errors import DaimonError
 from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
 from daimon.core.mcp_auth import mint_agent_mcp_token
@@ -118,6 +121,15 @@ from slack_sdk.errors import SlackApiError
 from sqlalchemy.exc import SQLAlchemyError
 
 log = structlog.get_logger()
+
+# Refusal copy for Delete against the deployment's built-in agent. Worded in
+# the shape ``agent_setup.gate`` uses for its own seeded-agent refusal: what is
+# refused, that admin rights do not change it, and the fork path out.
+_BUILTIN_AGENT_DELETE_MESSAGE = (
+    ":lock: This is the workspace's built-in agent, so it cannot be deleted "
+    "from here — not even by an admin. Fork it to get a copy you own, then "
+    "delete the fork."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -657,6 +669,29 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     is_admin=is_admin,
                     runtime=runtime,
                     tenant_id=tenant_id,
+                )
+                return
+
+            # Built-in agent: a policy refusal, not a failure. ``delete_agent``
+            # raises for this case and stays the server-side backstop, but a
+            # raise reaches only the boundary catch at the bottom of this
+            # function — which logs and reports to Sentry without touching
+            # Slack, so the click would look like nothing happened and the
+            # admin would click again. Read the marker off the agent already
+            # fetched for the stale guard (no extra round trip) and refuse in
+            # the shape ``agent_setup.gate`` uses: ephemeral, then return. No
+            # repaint — the agent still exists, so the panel on screen is still
+            # accurate, and the non-admin refusal above returns the same way.
+            if ma_agent.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
+                log.info(
+                    "slack.agent_setup.delete_refused_builtin",
+                    team_id=team_id,
+                    agent_name=target_name,
+                )
+                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+                    channel=channel_id or user_id,
+                    user=user_id,
+                    text=_BUILTIN_AGENT_DELETE_MESSAGE,
                 )
                 return
 

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
@@ -72,7 +72,6 @@ async def refuse_if_reachable_and_not_admin(
     agent_name: str,
     channel_id: str,
     user_id: str,
-    dev_allow_all: bool = False,
 ) -> bool:
     """Refuse a spec-touching action against a built-in or reachable agent.
 
@@ -96,8 +95,6 @@ async def refuse_if_reachable_and_not_admin(
                         tenant-scoped lookup key.
         channel_id:     Invoking channel, for the refusal ephemeral.
         user_id:        Invoking user, for the admin check and the ephemeral.
-        dev_allow_all:  Testing-only admin-gate override, threaded through
-                        unchanged from ``_dev_allow_all_admin(runtime)``.
 
     Returns:
         ``True`` if the caller must refuse and return early, ``False`` to
@@ -119,7 +116,7 @@ async def refuse_if_reachable_and_not_admin(
         )
         return True
 
-    is_admin = await resolve_is_admin(web_client, user_id=user_id, dev_allow_all=dev_allow_all)
+    is_admin = await resolve_is_admin(web_client, user_id=user_id)
     if is_admin:
         return False
 
@@ -153,7 +150,6 @@ async def refuse_if_shared_and_not_admin(
     agent_name: str,
     channel_id: str,
     user_id: str,
-    dev_allow_all: bool = False,
 ) -> bool:
     """Refuse an attachment write against a shared agent by a non-admin.
 
@@ -189,14 +185,12 @@ async def refuse_if_shared_and_not_admin(
                         tenant-scoped lookup key.
         channel_id:     Invoking channel, for the refusal ephemeral.
         user_id:        Invoking user, for the admin check and the ephemeral.
-        dev_allow_all:  Testing-only admin-gate override, threaded through
-                        unchanged from ``_dev_allow_all_admin(runtime)``.
 
     Returns:
         ``True`` if the caller must refuse and return early, ``False`` to
         proceed.
     """
-    is_admin = await resolve_is_admin(web_client, user_id=user_id, dev_allow_all=dev_allow_all)
+    is_admin = await resolve_is_admin(web_client, user_id=user_id)
     if is_admin:
         return False
 

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
@@ -46,9 +46,6 @@ from typing import Any
 
 import anthropic
 import structlog
-from daimon.adapters.slack.admin import (
-    _dev_allow_all_admin,  # pyright: ignore[reportPrivateUsage]
-)
 from daimon.adapters.slack.agent_setup import gate
 from daimon.adapters.slack.agent_setup.state import decode_private_metadata
 from daimon.adapters.slack.agent_setup.write import (
@@ -712,7 +709,6 @@ async def run_edit_agent_submission(
             agent_name=agent_name,
             channel_id=channel_id,
             user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
         )
         if refused:
             return
@@ -822,7 +818,6 @@ async def run_edit_repo_submission(
             agent_name=agent_name,
             channel_id=channel_id,
             user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
         )
         if refused:
             return
@@ -1036,7 +1031,6 @@ async def run_add_skill_submission(
             agent_name=agent_name,
             channel_id=channel_id,
             user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
         )
         if refused:
             return
@@ -1137,7 +1131,6 @@ async def run_add_mcp_submission(
             agent_name=agent_name,
             channel_id=channel_id,
             user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
         )
         if refused:
             return
@@ -1324,7 +1317,6 @@ async def run_paste_secrets_submission(
             agent_name=agent_name,
             channel_id=channel_id,
             user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
         )
         if refused:
             return

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/write.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/write.py
@@ -28,7 +28,7 @@ from daimon.core.defaults.ma_index import (
     find_agents_by_daimon_tag,
 )
 from daimon.core.defaults.mcp_merge import merge_default_mcp_server, merge_default_mcp_toolset
-from daimon.core.defaults.metadata import build_metadata
+from daimon.core.defaults.metadata import MA_METADATA_KEY_MANAGED, build_metadata
 from daimon.core.defaults.reconcile_agents import reconcile_agent
 from daimon.core.defaults.report import Action, ResourceOutcome
 from daimon.core.defaults.skills import resolve_refs
@@ -304,6 +304,16 @@ async def delete_agent(runtime: SlackRuntime, *, tenant_id: uuid.UUID, name: str
     agent = await find_agent_by_daimon_tag(runtime.anthropic, tenant_id=tenant_id, name=name)
     if agent is None:
         raise DaimonError(f"No agent named *{name}* found.")
+    if agent.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
+        # Server-side refusal, and on Slack the ONLY one: RosterEntry carries no
+        # managed flag, so the panel offers Delete on a seeded agent exactly as
+        # it does on a user agent, and the click branch checks only admin.
+        # Archiving here would take the deployment's built-in agent and its
+        # memory store with it.
+        raise DaimonError(
+            f"*{name}* is a built-in agent and cannot be deleted. "
+            "Fork it first, then delete the fork."
+        )
     await runtime.anthropic.beta.agents.archive(agent.id)
     await agent_lifecycle.archive_memory_store_best_effort(
         anthropic=runtime.anthropic,

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -149,6 +149,16 @@ def _log_bg_task_exception(task: asyncio.Task[None]) -> None:
         log.error("bg_task_failed", task_name=task.get_name(), exc_info=exc)
 
 
+def _author_id(event: dict[str, Any]) -> str:
+    """The Slack user id that authored an event, or "" when there is none.
+
+    One spelling, used by both the drain partition and
+    ``_compose_queued_content`` — deriving the author two different ways is how
+    a partition key and a rendered attribution drift apart.
+    """
+    return str(event.get("user") or "")
+
+
 def _compose_queued_content(events: list[dict[str, Any]]) -> str:
     """Compose pending mention texts into a single composite user message.
 
@@ -159,10 +169,10 @@ def _compose_queued_content(events: list[dict[str, Any]]) -> str:
     """
     if not events:
         return ""
-    user_ids = {str(e.get("user", "")) for e in events}
+    user_ids = {_author_id(e) for e in events}
     if len(user_ids) == 1:
         return "\n\n".join(str(e.get("text", "")) for e in events)
-    return "\n\n".join(f"[{e.get('user', '')}]: {e.get('text', '')}" for e in events)
+    return "\n\n".join(f"[{_author_id(e)}]: {e.get('text', '')}" for e in events)
 
 
 def _collect_files(events: list[dict[str, Any]]) -> list[SlackFile]:
@@ -1066,18 +1076,73 @@ class SlackApp:
             # turn independently re-enters _run_thread_turn, which admission-gates
             # and bills every turn — new session or reused.
             while queued := self._pending.pop(thread_id, []):
-                composite = _compose_queued_content(queued)
-                representative = queued[0]
-                await self._run_thread_turn(
-                    representative,
-                    channel=channel,
-                    web_client=web_client,
-                    tenant_id=tenant_id,
-                    thread_id=thread_id,
-                    content_override=composite,
-                    team_id=team_id,
-                    files=_collect_files(queued),
-                )
+                # Partition by author and run one composite turn per author,
+                # in first-seen arrival order. Coalescing distinct authors onto
+                # one turn would route B's mention into A's session, under A's
+                # vault token and Slack visibility, billed to A, with B's own
+                # per-user cap never evaluated. One turn = one caller.
+                # Mirrors Discord's _drain_pending_mentions (bot.py:900-914).
+                by_user: dict[str, list[dict[str, Any]]] = {}
+                for q_event in queued:
+                    author = _author_id(q_event)
+                    if not author:
+                        # No author to run as. `_run_thread_turn` would resolve a
+                        # principal for the empty string and bill a turn to a
+                        # phantom account. Discord cannot hit this — a Message
+                        # always has an author.
+                        log.warning(
+                            "slack.drain.skipped_authorless_event",
+                            thread_id=thread_id,
+                            team_id=team_id,
+                        )
+                        continue
+                    by_user.setdefault(author, []).append(q_event)
+                for user_events in by_user.values():
+                    # One author's failure must not consume the others'. Their
+                    # events are already popped from _pending, so the `finally`
+                    # notice below cannot reach them — without this they would
+                    # vanish with no turn and no message. Discord gets the same
+                    # property for free because `_handle_mention` renders turn
+                    # errors internally and never raises; `_run_thread_turn`
+                    # documents the opposite ("errors propagate to the listener
+                    # boundary"), so Slack has to isolate here.
+                    try:
+                        await self._run_thread_turn(
+                            user_events[0],
+                            channel=channel,
+                            web_client=web_client,
+                            tenant_id=tenant_id,
+                            thread_id=thread_id,
+                            content_override=_compose_queued_content(user_events),
+                            team_id=team_id,
+                            # Merge files from ALL of this author's queued events,
+                            # in first-seen order — user_events[0] alone would
+                            # silently drop files on their later mentions.
+                            files=_collect_files(user_events),
+                        )
+                    except (
+                        DaimonError,
+                        anthropic.APIError,
+                        SlackApiError,
+                        InvalidToken,
+                        SQLAlchemyError,
+                        aiohttp.ClientError,
+                        TimeoutError,
+                    ) as exc:
+                        log.exception(
+                            "slack.drain.turn_failed",
+                            thread_id=thread_id,
+                            team_id=team_id,
+                            exc_info=exc,
+                        )
+                        with contextlib.suppress(SlackApiError):
+                            await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
+                                channel=channel,
+                                text=(
+                                    "Sorry, something went wrong handling that — please try again."
+                                ),
+                                thread_ts=thread_id,
+                            )
         finally:
             self._processing.discard(thread_id)
             still_pending = self._pending.pop(thread_id, [])

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -175,6 +175,20 @@ def _compose_queued_content(events: list[dict[str, Any]]) -> str:
     return "\n\n".join(f"[{_author_id(e)}]: {e.get('text', '')}" for e in events)
 
 
+def _revokes_bot_token(event: dict[str, Any]) -> bool:
+    """Return True if a ``tokens_revoked`` event revoked the workspace bot token.
+
+    Slack sends ``tokens_revoked`` with ``{"tokens": {"oauth": [...], "bot": [...]}}``.
+    The ``oauth`` list fires when a single member revokes their own user token —
+    daimon triggers exactly that itself, from /privacy → Disconnect. Only a
+    non-empty ``bot`` list means the install is actually gone, so only that may
+    reach teardown; treating the whole event as an uninstall let one member's
+    Disconnect archive the tenant and delete the bot token for everyone.
+    """
+    tokens: dict[str, Any] = event.get("tokens") or {}
+    return bool(tokens.get("bot"))
+
+
 def _collect_files(events: list[dict[str, Any]]) -> list[SlackFile]:
     """Flatten the ``files`` arrays across events, preserving order.
 
@@ -654,7 +668,9 @@ class SlackApp:
             etype: str | None = event.get("type")
             if etype == "app_mention":
                 self._spawn(self._handle_app_mention(event, team_id=team_id))
-            elif etype in ("app_uninstalled", "tokens_revoked"):
+            elif etype == "app_uninstalled" or (
+                etype == "tokens_revoked" and _revokes_bot_token(event)
+            ):
                 self._spawn(self._handle_teardown(team_id=team_id))
         elif req.type == "slash_commands":
             # Slash commands arrive as req.type == "slash_commands".
@@ -735,7 +751,10 @@ class SlackApp:
             self._inflight.pop(tenant_id, None)
 
     async def _handle_teardown(self, *, team_id: str) -> None:
-        """Route app_uninstalled / tokens_revoked to teardown_slack_install.
+        """Archive the install: soft-archive the tenant, delete the bot token.
+
+        Reached from app_uninstalled unconditionally, and from tokens_revoked
+        only when the event names the bot token (see _revokes_bot_token).
 
         Soft-archives the tenant and deletes the bot-token row so subsequent
         events see no token and are dropped cleanly.

--- a/packages/adapters/slack/daimon/adapters/slack/credential_requests.py
+++ b/packages/adapters/slack/daimon/adapters/slack/credential_requests.py
@@ -41,10 +41,7 @@ import httpx
 import structlog
 from anthropic.types.beta import BetaManagedAgentsAgent
 from anthropic.types.beta.beta_managed_agents_skill_params import BetaManagedAgentsSkillParams
-from daimon.adapters.slack.admin import (
-    _dev_allow_all_admin,  # pyright: ignore[reportPrivateUsage]
-    resolve_is_admin,
-)
+from daimon.adapters.slack.admin import resolve_is_admin
 from daimon.adapters.slack.agent_setup.write import (
     load_agent_inline_pat,
     mask_tail,
@@ -349,7 +346,7 @@ async def _refuse_if_shared_and_not_admin_for_request(
 
     Returns True when the caller must return immediately (refused).
     """
-    if await resolve_is_admin(client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)):
+    if await resolve_is_admin(client, user_id=user_id):
         return False
     agent = await find_agent_by_derived_uuid(
         runtime.anthropic, tenant_id=tenant_id, agent_id=agent_id

--- a/packages/adapters/slack/daimon/adapters/slack/routines_panel/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/routines_panel/actions.py
@@ -278,6 +278,22 @@ async def handle_routine_action(runtime: SlackRuntime, payload: dict[str, Any]) 
             if row is None:
                 return
 
+            # Same authority as pause/resume/delete. last_result_tail is the
+            # agent's own output from a scheduled run and routinely carries
+            # business data, so reading it is not a lesser act than pausing.
+            is_admin = await resolve_is_admin(client, user_id=user_id)
+            is_creator = row.created_by_user_id is not None and row.created_by_user_id == user_id
+            if not (is_admin or is_creator):
+                await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
+                    channel=channel_id or user_id,
+                    user=user_id,
+                    text=(
+                        "Only the routine's creator or a workspace admin "
+                        "can read this routine's output."
+                    ),
+                )
+                return
+
             if row.last_error is not None:
                 output_text = row.last_error
             else:

--- a/packages/adapters/slack/daimon/adapters/slack/routines_panel/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/routines_panel/actions.py
@@ -24,10 +24,7 @@ from typing import Any
 import anthropic
 import structlog
 from cryptography.fernet import InvalidToken
-from daimon.adapters.slack.admin import (
-    _dev_allow_all_admin,  # pyright: ignore[reportPrivateUsage]
-    resolve_is_admin,
-)
+from daimon.adapters.slack.admin import resolve_is_admin
 from daimon.adapters.slack.errors import generate_request_id, surface_command_error
 from daimon.adapters.slack.interactions import resolve_web_client
 from daimon.adapters.slack.routines_panel.read import load_routines
@@ -244,10 +241,8 @@ async def handle_routine_action(runtime: SlackRuntime, payload: dict[str, Any]) 
                 )
                 return
             # Authority gate before showing the confirm modal (re-checked at
-            # submit for TOCTOU safety). Admin (honoring dev_allow_all) OR creator.
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            # submit for TOCTOU safety). Admin OR creator.
+            is_admin = await resolve_is_admin(client, user_id=user_id)
             is_creator = row.created_by_user_id is not None and row.created_by_user_id == user_id
             if not (is_admin or is_creator):
                 await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
@@ -310,10 +305,8 @@ async def handle_routine_action(runtime: SlackRuntime, payload: dict[str, Any]) 
             )
 
         elif action_value == "create":
-            # Admin gate at click time (honors dev_allow_all). Refused → ephemeral.
-            is_admin = await resolve_is_admin(
-                client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            # Admin gate at click time. Refused → ephemeral.
+            is_admin = await resolve_is_admin(client, user_id=user_id)
             if not is_admin:
                 await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
                     channel=channel_id or user_id,

--- a/packages/adapters/slack/daimon/adapters/slack/routines_panel/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/routines_panel/submit.py
@@ -25,10 +25,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import anthropic
 import structlog
-from daimon.adapters.slack.admin import (
-    _dev_allow_all_admin,  # pyright: ignore[reportPrivateUsage]
-    resolve_is_admin,
-)
+from daimon.adapters.slack.admin import resolve_is_admin
 from daimon.adapters.slack.routines_panel.read import load_routines
 from daimon.adapters.slack.routines_panel.state import RoutinesPanelState
 from daimon.adapters.slack.routines_panel.views import build_content_view
@@ -168,14 +165,13 @@ async def _refuse_non_admin(
     *,
     channel_id: str,
     user_id: str,
-    dev_allow_all: bool = False,
 ) -> bool:
     """Re-check is_admin server-side; send ephemeral and return True if non-admin.
 
     Every mutating run_* calls this first. Returns True = caller should return
     early (refused). Returns False = admin confirmed, proceed.
     """
-    is_admin = await resolve_is_admin(web_client, user_id=user_id, dev_allow_all=dev_allow_all)
+    is_admin = await resolve_is_admin(web_client, user_id=user_id)
     if not is_admin:
         await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
             channel=channel_id,
@@ -228,7 +224,6 @@ async def run_routines_create_submission(
             web_client,
             channel_id=channel_id,
             user_id=user_id,
-            dev_allow_all=_dev_allow_all_admin(runtime),
         )
         if refused:
             return
@@ -310,7 +305,7 @@ async def run_routines_delete_submission(
 ) -> None:
     """Post-ack: delete a routine after its confirm modal is submitted.
 
-    Re-checks tenant + authority (admin honoring dev_allow_all, OR the routine's
+    Re-checks tenant + authority (admin, OR the routine's
     creator) inside ``session.begin()`` (TOCTOU-safe, fail-closed), deletes the
     row, then refreshes the underlying panel view (``root_view_id``) in place and
     posts a confirmation ephemeral back to the invoking channel.
@@ -333,9 +328,7 @@ async def run_routines_delete_submission(
                     text="This routine no longer exists.",
                 )
                 return
-            is_admin = await resolve_is_admin(
-                web_client, user_id=user_id, dev_allow_all=_dev_allow_all_admin(runtime)
-            )
+            is_admin = await resolve_is_admin(web_client, user_id=user_id)
             is_creator = row.created_by_user_id is not None and row.created_by_user_id == user_id
             if not (is_admin or is_creator):
                 await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
@@ -299,7 +299,6 @@ def _build_runtime(
     settings.mcp.jwt_secret = None
     settings.github = MagicMock()
     settings.github.app_id = None
-    settings.slack.dev_allow_all_admin = False  # real default; MagicMock would be truthy
     return SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(handler),
@@ -566,7 +565,6 @@ async def test_handle_agent_setup_action_connect_mcp_sends_ephemeral_not_modal_u
     settings.mcp.jwt_secret = SecretStr("test-secret-32-bytes-long-padding!")
     settings.github = MagicMock()
     settings.github.app_id = None
-    settings.slack.dev_allow_all_admin = False  # real default; MagicMock would be truthy
     runtime = SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(handler),
@@ -1345,7 +1343,6 @@ async def test_handle_agent_setup_action_connect_mcp_non_admin_refused_no_epheme
     settings.mcp.jwt_secret = SecretStr("test-secret-32-bytes-long-padding!")
     settings.github = MagicMock()
     settings.github.app_id = None
-    settings.slack.dev_allow_all_admin = False
     runtime = SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(handler),

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_actions.py
@@ -37,13 +37,18 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 import yarl
+from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsModelConfig
 from cryptography.fernet import Fernet
 from daimon.adapters.slack.agent_setup.actions import (
     handle_agent_setup_action,
     handle_agent_setup_command,
 )
 from daimon.adapters.slack.runtime import SlackRuntime
-from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
+from daimon.core.defaults.metadata import (
+    MA_METADATA_KEY_MANAGED,
+    MA_METADATA_KEY_NAME,
+    MA_METADATA_KEY_TENANT,
+)
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.scope import ChannelConfigRow, ChannelScopeRef, TenantScopeRef
@@ -1268,6 +1273,236 @@ async def test_handle_agent_setup_action_delete_non_admin_refused_no_write(
     texts = _ephemeral_texts(client_fake)
     assert any("no longer have permission" in t for t in texts), (
         "non-admin agent_setup__delete must be refused (admin-only, unconditional)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Delete against the deployment's built-in agent.
+#
+# ``write.delete_agent`` raises for this case and stays the server-side
+# backstop, but on Slack a raise reaches only the boundary catch at the bottom
+# of handle_agent_setup_action -- log + Sentry, no Slack call -- and the caller
+# is fire-and-forget, so the click renders as nothing happening at all. These
+# two tests pin the visible refusal and its unmanaged counterpart.
+# ---------------------------------------------------------------------------
+
+
+def _make_ma_handler_recording_archive(
+    agent_payloads: list[dict[str, object]],
+    recorded_requests: list[str],
+) -> Any:
+    """Serve the given agents, record every request, and honour archive.
+
+    Extends the read-only handler above with POST ``/v1/agents/{id}/archive``
+    so a delete that is NOT refused runs to completion (archive, then the
+    roster re-read that repaints L1). ``recorded_requests`` collects
+    ``"METHOD /path"`` for every call, which is what lets a test assert that no
+    archive was ever attempted.
+    """
+    agent_store: dict[str, dict[str, object]] = {str(ag["id"]): ag for ag in agent_payloads}
+    archived_ids: set[str] = set()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+        recorded_requests.append(f"{method} {path}")
+
+        if method == "GET" and path == "/v1/agents":
+            live = [ag for agent_id, ag in agent_store.items() if agent_id not in archived_ids]
+            return httpx.Response(200, json={"data": live, "has_more": False})
+
+        archive_match = re.match(r"^/v1/agents/(?P<id>[^/]+)/archive$", path)
+        if archive_match and method == "POST":
+            agent_id_req = archive_match.group("id")
+            if agent_id_req not in agent_store:
+                return httpx.Response(
+                    404,
+                    json={
+                        "type": "error",
+                        "error": {"type": "not_found_error", "message": "not found"},
+                    },
+                )
+            archived_ids.add(agent_id_req)
+            return httpx.Response(
+                200,
+                json={
+                    **agent_store[agent_id_req],
+                    "archived_at": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        if method == "GET" and path.startswith("/v1/agents/"):
+            agent_id_req = path.removeprefix("/v1/agents/")
+            if agent_id_req in agent_store:
+                return httpx.Response(200, json=agent_store[agent_id_req])
+            return httpx.Response(
+                404,
+                json={
+                    "type": "error",
+                    "error": {"type": "not_found_error", "message": "not found"},
+                },
+            )
+
+        if method == "GET" and path == "/v1/environments":
+            return httpx.Response(200, json={"data": [], "has_more": False})
+
+        return httpx.Response(404, json={"error": f"unhandled {method} {path}"})
+
+    return handler
+
+
+def _views_update_bodies(client_fake: Any) -> list[str]:
+    """Serialized bodies of every views.update call, for hint assertions."""
+    calls = client_fake.mock.requests.get(("POST", yarl.URL(f"{_SLACK_API_BASE}/views.update")), [])
+    return [json.dumps(call.kwargs.get("json") or {}) for call in calls]
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_delete_builtin_agent_refuses_visibly_and_archives_nothing(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """Delete on the deployment's built-in agent refuses in Slack, not just server-side.
+
+    The roster carries no managed flag, so the panel offers Delete on a seeded
+    agent exactly as it does on a user agent. An admin clicking it must see why
+    it will not happen -- a silent no-op invites a second click and turns an
+    expected policy refusal into a Sentry event.
+    """
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+
+    now = datetime.now(UTC)
+    builtin_agent = BetaManagedAgentsAgent(
+        id=_MA_AGENT_ID,
+        type="agent",
+        name=_AGENT_NAME,
+        version=1,
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+        metadata={
+            MA_METADATA_KEY_TENANT: str(tenant_id),
+            MA_METADATA_KEY_NAME: _AGENT_NAME,
+            MA_METADATA_KEY_MANAGED: "true",
+        },
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        created_at=now,
+        updated_at=now,
+    ).model_dump(mode="json")
+
+    recorded_requests: list[str] = []
+    handler = _make_ma_handler_recording_archive([builtin_agent], recorded_requests)
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
+
+    payload = _action_payload("agent_setup__delete", selected_agent_name=_AGENT_NAME)
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    assert not [req for req in recorded_requests if req.endswith("/archive")], (
+        "deleting the built-in agent must reach no archive call on the Anthropic "
+        f"transport, got requests: {recorded_requests!r}"
+    )
+
+    texts = _ephemeral_texts(client_fake)
+    assert len(texts) == 1, f"exactly one refusal ephemeral must be posted, got {texts!r}"
+    assert "built-in agent" in texts[0], (
+        f"the refusal must say the agent is built in, got {texts[0]!r}"
+    )
+    assert "ork" in texts[0], (
+        f"the refusal must point at forking as the way forward, got {texts[0]!r}"
+    )
+
+    update_bodies = _views_update_bodies(client_fake)
+    assert not update_bodies, (
+        "a refused delete must leave the open panel untouched -- the agent still "
+        f"exists, so the rendered view is still accurate; got {update_bodies!r}"
+    )
+    assert not any("wastebasket" in body or "deleted." in body for body in update_bodies), (
+        "the panel must never claim the built-in agent was deleted, got "
+        f"views.update bodies: {update_bodies!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_setup_action_delete_unmanaged_agent_archives_and_repaints(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """An ordinary user agent still deletes -- the built-in refusal must not over-block."""
+    tenant_id, fernet_key, _ = await _seed_team(db_session)
+
+    now = datetime.now(UTC)
+    user_agent = BetaManagedAgentsAgent(
+        id=_MA_AGENT_ID,
+        type="agent",
+        name=_AGENT_NAME,
+        version=1,
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+        metadata={
+            MA_METADATA_KEY_TENANT: str(tenant_id),
+            MA_METADATA_KEY_NAME: _AGENT_NAME,
+        },
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        created_at=now,
+        updated_at=now,
+    ).model_dump(mode="json")
+
+    # A second agent survives the delete: the L1 empty state replaces the hint
+    # line entirely, so the repaint is only observable on a non-empty roster.
+    surviving_agent = BetaManagedAgentsAgent(
+        id=f"agent_{'b' * 24}",
+        type="agent",
+        name="other-agent",
+        version=1,
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+        metadata={
+            MA_METADATA_KEY_TENANT: str(tenant_id),
+            MA_METADATA_KEY_NAME: "other-agent",
+        },
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        created_at=now,
+        updated_at=now,
+    ).model_dump(mode="json")
+
+    recorded_requests: list[str] = []
+    handler = _make_ma_handler_recording_archive([user_agent, surviving_agent], recorded_requests)
+    runtime = _build_runtime(fernet_key, db_session_factory, anthropic_handler=handler)
+
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
+
+    payload = _action_payload("agent_setup__delete", selected_agent_name=_AGENT_NAME)
+    await handle_agent_setup_action(runtime, payload)  # type: ignore[arg-type]
+
+    assert f"POST /v1/agents/{_MA_AGENT_ID}/archive" in recorded_requests, (
+        "deleting an unmanaged agent must archive it on the Anthropic transport, got "
+        f"requests: {recorded_requests!r}"
+    )
+    assert not _ephemeral_texts(client_fake), (
+        f"an allowed delete must post no refusal ephemeral, got {_ephemeral_texts(client_fake)!r}"
+    )
+
+    update_bodies = _views_update_bodies(client_fake)
+    assert len(update_bodies) == 1, (
+        f"a successful delete must repaint L1 exactly once, got {update_bodies!r}"
+    )
+    # The repaint is asserted through the roster it renders, not through the
+    # delete hint: build_l1_view drops scope_hint whenever no agent is
+    # selected, and the success path deliberately clears the selection, so
+    # ``delete_hint`` never reaches the rendered view.
+    assert _AGENT_NAME not in update_bodies[0], (
+        f"the repainted roster must no longer offer the archived agent, got {update_bodies[0]!r}"
+    )
+    assert "other-agent" in update_bodies[0], (
+        f"the repainted roster must still offer the surviving agent, got {update_bodies[0]!r}"
     )
 
 

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_gate.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_gate.py
@@ -83,7 +83,6 @@ def _non_admin_users_info_payload(user_id: str = _USER_ID) -> dict[str, Any]:
 def _build_runtime(db_factory: async_sessionmaker[AsyncSession]) -> SlackRuntime:
     """Construct a SlackRuntime with a fake Anthropic transport and real DB factory."""
     settings = MagicMock()
-    settings.slack.dev_allow_all_admin = False
     return SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(make_fake_ma_handler()),
@@ -103,7 +102,6 @@ def _runtime_with_failing_sessionmaker() -> SlackRuntime:
         raise AssertionError("sessionmaker must not be called when the caller is already admin")
 
     settings = MagicMock()
-    settings.slack.dev_allow_all_admin = False
     return SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(make_fake_ma_handler()),
@@ -556,42 +554,3 @@ async def test_shared_gate_non_admin_passes_on_an_unreachable_unmanaged_agent(
 
         post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
         assert post_key not in mock.requests, "pass-through case must not post any ephemeral"
-
-
-async def test_shared_gate_dev_allow_all_lets_a_non_admin_through(
-    db_session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """dev_allow_all=True treats a non-admin as admin, matching the spec gate."""
-    async with db_session_factory() as session:
-        tenant = await make_tenant(session, platform="slack", workspace_id=_TEAM_ID)
-        await make_tenant_config(session, tenant=tenant, agent_name=_AGENT_NAME, mode="agent")
-        await session.commit()
-
-    with AioResponsesMock() as mock:
-        mock.get(  # pyright: ignore[reportUnknownMemberType]
-            _USERS_INFO_PATTERN,
-            payload=_non_admin_users_info_payload(),
-            repeat=True,
-        )
-        mock.post(  # pyright: ignore[reportUnknownMemberType]
-            f"{_SLACK_API_BASE}/chat.postEphemeral",
-            payload={"ok": True},
-            repeat=True,
-        )
-        client = AsyncWebClient(token="xoxb-test")
-        runtime = _build_runtime(db_session_factory)
-
-        refused = await refuse_if_shared_and_not_admin(
-            runtime,
-            client,
-            tenant_id=tenant.id,
-            agent_name=_AGENT_NAME,
-            channel_id=_CHANNEL_ID,
-            user_id=_USER_ID,
-            dev_allow_all=True,
-        )
-
-        assert refused is False, "the dev admin-gate override must open the attachment gate too"
-
-        post_key = ("POST", yarl.URL(f"{_SLACK_API_BASE}/chat.postEphemeral"))
-        assert post_key not in mock.requests, "the override path must not post any ephemeral"

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
@@ -553,7 +553,6 @@ def _build_runtime_with_db(
     settings.mcp.jwt_secret = None
     settings.github = MagicMock()
     settings.github.app_id = None
-    settings.slack.dev_allow_all_admin = False
     return SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(handler),
@@ -1563,10 +1562,6 @@ def _build_edit_repo_settings(*, app_id: str | None, fernet_key: str | None = No
     settings.github = MagicMock()
     settings.github.app_id = app_id
     settings.github.oauth_scopes = ("repo",)
-    # Explicitly off: a MagicMock attribute is truthy, so leaving this unset
-    # makes _dev_allow_all_admin treat every caller as an admin and every
-    # admin gate inert while the suite stays green.
-    settings.slack.dev_allow_all_admin = False
     return settings
 
 

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_write.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_write.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 from anthropic.types.beta import BetaManagedAgentsAgent
+from anthropic.types.beta.beta_managed_agents_model_config import BetaManagedAgentsModelConfig
 from cryptography.fernet import Fernet
 from daimon.adapters.slack.agent_setup import write as write_mod
 from daimon.adapters.slack.agent_setup.write import (
@@ -784,3 +785,112 @@ async def test_delete_agent_clears_tenant_default_naming_the_agent(
             "the tenant row naming the deleted agent must be gone so resolution "
             "falls through to the deployment default"
         )
+
+
+# ---------------------------------------------------------------------------
+# delete_agent — server-side refusal for defaults-managed ("system") agents
+# ---------------------------------------------------------------------------
+
+
+def _make_recording_archive_handler(
+    archived_ids: list[str],
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Archive handler that records which agent ids MA was actually asked to archive.
+
+    Lets a test assert the guard fired *before* the archive call, not merely
+    that `delete_agent` raised.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        m = re.fullmatch(r"/v1/agents/(?P<id>[^/]+)/archive", request.url.path)
+        if request.method != "POST" or not m:
+            raise NotHandled
+        archived_ids.append(m.group("id"))
+        now = datetime.now(UTC)
+        return httpx.Response(
+            200,
+            json=BetaManagedAgentsAgent(
+                id=m.group("id"),
+                type="agent",
+                name="doomed",
+                model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6"),
+                metadata={},
+                description=None,
+                archived_at=now,
+                created_at=now,
+                updated_at=now,
+                version=2,
+                mcp_servers=[],
+                skills=[],
+                tools=[],
+                system=None,
+            ).model_dump(mode="json"),
+        )
+
+    return handler
+
+
+async def test_delete_agent_refuses_defaults_managed_agent(db_session, db_session_factory) -> None:
+    """A workspace admin must not be able to archive the deployment's built-in agent.
+
+    The Slack roster carries no is_system flag, so the panel offers Delete for
+    seeded agents — the refusal has to live server-side or the deployment's
+    agent (and its memory store) go away in two clicks.
+    """
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="T_DELETE_MANAGED")
+    archived_ids: list[str] = []
+    client = build_fake_anthropic(
+        combine_handlers(
+            _make_recording_archive_handler(archived_ids),
+            make_fake_memory_store_handler(FakeMemoryStoreState()),
+            make_fake_ma_handler(),
+        )
+    )
+    await client.beta.agents.create(
+        name="daimon",
+        model="claude-sonnet-4-6",
+        metadata={
+            "daimon_tenant": str(tenant.id),
+            "daimon_name": "daimon",
+            "daimon_managed": "true",
+        },
+    )
+
+    runtime = MagicMock(spec=SlackRuntime)
+    runtime.anthropic = client
+    runtime.sessionmaker = db_session_factory
+
+    with pytest.raises(DaimonError, match="built-in agent"):
+        await write_mod.delete_agent(runtime, tenant_id=tenant.id, name="daimon")
+
+    assert archived_ids == [], (
+        "delete_agent must refuse a daimon_managed agent before calling agents.archive"
+    )
+
+
+async def test_delete_agent_still_archives_unmanaged_agent(db_session, db_session_factory) -> None:
+    """The managed guard must not over-block: user forks still delete normally."""
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="T_DELETE_UNMANAGED")
+    archived_ids: list[str] = []
+    client = build_fake_anthropic(
+        combine_handlers(
+            _make_recording_archive_handler(archived_ids),
+            make_fake_memory_store_handler(FakeMemoryStoreState()),
+            make_fake_ma_handler(),
+        )
+    )
+    agent = await client.beta.agents.create(
+        name="my-fork",
+        model="claude-sonnet-4-6",
+        metadata={"daimon_tenant": str(tenant.id), "daimon_name": "my-fork"},
+    )
+
+    runtime = MagicMock(spec=SlackRuntime)
+    runtime.anthropic = client
+    runtime.sessionmaker = db_session_factory
+
+    await write_mod.delete_agent(runtime, tenant_id=tenant.id, name="my-fork")
+
+    assert archived_ids == [agent.id], (
+        "an agent without the daimon_managed marker must still be archived"
+    )

--- a/packages/adapters/slack/tests/routines_panel/test_routines_create_submit.py
+++ b/packages/adapters/slack/tests/routines_panel/test_routines_create_submit.py
@@ -4,13 +4,16 @@ Covers:
 - evaluate_routines_create_submission: valid → proceed/clear + extra; missing
   field → response_action errors keyed to the right block.
 - run_routines_create_submission (real Postgres + transport-level fakes):
-  - dev_allow_all admin: a valid submission creates a routine row whose
+  - admin: a valid submission creates a routine row whose
     created_by_user_id is the submitting Slack user id.
-  - bad cron: no row created + :x: ephemeral posted.
+  - bad cron: no row created + an ephemeral naming the rejected cron expression
+    (a bare :x: would also match the non-admin refusal, which returns before
+    the cron is ever parsed).
 """
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
@@ -159,9 +162,49 @@ def _agent_handler(tenant_id_str: str, *, agent_name: str = _AGENT_NAME) -> Any:
     return _handler
 
 
+_USERS_INFO_PATTERN = re.compile(r"https://slack\.com/api/users\.info.*")
+
+
+def _override_users_info_admin(mock: Any) -> None:
+    """Replace the conftest non-admin users.info stub with an admin one.
+
+    aioresponses matches by insertion order and the conftest baseline is
+    registered with repeat=True, so a plain append never wins — the existing
+    users.info matchers have to be dropped first.
+
+    Reaches into aioresponses internals, so it fails loudly when they move: a
+    silent no-op here would leave the non-admin baseline winning and quietly
+    turn every caller into a test of the refusal path.
+    """
+    to_remove = [
+        k
+        for k, v in mock._matches.items()  # type: ignore[attr-defined]
+        if getattr(v, "url_or_pattern", None) == _USERS_INFO_PATTERN
+    ]
+    if not to_remove:
+        raise AssertionError(
+            "no users.info matcher found to override — aioresponses internals moved"
+        )
+    for k in to_remove:
+        del mock._matches[k]  # type: ignore[attr-defined]
+    mock.get(  # pyright: ignore[reportUnknownMemberType]
+        _USERS_INFO_PATTERN,
+        payload={
+            "ok": True,
+            "user": {
+                "id": _USER_ID,
+                "name": "admin",
+                "is_admin": True,
+                "is_owner": False,
+                "is_primary_owner": False,
+            },
+        },
+        repeat=True,
+    )
+
+
 def _build_runtime(handler: Any, db_session_factory: Any) -> SlackRuntime:
     settings: MagicMock = MagicMock()
-    settings.slack.dev_allow_all_admin = True
     return SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(handler),
@@ -174,13 +217,14 @@ def _build_runtime(handler: Any, db_session_factory: Any) -> SlackRuntime:
 
 
 @pytest.mark.asyncio
-async def test_run_routines_create_when_dev_allow_all_creates_row_with_creator_user_id(
+async def test_run_routines_create_when_admin_creates_row_with_creator_user_id(
     fake_slack_web_client: Any,
     db_session_factory: Any,
 ) -> None:
-    """A valid submission (dev_allow_all admin) creates a routine row whose
+    """A valid submission by an admin creates a routine row whose
     created_by_user_id is the submitting Slack user id — the whole point of the
     Slack-native create surface."""
+    _override_users_info_admin(fake_slack_web_client.mock)
     tenant_id = derive_tenant_uuid(platform="slack", workspace_id=_TEAM_ID)
     async with db_session_factory() as session:
         await make_tenant(session, platform="slack", workspace_id=_TEAM_ID, id=tenant_id)
@@ -228,7 +272,14 @@ async def test_run_routines_create_when_bad_cron_creates_no_row_and_posts_error(
     fake_slack_web_client: Any,
     db_session_factory: Any,
 ) -> None:
-    """A bad cron expression must create no routine row and post an :x: ephemeral."""
+    """A bad cron expression must create no routine row and post an ephemeral that
+    names the rejected expression.
+
+    The assertion deliberately does not settle for the bare ``:x:`` prefix: the
+    non-admin refusal in ``_refuse_non_admin`` also posts ``:x:`` and also
+    writes no row, so ``:x:`` alone proves nothing about cron validation.
+    """
+    _override_users_info_admin(fake_slack_web_client.mock)
     tenant_id = derive_tenant_uuid(platform="slack", workspace_id=_TEAM_ID)
     async with db_session_factory() as session:
         await make_tenant(session, platform="slack", workspace_id=_TEAM_ID, id=tenant_id)
@@ -258,4 +309,7 @@ async def test_run_routines_create_when_bad_cron_creates_no_row_and_posts_error(
     ephemeral_key = ("POST", yarl.URL("https://slack.com/api/chat.postEphemeral"))
     assert ephemeral_key in fake_slack_web_client.mock.requests, "bad cron should post an ephemeral"
     texts = [c.kwargs["json"]["text"] for c in fake_slack_web_client.mock.requests[ephemeral_key]]
-    assert any(":x:" in t for t in texts), "bad cron ephemeral must include :x:"
+    assert any("invalid cron `not a cron`" in t for t in texts), (
+        "bad cron ephemeral must name the rejected cron expression — only the "
+        "cron-validation branch can produce this text, unlike a bare :x:"
+    )

--- a/packages/adapters/slack/tests/routines_panel/test_routines_delete_submission.py
+++ b/packages/adapters/slack/tests/routines_panel/test_routines_delete_submission.py
@@ -30,8 +30,6 @@ _ROOT_VIEW_ID = "V_ROOT"
 
 def _build_runtime(db_session_factory: Any) -> SlackRuntime:
     settings: MagicMock = MagicMock()
-    # Prod default so the re-gate exercises the real admin-OR-creator path.
-    settings.slack.dev_allow_all_admin = False
     return SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(make_fake_ma_handler()),

--- a/packages/adapters/slack/tests/test_admin.py
+++ b/packages/adapters/slack/tests/test_admin.py
@@ -128,23 +128,3 @@ async def test_resolve_is_admin_returns_false_and_does_not_raise_on_slack_api_er
         result = await resolve_is_admin(client, user_id="U_TEST")
 
     assert result is False, "resolve_is_admin should return False (fail-closed) on SlackApiError"
-
-
-@pytest.mark.asyncio
-async def test_resolve_is_admin_returns_true_when_dev_allow_all_set_without_calling_users_info() -> (
-    None
-):
-    """dev_allow_all short-circuits to True before any users.info I/O.
-
-    Testing-only escape hatch (DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN). No users.info
-    response is registered, so if the function attempted the call it would raise —
-    reaching True proves the short-circuit skips the network entirely (and works
-    even when the bot lacks the users:read scope).
-    """
-    from slack_sdk.web.async_client import AsyncWebClient
-
-    with AioResponsesMock():
-        client = AsyncWebClient(token="xoxb-test")
-        result = await resolve_is_admin(client, user_id="U_NOBODY", dev_allow_all=True)
-
-    assert result is True, "dev_allow_all=True should grant admin without consulting users.info"

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -58,6 +58,7 @@ from daimon.testing.ma import (
 )
 from daimon.testing.ma import build_fake_anthropic
 from pydantic import SecretStr
+from slack_sdk.errors import SlackApiError
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -1149,6 +1150,506 @@ async def test_orchestrate_queue_coalesce_when_thread_in_flight_adds_hourglass_a
     assert mock_deliver_outputs.await_count == 2, (
         "a delivery failure is isolated inside a detached sweep task, so the "
         "queued turn never waited for it and both turns still swept"
+    )
+
+
+async def test_drain_partitions_queued_mentions_by_author_when_two_users_queue_in_one_thread(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """Two users queueing behind one in-flight turn drain as TWO turns, one
+    per author — never one composite turn under the first author's identity.
+
+    Coalescing distinct authors would run B's instructions inside A's session,
+    under A's vault token and Slack visibility, billed to A. The assertion is
+    on the sequence of ``external_id`` values reaching principal resolution:
+    each turn must resolve its own author.
+    """
+    team_id = "T_DRAIN_PARTITION"
+    channel = "C_TEST"
+    thread_ts = "9000000009.000001"
+    event_ts1 = "9000000009.000001"
+    event_ts2 = "9000000009.000002"
+    event_ts3 = "9000000009.000003"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+
+    app, _ = _make_orchestrate_app(db_session_factory)
+
+    turn_count = 0
+    # Gate that pauses the first run_turn call so event2 can arrive while task1
+    # is in-flight.  The test sets this after sending event2.
+    first_turn_gate = asyncio.Event()
+
+    async def _fake_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+        nonlocal turn_count
+        turn_count += 1
+        if turn_count == 1:
+            await first_turn_gate.wait()  # guaranteed suspension — event2 arrives here
+        # ToolUseBlock so the tool-use-gated output sweep runs for both turns.
+        state = TurnState(
+            content=[
+                ToolUseBlock(
+                    kind="tool_use", id="tu_part", type="agent.tool_use", name="bash", input={}
+                ),
+                TextBlock(kind="text", text="Partitioned response"),
+            ]
+        )
+        await lifecycle.on_terminal_success(state)
+        return state
+
+    event1: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": event_ts1,
+        "event_ts": event_ts1,
+        "channel": channel,
+        "user": "U_TEST_A",
+        "text": "<@U_BOT> first",
+    }
+    event2: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": event_ts2,
+        "thread_ts": thread_ts,
+        "event_ts": event_ts2,
+        "channel": channel,
+        "user": "U_TEST_B",
+        "text": "<@U_BOT> second",
+    }
+    event3: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": event_ts3,
+        "thread_ts": thread_ts,
+        "event_ts": event_ts3,
+        "channel": channel,
+        "user": "U_TEST_A",
+        "text": "<@U_BOT> third",
+    }
+
+    # Patch all store functions so concurrent tasks don't share the single test connection.
+    # The coalesce test verifies queue/drain logic, not DB correctness (that is tested
+    # in test_orchestrate_first_turn_*).
+    fake_principal = MagicMock()
+    fake_principal.account_id = uuid.uuid4()
+    resolved_authors: list[str] = []
+    fake_row = MagicMock()
+    fake_row.id = uuid.uuid4()
+
+    with (
+        patch(
+            "daimon.core.turn.admission.get_or_create_platform_principal", new_callable=AsyncMock
+        ) as mock_principal,
+        patch(
+            "daimon.core.turn.prepare.get_live_thread_session", new_callable=AsyncMock
+        ) as mock_get_session,
+        patch(
+            "daimon.core.turn.prepare.create_thread_session", new_callable=AsyncMock
+        ) as mock_create_ts,
+        patch("daimon.adapters.slack.app.update_watermark", new_callable=AsyncMock),
+        patch("daimon.core.turn.admission.reconcile_tenant_defaults", new_callable=AsyncMock),
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch(
+            "daimon.adapters.slack.app.deliver_session_outputs", new_callable=AsyncMock
+        ) as mock_deliver_outputs,
+    ):
+
+        async def _capture_principal(*_args: Any, **kwargs: Any) -> Any:
+            resolved_authors.append(str(kwargs["external_id"]))
+            return fake_principal
+
+        mock_principal.side_effect = _capture_principal
+        mock_get_session.return_value = None  # simulate new thread each time
+        mock_create_ts.return_value = fake_row
+        mock_resolve_agent.return_value = "agent_partition_id"
+        mock_resolve_env.return_value = "env_partition_id"
+        _now_p = datetime.now(UTC)
+        _agent_snap_p = BetaManagedAgentsSessionAgent(
+            id="agent_partition_id",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        )
+        mock_create_session.return_value = BetaManagedAgentsSession(
+            outcome_evaluations=[],
+            id="sess-partition-001",
+            agent=_agent_snap_p,
+            created_at=_now_p,
+            environment_id="env_partition_id",
+            metadata={},
+            resources=[],
+            stats=BetaManagedAgentsSessionStats(),
+            status="idle",
+            type="session",
+            updated_at=_now_p,
+            usage=BetaManagedAgentsSessionUsage(),
+            vault_ids=[],
+        )
+        mock_run_turn.side_effect = _fake_run_turn
+        mock_deliver_outputs.side_effect = [RuntimeError("delivery exploded"), None, None]
+
+        # Start the first orchestrate as a background task.
+        task1 = asyncio.create_task(
+            app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+                event1,
+                team_id=team_id,
+                channel=channel,
+                event_ts=event_ts1,
+                web_client=fake_slack_web_client.client,
+                tenant_id=tenant_id,
+            )
+        )
+        # Yield to the event loop so task1 runs past _processing.add(thread_id)
+        # and suspends inside run_turn at first_turn_gate.wait().
+        await asyncio.sleep(0)
+
+        # Second mention arrives while the first turn is in flight (task1 is
+        # paused at first_turn_gate — thread_id is in _processing).
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            event2,
+            team_id=team_id,
+            channel=channel,
+            event_ts=event_ts2,
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+        )
+
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            event3,
+            team_id=team_id,
+            channel=channel,
+            event_ts=event_ts3,
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+        )
+
+        # Release task1 to complete the first turn and drain the queue.
+        first_turn_gate.set()
+
+        # Wait for task1 to complete (it also drains the queue).
+        await task1
+
+        # Drain the detached output sweeps before asserting on delivery calls.
+        # The sleep(0) yields so the tasks' call_soon-scheduled done-callbacks
+        # (the _bg_tasks discards) actually run — gather over already-done
+        # tasks completes without ever yielding to the event loop.
+        while app._bg_tasks:  # pyright: ignore[reportPrivateUsage]
+            await asyncio.gather(
+                *list(app._bg_tasks),  # pyright: ignore[reportPrivateUsage]
+                return_exceptions=True,
+            )
+            await asyncio.sleep(0)
+
+    # Assert ⌛ reactions were added for both queued mentions.
+    reactions_calls = [
+        req
+        for (method, url), reqs in fake_slack_web_client.mock.requests.items()
+        if method == "POST" and url.path == "/api/reactions.add"
+        for req in reqs
+    ]
+    assert len(reactions_calls) >= 2, (
+        "reactions_add must be called with 'hourglass_flowing_sand' for each queued mention"
+    )
+
+    assert turn_count == 3, (
+        "three turns must run — the initial A turn plus one drain turn per "
+        f"distinct queued author, got {turn_count}"
+    )
+    assert resolved_authors == ["U_TEST_A", "U_TEST_B", "U_TEST_A"], (
+        "each drained turn must resolve its OWN author's principal; a composite "
+        "turn would resolve U_TEST_A twice and never resolve U_TEST_B "
+        f"(confused deputy), got {resolved_authors}"
+    )
+
+
+async def _drive_drain(
+    app: Any,
+    *,
+    team_id: str,
+    channel: str,
+    thread_ts: str,
+    tenant_id: uuid.UUID,
+    web_client: Any,
+    root_event: dict[str, Any],
+    queued_events: list[dict[str, Any]],
+    turn_side_effect: Any = None,
+) -> list[dict[str, Any]]:
+    """Run one _orchestrate whose first turn is held open while `queued_events`
+    arrive, then release it so the drain loop runs.
+
+    Returns one record per _run_thread_turn call: the author, the composed
+    content override, and the files that reached that turn. _run_thread_turn is
+    the drain loop's only output, so it is the honest observable for "which
+    turns ran, for whom, with what" — the question this whole partition exists
+    to answer.
+    """
+    calls: list[dict[str, Any]] = []
+    first_turn_gate = asyncio.Event()
+
+    async def _spy_turn(event: dict[str, Any], **kwargs: Any) -> None:
+        calls.append(
+            {
+                "user": event.get("user"),
+                "content_override": kwargs.get("content_override"),
+                "files": kwargs.get("files") or [],
+            }
+        )
+        if len(calls) == 1:
+            await first_turn_gate.wait()
+        elif turn_side_effect is not None:
+            turn_side_effect(event)
+
+    app._run_thread_turn = _spy_turn  # type: ignore[method-assign]
+
+    task = asyncio.create_task(
+        app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            root_event,
+            team_id=team_id,
+            channel=channel,
+            event_ts=str(root_event["event_ts"]),
+            web_client=web_client,
+            tenant_id=tenant_id,
+        )
+    )
+    await asyncio.sleep(0)  # let task reach the gate inside the first turn
+
+    for ev in queued_events:
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            ev,
+            team_id=team_id,
+            channel=channel,
+            event_ts=str(ev["event_ts"]),
+            web_client=web_client,
+            tenant_id=tenant_id,
+        )
+
+    first_turn_gate.set()
+    await task
+    return calls
+
+
+def _mention(
+    *,
+    ts: str,
+    user: str | None,
+    text: str,
+    channel: str,
+    thread_ts: str | None = None,
+    files: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    ev: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": ts,
+        "event_ts": ts,
+        "channel": channel,
+        "text": text,
+    }
+    if user is not None:
+        ev["user"] = user
+    if thread_ts is not None:
+        ev["thread_ts"] = thread_ts
+    if files is not None:
+        ev["files"] = files
+    return ev
+
+
+async def test_drain_merges_each_authors_files_and_never_crosses_them_between_authors(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """Files must follow their author into that author's turn, and only there.
+
+    The partition merges files across all of one author's queued events; a
+    regression that used only user_events[0] would silently drop files on their
+    later mentions, and one that kept the old flat _collect_files(queued) would
+    hand A's upload to B's session.
+    """
+    team_id, channel = "T_DRAIN_FILES", "C_TEST"
+    thread_ts = "9100000001.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    app, _ = _make_orchestrate_app(db_session_factory)
+
+    calls = await _drive_drain(
+        app,
+        team_id=team_id,
+        channel=channel,
+        thread_ts=thread_ts,
+        tenant_id=tenant_id,
+        web_client=fake_slack_web_client.client,
+        root_event=_mention(ts=thread_ts, user="U_A", text="<@U_BOT> root", channel=channel),
+        queued_events=[
+            _mention(
+                ts="9100000001.000002",
+                user="U_A",
+                text="<@U_BOT> a1",
+                channel=channel,
+                thread_ts=thread_ts,
+                files=[{"id": "F_A1"}],
+            ),
+            _mention(
+                ts="9100000001.000003",
+                user="U_B",
+                text="<@U_BOT> b1",
+                channel=channel,
+                thread_ts=thread_ts,
+                files=[{"id": "F_B1"}],
+            ),
+            _mention(
+                ts="9100000001.000004",
+                user="U_A",
+                text="<@U_BOT> a2",
+                channel=channel,
+                thread_ts=thread_ts,
+                files=[{"id": "F_A2"}],
+            ),
+        ],
+    )
+
+    drained = calls[1:]
+    by_user = {c["user"]: c for c in drained}
+    assert set(by_user) == {"U_A", "U_B"}, (
+        f"exactly one drained turn per distinct author, got {[c['user'] for c in drained]}"
+    )
+    assert [f["id"] for f in by_user["U_A"]["files"]] == ["F_A1", "F_A2"], (
+        "U_A's turn must carry files from BOTH of their queued mentions, in "
+        f"arrival order, got {by_user['U_A']['files']}"
+    )
+    assert [f["id"] for f in by_user["U_B"]["files"]] == ["F_B1"], (
+        f"U_B's turn must carry only their own file, got {by_user['U_B']['files']}"
+    )
+
+
+async def test_drain_runs_remaining_authors_when_one_authors_turn_raises(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """One author's failure must not consume the others' mentions.
+
+    Their events are already popped from _pending, so the finally-block notice
+    cannot reach them — without per-author isolation they vanish with no turn
+    and no message at all.
+    """
+    team_id, channel = "T_DRAIN_ISOLATE", "C_TEST"
+    thread_ts = "9100000002.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    app, _ = _make_orchestrate_app(db_session_factory)
+
+    def _explode_for_a(event: dict[str, Any]) -> None:
+        if event.get("user") == "U_A":
+            raise SlackApiError("boom", response={"ok": False, "error": "internal_error"})
+
+    calls = await _drive_drain(
+        app,
+        team_id=team_id,
+        channel=channel,
+        thread_ts=thread_ts,
+        tenant_id=tenant_id,
+        web_client=fake_slack_web_client.client,
+        root_event=_mention(ts=thread_ts, user="U_ROOT", text="<@U_BOT> root", channel=channel),
+        queued_events=[
+            _mention(
+                ts="9100000002.000002",
+                user="U_A",
+                text="<@U_BOT> a",
+                channel=channel,
+                thread_ts=thread_ts,
+            ),
+            _mention(
+                ts="9100000002.000003",
+                user="U_B",
+                text="<@U_BOT> b",
+                channel=channel,
+                thread_ts=thread_ts,
+            ),
+        ],
+        turn_side_effect=_explode_for_a,
+    )
+
+    attempted = [c["user"] for c in calls[1:]]
+    assert attempted == ["U_A", "U_B"], (
+        "U_B's turn must still be attempted after U_A's raised; a bare await "
+        f"would abandon the rest of the queue, got {attempted}"
+    )
+    posts = [
+        req
+        for (method, url), reqs in fake_slack_web_client.mock.requests.items()
+        if method == "POST" and url.path == "/api/chat.postMessage"
+        for req in reqs
+    ]
+
+    assert any("something went wrong" in str(r.kwargs) for r in posts), (
+        "the author whose turn raised must be told, not silently dropped"
+    )
+
+
+async def test_drain_skips_an_event_with_no_author_and_still_runs_the_real_ones(
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """An event with no `user` must not form its own turn.
+
+    Partitioning on a defaulted "" would resolve a principal for the empty
+    string and bill a phantom account. Discord cannot reach this state because
+    a Message always has an author.
+    """
+    team_id, channel = "T_DRAIN_NOAUTHOR", "C_TEST"
+    thread_ts = "9100000003.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    app, _ = _make_orchestrate_app(db_session_factory)
+
+    calls = await _drive_drain(
+        app,
+        team_id=team_id,
+        channel=channel,
+        thread_ts=thread_ts,
+        tenant_id=tenant_id,
+        web_client=fake_slack_web_client.client,
+        root_event=_mention(ts=thread_ts, user="U_ROOT", text="<@U_BOT> root", channel=channel),
+        queued_events=[
+            _mention(
+                ts="9100000003.000002",
+                user=None,
+                text="<@U_BOT> ghost",
+                channel=channel,
+                thread_ts=thread_ts,
+            ),
+            _mention(
+                ts="9100000003.000003",
+                user="U_REAL",
+                text="<@U_BOT> real",
+                channel=channel,
+                thread_ts=thread_ts,
+            ),
+        ],
+    )
+
+    drained = [c["user"] for c in calls[1:]]
+    assert drained == ["U_REAL"], (
+        f"the authorless event must run no turn at all, got authors {drained}"
     )
 
 

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -272,6 +272,93 @@ async def test_handle_teardown_when_app_uninstalled_archives_tenant_and_deletes_
     )
 
 
+async def test_on_request_when_tokens_revoked_carries_only_oauth_does_not_tear_down() -> None:
+    """A member revoking their own user token must not uninstall the workspace.
+
+    Slack sends tokens_revoked with {"tokens": {"oauth": [...], "bot": [...]}}.
+    The oauth list fires per-member — and daimon triggers it itself from
+    /privacy -> Disconnect, which calls auth_revoke on that member's user
+    token. Routing the whole event to teardown let one Disconnect click delete
+    the bot token and archive the tenant for everyone in the workspace.
+    """
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+
+    torn_down: list[str] = []
+
+    async def _spy_teardown(*, team_id: str) -> None:
+        torn_down.append(team_id)
+
+    app._handle_teardown = _spy_teardown  # type: ignore[method-assign]
+
+    req = _make_events_api_request(
+        event_type="tokens_revoked",
+        extra_event={"tokens": {"oauth": ["U_TEST"]}},
+    )
+    await app.on_request(fake_client, req)  # type: ignore[arg-type]
+
+    pending = list(app._bg_tasks)  # pyright: ignore[reportPrivateUsage]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    assert torn_down == [], (
+        "an oauth-only tokens_revoked is one member's user token, not the "
+        f"install — teardown must not run, got {torn_down}"
+    )
+
+
+async def test_on_request_when_tokens_revoked_carries_bot_tears_down() -> None:
+    """A tokens_revoked naming the bot token IS the install going away."""
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+
+    torn_down: list[str] = []
+
+    async def _spy_teardown(*, team_id: str) -> None:
+        torn_down.append(team_id)
+
+    app._handle_teardown = _spy_teardown  # type: ignore[method-assign]
+
+    req = _make_events_api_request(
+        event_type="tokens_revoked",
+        team_id="T_REVOKED_BOT",
+        extra_event={"tokens": {"oauth": ["U_TEST"], "bot": ["B_TEST"]}},
+    )
+    await app.on_request(fake_client, req)  # type: ignore[arg-type]
+
+    pending = list(app._bg_tasks)  # pyright: ignore[reportPrivateUsage]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    assert torn_down == ["T_REVOKED_BOT"], (
+        f"a bot-token revocation must reach teardown, got {torn_down}"
+    )
+
+
+async def test_on_request_when_app_uninstalled_tears_down() -> None:
+    """The uninstall path is unchanged by the tokens_revoked split."""
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+
+    torn_down: list[str] = []
+
+    async def _spy_teardown(*, team_id: str) -> None:
+        torn_down.append(team_id)
+
+    app._handle_teardown = _spy_teardown  # type: ignore[method-assign]
+
+    req = _make_events_api_request(event_type="app_uninstalled", team_id="T_UNINSTALLED")
+    await app.on_request(fake_client, req)  # type: ignore[arg-type]
+
+    pending = list(app._bg_tasks)  # pyright: ignore[reportPrivateUsage]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    assert torn_down == ["T_UNINSTALLED"], (
+        f"app_uninstalled must still reach teardown unconditionally, got {torn_down}"
+    )
+
+
 async def test_drain_and_close_flips_draining_and_calls_client_close() -> None:
     """drain_and_close sets draining=True and awaits client.close()."""
     fake_client = _FakeSocketClient()
@@ -1650,6 +1737,39 @@ async def test_drain_skips_an_event_with_no_author_and_still_runs_the_real_ones(
     drained = [c["user"] for c in calls[1:]]
     assert drained == ["U_REAL"], (
         f"the authorless event must run no turn at all, got authors {drained}"
+    )
+
+
+async def test_on_request_when_tokens_revoked_carries_an_empty_bot_list_does_not_tear_down() -> (
+    None
+):
+    """`{"bot": []}` is the payload that separates truthiness from key-presence.
+
+    A discriminator written as `"bot" in tokens` would tear the workspace down
+    on an empty list; the guard tests non-emptiness.
+    """
+    fake_client = _FakeSocketClient()
+    app = _make_app()
+
+    torn_down: list[str] = []
+
+    async def _spy_teardown(*, team_id: str) -> None:
+        torn_down.append(team_id)
+
+    app._handle_teardown = _spy_teardown  # type: ignore[method-assign]
+
+    req = _make_events_api_request(
+        event_type="tokens_revoked",
+        extra_event={"tokens": {"oauth": ["U_TEST"], "bot": []}},
+    )
+    await app.on_request(fake_client, req)  # type: ignore[arg-type]
+
+    pending = list(app._bg_tasks)  # pyright: ignore[reportPrivateUsage]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    assert torn_down == [], (
+        f"an empty bot list revokes no bot token — teardown must not run, got {torn_down}"
     )
 
 

--- a/packages/adapters/slack/tests/test_credential_requests.py
+++ b/packages/adapters/slack/tests/test_credential_requests.py
@@ -24,8 +24,7 @@ run_* submissions:
     updated in place and the requester gets an ephemeral.
   - A second submission of a consumed row writes nothing.
   - mcp: missing daimon-mcp configuration refuses BEFORE the consume.
-  - repo: non-admin refused before the consume; an admin (via the dev
-    override, which must reach this gate) binds a public repo.
+  - repo: non-admin refused before the consume; an admin binds a public repo.
   - skill_repo: the pasted token binds the repo and the imported skills are
     attached to the agent the request named.
 """
@@ -33,6 +32,7 @@ run_* submissions:
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -81,6 +81,39 @@ _MESSAGE_TS = "1700000002.000200"
 _EPHEMERAL_URL = yarl.URL("https://slack.com/api/chat.postEphemeral")
 _VIEWS_OPEN_URL = yarl.URL("https://slack.com/api/views.open")
 _CHAT_UPDATE_URL = yarl.URL("https://slack.com/api/chat.update")
+
+_USERS_INFO_PATTERN = re.compile(r"https://slack\.com/api/users\.info.*")
+
+
+def _override_users_info_admin(mock: Any) -> None:
+    """Replace the conftest non-admin users.info stub with an admin one.
+
+    aioresponses matches by insertion order and the conftest baseline is
+    registered with repeat=True, so a plain append never wins — the existing
+    users.info matchers have to be dropped first.
+    """
+    to_remove = [
+        k
+        for k, v in mock._matches.items()  # type: ignore[attr-defined]
+        if getattr(v, "url_or_pattern", None) == _USERS_INFO_PATTERN
+    ]
+    for k in to_remove:
+        del mock._matches[k]  # type: ignore[attr-defined]
+    mock.get(  # pyright: ignore[reportUnknownMemberType]
+        _USERS_INFO_PATTERN,
+        payload={
+            "ok": True,
+            "user": {
+                "id": _USER_ID,
+                "name": "admin",
+                "is_admin": True,
+                "is_owner": False,
+                "is_primary_owner": False,
+            },
+        },
+        repeat=True,
+    )
+
 
 # ---------------------------------------------------------------------------
 # build_credential_modal
@@ -251,16 +284,12 @@ def _build_runtime(
     fernet_key: str,
     db_factory: async_sessionmaker[AsyncSession],
     *,
-    dev_allow_all_admin: bool = False,
     anthropic_handler: Any = None,
 ) -> SlackRuntime:
     settings = MagicMock()
     settings.crypto.keys = (SecretStr(fernet_key),)
     settings.mcp.public_url = None
     settings.mcp.jwt_secret = None
-    # MagicMock attributes are truthy — the admin override must be pinned off
-    # explicitly or every gate test silently runs as a dev-mode admin.
-    settings.slack.dev_allow_all_admin = dev_allow_all_admin
     settings.github.oauth_scopes = ("repo",)
     return SlackRuntime(
         settings=settings,
@@ -604,16 +633,15 @@ async def test_repo_submission_by_admin_binds_a_public_repo(
     db_session_factory: async_sessionmaker[AsyncSession],
     fake_slack_web_client: Any,
 ) -> None:
-    """The dev override reaches the request gate the same way it reaches the
-    panel gate — without it, `resolve_is_admin` reads `users.info` and this
-    non-admin fake refuses before the consume."""
+    """A workspace admin (per users.info) passes the gate and binds the repo."""
     monkeypatch.setattr(credential_requests_mod, "is_public_repo", AsyncMock(return_value=True))
+    _override_users_info_admin(fake_slack_web_client.mock)
     tenant_id, fernet_key = await _seed_team(db_session)
     token = await _seed_request(
         db_session, tenant_id=tenant_id, kind="repo", target="https://github.com/o/r"
     )
     await db_session.commit()
-    runtime = _build_runtime(fernet_key, db_session_factory, dev_allow_all_admin=True)
+    runtime = _build_runtime(fernet_key, db_session_factory)
 
     await run_repo_bind_credential_submission(
         runtime,

--- a/packages/adapters/slack/tests/test_routines_actions.py
+++ b/packages/adapters/slack/tests/test_routines_actions.py
@@ -7,6 +7,7 @@ FakeSlackWebClient from conftest (no AsyncMock on client.* methods).
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Any
 from unittest.mock import MagicMock
@@ -18,7 +19,7 @@ from cryptography.fernet import Fernet
 from daimon.adapters.slack.routines_panel.actions import handle_routine_action
 from daimon.adapters.slack.runtime import SlackRuntime
 from daimon.core.github_credentials import build_multifernet, encrypt_token
-from daimon.core.stores.routines import create_routine, get_routine
+from daimon.core.stores.routines import create_routine, get_routine, record_result
 from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import build_fake_anthropic, make_fake_ma_handler
@@ -32,7 +33,50 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 _TEAM_ID = "T_ACTIONS"
 _USER_ID = "U_CREATOR"
 _OTHER_USER_ID = "U_NON_ADMIN"
+_ADMIN_USER_ID = "U_ADMIN_NON_CREATOR"
 _VIEW_ID = "V_TEST"
+
+# users.info is GET with user= in the query string; the conftest registers a
+# non-admin baseline against this same pattern.
+_USERS_INFO_PATTERN = re.compile(r"https://slack\.com/api/users\.info.*")
+
+
+def _override_users_info_admin(mock: Any) -> None:
+    """Replace the conftest non-admin users.info stub with an admin one.
+
+    aioresponses matches by insertion order and the conftest baseline is
+    registered with repeat=True, so a plain append never wins — the existing
+    users.info matchers have to be dropped first.
+
+    Reaches into aioresponses internals, so it fails loudly when they move: a
+    silent no-op here would leave the non-admin baseline winning and quietly
+    turn every caller into a test of the refusal path.
+    """
+    to_remove = [
+        k
+        for k, v in mock._matches.items()  # type: ignore[attr-defined]
+        if getattr(v, "url_or_pattern", None) == _USERS_INFO_PATTERN
+    ]
+    if not to_remove:
+        raise AssertionError(
+            "no users.info matcher found to override — aioresponses internals moved"
+        )
+    for k in to_remove:
+        del mock._matches[k]  # type: ignore[attr-defined]
+    mock.get(  # pyright: ignore[reportUnknownMemberType]
+        _USERS_INFO_PATTERN,
+        payload={
+            "ok": True,
+            "user": {
+                "id": _ADMIN_USER_ID,
+                "name": "admin",
+                "is_admin": True,
+                "is_owner": False,
+                "is_primary_owner": False,
+            },
+        },
+        repeat=True,
+    )
 
 
 async def _seed_team(
@@ -179,6 +223,14 @@ async def test_handle_routine_action_non_admin_non_creator_leaves_enabled_unchan
     assert after is not None, "routine must still exist"
     assert after.enabled is True, "non-admin/non-creator click must not change enabled state"
 
+    # "enabled is still True" on its own is also what a silently dropped click
+    # looks like, so pin the refusal branch by its own wording.
+    client_fake: Any = fake_slack_web_client
+    bodies = _ephemeral_bodies(client_fake.mock)
+    assert any("can pause or resume this routine" in b for b in bodies), (
+        "the authority refusal must be surfaced to the clicker, not silently dropped"
+    )
+
 
 @pytest.mark.asyncio
 async def test_handle_routine_action_cross_tenant_routine_id_is_refused_with_no_write(
@@ -214,6 +266,14 @@ async def test_handle_routine_action_cross_tenant_routine_id_is_refused_with_no_
         after = await get_routine(s, routine_a.id, tenant_id=tenant_a_id)
     assert after is not None, "routine A must still exist"
     assert after.enabled is True, "cross-tenant routine_id must be refused without any DB write"
+
+    # The clicker IS routine A's creator, so only the tenant scope can refuse
+    # here — pin its wording so a silent no-op cannot pass for the tenant gate.
+    client_fake: Any = fake_slack_web_client
+    bodies = _ephemeral_bodies(client_fake.mock)
+    assert any("This routine no longer exists." in b for b in bodies), (
+        "the tenant gate must refuse via the not-found ephemeral, not silently"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -295,6 +355,13 @@ async def test_handle_routine_action_delete_by_non_admin_non_creator_is_refused(
     )
     assert not views_push_calls, "non-admin non-creator delete must not push a confirm modal"
 
+    # "no modal" alone is also what a silently dropped click looks like, so pin
+    # the refusal branch by its own wording.
+    bodies = _ephemeral_bodies(client_fake.mock)
+    assert any("can delete this routine" in b for b in bodies), (
+        "the authority refusal must be surfaced to the clicker, not silently dropped"
+    )
+
 
 async def test_handle_routines_command_replaces_loading_modal_with_error_on_failure(
     fake_slack_web_client: Any,
@@ -336,3 +403,148 @@ async def test_handle_routines_command_replaces_loading_modal_with_error_on_fail
     text = body["view"]["blocks"][0]["text"]["text"]
     assert "routine store unavailable" in text
     assert "rid:" in text
+
+
+def _output_payload(
+    routine_id: uuid.UUID, *, team_id: str = _TEAM_ID, user_id: str = _USER_ID
+) -> dict[str, object]:
+    return {
+        "team": {"id": team_id},
+        "user": {"id": user_id},
+        "view": {"id": _VIEW_ID, "private_metadata": "C_TEST"},
+        "actions": [
+            {
+                "action_id": f"routine_action:{routine_id}",
+                "selected_option": {"value": "output"},
+            }
+        ],
+    }
+
+
+def _ephemeral_bodies(mock: Any) -> list[str]:
+    """Every chat.postEphemeral body recorded on the fake, as raw strings."""
+    key = ("POST", yarl.URL("https://slack.com/api/chat.postEphemeral"))
+    calls: list[Any] = list(mock.requests.get(key) or [])
+    return [str(call.kwargs) for call in calls]
+
+
+async def test_handle_routine_action_output_by_non_admin_non_creator_does_not_leak_last_output(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """last_result_tail is a scheduled run's agent output and routinely carries
+    business data, so reading it needs the same authority as pausing.
+
+    The branch previously fetched the row and posted its output with no
+    authority check at all, so any workspace member could read any routine's
+    last run.
+    """
+    tenant_id, fernet_key, _ = await _seed_team(db_session, team_id="T_OUT_GATE")
+    routine = await create_routine(
+        db_session,
+        tenant_id=tenant_id,
+        created_by_user_id="U_ORIGINAL_CREATOR",
+        agent_id="agent-z",
+        agent_name="Test Agent",
+        cron_expr="0 * * * *",
+        timezone_="UTC",
+        trigger_message="gated routine",
+        enabled=True,
+    )
+    await db_session.flush()
+    await record_result(db_session, routine.id, tail="Q3 revenue was 4.2M", error=None)
+    await db_session.flush()
+
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    payload = _output_payload(routine.id, team_id="T_OUT_GATE", user_id=_OTHER_USER_ID)
+
+    await handle_routine_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    bodies = _ephemeral_bodies(client_fake.mock)
+    assert not any("Q3 revenue was 4.2M" in b for b in bodies), (
+        "a non-admin non-creator must never receive the routine's last output"
+    )
+    assert any("can read this routine's output" in b for b in bodies), (
+        "the refusal must be surfaced to the clicker, not silently dropped"
+    )
+
+
+async def test_handle_routine_action_output_by_creator_returns_last_output(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """The creator still reads their own routine's output — the gate is
+    admin-or-creator, matching pause/resume/delete, not admin-only."""
+    tenant_id, fernet_key, _ = await _seed_team(db_session, team_id="T_OUT_OK")
+    routine = await create_routine(
+        db_session,
+        tenant_id=tenant_id,
+        created_by_user_id=_USER_ID,
+        agent_id="agent-z",
+        agent_name="Test Agent",
+        cron_expr="0 * * * *",
+        timezone_="UTC",
+        trigger_message="my routine",
+        enabled=True,
+    )
+    await db_session.flush()
+    await record_result(db_session, routine.id, tail="Q3 revenue was 4.2M", error=None)
+    await db_session.flush()
+
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    payload = _output_payload(routine.id, team_id="T_OUT_OK", user_id=_USER_ID)
+
+    await handle_routine_action(runtime, payload)  # type: ignore[arg-type]
+
+    client_fake: Any = fake_slack_web_client
+    bodies = _ephemeral_bodies(client_fake.mock)
+    assert any("Q3 revenue was 4.2M" in b for b in bodies), (
+        "the creator is authorised and must receive the output"
+    )
+
+
+async def test_handle_routine_action_output_by_admin_non_creator_returns_last_output(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: object,
+) -> None:
+    """A workspace admin who did not create the routine still reads its output.
+
+    The gate is admin OR creator. Without this case a regression narrowing it to
+    creator-only would pass: the refusal test uses a non-admin non-creator and
+    the allow test uses the creator, so neither notices the admin arm going away.
+    """
+    client_fake: Any = fake_slack_web_client
+    _override_users_info_admin(client_fake.mock)
+
+    tenant_id, fernet_key, _ = await _seed_team(db_session, team_id="T_OUT_ADMIN")
+    routine = await create_routine(
+        db_session,
+        tenant_id=tenant_id,
+        created_by_user_id="U_ORIGINAL_CREATOR",  # not the clicker
+        agent_id="agent-z",
+        agent_name="Test Agent",
+        cron_expr="0 * * * *",
+        timezone_="UTC",
+        trigger_message="someone else's routine",
+        enabled=True,
+    )
+    await db_session.flush()
+    await record_result(db_session, routine.id, tail="Q3 revenue was 4.2M", error=None)
+    await db_session.flush()
+
+    runtime = _build_runtime(fernet_key, db_session_factory)
+    payload = _output_payload(routine.id, team_id="T_OUT_ADMIN", user_id=_ADMIN_USER_ID)
+
+    await handle_routine_action(runtime, payload)  # type: ignore[arg-type]
+
+    bodies = _ephemeral_bodies(client_fake.mock)
+    assert any("Q3 revenue was 4.2M" in b for b in bodies), (
+        "a workspace admin is authorised even when they did not create the routine"
+    )
+    assert not any("can read this routine's output" in b for b in bodies), (
+        "an admin must not be shown the creator-or-admin refusal"
+    )

--- a/packages/adapters/slack/tests/test_routines_actions.py
+++ b/packages/adapters/slack/tests/test_routines_actions.py
@@ -55,9 +55,6 @@ async def _seed_team(
 def _build_runtime(fernet_key: str, db_factory: async_sessionmaker[AsyncSession]) -> SlackRuntime:
     settings = MagicMock()
     settings.crypto.keys = (SecretStr(fernet_key),)
-    # Prod default: no dev admin override, so the delete gate exercises the real
-    # admin-OR-creator path (MagicMock would otherwise make this truthy).
-    settings.slack.dev_allow_all_admin = False
     return SlackRuntime(
         settings=settings,
         anthropic=build_fake_anthropic(make_fake_ma_handler()),

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -234,15 +234,6 @@ class SlackSettings(BaseModel):
             "scheduler process (8082) — all process groups share one host."
         ),
     )
-    dev_allow_all_admin: bool = Field(
-        default=False,
-        description=(
-            "Testing-only flag: when True, treats every Slack user as a "
-            "workspace admin, bypassing the normal admin lookup, so a "
-            "non-admin tester can exercise agent CRUD on a test deployment. "
-            "Must stay unset in production."
-        ),
-    )
 
 
 class GithubSettings(BaseModel):


### PR DESCRIPTION
## Summary

Five independent security fixes in the Slack adapter, one commit each, plus a changelog entry.

The largest is a confused-deputy hole in the mention drain loop: mentions queued behind an in-flight turn were coalesced into a single turn regardless of author, so a second member's instructions executed inside the first member's session — under their vault token and Slack visibility, billed to them, with the second member's own per-user cap never evaluated. Discord closed exactly this in `_drain_pending_mentions` ("One turn = one caller"); Slack never did.

The rest close a workspace-wide teardown any single member could trigger, a testing-only flag that opened ~25 admin gates for every member of every install, an unguarded delete path for the deployment's built-in agent, and an ungated read of scheduled-run output.

One commit is breaking: `DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN` is removed.

## Commits

1. **`fix(slack): partition the drain queue by author`** — one turn per author, first-seen order. Files are scoped to the author whose turn they run in, and merge across all of that author's queued events. One author's failure no longer consumes the others' mentions (their events are already popped from `_pending`, so the `finally` notice cannot reach them — they would vanish with no turn and no message). An event with no author is skipped rather than partitioned under `""`, which would resolve a principal for the empty string and bill a phantom account.
2. **`fix(slack): only tear down the install when tokens_revoked names the bot token`** — Slack also emits `tokens_revoked` when one member revokes their own user token, which daimon triggers itself from `/privacy` → Disconnect. The teardown now requires a non-empty `bot` list. `app_uninstalled` is untouched and still tears down unconditionally; the dangerous direction here is missing a real uninstall.
3. **`fix(agent-setup): refuse deletion of defaults-managed agents`** — both adapters refuse server-side before `agents.archive`. Discord's greyed-out button was client-side only; the Slack panel offered deletion outright. Slack additionally checks the marker inline and posts an ephemeral, because the block-actions boundary only logs and Sentry-captures — without it the refusal is invisible and the admin just sees nothing happen.
4. **`fix(slack)!: delete the dev_allow_all_admin escape hatch`** — **breaking.** `resolve_is_admin` is now `(client, *, user_id)` and always calls `users.info`, still fail-closed on `SlackApiError`.
5. **`fix(slack): gate the routines output branch on admin-or-creator`** — same authority as pause/resume/delete.
6. **`docs(changelog)`**

## Breaking change / upgrade note

`DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN` is gone. `Settings` carries `extra="ignore"`, so a deployment that still sets it **boots normally** — the variable is silently dropped and every Slack admin gate begins enforcing. Remove it from your environment, and promote a real workspace admin for any account that relied on it.

## Scope — what this does not fix

- `/routines` still opens for every workspace member and still lists every routine's trigger message. Only the last-run output is now gated. Admin-gating the whole panel would strand non-admin creators, because Slack's chat-side routine tools are admin-tagged and unreachable — that trade-off needs a decision, not a drive-by fix.
- The Discord panel's Delete button stays client-side-disabled. The server-side refusal is the fix; making Slack's roster carry the managed flag so its button can be disabled too is separate.

## Testing

Fourteen new tests across the five fixes, all transport-level fakes (`aioresponses` for Slack, `httpx.MockTransport` for the Anthropic SDK) against real Postgres — no method-level mocks on `client.beta.*`. Every fix was verified red before the change, and each of the six commits was tested in isolation in a separate worktree.

Two tests worth calling out because they were written to fail for the right reason:

- The delete-refusal tests record which agent ids MA was asked to archive and assert `archived_ids == []`, proving the guard fires *before* the archive call rather than merely that something raised.
- The routines output gate is pinned by three cases — non-admin non-creator refused, creator allowed, admin-non-creator allowed. Narrowing the gate to creator-only fails the third; nothing previously caught that.

A review pass also found three pre-existing refusal tests whose only assertions were negatives (`enabled is True`, `not views_push_calls`) — satisfied by any silent no-op, including a missing token or an unparseable id. Each now also asserts its refusal text reaches the clicker. One test in this branch had become vacuous when the flag was removed (it asserted on a bare `:x:` that the non-admin refusal also emits); it now asserts the cron-specific text.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally — 4918 passed, 4 skipped
- [x] `uv run pyright` passes locally (strict mode) — 0 errors
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes — 6 contracts kept, 0 broken
