### PR TITLE
fix(core): refuse the workspace nuke unless the workspace is marked disposable

### DIFF
--- a/packages/adapters/cli/tests/contract_flows/conftest.py
+++ b/packages/adapters/cli/tests/contract_flows/conftest.py
@@ -24,6 +24,7 @@ from daimon.core._models import Base
 from daimon.core.config import Settings
 from daimon.core.ma import delete_entire_workspace_for_testing
 from daimon.testing.factories import make_tenant
+from daimon.testing.workspace_sentinel import require_disposable_workspace
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -129,6 +130,7 @@ async def seed_tenant(db_session_factory: async_sessionmaker[AsyncSession]) -> N
 @pytest_asyncio.fixture(scope="module", autouse=True)
 async def _cleanup(anthropic_client: AsyncAnthropic) -> AsyncIterator[None]:  # pyright: ignore[reportUnusedFunction]
     """Nuke all MA resources before and after each test module."""
+    await require_disposable_workspace(anthropic_client)
     await delete_entire_workspace_for_testing(
         anthropic_client, i_understand_this_destroys_all_tenants=True
     )

--- a/packages/core/daimon/core/defaults/metadata.py
+++ b/packages/core/daimon/core/defaults/metadata.py
@@ -13,6 +13,12 @@ MA_METADATA_KEY_ACCOUNT = "daimon_account"
 MA_METADATA_KEY_MANAGED = "daimon_managed"
 MA_METADATA_KEY_SPEC_HASH = "daimon_spec_hash"
 
+# Marks a whole MA workspace as a throwaway one that the test-only workspace
+# nuke is allowed to empty. Stamped on a single sentinel agent, never on a
+# tenant resource — see `daimon.core.ma.find_workspace_disposable_sentinel`.
+MA_METADATA_KEY_WORKSPACE = "daimon_workspace"
+MA_METADATA_VALUE_WORKSPACE_DISPOSABLE = "disposable"
+
 
 def compute_spec_fingerprint(payload: dict[str, Any]) -> str:
     """Stable short digest of a JSON-serializable payload.

--- a/packages/core/daimon/core/ma.py
+++ b/packages/core/daimon/core/ma.py
@@ -241,14 +241,50 @@ async def delete_skill_and_versions(anthropic: AsyncAnthropic, skill_id: str) ->
     await anthropic.beta.skills.delete(skill_id)
 
 
+# Name of the agent that marks a workspace as disposable. Only the metadata
+# decides — the name is a courtesy to whoever finds the agent in the console.
+WORKSPACE_SENTINEL_AGENT_NAME = "workspace-disposable-sentinel"
+
+WORKSPACE_NOT_DISPOSABLE_MESSAGE = (
+    "Refusing to empty this Managed Agents workspace: it is not marked disposable, "
+    "so the destructive cleanup stopped before deleting anything. The marker exists "
+    "so that a misrouted API key cannot wipe a shared workspace other installs depend "
+    "on. If this workspace really is a throwaway one, mark it with: "
+    "uv run python -m daimon.testing.mark_disposable --yes"
+)
+
+
+async def find_workspace_disposable_sentinel(
+    client: AsyncAnthropic,
+) -> BetaManagedAgentsAgent | None:
+    """Return the agent marking this MA workspace as disposable, else None.
+
+    The sentinel is workspace-wide, not tenant-scoped: it answers "may the test
+    suite destroy everything reachable from this API key?" and nothing else.
+    """
+    from daimon.core.defaults.metadata import (  # noqa: PLC0415
+        MA_METADATA_KEY_WORKSPACE,
+        MA_METADATA_VALUE_WORKSPACE_DISPOSABLE,
+    )
+
+    async for agent in client.beta.agents.list(limit=100):
+        if agent.metadata.get(MA_METADATA_KEY_WORKSPACE) == MA_METADATA_VALUE_WORKSPACE_DISPOSABLE:
+            return agent
+    return None
+
+
 async def delete_entire_workspace_for_testing(
     client: AsyncAnthropic, *, i_understand_this_destroys_all_tenants: bool = False
 ) -> None:
     """Delete every skill/environment/agent in the shared MA workspace.
 
     DESTRUCTIVE — the workspace is shared by ALL tenants on the operator's one
-    API key. Test-only: the required flag must be set True by the caller; a
-    production path that forgets it raises RuntimeError before any MA call.
+    API key. Test-only, and fail-closed twice over: the caller must set the
+    required flag (a production path that forgets it raises RuntimeError before
+    any MA call), AND the workspace itself must carry a disposable sentinel
+    agent (see `find_workspace_disposable_sentinel`). The flag alone is worth
+    little — the caller that passes it is the same caller that would be pointed
+    at the wrong workspace. The sentinel travels with the workspace instead.
 
     Deletion order is dependency-safe: skills (versions first via
     delete_skill_and_versions) → environments (delete, 409 fallback to archive)
@@ -264,6 +300,9 @@ async def delete_entire_workspace_for_testing(
             "for ALL tenants; pass i_understand_this_destroys_all_tenants=True "
             "from a test."
         )
+    sentinel = await find_workspace_disposable_sentinel(client)
+    if sentinel is None:
+        raise DaimonError(WORKSPACE_NOT_DISPOSABLE_MESSAGE)
     errors: list[Exception] = []
 
     # Skills: versions first (MA requires this), then skill.
@@ -295,8 +334,12 @@ async def delete_entire_workspace_for_testing(
             elif err.status_code != 404:
                 errors.append(err)
 
-    # Agents: archive only — DELETE /v1/agents/{id} returns 404
+    # Agents: archive only — DELETE /v1/agents/{id} returns 404.
+    # The sentinel is spared: archiving it would un-mark the workspace and make
+    # the next module's pre-clean refuse.
     async for agent in client.beta.agents.list(limit=100):
+        if agent.id == sentinel.id:
+            continue
         try:
             await client.beta.agents.archive(agent.id)
         except APIStatusError as err:

--- a/packages/core/tests/contracts/conftest.py
+++ b/packages/core/tests/contracts/conftest.py
@@ -23,7 +23,10 @@ import uvicorn
 from anthropic import AsyncAnthropic
 from daimon.adapters.mcp.server import create_mcp_app
 from daimon.core.config import Settings
-from daimon.core.ma import delete_entire_workspace_for_testing
+from daimon.core.ma import (
+    delete_entire_workspace_for_testing,
+    find_workspace_disposable_sentinel,
+)
 from daimon.core.skill_zip import build_skill_zip
 from daimon.testing.ma import _require_api_key
 
@@ -39,9 +42,32 @@ async def anthropic_client() -> AsyncAnthropic:
     return AsyncAnthropic(api_key=key)
 
 
+_NOT_DISPOSABLE_BANNER = """
+================================================================================
+THIS SUITE DESTROYS THE ENTIRE MANAGED AGENTS WORKSPACE.
+
+Every skill, environment and agent reachable from DAIMON_TEST_ANTHROPIC_API_KEY
+is deleted before and after each test module. Only ever point that key at a
+disposable dev workspace — never at one any real install depends on.
+
+The workspace behind the current key is NOT marked disposable, so nothing was
+touched. If it genuinely is a throwaway workspace, mark it with:
+
+    uv run python -m daimon.testing.mark_disposable --yes
+================================================================================
+"""
+
+
 @pytest_asyncio.fixture(scope="module", autouse=True)
 async def _cleanup(anthropic_client: AsyncAnthropic) -> AsyncIterator[None]:  # pyright: ignore[reportUnusedFunction]
-    """Module-scoped cleanup: delete all workspace resources before and after."""
+    """Module-scoped cleanup: delete all workspace resources before and after.
+
+    Gated on the disposable sentinel. The sentinel is deliberately NOT created
+    here — auto-marking would make the guard permit exactly the mistake it
+    exists to catch.
+    """
+    if await find_workspace_disposable_sentinel(anthropic_client) is None:
+        pytest.fail(_NOT_DISPOSABLE_BANNER, pytrace=False)
     await delete_entire_workspace_for_testing(
         anthropic_client, i_understand_this_destroys_all_tenants=True
     )

--- a/packages/core/tests/contracts/conftest.py
+++ b/packages/core/tests/contracts/conftest.py
@@ -23,12 +23,10 @@ import uvicorn
 from anthropic import AsyncAnthropic
 from daimon.adapters.mcp.server import create_mcp_app
 from daimon.core.config import Settings
-from daimon.core.ma import (
-    delete_entire_workspace_for_testing,
-    find_workspace_disposable_sentinel,
-)
+from daimon.core.ma import delete_entire_workspace_for_testing
 from daimon.core.skill_zip import build_skill_zip
 from daimon.testing.ma import _require_api_key
+from daimon.testing.workspace_sentinel import require_disposable_workspace
 
 # Each test module in this package must set:
 #   pytestmark = pytest.mark.contract
@@ -42,32 +40,10 @@ async def anthropic_client() -> AsyncAnthropic:
     return AsyncAnthropic(api_key=key)
 
 
-_NOT_DISPOSABLE_BANNER = """
-================================================================================
-THIS SUITE DESTROYS THE ENTIRE MANAGED AGENTS WORKSPACE.
-
-Every skill, environment and agent reachable from DAIMON_TEST_ANTHROPIC_API_KEY
-is deleted before and after each test module. Only ever point that key at a
-disposable dev workspace — never at one any real install depends on.
-
-The workspace behind the current key is NOT marked disposable, so nothing was
-touched. If it genuinely is a throwaway workspace, mark it with:
-
-    uv run python -m daimon.testing.mark_disposable --yes
-================================================================================
-"""
-
-
 @pytest_asyncio.fixture(scope="module", autouse=True)
 async def _cleanup(anthropic_client: AsyncAnthropic) -> AsyncIterator[None]:  # pyright: ignore[reportUnusedFunction]
-    """Module-scoped cleanup: delete all workspace resources before and after.
-
-    Gated on the disposable sentinel. The sentinel is deliberately NOT created
-    here — auto-marking would make the guard permit exactly the mistake it
-    exists to catch.
-    """
-    if await find_workspace_disposable_sentinel(anthropic_client) is None:
-        pytest.fail(_NOT_DISPOSABLE_BANNER, pytrace=False)
+    """Module-scoped cleanup: delete all workspace resources before and after."""
+    await require_disposable_workspace(anthropic_client)
     await delete_entire_workspace_for_testing(
         anthropic_client, i_understand_this_destroys_all_tenants=True
     )

--- a/packages/core/tests/test_ma.py
+++ b/packages/core/tests/test_ma.py
@@ -29,11 +29,18 @@ from anthropic.types.beta.sessions import (
     BetaManagedAgentsTextBlock,
     BetaManagedAgentsUserMessageEvent,
 )
-from daimon.core.errors import TurnError
+from daimon.core.defaults.metadata import (
+    MA_METADATA_KEY_WORKSPACE,
+    MA_METADATA_VALUE_WORKSPACE_DISPOSABLE,
+)
+from daimon.core.errors import DaimonError, TurnError
 from daimon.core.ma import (
     _INTERRUPT_TERMINAL,
     _TERMINAL_STOP_REASONS,
+    WORKSPACE_SENTINEL_AGENT_NAME,
+    delete_entire_workspace_for_testing,
     delete_sessions_for_account,
+    find_workspace_disposable_sentinel,
     replay_events,
     send_interrupt_and_wait,
     terminal_stop_reason,
@@ -706,3 +713,154 @@ async def test_update_agent_with_version_retry_propagates_second_conflict() -> N
 
     assert exc_info.value.status_code == 409, "second conflict must propagate as 409"
     assert update_count == 2, "must attempt exactly two updates before propagating"
+
+
+# ---------------------------------------------------------------------------
+# delete_entire_workspace_for_testing sentinel guard tests
+# ---------------------------------------------------------------------------
+
+
+def _build_workspace_nuke_client(
+    agents: list[BetaManagedAgentsAgent],
+    seen: list[tuple[str, str]],
+) -> AsyncAnthropic:
+    """Transport-level client covering every endpoint the nuke can touch.
+
+    Appends `(method, path)` to `seen` for every request so a test can assert
+    that NOTHING mutating was issued. Every mutating route is registered so an
+    unwanted call shows up in `seen` rather than as an unrouted-request error.
+    """
+    router = MARouter()
+
+    def handle_agents_list(request: httpx.Request, match: Any) -> httpx.Response:
+        return list_response([a.model_dump(mode="json") for a in agents])
+
+    def handle_empty_list(request: httpx.Request, match: Any) -> httpx.Response:
+        return list_response([])
+
+    def handle_agent_archive(request: httpx.Request, match: Any) -> httpx.Response:
+        archived = next(a for a in agents if a.id == match.group(1))
+        return httpx.Response(200, json=archived.model_dump(mode="json"))
+
+    def handle_environment_delete(request: httpx.Request, match: Any) -> httpx.Response:
+        return httpx.Response(200, json={"id": match.group(1), "type": "environment_deleted"})
+
+    router.add("GET", r"/v1/agents", handle_agents_list)
+    router.add("GET", r"/v1/skills", handle_empty_list)
+    router.add("GET", r"/v1/environments", handle_empty_list)
+    router.add("POST", r"/v1/agents/([^/]+)/archive", handle_agent_archive)
+    router.add("DELETE", r"/v1/environments/([^/]+)", handle_environment_delete)
+
+    def record_then_dispatch(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        return router.dispatch(request)
+
+    return build_fake_anthropic(record_then_dispatch)
+
+
+async def test_delete_entire_workspace_raises_and_touches_nothing_when_sentinel_is_absent() -> None:
+    now = datetime.now(UTC).isoformat()
+    tenant_agent = BetaManagedAgentsAgent(
+        id="agent_tenant",
+        archived_at=None,
+        created_at=now,
+        description=None,
+        mcp_servers=[],
+        metadata={"daimon_tenant": str(uuid.uuid4())},
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6"),
+        name="someone-elses-agent",
+        skills=[],
+        system=None,
+        tools=[],
+        type="agent",
+        updated_at=now,
+        version=1,
+    )
+    seen: list[tuple[str, str]] = []
+    client = _build_workspace_nuke_client([tenant_agent], seen)
+
+    with pytest.raises(DaimonError) as exc_info:
+        await delete_entire_workspace_for_testing(
+            client, i_understand_this_destroys_all_tenants=True
+        )
+
+    assert "not marked disposable" in str(exc_info.value), (
+        "the refusal must say why it refused, not just that it failed"
+    )
+    assert "daimon.testing.mark_disposable" in str(exc_info.value), (
+        "the refusal must name the command that marks a workspace disposable"
+    )
+    assert [m for m, _ in seen] == ["GET"], f"an unmarked workspace must see reads only, got {seen}"
+
+
+async def test_delete_entire_workspace_archives_other_agents_but_spares_sentinel() -> None:
+    now = datetime.now(UTC).isoformat()
+    sentinel = BetaManagedAgentsAgent(
+        id="agent_sentinel",
+        archived_at=None,
+        created_at=now,
+        description=None,
+        mcp_servers=[],
+        metadata={MA_METADATA_KEY_WORKSPACE: MA_METADATA_VALUE_WORKSPACE_DISPOSABLE},
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6"),
+        name=WORKSPACE_SENTINEL_AGENT_NAME,
+        skills=[],
+        system=None,
+        tools=[],
+        type="agent",
+        updated_at=now,
+        version=1,
+    )
+    disposable_agent = BetaManagedAgentsAgent(
+        id="agent_disposable",
+        archived_at=None,
+        created_at=now,
+        description=None,
+        mcp_servers=[],
+        metadata={"daimon_tenant": str(uuid.uuid4())},
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6"),
+        name="scratch-agent",
+        skills=[],
+        system=None,
+        tools=[],
+        type="agent",
+        updated_at=now,
+        version=1,
+    )
+    seen: list[tuple[str, str]] = []
+    client = _build_workspace_nuke_client([sentinel, disposable_agent], seen)
+
+    await delete_entire_workspace_for_testing(client, i_understand_this_destroys_all_tenants=True)
+
+    archived_paths = [path for method, path in seen if method == "POST"]
+    assert archived_paths == ["/v1/agents/agent_disposable/archive"], (
+        f"only the non-sentinel agent may be archived, got {archived_paths}"
+    )
+
+
+async def test_find_workspace_disposable_sentinel_returns_none_when_no_agent_carries_the_marker() -> (
+    None
+):
+    now = datetime.now(UTC).isoformat()
+    plain_agent = BetaManagedAgentsAgent(
+        id="agent_plain",
+        archived_at=None,
+        created_at=now,
+        description=None,
+        mcp_servers=[],
+        metadata={"daimon_tenant": str(uuid.uuid4())},
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6"),
+        name="plain-agent",
+        skills=[],
+        system=None,
+        tools=[],
+        type="agent",
+        updated_at=now,
+        version=1,
+    )
+    seen: list[tuple[str, str]] = []
+    client = _build_workspace_nuke_client([plain_agent], seen)
+
+    assert await find_workspace_disposable_sentinel(client) is None, (
+        "a tenant agent without the workspace marker must not count as a sentinel"
+    )

--- a/packages/testing/daimon/testing/mark_disposable.py
+++ b/packages/testing/daimon/testing/mark_disposable.py
@@ -1,0 +1,77 @@
+"""Mark the MA workspace behind DAIMON_TEST_ANTHROPIC_API_KEY as disposable.
+
+    uv run python -m daimon.testing.mark_disposable          # summary only
+    uv run python -m daimon.testing.mark_disposable --yes    # mark it
+
+Prints what is currently in the workspace first, because the only thing this
+command guards against is being pointed at the wrong one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from anthropic import AsyncAnthropic
+from daimon.core.defaults.metadata import MA_METADATA_KEY_TENANT
+from daimon.testing.workspace_sentinel import mark_workspace_disposable
+
+
+async def _summarize_and_mark(*, api_key: str, confirmed: bool) -> int:
+    client = AsyncAnthropic(api_key=api_key)
+
+    agent_count = 0
+    tenant_ids: set[str] = set()
+    async for agent in client.beta.agents.list(limit=100):
+        agent_count += 1
+        tenant_id = agent.metadata.get(MA_METADATA_KEY_TENANT)
+        if tenant_id is not None:
+            tenant_ids.add(tenant_id)
+
+    print(f"agents in this workspace: {agent_count}")
+    print(f"distinct {MA_METADATA_KEY_TENANT} values: {len(tenant_ids)}")
+    for tenant_id in sorted(tenant_ids):
+        print(f"  {tenant_id}")
+
+    if not confirmed:
+        print(
+            "\nMarking this workspace disposable lets the contract test suite DELETE "
+            "every skill, environment and agent in it. If the summary above looks like "
+            "a workspace anyone depends on, stop. Otherwise re-run with --yes."
+        )
+        return 1
+
+    sentinel_id = await mark_workspace_disposable(client)
+    print(f"\nmarked disposable; sentinel agent: {sentinel_id}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m daimon.testing.mark_disposable",
+        description="Mark the MA workspace behind DAIMON_TEST_ANTHROPIC_API_KEY as disposable.",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="confirm; without it the command only prints the workspace summary",
+    )
+    args = parser.parse_args()
+    confirmed: bool = args.yes
+
+    api_key = os.environ.get("DAIMON_TEST_ANTHROPIC_API_KEY")
+    if not api_key:
+        print(
+            "DAIMON_TEST_ANTHROPIC_API_KEY is not set — export the key for the "
+            "workspace you want to mark, then re-run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return asyncio.run(_summarize_and_mark(api_key=api_key, confirmed=confirmed))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/testing/daimon/testing/workspace_sentinel.py
+++ b/packages/testing/daimon/testing/workspace_sentinel.py
@@ -1,0 +1,40 @@
+"""Mark an MA workspace as disposable so the test-only workspace nuke may run.
+
+The marker is a single agent carrying `daimon_workspace=disposable` metadata;
+`daimon.core.ma.delete_entire_workspace_for_testing` refuses to delete anything
+in a workspace that has none.
+"""
+
+from __future__ import annotations
+
+from anthropic import AsyncAnthropic
+from daimon.core.defaults.metadata import (
+    MA_METADATA_KEY_WORKSPACE,
+    MA_METADATA_VALUE_WORKSPACE_DISPOSABLE,
+)
+from daimon.core.ma import (
+    WORKSPACE_SENTINEL_AGENT_NAME,
+    find_workspace_disposable_sentinel,
+)
+
+
+async def mark_workspace_disposable(client: AsyncAnthropic) -> str:
+    """Return the id of this workspace's disposable sentinel, creating it if absent.
+
+    Idempotent: an existing sentinel is reused, so repeat calls never accumulate
+    marker agents. The agent is never run — it exists only to carry the metadata.
+    """
+    existing = await find_workspace_disposable_sentinel(client)
+    if existing is not None:
+        return existing.id
+    created = await client.beta.agents.create(
+        model="claude-haiku-4-5",
+        name=WORKSPACE_SENTINEL_AGENT_NAME,
+        description=(
+            "Marks this workspace as disposable: daimon's contract-test cleanup "
+            "may delete every skill, environment and agent here. Delete this agent "
+            "to withdraw that permission."
+        ),
+        metadata={MA_METADATA_KEY_WORKSPACE: MA_METADATA_VALUE_WORKSPACE_DISPOSABLE},
+    )
+    return created.id

--- a/packages/testing/daimon/testing/workspace_sentinel.py
+++ b/packages/testing/daimon/testing/workspace_sentinel.py
@@ -7,6 +7,7 @@ in a workspace that has none.
 
 from __future__ import annotations
 
+import pytest
 from anthropic import AsyncAnthropic
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_WORKSPACE,
@@ -38,3 +39,34 @@ async def mark_workspace_disposable(client: AsyncAnthropic) -> str:
         metadata={MA_METADATA_KEY_WORKSPACE: MA_METADATA_VALUE_WORKSPACE_DISPOSABLE},
     )
     return created.id
+
+
+_NOT_DISPOSABLE_BANNER = """
+================================================================================
+THIS SUITE DESTROYS THE ENTIRE MANAGED AGENTS WORKSPACE.
+
+Every skill, environment and agent reachable from DAIMON_TEST_ANTHROPIC_API_KEY
+is deleted before and after each test module. Only ever point that key at a
+disposable dev workspace — never at one any real install depends on.
+
+The workspace behind the current key is NOT marked disposable, so nothing was
+touched. If it genuinely is a throwaway workspace, mark it with:
+
+    uv run python -m daimon.testing.mark_disposable --yes
+================================================================================
+"""
+
+
+async def require_disposable_workspace(client: AsyncAnthropic) -> None:
+    """Fail the run unless this MA workspace is marked disposable.
+
+    Every contract-test conftest whose cleanup calls
+    `delete_entire_workspace_for_testing` must call this before its first nuke.
+    It deliberately does NOT create the sentinel: auto-marking would make the
+    guard wave through exactly the mistake it exists to catch.
+
+    Fails rather than skips, unlike `_require_api_key` — a suite aimed at the
+    wrong workspace must be loud, not quietly green.
+    """
+    if await find_workspace_disposable_sentinel(client) is None:
+        pytest.fail(_NOT_DISPOSABLE_BANNER, pytrace=False)

--- a/packages/testing/tests/test_workspace_sentinel.py
+++ b/packages/testing/tests/test_workspace_sentinel.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import httpx
+import pytest
 from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsModelConfig
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_WORKSPACE,
@@ -11,7 +12,10 @@ from daimon.core.defaults.metadata import (
 )
 from daimon.core.ma import WORKSPACE_SENTINEL_AGENT_NAME
 from daimon.testing.ma import MARouter, build_fake_anthropic, json_body, list_response
-from daimon.testing.workspace_sentinel import mark_workspace_disposable
+from daimon.testing.workspace_sentinel import (
+    mark_workspace_disposable,
+    require_disposable_workspace,
+)
 
 
 def _build_agent_crud_client(created: list[dict[str, Any]]) -> Any:
@@ -79,3 +83,24 @@ async def test_mark_workspace_disposable_reuses_existing_sentinel_when_called_tw
 
     assert second_id == first_id, "a second call must adopt the existing sentinel"
     assert len(created) == 1, "marking twice must not accumulate duplicate sentinel agents"
+
+
+async def test_require_disposable_workspace_fails_the_run_when_workspace_is_unmarked() -> None:
+    created: list[dict[str, Any]] = []
+    client = _build_agent_crud_client(created)
+
+    with pytest.raises(pytest.fail.Exception) as exc_info:
+        await require_disposable_workspace(client)
+
+    assert "mark_disposable --yes" in str(exc_info.value), (
+        "the banner must tell the operator how to mark a throwaway workspace"
+    )
+    assert created == [], "the guard must never mark the workspace on the caller's behalf"
+
+
+async def test_require_disposable_workspace_returns_when_sentinel_is_present() -> None:
+    created: list[dict[str, Any]] = []
+    client = _build_agent_crud_client(created)
+    await mark_workspace_disposable(client)
+
+    await require_disposable_workspace(client)

--- a/packages/testing/tests/test_workspace_sentinel.py
+++ b/packages/testing/tests/test_workspace_sentinel.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsModelConfig
+from daimon.core.defaults.metadata import (
+    MA_METADATA_KEY_WORKSPACE,
+    MA_METADATA_VALUE_WORKSPACE_DISPOSABLE,
+)
+from daimon.core.ma import WORKSPACE_SENTINEL_AGENT_NAME
+from daimon.testing.ma import MARouter, build_fake_anthropic, json_body, list_response
+from daimon.testing.workspace_sentinel import mark_workspace_disposable
+
+
+def _build_agent_crud_client(created: list[dict[str, Any]]) -> Any:
+    """Transport-level client whose POST /v1/agents appends to the workspace.
+
+    `created` doubles as the workspace roster returned by GET /v1/agents, so a
+    second call to `mark_workspace_disposable` sees whatever the first created.
+    """
+    router = MARouter()
+
+    def handle_agents_list(request: httpx.Request, match: Any) -> httpx.Response:
+        return list_response(created)
+
+    def handle_agent_create(request: httpx.Request, match: Any) -> httpx.Response:
+        body = json_body(request)
+        now = datetime.now(UTC).isoformat()
+        agent = BetaManagedAgentsAgent(
+            id=f"agent_created_{len(created)}",
+            archived_at=None,
+            created_at=now,
+            description=body.get("description"),
+            mcp_servers=[],
+            metadata=body.get("metadata", {}),
+            model=BetaManagedAgentsModelConfig(id=body["model"]),
+            name=body["name"],
+            skills=[],
+            system=None,
+            tools=[],
+            type="agent",
+            updated_at=now,
+            version=1,
+        ).model_dump(mode="json")
+        created.append(agent)
+        return httpx.Response(200, json=agent)
+
+    router.add("GET", r"/v1/agents", handle_agents_list)
+    router.add("POST", r"/v1/agents", handle_agent_create)
+    return build_fake_anthropic(router.dispatch)
+
+
+async def test_mark_workspace_disposable_creates_a_marked_sentinel_when_workspace_has_none() -> (
+    None
+):
+    created: list[dict[str, Any]] = []
+    client = _build_agent_crud_client(created)
+
+    sentinel_id = await mark_workspace_disposable(client)
+
+    assert len(created) == 1, "an unmarked workspace must gain exactly one sentinel agent"
+    assert created[0]["id"] == sentinel_id, "the returned id must be the created sentinel's"
+    assert created[0]["name"] == WORKSPACE_SENTINEL_AGENT_NAME, (
+        "the sentinel must be findable by name in the MA console"
+    )
+    assert created[0]["metadata"] == {
+        MA_METADATA_KEY_WORKSPACE: MA_METADATA_VALUE_WORKSPACE_DISPOSABLE
+    }, "the marker metadata is what the nuke guard actually reads"
+
+
+async def test_mark_workspace_disposable_reuses_existing_sentinel_when_called_twice() -> None:
+    created: list[dict[str, Any]] = []
+    client = _build_agent_crud_client(created)
+
+    first_id = await mark_workspace_disposable(client)
+    second_id = await mark_workspace_disposable(client)
+
+    assert second_id == first_id, "a second call must adopt the existing sentinel"
+    assert len(created) == 1, "marking twice must not accumulate duplicate sentinel agents"


### PR DESCRIPTION
The contract suites' autouse cleanup deletes every skill, environment, and agent reachable from `DAIMON_TEST_ANTHROPIC_API_KEY` — with nothing checking which workspace that key points at. Point it at the wrong key once and a shared workspace is gone.

`delete_entire_workspace_for_testing` now refuses to run unless the workspace contains a sentinel agent carrying `daimon_workspace: disposable` metadata. Dev workspaces get marked once with `uv run python -m daimon.testing.mark_disposable --yes` (prints agent count and distinct tenants before it does anything). Both contract conftests fail fast with a banner instead of raising mid-fixture, and the sentinel is spared by the cleanup itself so the mark survives runs.

- Guard and sentinel lookup live in core (`ma.py`, metadata constants); the marker helper and CLI live in `daimon.testing`
- Tests: refusal makes zero mutating calls; a marked run spares the sentinel; marking is idempotent
- 64 passed; pyright, ruff, lint-imports, anti-pattern lint all clean