### PR TITLE
feat(slack): cross-process turn liveness — marker, boot sweep, and recovery card adoption

### DIFF
--- a/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
+++ b/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
@@ -55,6 +55,7 @@ from daimon.core.pending_file_sweeper import sweep_pending_file_deletes
 from daimon.core.pricing import MODEL_PRICING
 from daimon.core.scheduler import FireFn, run_one_tick
 from daimon.core.scope import DeploymentDefault
+from daimon.core.slack_event_dedup_sweep import sweep_expired_slack_event_dedup
 from daimon.core.stores.domain import RoutineRow
 from daimon.core.stores.identity import get_or_create_platform_principal
 from daimon.core.stores.routines import record_result, update_routine_agent_id
@@ -324,6 +325,18 @@ async def _sweep_wizard_sessions(sm: async_sessionmaker[AsyncSession]) -> None:
         log.exception("scheduler.wizard_sweep.failed")
 
 
+async def _sweep_slack_event_dedup(sm: async_sessionmaker[AsyncSession]) -> None:
+    """Prune aged slack_event_dedup rows once. Boundary catch: a sweep
+    failure must not kill the scheduler loop — the next tick retries.
+
+    No `anthropic.APIError` in the catch: this sweep makes no upstream call.
+    """
+    try:
+        await sweep_expired_slack_event_dedup(sm, now=datetime.now(UTC))
+    except SQLAlchemyError:
+        log.exception("scheduler.slack_event_dedup_sweep.failed")
+
+
 def _validate_mcp_settings(settings: Settings) -> None:
     """Single-tenant deployments require both ``settings.mcp.jwt_secret`` and
     ``settings.mcp.public_url`` so each routine fire can bind the daimon-mcp
@@ -442,6 +455,7 @@ async def run(
             await _sweep_pending_files(client, sm)
             await _sweep_headless_usage(client, sm, markup=settings.billing.markup)
             await _sweep_wizard_sessions(sm)
+            await _sweep_slack_event_dedup(sm)
             return 0
 
         while not stop_event.is_set():
@@ -457,6 +471,7 @@ async def run(
             await _sweep_pending_files(client, sm)
             await _sweep_headless_usage(client, sm, markup=settings.billing.markup)
             await _sweep_wizard_sessions(sm)
+            await _sweep_slack_event_dedup(sm)
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(
                     stop_event.wait(), timeout=scheduler_settings.tick_interval_s

--- a/packages/adapters/scheduler/tests/test_main.py
+++ b/packages/adapters/scheduler/tests/test_main.py
@@ -26,6 +26,7 @@ from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
 from daimon.adapters.scheduler.main import (
     _build_fire,  # pyright: ignore[reportPrivateUsage]  # test seam for balance gate + debit binding
     _CapsAdapter,  # pyright: ignore[reportPrivateUsage]  # named test seam for cap wiring
+    _sweep_slack_event_dedup,  # pyright: ignore[reportPrivateUsage]  # test seam for the slack_event_dedup sweep wrapper
     _sweep_wizard_sessions,  # pyright: ignore[reportPrivateUsage]  # test seam for the wizard sweep wrapper
     _validate_mcp_settings,  # pyright: ignore[reportPrivateUsage]  # boot-validation seam
 )
@@ -790,4 +791,45 @@ async def test_sweep_wizard_sessions_forwards_sessionmaker_and_returns_cleanly(
 
     assert captured_sm == [db_session_factory], (
         "wrapper must forward the injected sessionmaker to the core sweep unchanged"
+    )
+
+
+async def test_sweep_slack_event_dedup_swallows_sqlalchemy_error(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A SQLAlchemyError from the core sweep must not propagate — the wrapper's
+    named boundary catch exists so a DB hiccup cannot kill the scheduler loop."""
+    with unittest.mock.patch(
+        "daimon.adapters.scheduler.main.sweep_expired_slack_event_dedup",
+        side_effect=SQLAlchemyError("boom"),
+    ):
+        await _sweep_slack_event_dedup(db_session_factory)  # must not raise
+
+
+async def test_sweep_slack_event_dedup_forwards_sessionmaker_and_returns_cleanly(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Happy path: the wrapper forwards the injected sessionmaker to the core
+    sweep and passes a timezone-aware `now`."""
+    captured_sm: list[async_sessionmaker[AsyncSession]] = []
+    captured_now: list[datetime] = []
+
+    async def fake_sweep(
+        sm: async_sessionmaker[AsyncSession], *, now: datetime, limit: int = 500
+    ) -> int:
+        captured_sm.append(sm)
+        captured_now.append(now)
+        return 0
+
+    with unittest.mock.patch(
+        "daimon.adapters.scheduler.main.sweep_expired_slack_event_dedup",
+        side_effect=fake_sweep,
+    ):
+        await _sweep_slack_event_dedup(db_session_factory)
+
+    assert captured_sm == [db_session_factory], (
+        "wrapper must forward the injected sessionmaker to the core sweep unchanged"
+    )
+    assert captured_now[0].tzinfo is not None, (
+        "wrapper must pass a timezone-aware `now` to the core sweep"
     )

--- a/packages/adapters/slack/daimon/adapters/slack/__main__.py
+++ b/packages/adapters/slack/daimon/adapters/slack/__main__.py
@@ -11,10 +11,11 @@ import asyncio
 import contextlib
 import signal
 import sys
+from datetime import UTC, datetime
 
 import structlog
 from daimon.adapters.slack.app import SlackApp
-from daimon.adapters.slack.boot_sweep import run_boot_sweep
+from daimon.adapters.slack.boot_sweep import retire_orphaned_turns, run_boot_sweep
 from daimon.adapters.slack.runtime import build_runtime
 from daimon.core.config import load_settings
 from daimon.core.health import start_liveness_responder
@@ -81,6 +82,26 @@ async def main() -> None:
         log.info("starting_slack_listener", health_port=settings.slack.health_port)
         try:
             await client.connect()
+            # Orphan-turn retirement, created BEFORE the reconcile sweep below.
+            # asyncio.create_task schedules in creation order, and this sweep
+            # does far less work than a per-tenant reconcile at concurrency 2,
+            # so it finishes first in practice — the "a user reading the
+            # thread sees the truth before anything else happens" posture
+            # Discord gets by running its sweep first in on_ready, delivered
+            # here without a second control-flow shape in main(). Crash is
+            # logged, never raised — the listener must outlive its sweep.
+            orphan_sweep_task: asyncio.Task[None] = asyncio.create_task(
+                retire_orphaned_turns(runtime, now=datetime.now(UTC))
+            )
+            _bg_tasks.add(orphan_sweep_task)
+
+            def _on_orphan_sweep_done(task: asyncio.Task[None]) -> None:
+                _bg_tasks.discard(task)
+                if not task.cancelled() and task.exception() is not None:
+                    log.error("slack.orphan_sweep_crashed", exc_info=task.exception())
+
+            orphan_sweep_task.add_done_callback(_on_orphan_sweep_done)
+
             # Boot-time reconcile sweep, in the background so a slow provider
             # cannot delay mention handling. A crash is logged, never raised —
             # the listener must outlive its sweep.

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -1273,8 +1273,10 @@ class SlackApp:
         # Slack-specific copy). The clear runs on any exception, not just the
         # happy path, and covers BOTH prepared.mapping_id and
         # outcome.mapping_id because recovery moves the turn to a new mapping
-        # row and leaves the marker on the old one, still pointing at the same
-        # message -- a ceiling breach is not a special case here either:
+        # row and leaves the marker on the old one -- sufficient because
+        # _recovery_lifecycle adopts the pre-recovery card, so the marker left
+        # on the old mapping row still addresses the card being rendered into.
+        # A ceiling breach is not a special case here either:
         # run_prepared_turn already marked the active mapping dead and returns
         # a normal RunOutcome, so it takes this same path. _deregister_cancel
         # is pop(ts, None), so the double call after on_terminal_success's own
@@ -1472,8 +1474,21 @@ class SlackApp:
                     model_id=_lc_model_id,
                     register=self._register_cancel,
                     deregister=self._deregister_cancel,
+                    # Take over the failed attempt's card so it is edited into
+                    # this turn's answer rather than left standing beside a
+                    # second, successful card.
+                    adopt_status_ts=lifecycle.status_ts,
                 )
                 lifecycle_holder[0] = new_lifecycle
+                # An adopting lifecycle never posts, so it never re-registers
+                # itself -- the entry left by the original post is still bound
+                # to the first attempt's Event, and a click on the adopted card
+                # must stop the turn that is actually running. This rebind is a
+                # plain dict assignment, so re-registering the same key
+                # overwrites in place, and it lands before the recovery turn's
+                # first flush, not after it.
+                if lifecycle.status_ts is not None:
+                    self._register_cancel(lifecycle.status_ts, cancel, str(event.get("user") or ""))
                 return new_lifecycle
 
             async with self.runtime.sessionmaker() as s:

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -1330,8 +1330,8 @@ class SlackApp:
             # Turn marker: message ts + channel + start time, written as soon as
             # the mapping row is known and the card exists (D-03). Slack passes
             # active_turn_channel_id where Discord does not -- a Slack message is
-            # addressed by (channel, ts), so a boot sweep cannot call chat_update
-            # to repair a wedged card without the channel (D-08).
+            # addressed by (channel, ts), so a boot sweep cannot repair a wedged
+            # card without the channel to address the update call (D-08).
             if prepared.mapping_id is not None and lifecycle.status_ts is not None:
                 async with self.runtime.sessionmaker() as _at_session:
                     await mark_turn_active(

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -1112,12 +1112,12 @@ class SlackApp:
         """Turn body: admission → card+Cancel → bind_session → marker → context → turn → watermark.
 
         Immediately after admission, the lifecycle is constructed and its
-        status card + Cancel registration are posted (``post_initial()``, D-01/D-02)
+        status card + Cancel registration are posted (``post_initial()``)
         -- before ``bind_session``, since MA ``sessions.create`` plus the
         interstitial history replay and image download below can hold for
         minutes and the user must see something first. Once ``bind_session``
         returns, the turn marker (message ts, channel, start time) is written
-        against the mapping row (D-03).
+        against the mapping row.
 
         On first mention for a thread: creates a new MA session + ``thread_sessions``
         row, replays thread history via ``build_context_xml`` (one Slack page).
@@ -1247,7 +1247,7 @@ class SlackApp:
         # Post the status card and register Cancel BEFORE bind_session --
         # MA sessions.create plus the history replay and image download below
         # can hold for minutes, and the card must exist before all of that,
-        # not merely before run_prepared_turn (D-01/D-02).
+        # not merely before run_prepared_turn.
         await lifecycle.post_initial()
 
         # Mapping-row ids the turn marker has been written against, tracked
@@ -1268,12 +1268,12 @@ class SlackApp:
         # entry and a turn marker for the life of the process. The stale card
         # left behind by such a failure is deliberately NOT collapsed here --
         # exact Discord parity, and the boundary catch already posts an
-        # in-thread failure notice with a request id (D-07, and the previous
-        # phase's D-08: render through the existing generic error path, no
-        # Slack-specific copy). The clear runs on any exception, not just the
-        # happy path, and covers BOTH prepared.mapping_id and
-        # outcome.mapping_id because recovery moves the turn to a new mapping
-        # row and leaves the marker on the old one -- sufficient because
+        # in-thread failure notice with a request id (rendered through the
+        # existing generic error path, no Slack-specific copy). The clear
+        # runs on any exception, not just the happy path, and covers BOTH
+        # prepared.mapping_id and outcome.mapping_id because recovery moves
+        # the turn to a new mapping row and leaves the marker on the old
+        # one -- sufficient because
         # _recovery_lifecycle adopts the pre-recovery card, so the marker left
         # on the old mapping row still addresses the card being rendered into.
         # A ceiling breach is not a special case here either:
@@ -1330,10 +1330,10 @@ class SlackApp:
             reused = prepared.reused
 
             # Turn marker: message ts + channel + start time, written as soon as
-            # the mapping row is known and the card exists (D-03). Slack passes
+            # the mapping row is known and the card exists. Slack passes
             # active_turn_channel_id where Discord does not -- a Slack message is
             # addressed by (channel, ts), so a boot sweep cannot repair a wedged
-            # card without the channel to address the update call (D-08).
+            # card without the channel to address the update call.
             if prepared.mapping_id is not None and lifecycle.status_ts is not None:
                 async with self.runtime.sessionmaker() as _at_session:
                     await mark_turn_active(

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -113,7 +113,7 @@ from daimon.core.stores.slack_turn_contexts import (
     delete_slack_turn_context,
 )
 from daimon.core.stores.slack_user_tokens import get_slack_user_token
-from daimon.core.stores.thread_sessions import update_watermark
+from daimon.core.stores.thread_sessions import mark_turn_active, update_watermark
 from daimon.core.turn import turn_deadline
 from daimon.core.turn.admission import AdmissionDenied, MissingTurnConfigError, admit
 from daimon.core.turn.gating import should_admit_turn
@@ -1105,7 +1105,15 @@ class SlackApp:
         content_override: str | None = None,
         files: list[SlackFile] | None = None,
     ) -> None:
-        """Turn body: principal → MA session find-or-create → context build → turn → watermark.
+        """Turn body: admission → card+Cancel → bind_session → marker → context → turn → watermark.
+
+        Immediately after admission, the lifecycle is constructed and its
+        status card + Cancel registration are posted (``post_initial()``, D-01/D-02)
+        -- before ``bind_session``, since MA ``sessions.create`` plus the
+        interstitial history replay and image download below can hold for
+        minutes and the user must see something first. Once ``bind_session``
+        returns, the turn marker (message ts, channel, start time) is written
+        against the mapping row (D-03).
 
         On first mention for a thread: creates a new MA session + ``thread_sessions``
         row, replays thread history via ``build_context_xml`` (one Slack page).
@@ -1214,6 +1222,30 @@ class SlackApp:
         _lc_agent_name: str = agent.name
         _lc_model_id: str = agent.model.id
 
+        # lifecycle_holder tracks whichever SlackTurnLifecycle actually
+        # completed the turn -- recovery_lifecycle rebuilds a fresh one against
+        # the recreated session, and the watermark write further down must read
+        # final_ts off THAT lifecycle, not the pre-recovery one.
+        cancel_event = asyncio.Event()
+        lifecycle = SlackTurnLifecycle(
+            client=web_client,
+            channel=channel,
+            thread_ts=thread_id,
+            cancel=cancel_event,
+            author_id=str(event.get("user") or ""),
+            agent_name=_lc_agent_name,
+            model_id=_lc_model_id,
+            register=self._register_cancel,
+            deregister=self._deregister_cancel,
+        )
+        lifecycle_holder: list[SlackTurnLifecycle] = [lifecycle]
+
+        # Post the status card and register Cancel BEFORE bind_session --
+        # MA sessions.create plus the history replay and image download below
+        # can hold for minutes, and the card must exist before all of that,
+        # not merely before run_prepared_turn (D-01/D-02).
+        await lifecycle.post_initial()
+
         # One shared ceiling deadline for THIS turn, computed once the clock
         # starts (D-03/D-04): right after admission passes, not before --
         # admit() itself is deliberately outside the ceiling. Passed as the
@@ -1255,6 +1287,23 @@ class SlackApp:
         ma_session_id = prepared.ma_session_id
         watermark = prepared.watermark
         reused = prepared.reused
+
+        # Turn marker: message ts + channel + start time, written as soon as
+        # the mapping row is known and the card exists (D-03). Slack passes
+        # active_turn_channel_id where Discord does not -- a Slack message is
+        # addressed by (channel, ts), so a boot sweep cannot call chat_update
+        # to repair a wedged card without the channel (D-08).
+        if prepared.mapping_id is not None and lifecycle.status_ts is not None:
+            async with self.runtime.sessionmaker() as _at_session:
+                await mark_turn_active(
+                    _at_session,
+                    id=prepared.mapping_id,
+                    active_turn_message_id=lifecycle.status_ts,
+                    active_turn_channel_id=channel,
+                    now=datetime.now(UTC),
+                )
+                await _at_session.commit()
+
         log.info(
             "slack.session.ready",
             session_id=ma_session_id,
@@ -1347,30 +1396,14 @@ class SlackApp:
                 )
 
         # --- Run the turn (D-08/D-09/D-10: run_prepared_turn owns the driver
-        # call and the one-shot dead-session recovery cycle). ---
-        # lifecycle_holder tracks whichever SlackTurnLifecycle actually
-        # completed the turn -- recovery_lifecycle rebuilds a fresh one against
-        # the recreated session, and the watermark write below must read
-        # final_ts off THAT lifecycle, not the pre-recovery one.
+        # call and the one-shot dead-session recovery cycle). lifecycle and
+        # lifecycle_holder were constructed above, before bind_session. ---
         log.info(
             "slack.turn.started",
             thread_id=thread_id,
             session_id=ma_session_id,
             reused=reused,
         )
-        cancel_event = asyncio.Event()
-        lifecycle = SlackTurnLifecycle(
-            client=web_client,
-            channel=channel,
-            thread_ts=thread_id,
-            cancel=cancel_event,
-            author_id=str(event.get("user") or ""),
-            agent_name=_lc_agent_name,
-            model_id=_lc_model_id,
-            register=self._register_cancel,
-            deregister=self._deregister_cancel,
-        )
-        lifecycle_holder: list[SlackTurnLifecycle] = [lifecycle]
 
         async def _reseed_user_message() -> str:
             """Full history re-seed for the recreated session (dead-session recovery)."""

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -113,7 +113,11 @@ from daimon.core.stores.slack_turn_contexts import (
     delete_slack_turn_context,
 )
 from daimon.core.stores.slack_user_tokens import get_slack_user_token
-from daimon.core.stores.thread_sessions import mark_turn_active, update_watermark
+from daimon.core.stores.thread_sessions import (
+    clear_active_turn,
+    mark_turn_active,
+    update_watermark,
+)
 from daimon.core.turn import turn_deadline
 from daimon.core.turn.admission import AdmissionDenied, MissingTurnConfigError, admit
 from daimon.core.turn.gating import should_admit_turn
@@ -1246,273 +1250,330 @@ class SlackApp:
         # not merely before run_prepared_turn (D-01/D-02).
         await lifecycle.post_initial()
 
-        # One shared ceiling deadline for THIS turn, computed once the clock
-        # starts (D-03/D-04): right after admission passes, not before --
-        # admit() itself is deliberately outside the ceiling. Passed as the
-        # SAME value to both bind_session and run_prepared_turn below rather
-        # than letting each default its own `deadline=None` window -- the
-        # fail-safe default exists so no caller is ever unbounded, but a
-        # caller that makes BOTH calls would otherwise get two independent
-        # ~45-minute budgets (bind, then run) instead of one shared one.
-        #
-        # This budget does NOT cover the interstitial Slack-API work below
-        # (build_context_xml / build_delta_xml thread-history replay,
-        # download_as_image_blocks) or the create_slack_turn_context write --
-        # all of that is adapter-owned I/O, neither bounded nor cancelled by
-        # the deadline, and runs to completion regardless. That is deliberate,
-        # not an oversight: it means the interstitial CONSUMES the shared
-        # budget rather than getting a window of its own, so a slow history
-        # replay leaves the pump less than the full ceiling, and an
-        # interstitial that outruns the deadline entirely makes
-        # run_prepared_turn fail immediately at its first await with a
-        # ceiling TurnError. Bounding the interstitial itself is separate,
-        # deferred work.
-        turn_deadline_at = turn_deadline(now=datetime.now(UTC))
+        # Mapping-row ids the turn marker has been written against, tracked
+        # from here rather than built inline in the finally below: unlike
+        # Discord (whose try opens after bind_session, so `prepared` is bound
+        # on every path that reaches its finally), this outer try opens BEFORE
+        # bind_session, so neither `prepared` nor `outcome` is guaranteed bound
+        # at the finally. The accumulator is bound on every path instead.
+        _marker_mapping_ids: set[uuid.UUID] = set()
 
-        # --- Stage two: bind_session (find-or-create, mapping write,
-        # recorder binding) -- D-01 bind_session(). Slack has no
-        # per_caller_thread_sessions equivalent: session_account_id is always
-        # the admitted caller's account, and threads always pre-exist. ---
-        prepared = await bind_session(
-            self.runtime.turn_deps,
-            admission,
-            tenant_id=tenant_id,
-            platform="slack",
-            external_user_id=str(event.get("user") or ""),
-            thread_id=thread_id,
-            session_account_id=admission.account_id,
-            reuse_existing=True,
-            deadline=turn_deadline_at,
-        )
-        ma_session_id = prepared.ma_session_id
-        watermark = prepared.watermark
-        reused = prepared.reused
-
-        # Turn marker: message ts + channel + start time, written as soon as
-        # the mapping row is known and the card exists (D-03). Slack passes
-        # active_turn_channel_id where Discord does not -- a Slack message is
-        # addressed by (channel, ts), so a boot sweep cannot call chat_update
-        # to repair a wedged card without the channel (D-08).
-        if prepared.mapping_id is not None and lifecycle.status_ts is not None:
-            async with self.runtime.sessionmaker() as _at_session:
-                await mark_turn_active(
-                    _at_session,
-                    id=prepared.mapping_id,
-                    active_turn_message_id=lifecycle.status_ts,
-                    active_turn_channel_id=channel,
-                    now=datetime.now(UTC),
-                )
-                await _at_session.commit()
-
-        log.info(
-            "slack.session.ready",
-            session_id=ma_session_id,
-            thread_id=thread_id,
-            reused=reused,
-            watermark=watermark,
-        )
-
-        # --- Build user message ---
-        proxy_base = self.runtime.settings.mcp.app_root_url
-        proxy_secret = (
-            self.runtime.settings.mcp.jwt_secret.get_secret_value()
-            if self.runtime.settings.mcp.jwt_secret is not None
-            else None
-        )
-        now_i = int(time.time())
-        # None when the proxy is unconfigured — no signing secret to mint URLs with.
-        proxy_ctx = (
-            ProxyUrlContext(public_url=proxy_base, secret=proxy_secret, team_id=team_id, now=now_i)
-            if proxy_base is not None and proxy_secret is not None
-            else None
-        )
-
-        user_text = (
-            content_override if content_override is not None else str(event.get("text") or "")
-        )
-        author_id = str(event.get("user") or "")
-        if not reused:
-            # First turn: replay thread history (one Slack page from the root).
-            user_message = await build_context_xml(
-                web_client,
-                channel=channel,
-                thread_ts=thread_id,
-                user_query=user_text,
-                author_id=author_id,
-                proxy=proxy_ctx,
-            )
-        elif watermark is not None:
-            # Continuation: replay only messages since the last watermark.
-            user_message = await build_delta_xml(
-                web_client,
-                channel=channel,
-                thread_ts=thread_id,
-                watermark_ts=watermark,
-                user_query=user_text,
-                author_id=author_id,
-                proxy=proxy_ctx,
-            )
-        else:
-            # Reused session with no watermark (prior turn's final_ts was None).
-            # The MA session already holds prior context; replay only the new query.
-            user_message = user_text
-
-        # --- Attachments & vision ---
-        files = files or []
-        trigger_images = [f for f in files if is_vision_image(f)]
-        data_files = [f for f in files if not is_vision_image(f)]
-
-        image_blocks, images_skipped = await download_as_image_blocks(
-            trigger_images, token=web_client.token or "", http_client=self.runtime.http_client
-        )
-        skipped_ids = {f["id"] for f, _ in images_skipped}
-        inlined = [f for f in trigger_images if f["id"] not in skipped_ids]
-
-        synthetic_prefix = ""
-        if proxy_ctx is not None:
-            synthetic_prefix = "\n".join(
-                part
-                for part in (
-                    build_attachment_url_prefix(data_files, proxy_ctx),
-                    build_image_url_prefix(inlined, proxy_ctx),
-                    build_skipped_image_prefix(images_skipped, proxy_ctx),
-                )
-                if part
-            )
-            if synthetic_prefix:
-                user_message = synthetic_prefix + "\n" + user_message
-
-            # Only claim the images were "linked" when the proxy is configured —
-            # that's the branch that actually minted fetchable URLs into the prefix.
-            if images_skipped:
-                await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
-                    channel=channel,
-                    thread_ts=thread_id,
-                    text=(
-                        "Some images couldn't be inlined — I've linked them for the agent to "
-                        "fetch instead: "
-                        + ", ".join(f"`{f['name']}` ({r})" for f, r in images_skipped)
-                    ),
-                )
-
-        # --- Run the turn (D-08/D-09/D-10: run_prepared_turn owns the driver
-        # call and the one-shot dead-session recovery cycle). lifecycle and
-        # lifecycle_holder were constructed above, before bind_session. ---
-        log.info(
-            "slack.turn.started",
-            thread_id=thread_id,
-            session_id=ma_session_id,
-            reused=reused,
-        )
-
-        async def _reseed_user_message() -> str:
-            """Full history re-seed for the recreated session (dead-session recovery)."""
-            full_message = await build_context_xml(
-                web_client,
-                channel=channel,
-                thread_ts=thread_id,
-                user_query=user_text,
-                author_id=author_id,
-                proxy=proxy_ctx,
-            )
-            if synthetic_prefix:
-                full_message = synthetic_prefix + "\n" + full_message
-            return full_message
-
-        def _recovery_lifecycle(cancel: asyncio.Event) -> TurnLifecycle:
-            new_lifecycle = SlackTurnLifecycle(
-                client=web_client,
-                channel=channel,
-                thread_ts=thread_id,
-                cancel=cancel,
-                author_id=str(event.get("user") or ""),
-                agent_name=_lc_agent_name,
-                model_id=_lc_model_id,
-                register=self._register_cancel,
-                deregister=self._deregister_cancel,
-            )
-            lifecycle_holder[0] = new_lifecycle
-            return new_lifecycle
-
-        async with self.runtime.sessionmaker() as s:
-            turn_context = await create_slack_turn_context(
-                s,
-                tenant_id=tenant_id,
-                account_id=admission.account_id,
-                channel_id=channel,
-                thread_ts=thread_id,
-                started_at=datetime.now(tz=UTC),
-            )
-            await s.commit()
+        # Outer bookkeeping try/finally -- registry hygiene and marker hygiene
+        # only. It renders nothing, posts nothing, collapses nothing, and adds
+        # no error handling: `_handle_app_mention`'s boundary catch keeps
+        # handling every failure exactly as it does today. It exists because
+        # post_initial() now runs before bind_session, so a raise from the
+        # bind, the history replay, the image download, or the turn-context
+        # write below would otherwise strand a live-looking Cancel registry
+        # entry and a turn marker for the life of the process. The stale card
+        # left behind by such a failure is deliberately NOT collapsed here --
+        # exact Discord parity, and the boundary catch already posts an
+        # in-thread failure notice with a request id (D-07, and the previous
+        # phase's D-08: render through the existing generic error path, no
+        # Slack-specific copy). The clear runs on any exception, not just the
+        # happy path, and covers BOTH prepared.mapping_id and
+        # outcome.mapping_id because recovery moves the turn to a new mapping
+        # row and leaves the marker on the old one, still pointing at the same
+        # message -- a ceiling breach is not a special case here either:
+        # run_prepared_turn already marked the active mapping dead and returns
+        # a normal RunOutcome, so it takes this same path. _deregister_cancel
+        # is pop(ts, None), so the double call after on_terminal_success's own
+        # finally is harmless; the observable effect is that a Cancel click on
+        # a card left behind by a bind-phase failure now gets the honest
+        # "already finished" ephemeral instead of silently setting a dead
+        # Event. A marker-clear failure must not mask the turn's own outcome,
+        # which is why each clear below is individually suppressed on
+        # SQLAlchemyError -- a missed clear is recovered by the next boot sweep.
         try:
-            outcome = await run_prepared_turn(
+            # One shared ceiling deadline for THIS turn, computed once the clock
+            # starts (D-03/D-04): right after admission passes, not before --
+            # admit() itself is deliberately outside the ceiling. Passed as the
+            # SAME value to both bind_session and run_prepared_turn below rather
+            # than letting each default its own `deadline=None` window -- the
+            # fail-safe default exists so no caller is ever unbounded, but a
+            # caller that makes BOTH calls would otherwise get two independent
+            # ~45-minute budgets (bind, then run) instead of one shared one.
+            #
+            # This budget does NOT cover the interstitial Slack-API work below
+            # (build_context_xml / build_delta_xml thread-history replay,
+            # download_as_image_blocks) or the create_slack_turn_context write --
+            # all of that is adapter-owned I/O, neither bounded nor cancelled by
+            # the deadline, and runs to completion regardless. That is deliberate,
+            # not an oversight: it means the interstitial CONSUMES the shared
+            # budget rather than getting a window of its own, so a slow history
+            # replay leaves the pump less than the full ceiling, and an
+            # interstitial that outruns the deadline entirely makes
+            # run_prepared_turn fail immediately at its first await with a
+            # ceiling TurnError. Bounding the interstitial itself is separate,
+            # deferred work.
+            turn_deadline_at = turn_deadline(now=datetime.now(UTC))
+
+            # --- Stage two: bind_session (find-or-create, mapping write,
+            # recorder binding) -- D-01 bind_session(). Slack has no
+            # per_caller_thread_sessions equivalent: session_account_id is always
+            # the admitted caller's account, and threads always pre-exist. ---
+            prepared = await bind_session(
                 self.runtime.turn_deps,
-                prepared,
+                admission,
                 tenant_id=tenant_id,
                 platform="slack",
-                thread_id=thread_id,
                 external_user_id=str(event.get("user") or ""),
-                user_message=user_message,
-                lifecycle=lifecycle,
-                cancel=cancel_event,
-                reseed_user_message=_reseed_user_message,
-                recovery_lifecycle=_recovery_lifecycle,
-                image_blocks=image_blocks or None,
-                render_interval_s=2.0,
+                thread_id=thread_id,
+                session_account_id=admission.account_id,
+                reuse_existing=True,
                 deadline=turn_deadline_at,
             )
-        finally:
-            # Leak-policy bookkeeping only — a delete failure must not mask the
-            # turn's own outcome; stale rows age out via the reader-side TTL.
-            with contextlib.suppress(SQLAlchemyError):
-                async with self.runtime.sessionmaker() as s:
-                    await delete_slack_turn_context(s, id=turn_context.id)
-                    await s.commit()
+            ma_session_id = prepared.ma_session_id
+            watermark = prepared.watermark
+            reused = prepared.reused
 
-        mapping_id = outcome.mapping_id
-        final_lifecycle = lifecycle_holder[0]
+            # Turn marker: message ts + channel + start time, written as soon as
+            # the mapping row is known and the card exists (D-03). Slack passes
+            # active_turn_channel_id where Discord does not -- a Slack message is
+            # addressed by (channel, ts), so a boot sweep cannot call chat_update
+            # to repair a wedged card without the channel (D-08).
+            if prepared.mapping_id is not None and lifecycle.status_ts is not None:
+                async with self.runtime.sessionmaker() as _at_session:
+                    await mark_turn_active(
+                        _at_session,
+                        id=prepared.mapping_id,
+                        active_turn_message_id=lifecycle.status_ts,
+                        active_turn_channel_id=channel,
+                        now=datetime.now(UTC),
+                    )
+                    await _at_session.commit()
+                _marker_mapping_ids.add(prepared.mapping_id)
 
-        # --- Watermark --- Preserves Slack's original gate exactly (unconditional
-        # on final_ts, no state.error branch) -- Discord's inline sequence had an
-        # error-vs-success split here, but that is NOT one of SPEC Req 7's four
-        # named behaviour changes, so it is not introduced for Slack either.
-        if mapping_id is not None and final_lifecycle.final_ts is not None:
+            log.info(
+                "slack.session.ready",
+                session_id=ma_session_id,
+                thread_id=thread_id,
+                reused=reused,
+                watermark=watermark,
+            )
+
+            # --- Build user message ---
+            proxy_base = self.runtime.settings.mcp.app_root_url
+            proxy_secret = (
+                self.runtime.settings.mcp.jwt_secret.get_secret_value()
+                if self.runtime.settings.mcp.jwt_secret is not None
+                else None
+            )
+            now_i = int(time.time())
+            # None when the proxy is unconfigured — no signing secret to mint URLs with.
+            proxy_ctx = (
+                ProxyUrlContext(
+                    public_url=proxy_base, secret=proxy_secret, team_id=team_id, now=now_i
+                )
+                if proxy_base is not None and proxy_secret is not None
+                else None
+            )
+
+            user_text = (
+                content_override if content_override is not None else str(event.get("text") or "")
+            )
+            author_id = str(event.get("user") or "")
+            if not reused:
+                # First turn: replay thread history (one Slack page from the root).
+                user_message = await build_context_xml(
+                    web_client,
+                    channel=channel,
+                    thread_ts=thread_id,
+                    user_query=user_text,
+                    author_id=author_id,
+                    proxy=proxy_ctx,
+                )
+            elif watermark is not None:
+                # Continuation: replay only messages since the last watermark.
+                user_message = await build_delta_xml(
+                    web_client,
+                    channel=channel,
+                    thread_ts=thread_id,
+                    watermark_ts=watermark,
+                    user_query=user_text,
+                    author_id=author_id,
+                    proxy=proxy_ctx,
+                )
+            else:
+                # Reused session with no watermark (prior turn's final_ts was None).
+                # The MA session already holds prior context; replay only the new query.
+                user_message = user_text
+
+            # --- Attachments & vision ---
+            files = files or []
+            trigger_images = [f for f in files if is_vision_image(f)]
+            data_files = [f for f in files if not is_vision_image(f)]
+
+            image_blocks, images_skipped = await download_as_image_blocks(
+                trigger_images, token=web_client.token or "", http_client=self.runtime.http_client
+            )
+            skipped_ids = {f["id"] for f, _ in images_skipped}
+            inlined = [f for f in trigger_images if f["id"] not in skipped_ids]
+
+            synthetic_prefix = ""
+            if proxy_ctx is not None:
+                synthetic_prefix = "\n".join(
+                    part
+                    for part in (
+                        build_attachment_url_prefix(data_files, proxy_ctx),
+                        build_image_url_prefix(inlined, proxy_ctx),
+                        build_skipped_image_prefix(images_skipped, proxy_ctx),
+                    )
+                    if part
+                )
+                if synthetic_prefix:
+                    user_message = synthetic_prefix + "\n" + user_message
+
+                # Only claim the images were "linked" when the proxy is configured —
+                # that's the branch that actually minted fetchable URLs into the prefix.
+                if images_skipped:
+                    await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
+                        channel=channel,
+                        thread_ts=thread_id,
+                        text=(
+                            "Some images couldn't be inlined — I've linked them for the agent to "
+                            "fetch instead: "
+                            + ", ".join(f"`{f['name']}` ({r})" for f, r in images_skipped)
+                        ),
+                    )
+
+            # --- Run the turn (D-08/D-09/D-10: run_prepared_turn owns the driver
+            # call and the one-shot dead-session recovery cycle). lifecycle and
+            # lifecycle_holder were constructed above, before bind_session. ---
+            log.info(
+                "slack.turn.started",
+                thread_id=thread_id,
+                session_id=ma_session_id,
+                reused=reused,
+            )
+
+            async def _reseed_user_message() -> str:
+                """Full history re-seed for the recreated session (dead-session recovery)."""
+                full_message = await build_context_xml(
+                    web_client,
+                    channel=channel,
+                    thread_ts=thread_id,
+                    user_query=user_text,
+                    author_id=author_id,
+                    proxy=proxy_ctx,
+                )
+                if synthetic_prefix:
+                    full_message = synthetic_prefix + "\n" + full_message
+                return full_message
+
+            def _recovery_lifecycle(cancel: asyncio.Event) -> TurnLifecycle:
+                new_lifecycle = SlackTurnLifecycle(
+                    client=web_client,
+                    channel=channel,
+                    thread_ts=thread_id,
+                    cancel=cancel,
+                    author_id=str(event.get("user") or ""),
+                    agent_name=_lc_agent_name,
+                    model_id=_lc_model_id,
+                    register=self._register_cancel,
+                    deregister=self._deregister_cancel,
+                )
+                lifecycle_holder[0] = new_lifecycle
+                return new_lifecycle
+
             async with self.runtime.sessionmaker() as s:
-                await update_watermark(
-                    s, id=mapping_id, watermark_message_id=final_lifecycle.final_ts
+                turn_context = await create_slack_turn_context(
+                    s,
+                    tenant_id=tenant_id,
+                    account_id=admission.account_id,
+                    channel_id=channel,
+                    thread_ts=thread_id,
+                    started_at=datetime.now(tz=UTC),
                 )
                 await s.commit()
-            log.info(
-                "slack.watermark.updated",
-                thread_id=thread_id,
-                watermark=final_lifecycle.final_ts,
-            )
-        else:
-            log.info("slack.turn.completed", thread_id=thread_id, session_id=outcome.ma_session_id)
+            try:
+                outcome = await run_prepared_turn(
+                    self.runtime.turn_deps,
+                    prepared,
+                    tenant_id=tenant_id,
+                    platform="slack",
+                    thread_id=thread_id,
+                    external_user_id=str(event.get("user") or ""),
+                    user_message=user_message,
+                    lifecycle=lifecycle,
+                    cancel=cancel_event,
+                    reseed_user_message=_reseed_user_message,
+                    recovery_lifecycle=_recovery_lifecycle,
+                    image_blocks=image_blocks or None,
+                    render_interval_s=2.0,
+                    deadline=turn_deadline_at,
+                )
+            finally:
+                # Leak-policy bookkeeping only — a delete failure must not mask the
+                # turn's own outcome; stale rows age out via the reader-side TTL.
+                with contextlib.suppress(SQLAlchemyError):
+                    async with self.runtime.sessionmaker() as s:
+                        await delete_slack_turn_context(s, id=turn_context.id)
+                        await s.commit()
 
-        # Detached output sweep. `outcome.ma_session_id` is the post-recovery
-        # session id, so outputs stranded in a dead session are not
-        # recoverable. A detached sweep is not counted by drain_and_close's
-        # `_processing` poll, so SIGTERM can kill one mid-flight —
-        # post-then-delete makes that self-healing (redelivered on the next
-        # turn's sweep, or double-posted inside the already-accepted
-        # post-then-delete crash window).
-        if not any(isinstance(block, ToolUseBlock) for block in outcome.state.content):
-            return
-        # Read the chain link synchronously, before spawning, so it cannot be lost.
-        previous = self._output_sweeps.get(outcome.ma_session_id)
-        task = self._spawn(
-            self._sweep_session_outputs(
-                previous,
-                web_client,
-                session_id=outcome.ma_session_id,
-                channel_id=channel,
-                thread_ts=thread_id,
-                team_id=team_id,
+            if outcome.mapping_id is not None:
+                _marker_mapping_ids.add(outcome.mapping_id)
+
+            mapping_id = outcome.mapping_id
+            final_lifecycle = lifecycle_holder[0]
+
+            # --- Watermark --- Preserves Slack's original gate exactly (unconditional
+            # on final_ts, no state.error branch) -- Discord's inline sequence had an
+            # error-vs-success split here, but that is NOT one of SPEC Req 7's four
+            # named behaviour changes, so it is not introduced for Slack either.
+            if mapping_id is not None and final_lifecycle.final_ts is not None:
+                async with self.runtime.sessionmaker() as s:
+                    await update_watermark(
+                        s, id=mapping_id, watermark_message_id=final_lifecycle.final_ts
+                    )
+                    await s.commit()
+                log.info(
+                    "slack.watermark.updated",
+                    thread_id=thread_id,
+                    watermark=final_lifecycle.final_ts,
+                )
+            else:
+                log.info(
+                    "slack.turn.completed", thread_id=thread_id, session_id=outcome.ma_session_id
+                )
+
+            # Detached output sweep. `outcome.ma_session_id` is the post-recovery
+            # session id, so outputs stranded in a dead session are not
+            # recoverable. A detached sweep is not counted by drain_and_close's
+            # `_processing` poll, so SIGTERM can kill one mid-flight —
+            # post-then-delete makes that self-healing (redelivered on the next
+            # turn's sweep, or double-posted inside the already-accepted
+            # post-then-delete crash window).
+            if not any(isinstance(block, ToolUseBlock) for block in outcome.state.content):
+                return
+            # Read the chain link synchronously, before spawning, so it cannot be lost.
+            previous = self._output_sweeps.get(outcome.ma_session_id)
+            task = self._spawn(
+                self._sweep_session_outputs(
+                    previous,
+                    web_client,
+                    session_id=outcome.ma_session_id,
+                    channel_id=channel,
+                    thread_ts=thread_id,
+                    team_id=team_id,
+                )
             )
-        )
-        self._output_sweeps[outcome.ma_session_id] = task
-        task.add_done_callback(functools.partial(self._forget_output_sweep, outcome.ma_session_id))
+            self._output_sweeps[outcome.ma_session_id] = task
+            task.add_done_callback(
+                functools.partial(self._forget_output_sweep, outcome.ma_session_id)
+            )
+        finally:
+            # Bookkeeping only -- see the comment above the try. Deregister
+            # first (idempotent pop), then clear the marker on every mapping
+            # row it could be stranded on, each id suppressed independently
+            # so one failed clear cannot skip the other row.
+            if lifecycle.status_ts is not None:
+                self._deregister_cancel(lifecycle.status_ts)
+            for _marker_id in _marker_mapping_ids:
+                with contextlib.suppress(SQLAlchemyError):
+                    async with self.runtime.sessionmaker() as _clear_session:
+                        await clear_active_turn(_clear_session, id=_marker_id)
+                        await _clear_session.commit()
 
     async def drain_and_close(self, client: AsyncBaseSocketModeClient) -> None:
         """Graceful shutdown drain.

--- a/packages/adapters/slack/daimon/adapters/slack/blockkit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/blockkit.py
@@ -142,7 +142,7 @@ _PHASE_TITLE: dict[TurnPhase, str] = {
 _TERMINAL_PHASES = frozenset({TurnPhase.DONE, TurnPhase.ERROR})
 
 # Copy is byte-identical to the Discord adapter's orphan-retirement embed: the
-# two adapters must say the same thing about the same event (D-09).
+# two adapters must say the same thing about the same event.
 INTERRUPTED_NOTICE: str = (
     f"{_EMOJI_CROSS} This turn was interrupted by a restart and cannot be "
     "resumed. Nothing was lost on your side — mention me again to retry."

--- a/packages/adapters/slack/daimon/adapters/slack/blockkit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/blockkit.py
@@ -141,6 +141,13 @@ _PHASE_TITLE: dict[TurnPhase, str] = {
 
 _TERMINAL_PHASES = frozenset({TurnPhase.DONE, TurnPhase.ERROR})
 
+# Copy is byte-identical to the Discord adapter's orphan-retirement embed: the
+# two adapters must say the same thing about the same event (D-09).
+INTERRUPTED_NOTICE: str = (
+    f"{_EMOJI_CROSS} This turn was interrupted by a restart and cannot be "
+    "resumed. Nothing was lost on your side — mention me again to retry."
+)
+
 # ---------------------------------------------------------------------------
 # Pure functions
 # ---------------------------------------------------------------------------
@@ -306,3 +313,18 @@ def to_blocks(state: State, *, now: float | None) -> list[dict[str, Any]]:
     )
 
     return blocks
+
+
+def to_interrupted_blocks() -> list[dict[str, Any]]:
+    """Render the frozen status card a boot sweep leaves behind.
+
+    Deliberately NOT ``to_blocks(State(phase=TurnPhase.ERROR, ...))``: a fresh
+    boot process has the DB row and nothing else -- no agent name, no usage,
+    no monotonic start -- so the terminal collapse would render an empty
+    agent field and a misleading "0s · 0 in / 0 out" for a turn that may have
+    run 40 minutes.
+
+    Takes no arguments and emits no ``actions`` block, so the Cancel button is
+    gone by construction -- there is no live turn left to cancel.
+    """
+    return [{"type": "section", "text": {"type": "mrkdwn", "text": INTERRUPTED_NOTICE}}]

--- a/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
+++ b/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
@@ -23,29 +23,55 @@ Deliberately NOT ported from Discord's sweep:
   post into (the app can only speak where it was invited), and the OAuth
   success page is the install-feedback surface. The sweep is silent; logs
   are the operator surface.
+
+The module's second half, ``retire_orphaned_turns``, is boot-time orphan-turn
+retirement: on every process start it lays to rest every Slack turn whose
+render loop died with the previous container, editing the frozen status card
+in place and clearing the turn marker. It shares this module with the
+reconcile sweep above only because both are boot-time jobs for the Slack
+worker -- the two halves have disjoint dependencies, disjoint tables, and no
+call into one another.
 """
 
 from __future__ import annotations
 
 import asyncio
 import uuid
+from datetime import datetime
 from pathlib import Path
 
+import aiohttp
 import anthropic as _anthropic
 import structlog
 from anthropic import AsyncAnthropic
+from cryptography.fernet import InvalidToken
+from daimon.adapters.slack.blockkit import to_interrupted_blocks
+from daimon.adapters.slack.interactions import resolve_web_client
+from daimon.adapters.slack.runtime import SlackRuntime
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.defaults.provisioning import reconcile_tenant_defaults
 from daimon.core.defaults.report import compose_failure_reason
 from daimon.core.errors import DaimonError
 from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.domain import ThreadSessionRow
 from daimon.core.stores.tenants import list_tenants_by_platform, set_provision_status
+from daimon.core.stores.thread_sessions import clear_active_turn, list_orphaned_turns
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.async_client import AsyncWebClient
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 log = structlog.get_logger()
 
 _SWEEP_CONCURRENCY = 2
+
+# Slack's notification-fallback requirement (blocks= always ships with text=).
+_INTERRUPTED_FALLBACK_TEXT = "This turn was interrupted by a restart."
+
+# Everything a chat.update can raise. Mirrors lifecycle.py's _SLACK_SEND_ERRORS
+# exactly -- no error-code branching, the same posture the rest of the Slack
+# adapter takes on every send.
+_SLACK_UPDATE_ERRORS = (SlackApiError, aiohttp.ClientError, TimeoutError)
 
 
 async def run_boot_sweep(
@@ -183,3 +209,119 @@ async def _record_failure(
             )
     except SQLAlchemyError:
         log.exception("slack.boot_sweep_status_flip_failed", tenant_id=str(tenant_id))
+
+
+async def retire_orphaned_turns(runtime: SlackRuntime, *, now: datetime) -> None:
+    """Lay to rest every Slack turn whose render loop died with the previous
+    process, editing its frozen status card in place and clearing its marker.
+
+    A turn's render loop lives in the process that started it, so a deploy
+    mid-turn freezes the status card on "thinking" forever while MA completes
+    and bills the answer server-side. The user sees a spinner that never
+    stops and has no way to tell it is dead. Marking it honestly is cheap;
+    a lameduck drain story that avoids this in the first place is not.
+
+    Builds its own per-tenant AsyncWebClient rather than taking one as a
+    dependency: unlike Discord's single deployment-wide bot token, Slack's
+    token is per-workspace, decrypted per use via ``resolve_web_client``, and
+    never cached (STURN-03). Rows are grouped by tenant so a workspace with
+    several wedged threads decrypts once, not once per row.
+
+    An unreachable tenant -- an uninstalled workspace (no token row), a
+    Fernet key rotated out from under a stored token, or a tenant absent from
+    the platform listing -- still has every one of its rows cleared. So does
+    a legacy row with no channel (every orphan already in production before
+    this shipped, since the column is new, nullable, and unbackfilled) and a
+    row whose card edit fails for any reason (deleted message, archived
+    channel, revoked token). Otherwise an unreachable or already-gone card
+    would be retried on every single boot forever (D-10).
+
+    No once-per-process guard (D-15, superseding D-10's letter): this
+    function lives in a module of free functions with no ``self``, so a guard
+    would need module-level mutable state, which ``guideline:architecture``
+    rule 3 ("no global state") forbids. It is also structurally unnecessary
+    here -- the spawn site in ``__main__.py`` is a straight-line statement
+    inside ``main()``, and Socket Mode reconnects are handled entirely inside
+    ``SocketModeClient`` (``connect()`` starts ``monitor_current_session``,
+    which reconnects on its own tasks); ``main()``'s body never re-executes,
+    so this function cannot run twice in one process. If this sweep is ever
+    moved onto a reconnect-driven hook (an event handler that genuinely
+    re-fires, the way Discord's ``on_ready`` does), the guard becomes
+    mandatory again -- a marker set by the process that is currently running
+    is a live turn, not an orphan.
+
+    Accepted, undefended race (parity with Discord): a mention landing on the
+    same thread between the ``list_orphaned_turns`` read and the
+    ``clear_active_turn`` write would have its fresh marker cleared by this
+    sweep. The window requires a full admission plus an MA ``sessions.create``
+    to complete inside one row's ``chat_update``. Discord has the identical
+    race and accepts it; a compare-and-clear ``clear_active_turn`` would
+    change a core store shared with Discord for a race neither adapter has
+    ever observed.
+    """
+    async with runtime.sessionmaker() as session:
+        orphans = await list_orphaned_turns(session, platform="slack")
+    if not orphans:
+        return
+    log.info("slack.turn.orphans_found", count=len(orphans))
+
+    tenants = await list_tenants_by_platform(runtime.sessionmaker, platform="slack")
+    team_id_by_tenant = {t.id: t.external_id for t in tenants}
+
+    by_tenant: dict[uuid.UUID, list[ThreadSessionRow]] = {}
+    for row in orphans:
+        by_tenant.setdefault(row.tenant_id, []).append(row)
+
+    for tenant_id, rows in by_tenant.items():
+        client: AsyncWebClient | None = None
+        team_id = team_id_by_tenant.get(tenant_id)
+        if team_id is not None:
+            try:
+                client = await resolve_web_client(runtime, team_id=team_id)
+            except (InvalidToken, SQLAlchemyError) as err:
+                # Per-tenant supervisor boundary -- mirrors _seed_tenant_defaults:
+                # one tenant's bad key must not stop the sweep over its siblings.
+                log.warning(
+                    "slack.turn.orphan_token_unusable", tenant_id=str(tenant_id), error=str(err)
+                )
+        if client is None:
+            # Uninstalled workspace, or a key we can no longer decrypt with.
+            # Not an error -- an uninstalled workspace is a normal outcome
+            # (app.py:837-839 treats a missing token row the same way). Still
+            # clear below so these rows are not retried forever.
+            log.info(
+                "slack.turn.orphan_tenant_unreachable", tenant_id=str(tenant_id), rows=len(rows)
+            )
+
+        for row in rows:
+            channel_id = row.active_turn_channel_id
+            message_id = row.active_turn_message_id
+            if client is not None and channel_id is not None and message_id is not None:
+                try:
+                    await client.chat_update(  # pyright: ignore[reportUnknownMemberType]
+                        channel=channel_id,
+                        ts=message_id,
+                        blocks=to_interrupted_blocks(),
+                        text=_INTERRUPTED_FALLBACK_TEXT,
+                    )
+                    log.info(
+                        "slack.turn.orphan_retired",
+                        thread_id=row.thread_id,
+                        channel_id=row.active_turn_channel_id,
+                        status_ts=row.active_turn_message_id,
+                        # How long the user stared at a spinner -- after a
+                        # crash this is the only surviving trace, since the
+                        # turn's own logs died with its container.
+                        frozen_for_s=(
+                            (now - row.active_turn_started_at).total_seconds()
+                            if row.active_turn_started_at is not None
+                            else None
+                        ),
+                    )
+                except _SLACK_UPDATE_ERRORS as err:
+                    log.warning(
+                        "slack.turn.orphan_retire_failed", thread_id=row.thread_id, error=str(err)
+                    )
+            async with runtime.sessionmaker() as session:
+                await clear_active_turn(session, id=row.id)
+                await session.commit()

--- a/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
+++ b/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
@@ -227,7 +227,7 @@ async def retire_orphaned_turns(runtime: SlackRuntime, *, now: datetime) -> None
     Builds its own per-tenant AsyncWebClient rather than taking one as a
     dependency: unlike Discord's single deployment-wide bot token, Slack's
     token is per-workspace, decrypted per use via ``resolve_web_client``, and
-    never cached (STURN-03). Rows are grouped by tenant so a workspace with
+    never cached. Rows are grouped by tenant so a workspace with
     several wedged threads decrypts once, not once per row.
 
     An unreachable tenant -- an uninstalled workspace (no token row), a

--- a/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
+++ b/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
@@ -55,7 +55,10 @@ from daimon.core.errors import DaimonError
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.domain import ThreadSessionRow
 from daimon.core.stores.tenants import list_tenants_by_platform, set_provision_status
-from daimon.core.stores.thread_sessions import clear_active_turn, list_orphaned_turns
+from daimon.core.stores.thread_sessions import (
+    clear_active_turn_if_message_id,
+    list_orphaned_turns,
+)
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 from sqlalchemy.exc import SQLAlchemyError
@@ -250,14 +253,45 @@ async def retire_orphaned_turns(runtime: SlackRuntime, *, now: datetime) -> None
     mandatory again -- a marker set by the process that is currently running
     is a live turn, not an orphan.
 
-    Accepted, undefended race (parity with Discord): a mention landing on the
-    same thread between the ``list_orphaned_turns`` read and the
-    ``clear_active_turn`` write would have its fresh marker cleared by this
-    sweep. The window requires a full admission plus an MA ``sessions.create``
-    to complete inside one row's ``chat_update``. Discord has the identical
-    race and accepts it; a compare-and-clear ``clear_active_turn`` would
-    change a core store shared with Discord for a race neither adapter has
-    ever observed.
+    This function also assumes ONE Slack adapter process. With two
+    overlapping instances -- a rolling deploy that starts the new process
+    before the old one has stopped -- it would retire the sibling's genuinely
+    live turns, because a marker set by another live process is
+    indistinguishable from one left behind by a crash. The compare-and-clear
+    below narrows this but does not remove it: a sibling's turn whose marker
+    has not changed since this function's read still matches the predicate.
+    Gate on an owner id before scaling this service out.
+
+    The actual race: ``list_orphaned_turns`` is read ONCE up front, for every
+    tenant, and the per-tenant, per-row loop that follows is fully sequential
+    with live ``chat_update`` calls and no concurrency bound -- unlike the
+    reconcile half of this module, which runs at a bounded semaphore. So the
+    window between a given row's read and its clear scales with total sweep duration,
+    not with one row's edit latency; a row late in a large sweep is exposed
+    longest, which is exactly the fleet-wide-crash case this function exists
+    for. Socket Mode dispatch is already live before the sweep task is created:
+    the listener is registered and the client connected before
+    ``asyncio.create_task`` schedules this coroutine, so a mention can be in
+    flight before this function gets its first scheduling opportunity.
+
+    The card edit itself was never the unsafe half. The ``chat_update`` below
+    targets the ts read at sweep start, and a newly admitted turn posts a NEW
+    card at a NEW ts before its own marker is written -- so the ts this
+    function holds always names the genuinely frozen card, never the live
+    one. Even when the new turn reuses the same mapping row, the edit lands
+    on the dead card and the clear below then correctly skips.
+
+    What the clear does about the exposure above: it is now predicated on the
+    marker still naming the message this function read, so a marker written
+    since the read survives. A skip is self-healing -- the process that wrote
+    it clears it on its own terminal path, or crashes and is swept on the
+    next boot.
+
+    The boot ordering was deliberately NOT changed to close the window
+    described above: completing this sweep before ``client.connect()`` would
+    diverge from the Discord adapter, whose sweep also runs after connect,
+    and would delay event acceptance by the sweep's duration. The
+    compare-and-clear makes the window harmless instead of absent.
     """
     async with runtime.sessionmaker() as session:
         orphans = await list_orphaned_turns(session, platform="slack")
@@ -294,9 +328,16 @@ async def retire_orphaned_turns(runtime: SlackRuntime, *, now: datetime) -> None
             )
 
         for row in rows:
-            channel_id = row.active_turn_channel_id
             message_id = row.active_turn_message_id
-            if client is not None and channel_id is not None and message_id is not None:
+            if message_id is None:  # pragma: no cover - list_orphaned_turns filters this out
+                # list_orphaned_turns only ever returns rows whose
+                # active_turn_message_id IS NOT NULL -- this narrows the Pydantic
+                # model's str | None honestly rather than asserting or casting
+                # past it. A row with no marker is not an orphan, so skipping it
+                # here leaks nothing.
+                continue
+            channel_id = row.active_turn_channel_id
+            if client is not None and channel_id is not None:
                 try:
                     await client.chat_update(  # pyright: ignore[reportUnknownMemberType]
                         channel=channel_id,
@@ -323,5 +364,18 @@ async def retire_orphaned_turns(runtime: SlackRuntime, *, now: datetime) -> None
                         "slack.turn.orphan_retire_failed", thread_id=row.thread_id, error=str(err)
                     )
             async with runtime.sessionmaker() as session:
-                await clear_active_turn(session, id=row.id)
+                cleared = await clear_active_turn_if_message_id(
+                    session, id=row.id, expected_message_id=message_id
+                )
                 await session.commit()
+            if not cleared:
+                # The marker moved between this sweep's read and this row's
+                # clear -- a live process wrote it after the read, so it owns
+                # the row now and will clear it on its own terminal path, or
+                # crash and be picked up by the next boot's sweep. Not a
+                # warning: this is the compare-and-clear working as intended.
+                log.info(
+                    "slack.turn.orphan_marker_moved",
+                    thread_id=row.thread_id,
+                    message_id=message_id,
+                )

--- a/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
+++ b/packages/adapters/slack/daimon/adapters/slack/boot_sweep.py
@@ -237,11 +237,11 @@ async def retire_orphaned_turns(runtime: SlackRuntime, *, now: datetime) -> None
     this shipped, since the column is new, nullable, and unbackfilled) and a
     row whose card edit fails for any reason (deleted message, archived
     channel, revoked token). Otherwise an unreachable or already-gone card
-    would be retried on every single boot forever (D-10).
+    would be retried on every single boot forever.
 
-    No once-per-process guard (D-15, superseding D-10's letter): this
-    function lives in a module of free functions with no ``self``, so a guard
-    would need module-level mutable state, which ``guideline:architecture``
+    No once-per-process guard: this function lives in a module of free
+    functions with no ``self``, so a guard would need module-level mutable
+    state, which ``guideline:architecture``
     rule 3 ("no global state") forbids. It is also structurally unnecessary
     here -- the spawn site in ``__main__.py`` is a straight-line statement
     inside ``main()``, and Socket Mode reconnects are handled entirely inside

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -187,7 +187,7 @@ class SlackTurnLifecycle:
         await self._maybe_flush()
 
     async def on_sse_event(self, event: RawMessageStreamEvent) -> None:
-        # Cheap local tap per the hardened TurnLifecycle contract (D-12):
+        # Cheap local tap per the hardened TurnLifecycle contract:
         # the pump awaits this hook inline, so it stays a local reducer
         # call only. The Block Kit flush (chat-API I/O) rides the render
         # tick instead, where a slow or rate-limited chat.update only
@@ -428,7 +428,7 @@ class SlackTurnLifecycle:
                 self._deregister(self._status_ts)
 
     async def on_render(self, state: TurnState) -> None:
-        """Sole delivery path (D-12). `state` is unused: Slack's card is
+        """Sole delivery path. `state` is unused: Slack's card is
         driven by its own Block Kit `State` folded in `on_sse_event` — this
         hook is the tick that delivers it."""
         if self._terminal:

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -135,6 +135,31 @@ class SlackTurnLifecycle:
         self._terminal: bool = False
         self.final_ts: str | None = None
 
+    @property
+    def status_ts(self) -> str | None:
+        """The ts of the status message this lifecycle is rendering into, or
+        None if nothing has been posted yet.
+
+        Public so the caller can record the turn marker (message ts, channel,
+        started_at) as soon as the card exists; nothing else should need it.
+        """
+        return self._status_ts
+
+    async def post_initial(self) -> None:
+        """Post the initial status card immediately, before session setup.
+
+        Called before session binding so the user gets instant feedback and
+        the Cancel button exists before the first SSE event -- MA
+        sessions.create plus the history replay and image download that
+        follow can hold for minutes. Runs before the turn starts (and
+        therefore before any render tick exists), so this is the one place
+        that deliberately flushes directly instead of waiting on an SSE
+        event. The cancel registration rides this first post via
+        _maybe_flush's first-post branch, so Cancel is live before the first
+        SSE event rather than after it.
+        """
+        await self._maybe_flush()
+
     async def on_sse_event(self, event: RawMessageStreamEvent) -> None:
         embed_event = _map_sse_event(event)
         if embed_event is None:

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -24,6 +24,13 @@ Design decisions:
   debounce already dominated flush timing and is unchanged; terminal flushes
   (`_flush_terminal`/`_flush_cancelled`) and `post_initial` are unaffected —
   they bypass both the debounce and the render path.
+- `adopt_status_ts` (dead-session recovery only) seeds `_status_ts` before
+  anything is posted, with three mechanical consequences: the first
+  `_maybe_flush` takes the update branch, never the post branch; `_last_flush`
+  starts at `0.0` against a `time.monotonic` clock, so the debounce is already
+  satisfied and the first render tick updates with no wait; and `_register` is
+  therefore never called, so the caller handing over the ts owns rebinding the
+  cancel registry entry to the new cancel Event.
 """
 
 from __future__ import annotations
@@ -124,6 +131,7 @@ class SlackTurnLifecycle:
         register: Callable[[str, asyncio.Event, str], None],
         deregister: Callable[[str], None],
         clock: Callable[[], float] = time.monotonic,
+        adopt_status_ts: str | None = None,
     ) -> None:
         self._client = client
         self._channel = channel
@@ -139,7 +147,16 @@ class SlackTurnLifecycle:
             agent_name=agent_name,
             started_at=self._clock(),
         )
-        self._status_ts: str | None = None
+        # Seeded only by dead-session recovery, which hands over the card the
+        # failed attempt already posted. Without this the recovery lifecycle
+        # posts a SECOND card, and the first one is never finalised — the turn
+        # driver withholds the failed attempt's terminal hook while a recovery
+        # is in flight, so on a successful recovery nothing ever collapses card
+        # one and it sits on "thinking" beside the answer. The turn marker
+        # written against the pre-recovery mapping row addresses the adopted
+        # card, so a restarted process repairs the card the user is actually
+        # watching rather than an abandoned one.
+        self._status_ts: str | None = adopt_status_ts
         self._last_flush: float = 0.0
         self._terminal: bool = False
         self.final_ts: str | None = None

--- a/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
+++ b/packages/adapters/slack/daimon/adapters/slack/lifecycle.py
@@ -15,6 +15,15 @@ Design decisions:
   locked by live-workspace probe).
 - text= always passed alongside blocks= to satisfy Slack's notification
   fallback requirement (Pitfall 3).
+- The Block Kit flush rides the render tick (`on_render`), not `on_sse_event`:
+  the driver awaits `on_sse_event` inline in its consume loop, so a debounced
+  `chat.update` living there would stall read-timeout detection and deaden
+  Cancel for as long as a rate-limited edit's Retry-After wait. `on_render`
+  runs on a separate render task, so the same stall now only delays a render
+  tick. First-update latency is at most one render tick (~2s); the 5.0s
+  debounce already dominated flush timing and is unchanged; terminal flushes
+  (`_flush_terminal`/`_flush_cancelled`) and `post_initial` are unaffected —
+  they bypass both the debounce and the render path.
 """
 
 from __future__ import annotations
@@ -161,11 +170,15 @@ class SlackTurnLifecycle:
         await self._maybe_flush()
 
     async def on_sse_event(self, event: RawMessageStreamEvent) -> None:
+        # Cheap local tap per the hardened TurnLifecycle contract (D-12):
+        # the pump awaits this hook inline, so it stays a local reducer
+        # call only. The Block Kit flush (chat-API I/O) rides the render
+        # tick instead, where a slow or rate-limited chat.update only
+        # delays the render task, never the consume loop.
         embed_event = _map_sse_event(event)
         if embed_event is None:
             return
         self._state = update(self._state, embed_event)
-        await self._maybe_flush()
 
     async def _maybe_flush(self) -> None:
         """Post or update the status message, subject to debounce. No-op after terminal."""
@@ -398,7 +411,12 @@ class SlackTurnLifecycle:
                 self._deregister(self._status_ts)
 
     async def on_render(self, state: TurnState) -> None:
-        """No-op — Block Kit state is driven by SSE events, not render ticks."""
+        """Sole delivery path (D-12). `state` is unused: Slack's card is
+        driven by its own Block Kit `State` folded in `on_sse_event` — this
+        hook is the tick that delivers it."""
+        if self._terminal:
+            return
+        await self._maybe_flush()
 
     async def on_reconnect(self, reason: ReconnectReason) -> None:
         pass

--- a/packages/adapters/slack/tests/__snapshots__/test_lifecycle_snapshots.ambr
+++ b/packages/adapters/slack/tests/__snapshots__/test_lifecycle_snapshots.ambr
@@ -42,6 +42,41 @@
       dict({
         'blocks': list([
           dict({
+            'text': dict({
+              'text': '*🧠 thinking*',
+              'type': 'mrkdwn',
+            }),
+            'type': 'section',
+          }),
+          dict({
+            'elements': list([
+              dict({
+                'text': '⏱️ 12s',
+                'type': 'mrkdwn',
+              }),
+            ]),
+            'type': 'context',
+          }),
+          dict({
+            'elements': list([
+              dict({
+                'action_id': 'cancel_turn',
+                'style': 'danger',
+                'text': dict({
+                  'text': 'Cancel',
+                  'type': 'plain_text',
+                }),
+                'type': 'button',
+              }),
+            ]),
+            'type': 'actions',
+          }),
+        ]),
+        'text': 'thinking …',
+      }),
+      dict({
+        'blocks': list([
+          dict({
             'elements': list([
               dict({
                 'text': '❌ upstream timeout · Atlas · 12s · 500 in / 80 out · $0.003',

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -2799,9 +2799,9 @@ async def test_run_thread_turn_bind_phase_ceiling_does_not_escape_handle_app_men
     -- no exception escapes the background task. The status card now posts
     BEFORE `bind_session`, so a bind-phase ceiling breach leaves
     exactly two posts in the thread: the status card first, then the
-    boundary's in-thread failure notice last. Pins that plan 19-03's new
-    ceiling raise site lands in Slack's existing boundary with zero new
-    adapter error-handling code (T-19-10-C). Reuses
+    boundary's in-thread failure notice last. Pins that the core ceiling
+    raise site lands in Slack's existing boundary with zero new
+    adapter error-handling code. Reuses
     `test_handle_app_mention_failure_posts_error_into_thread`'s harness
     shape/assertions rather than inventing a second one.
     """

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -1033,8 +1033,22 @@ async def test_orchestrate_queue_coalesce_when_thread_in_flight_adds_hourglass_a
     # in test_orchestrate_first_turn_*).
     fake_principal = MagicMock()
     fake_principal.account_id = uuid.uuid4()
-    fake_row = MagicMock()
-    fake_row.id = uuid.uuid4()
+    # The patched store returns the same validated Pydantic type the real
+    # store returns, so a field the production code reads is a real value
+    # or a loud failure, never an auto-generated mock attribute.
+    now = datetime.now(UTC)
+    fake_thread_session_row = ThreadSessionRow(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id=thread_ts,
+        account_id=uuid.uuid4(),
+        ma_session_id="sess-coalesce-001",
+        watermark_message_id=None,
+        status="live",
+        created_at=now,
+        updated_at=now,
+    )
 
     with (
         patch(
@@ -1064,7 +1078,7 @@ async def test_orchestrate_queue_coalesce_when_thread_in_flight_adds_hourglass_a
     ):
         mock_principal.return_value = fake_principal
         mock_get_session.return_value = None  # simulate new thread each time
-        mock_create_ts.return_value = fake_row
+        mock_create_ts.return_value = fake_thread_session_row
         mock_resolve_agent.return_value = "agent_coalesce_id"
         mock_resolve_env.return_value = "env_coalesce_id"
         _now_c = datetime.now(UTC)

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -3438,6 +3438,251 @@ async def test_marker_is_written_with_channel_before_the_turn_runs(
     )
 
 
+async def test_a_recovered_turn_keeps_editing_the_card_the_marker_points_at(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """A Slack turn that recovers from a dead session keeps rendering into the
+    card it started with, instead of abandoning it for a second, untracked one.
+
+    Drives one dead-session-recovery scenario through the real adapter
+    boundary and pins four properties from a single set of observations taken
+    mid-recovery (inside the second run_turn call):
+
+    1. One card. Exactly one chat.postMessage happens across the whole turn --
+       the count observed mid-recovery is already 1, and it never grows.
+    2. The marker addresses the live card. The one row list_orphaned_turns
+       would return mid-recovery has active_turn_message_id/channel equal to
+       the card the recovered turn is rendering into, not the abandoned first
+       card -- this is what a restarted process would find and repair.
+    3. The terminal render lands there. The recovered turn's answer is
+       chat.update'd onto that same card.
+    4. Cancel is rebound. The registry entry for that card's ts is bound to
+       the SECOND run_turn call's cancel Event (identity, not equality), and
+       the author id is unchanged, so a Cancel click during recovery stops
+       the turn that is actually running and is still refused for anyone but
+       the author.
+
+    The Slack API fake returns a constant ts for every chat.postMessage, so a
+    second card would be indistinguishable from the first by ts alone -- the
+    postMessage COUNT is what proves adoption. Weakening assertion 1 to a ts
+    comparison would make this test pass against the pre-adoption code.
+    """
+    import anthropic as _anthropic
+    from daimon.core.errors import TurnError
+    from daimon.core.stores.identity import get_or_create_platform_principal
+
+    team_id = "T_RECOVERED_TURN"
+    channel = "C_TEST"
+    thread_ts = "9000000050.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    async with db_session_factory() as s:
+        await get_or_create_platform_principal(
+            s, tenant_id=tenant_id, platform="slack", external_id="U_TEST_RECOVER"
+        )
+        await s.commit()
+
+    app, _ = _make_orchestrate_app(db_session_factory)
+
+    _now = datetime.now(UTC)
+
+    def _fake_session(session_id: str) -> BetaManagedAgentsSession:
+        return BetaManagedAgentsSession(
+            outcome_evaluations=[],
+            id=session_id,
+            agent=BetaManagedAgentsSessionAgent(
+                id="agent_test_id",
+                mcp_servers=[],
+                model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+                name="test-agent",
+                skills=[],
+                tools=[],
+                type="agent",
+                version=1,
+            ),
+            created_at=_now,
+            environment_id="env_test_id",
+            metadata={},
+            resources=[],
+            stats=BetaManagedAgentsSessionStats(),
+            status="idle",
+            type="session",
+            updated_at=_now,
+            usage=BetaManagedAgentsSessionUsage(),
+            vault_ids=[],
+        )
+
+    first_session = _fake_session("sess-recover-first-001")
+    recovered_session = _fake_session("sess-recover-second-002")
+
+    # A real 404 APIStatusError behind a real httpx.Response -- the dead-session
+    # signature the recovery cycle recognizes and recovers from.
+    fake_request = MagicMock(spec=httpx.Request)
+    fake_response = httpx.Response(404, json={"type": "not_found_error", "message": "gone"})
+    fake_response.request = fake_request
+    dead_cause = _anthropic.APIStatusError(
+        "Session not found", response=fake_response, body={"type": "not_found_error"}
+    )
+    dead_state = TurnState(
+        error=TurnError(kind="upstream", message="Session not found", cause=dead_cause)
+    )
+    _ANSWER = "Recovered turn answer, distinctive marker qzx91."
+    success_state = TurnState(content=[TextBlock(kind="text", text=_ANSWER)])
+
+    post_url = URL("https://slack.com/api/chat.postMessage")
+    update_url = URL("https://slack.com/api/chat.update")
+
+    def _post_count() -> int:
+        return sum(
+            len(reqs)
+            for (_, url), reqs in fake_slack_web_client.mock.requests.items()
+            if url == post_url
+        )
+
+    observed: dict[str, Any] = {}
+
+    async def _fake_run_turn(
+        *, lifecycle: Any, session_id: str, cancel: asyncio.Event, **kwargs: Any
+    ) -> TurnState:
+        if session_id == first_session.id:
+            observed["first_lifecycle"] = lifecycle
+            observed["first_cancel"] = cancel
+            # The deferred wrapper withholds this -- it must not render yet.
+            await lifecycle.on_terminal_failure(dead_state, dead_cause)
+            return dead_state
+
+        assert session_id == recovered_session.id, (
+            f"run_turn must be called only for the two known sessions, got {session_id}"
+        )
+        # Observations taken BEFORE any hook on the recovery lifecycle, so they
+        # reflect state while the recovered turn is actually in flight.
+        observed["post_count_mid_recovery"] = _post_count()
+        observed["status_ts"] = lifecycle.status_ts
+        observed["registry"] = dict(app._cancel_registry)  # pyright: ignore[reportPrivateUsage]
+        observed["second_cancel"] = cancel
+        async with db_session_factory() as s:
+            observed["orphans_mid_recovery"] = await list_orphaned_turns(s, platform="slack")
+        await lifecycle.on_terminal_success(success_state)
+        return success_state
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": thread_ts,
+        "event_ts": thread_ts,
+        "channel": channel,
+        "user": "U_TEST_RECOVER",
+        "text": "<@U_BOT> hello",
+    }
+
+    with (
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.adapters.slack.app.deliver_session_outputs", new_callable=AsyncMock),
+    ):
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env.return_value = "env_test_id"
+        mock_create_session.side_effect = [first_session, recovered_session]
+        mock_run_turn.side_effect = _fake_run_turn
+
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            event,
+            team_id=team_id,
+            channel=channel,
+            event_ts=thread_ts,
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+        )
+        while app._bg_tasks:  # pyright: ignore[reportPrivateUsage]
+            await asyncio.gather(
+                *list(app._bg_tasks),  # pyright: ignore[reportPrivateUsage]
+                return_exceptions=True,
+            )
+            await asyncio.sleep(0)
+
+    # Non-vacuity: recovery must actually have run.
+    assert mock_run_turn.call_count == 2, "run_turn must be called twice: dead + recovered"
+    second_call_kwargs = mock_run_turn.call_args_list[1].kwargs
+    assert second_call_kwargs["session_id"] == recovered_session.id, (
+        "the second run_turn call must run against the recovered session"
+    )
+
+    # 1. One card.
+    assert observed["post_count_mid_recovery"] == 1, (
+        "mid-recovery, exactly one status card must have been posted -- a "
+        "recovered turn must not post a second card before anything else runs"
+    )
+    assert _post_count() == 1, (
+        "a recovered turn must not post a second status card, because nothing "
+        "would ever finalise the first one and the database marker would "
+        "address a card nobody is rendering into"
+    )
+
+    # 2. The marker addresses the live card.
+    orphans_mid_recovery = observed["orphans_mid_recovery"]
+    assert len(orphans_mid_recovery) == 1, (
+        "exactly one orphan-eligible row must exist while the recovered turn runs"
+    )
+    mid_row = orphans_mid_recovery[0]
+    assert mid_row.active_turn_message_id == observed["status_ts"], (
+        "the marker a restarted process would find must address the card the "
+        "recovered turn is rendering into"
+    )
+    assert mid_row.active_turn_channel_id == channel, (
+        "the marker's channel must equal the mention's channel"
+    )
+
+    # 3. The terminal render lands there.
+    update_calls = [
+        req
+        for (_, url), reqs in fake_slack_web_client.mock.requests.items()
+        if url == update_url
+        for req in reqs
+    ]
+    assert update_calls, "the recovered turn's terminal success must chat.update"
+    last_update_body = update_calls[-1].kwargs["json"]
+    assert last_update_body["ts"] == observed["status_ts"], (
+        "the card the user has been watching is the one that ends up carrying "
+        "the answer, so nothing is left showing a running turn"
+    )
+    rendered_text = json.dumps(last_update_body.get("blocks", []))
+    assert _ANSWER in rendered_text, "the recovered turn's answer must land on the adopted card"
+
+    # 4. Cancel is rebound.
+    registry = observed["registry"]
+    assert observed["status_ts"] in registry, (
+        "the adopted card's ts must have a cancel registry entry during recovery"
+    )
+    rebound_event, rebound_author = registry[observed["status_ts"]]
+    assert rebound_event is observed["second_cancel"], (
+        "a Cancel click during a recovered turn must stop the turn that is "
+        "actually running -- the registry entry must be the SECOND call's Event"
+    )
+    assert rebound_event is not observed["first_cancel"], (
+        "the registry entry must no longer be bound to the first attempt's Event"
+    )
+    assert rebound_author == "U_TEST_RECOVER", "the rebind must not change who is allowed to cancel"
+
+    # Final state: both mapping rows must end the turn unmarked.
+    async with db_session_factory() as s:
+        final_orphans = await list_orphaned_turns(s, platform="slack")
+    assert final_orphans == [], (
+        "both the dead pre-recovery row and the post-recovery row must end the turn unmarked"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Cancel registry: block_actions routing + author gate
 # ---------------------------------------------------------------------------

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import json
 import pathlib
@@ -25,6 +26,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import httpx
+import pytest
 import structlog.testing
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import (
@@ -3919,3 +3921,176 @@ async def test_orchestrate_tenant_cap_when_in_thread_sheds_in_thread(
         "an in-thread shed must be announced in that thread, not at channel root"
     )
     mock_run_turn.assert_not_called()  # pyright: ignore[reportUnknownMemberType]
+
+
+# ---------------------------------------------------------------------------
+# Ceiling breach releases both concurrency slots (D-06, plan 20-06)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ceiling_phase", ["bind", "pump"])
+async def test_ceiling_breach_releases_tenant_slot_and_thread_flag(
+    ceiling_phase: str,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """A ceiling breach must release BOTH concurrency slots -- the per-tenant
+    in-flight count and the per-thread processing flag -- on both control-flow
+    paths that reach _orchestrate's finally (app.py:1081-1084): the
+    bind-phase raise (prepare.py:255-265, which unwinds through
+    _orchestrate's try -- it has no except) and the pump-phase return
+    (run.py:355-372, which falls out the bottom normally instead of raising).
+
+    Reading app._inflight alone is a weak assertion -- it would pass a
+    _release_inflight that decrements without popping the key at zero. The
+    assertion that actually retires the design doc's "three wedged threads
+    freeze the whole workspace" concern is behavioural: with
+    max_concurrent_turns_per_tenant=1, a SECOND mention on the SAME tenant
+    must be ADMITTED (not shed) once the first mention's ceilinged turn has
+    unwound.
+
+    Both mentions are driven through _handle_app_mention, not _orchestrate
+    directly -- _orchestrate's finally has no except, so the bind-phase raise
+    propagates straight out of it, making "after _orchestrate returns, assert
+    ..." unreachable on that leg. _handle_app_mention's boundary catches
+    DaimonError (TurnError is one), so both legs return normally from the
+    same call shape and the assertions below are written once.
+
+    Why the design doc's concern no longer holds: the cap is an in-process
+    dict[uuid.UUID, int] (app.py:196) that a process crash resets to zero, so
+    "three wedged threads freeze the whole workspace" was only ever true for
+    an in-process wedge -- and the core turn ceiling (TURN_CEILING_S, 45
+    minutes) now bounds an in-process wedge identically on both adapters.
+    """
+    from daimon.core.turn.ceiling import ceiling_error
+
+    team_id = f"T_CEILING_RELEASE_{ceiling_phase.upper()}"
+    channel = "C_TEST"
+    thread_ts_1 = "9000000046.000001"
+    thread_ts_2 = "9000000046.000002"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    await upsert_slack_bot_token(
+        db_session,
+        team_id=team_id,
+        encrypted_token=encrypt_token(fernet, "xoxb-ceiling-release"),
+    )
+    await db_session.flush()
+
+    app, _ = _make_orchestrate_app(
+        db_session_factory, max_concurrent_turns_per_tenant=1, crypto_key=fernet_key
+    )
+
+    def _make_event(thread_ts: str) -> dict[str, Any]:
+        return {
+            "type": "app_mention",
+            "channel": channel,
+            "event_ts": thread_ts,
+            "ts": thread_ts,
+            "thread_ts": thread_ts,
+            "user": "U_CEILING_RELEASE",
+            "text": "<@U_BOT> hello",
+        }
+
+    _now = datetime.now(UTC)
+    _fake_session = BetaManagedAgentsSession(
+        outcome_evaluations=[],
+        id="sess-ceiling-release-001",
+        agent=BetaManagedAgentsSessionAgent(
+            id="agent_test_id",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at=_now,
+        environment_id="env_test_id",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=_now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+    )
+
+    async def _sleepy_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+        await asyncio.sleep(5.0)
+        return TurnState(content=[])
+
+    with contextlib.ExitStack() as stack:
+        mock_resolve_agent = stack.enter_context(
+            patch("daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock)
+        )
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env = stack.enter_context(
+            patch("daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock)
+        )
+        mock_resolve_env.return_value = "env_test_id"
+
+        if ceiling_phase == "bind":
+            mock_bind_session = stack.enter_context(
+                patch("daimon.adapters.slack.app.bind_session", new_callable=AsyncMock)
+            )
+            mock_bind_session.side_effect = ceiling_error()
+        else:
+            mock_create_session = stack.enter_context(
+                patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock)
+            )
+            mock_create_session.return_value = _fake_session
+            mock_turn_deadline = stack.enter_context(
+                patch("daimon.adapters.slack.app.turn_deadline")
+            )
+            mock_turn_deadline.side_effect = lambda *, now, **_: now + timedelta(seconds=2)
+            mock_run_turn = stack.enter_context(
+                patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock)
+            )
+            mock_run_turn.side_effect = _sleepy_run_turn
+
+        # First mention breaches the ceiling on the parametrized phase.
+        await app._handle_app_mention(  # pyright: ignore[reportPrivateUsage]
+            _make_event(thread_ts_1), team_id=team_id
+        )
+
+        assert tenant_id not in app._inflight, (  # pyright: ignore[reportPrivateUsage]
+            "a ceiling breach must POP the tenant's in-flight key at zero, not "
+            "merely decrement it to zero -- _release_inflight's own contract"
+        )
+        assert thread_ts_1 not in app._processing, (  # pyright: ignore[reportPrivateUsage]
+            "a ceiling breach must discard the per-thread processing flag"
+        )
+
+        # Second mention on the SAME tenant -- the behavioural assertion that
+        # actually retires the design doc's concern.
+        with structlog.testing.capture_logs() as captured:
+            await app._handle_app_mention(  # pyright: ignore[reportPrivateUsage]
+                _make_event(thread_ts_2), team_id=team_id
+            )
+
+    shed_logs = [c for c in captured if c.get("event") == "turn.skipped.concurrency_shed"]
+    assert shed_logs == [], (
+        "a second mention on the same tenant must be ADMITTED after a ceiling "
+        "breach releases the slot, not shed as if the tenant were still saturated"
+    )
+    shed_ephemeral = [
+        req
+        for (_, url), reqs in fake_slack_web_client.mock.requests.items()
+        if url == URL("https://slack.com/api/chat.postEphemeral")
+        for req in reqs
+        if "too many chats in flight" in req.kwargs["json"].get("text", "")
+    ]
+    assert shed_ephemeral == [], (
+        "the second mention must not receive the concurrency-shed ephemeral notice"
+    )
+    assert tenant_id not in app._inflight  # pyright: ignore[reportPrivateUsage]
+    assert thread_ts_2 not in app._processing  # pyright: ignore[reportPrivateUsage]

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -47,7 +47,11 @@ from daimon.core.stores import tenant_ledger, usage_events
 from daimon.core.stores.scoped_config_write import set_fields
 from daimon.core.stores.slack_bot_tokens import get_slack_bot_token, upsert_slack_bot_token
 from daimon.core.stores.tenants import get_tenant
-from daimon.core.stores.thread_sessions import create_thread_session, get_live_thread_session
+from daimon.core.stores.thread_sessions import (
+    create_thread_session,
+    get_live_thread_session,
+    list_orphaned_turns,
+)
 from daimon.core.turn.posture import Billed, BillingPosture
 from daimon.core.turn.state import TextBlock, ToolUseBlock, TurnState
 from daimon.testing.ma import (
@@ -58,6 +62,7 @@ from daimon.testing.ma import (
 )
 from daimon.testing.ma import build_fake_anthropic
 from pydantic import SecretStr
+from slack_sdk.errors import SlackApiError
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -1426,7 +1431,9 @@ async def test_run_thread_turn_two_turns_same_session_chain_sweeps_serially(
         patch(
             "daimon.core.turn.prepare.get_live_thread_session", new_callable=AsyncMock
         ) as mock_get_session,
-        patch("daimon.core.turn.prepare.create_thread_session", new_callable=AsyncMock),
+        patch(
+            "daimon.core.turn.prepare.create_thread_session", new_callable=AsyncMock
+        ) as mock_create_ts,
         patch("daimon.adapters.slack.app.update_watermark", new_callable=AsyncMock),
         patch(
             "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
@@ -1443,6 +1450,12 @@ async def test_run_thread_turn_two_turns_same_session_chain_sweeps_serially(
         ) as mock_deliver_outputs,
     ):
         mock_get_session.return_value = None
+        # A real UUID, not a bare AsyncMock attribute -- the turn marker
+        # write/clear (mark_turn_active/clear_active_turn) now reads
+        # prepared.mapping_id and issues a real DB UPDATE against it.
+        fake_thread_session_row = MagicMock()
+        fake_thread_session_row.id = uuid.uuid4()
+        mock_create_ts.return_value = fake_thread_session_row
         mock_resolve_agent.return_value = "agent_sweep_id"
         mock_resolve_env.return_value = "env_sweep_id"
         # Both turns land on the SAME MA session id — the chain key.
@@ -2755,10 +2768,12 @@ async def test_run_thread_turn_bind_phase_ceiling_does_not_escape_handle_app_men
 ) -> None:
     """A `bind_session` ceiling breach (D-03/D-10) must surface through
     Slack's EXISTING generic `DaimonError` boundary in `_handle_app_mention`
-    -- exactly one in-thread failure message is posted and no exception
-    escapes the background task. Pins that plan 19-03's new ceiling raise
-    site lands in Slack's existing boundary with zero new adapter
-    error-handling code (T-19-10-C). Reuses
+    -- no exception escapes the background task. The status card now posts
+    BEFORE `bind_session` (D-02), so a bind-phase ceiling breach leaves
+    exactly two posts in the thread: the status card first, then the
+    boundary's in-thread failure notice last. Pins that plan 19-03's new
+    ceiling raise site lands in Slack's existing boundary with zero new
+    adapter error-handling code (T-19-10-C). Reuses
     `test_handle_app_mention_failure_posts_error_into_thread`'s harness
     shape/assertions rather than inventing a second one.
     """
@@ -2819,12 +2834,456 @@ async def test_run_thread_turn_bind_phase_ceiling_does_not_escape_handle_app_men
         if url == URL("https://slack.com/api/chat.postMessage")
         for req in reqs
     ]
-    assert len(posts) == 1, (
-        "a bind-phase ceiling breach must post exactly one in-thread failure message"
+    assert len(posts) == 2, (
+        "the status card posts before bind_session (D-02); a bind-phase ceiling "
+        "breach must leave exactly two posts -- the card, then the failure notice"
     )
-    body = posts[0].kwargs["json"]
+    first_body = posts[0].kwargs["json"]
+    assert "rid:" not in first_body.get("text", ""), (
+        "the FIRST post must be the pre-bind status card, not the failure notice"
+    )
+    failure_posts = [p for p in posts if "rid:" in p.kwargs["json"].get("text", "")]
+    assert len(failure_posts) == 1, "exactly one post must be the boundary's failure notice"
+    body = failure_posts[0].kwargs["json"]
     assert body["channel"] == channel
     assert body["thread_ts"] == thread_ts, "the failure notice must land in the mention's thread"
+
+
+# ---------------------------------------------------------------------------
+# Turn marker + cancel-registry bookkeeping across the pre-bind stretch (20-02)
+# ---------------------------------------------------------------------------
+
+
+async def test_bind_phase_failure_leaves_no_cancel_registry_entry(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """A card left behind by a bind-phase failure must not keep a live Cancel
+    entry for the life of the process -- the outer bookkeeping finally opens
+    at post_initial(), before bind_session, so it still runs on this path."""
+    from daimon.core.turn.ceiling import ceiling_error
+
+    team_id = "T_BIND_FAIL_CANCEL"
+    channel = "C_TEST"
+    thread_ts = "9000000042.000001"
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
+    await upsert_slack_bot_token(
+        db_session,
+        team_id=team_id,
+        encrypted_token=encrypt_token(fernet, "xoxb-bind-fail"),
+    )
+    await db_session.flush()
+
+    app, _ = _make_orchestrate_app(db_session_factory, crypto_key=fernet_key)
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "channel": channel,
+        "event_ts": thread_ts,
+        "ts": thread_ts,
+        "thread_ts": thread_ts,
+        "user": "U_AUTHOR_BIND_FAIL",
+        "text": "<@U_BOT> hello",
+    }
+
+    with (
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.admission.is_over_balance", new_callable=AsyncMock
+        ) as mock_over_balance,
+        patch("daimon.core.turn.admission.is_over_cap", new_callable=AsyncMock) as mock_over_cap,
+        patch(
+            "daimon.adapters.slack.app.bind_session", new_callable=AsyncMock
+        ) as mock_bind_session,
+    ):
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env.return_value = "env_test_id"
+        mock_over_balance.return_value = False
+        mock_over_cap.return_value = False
+        mock_bind_session.side_effect = ceiling_error()
+
+        await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
+
+    assert app._cancel_registry == {}, (  # pyright: ignore[reportPrivateUsage]
+        "a card left behind by a bind-phase failure must not keep a live Cancel "
+        "entry -- the outer finally must deregister it even though bind_session "
+        "never returned"
+    )
+
+
+async def test_interstitial_failure_clears_the_marker_and_the_cancel_registry(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """A failure AFTER bind_session succeeds (so the marker IS written) but
+    BEFORE run_prepared_turn -- the stretch the inner finally cannot reach --
+    must still clear both the marker and the cancel-registry entry. This is
+    the path that fails if the outer try is placed too low (e.g. only around
+    run_prepared_turn, matching the inner finally instead of opening at
+    post_initial()). Drives through _handle_app_mention (not _orchestrate
+    directly) so the assertion also proves no exception escapes the real
+    listener boundary."""
+    from daimon.core.stores.identity import get_or_create_platform_principal
+
+    team_id = "T_INTERSTITIAL_FAIL"
+    channel = "C_TEST"
+    thread_ts = "9000000043.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+    fernet_key = Fernet.generate_key().decode()
+    fernet = build_multifernet((fernet_key,))
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    await upsert_slack_bot_token(
+        db_session,
+        team_id=team_id,
+        encrypted_token=encrypt_token(fernet, "xoxb-interstitial"),
+    )
+    await db_session.flush()
+    async with db_session_factory() as s:
+        await get_or_create_platform_principal(
+            s, tenant_id=tenant_id, platform="slack", external_id="U_TEST_INTERSTITIAL"
+        )
+        await s.commit()
+
+    app, _ = _make_orchestrate_app(db_session_factory, crypto_key=fernet_key)
+
+    _now = datetime.now(UTC)
+    _fake_session = BetaManagedAgentsSession(
+        outcome_evaluations=[],
+        id="sess-interstitial-001",
+        agent=BetaManagedAgentsSessionAgent(
+            id="agent_test_id",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at=_now,
+        environment_id="env_test_id",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=_now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+    )
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": thread_ts,
+        "event_ts": thread_ts,
+        "channel": channel,
+        "user": "U_TEST_INTERSTITIAL",
+        "text": "<@U_BOT> hello",
+    }
+
+    with (
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+        patch(
+            "daimon.adapters.slack.app.download_as_image_blocks", new_callable=AsyncMock
+        ) as mock_download_images,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+    ):
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env.return_value = "env_test_id"
+        mock_create_session.return_value = _fake_session
+        mock_download_images.side_effect = SlackApiError("down", MagicMock())
+
+        # No exception must escape -- the real listener boundary in
+        # _handle_app_mention handles it.
+        await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
+
+    mock_run_turn.assert_not_called()  # pyright: ignore[reportUnknownMemberType]
+    assert app._cancel_registry == {}, (  # pyright: ignore[reportPrivateUsage]
+        "an interstitial failure between bind_session and run_prepared_turn "
+        "must still drop the cancel-registry entry"
+    )
+    async with db_session_factory() as s:
+        orphaned = await list_orphaned_turns(s, platform="slack")
+    assert orphaned == [], (
+        "an interstitial failure between bind_session and run_prepared_turn must "
+        "still clear the turn marker -- otherwise a boot sweep would find a wedged "
+        "card for a turn that already unwound to the boundary catch"
+    )
+
+
+async def test_run_thread_turn_clears_the_active_turn_marker_on_success(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """On the success path, the outer finally clears the marker it wrote --
+    no row is left behind for a boot sweep to (wrongly) treat as wedged."""
+    from daimon.core.stores.identity import get_or_create_platform_principal
+
+    team_id = "T_MARKER_CLEAR_SUCCESS"
+    channel = "C_TEST"
+    thread_ts = "9000000044.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    async with db_session_factory() as s:
+        pre_principal = await get_or_create_platform_principal(
+            s, tenant_id=tenant_id, platform="slack", external_id="U_TEST_MARKER_CLEAR"
+        )
+        await s.commit()
+
+    app, _ = _make_orchestrate_app(db_session_factory)
+
+    async def _fake_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+        state = TurnState(
+            content=[
+                ToolUseBlock(
+                    kind="tool_use", id="tu_marker", type="agent.tool_use", name="bash", input={}
+                ),
+                TextBlock(kind="text", text="Done."),
+            ]
+        )
+        await lifecycle.on_terminal_success(state)
+        return state
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": thread_ts,
+        "event_ts": thread_ts,
+        "channel": channel,
+        "user": "U_TEST_MARKER_CLEAR",
+        "text": "<@U_BOT> hello",
+    }
+
+    _now = datetime.now(UTC)
+    _fake_session = BetaManagedAgentsSession(
+        outcome_evaluations=[],
+        id="sess-marker-clear-001",
+        agent=BetaManagedAgentsSessionAgent(
+            id="agent_test_id",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at=_now,
+        environment_id="env_test_id",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=_now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+    )
+
+    with (
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.adapters.slack.app.deliver_session_outputs", new_callable=AsyncMock),
+    ):
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env.return_value = "env_test_id"
+        mock_create_session.return_value = _fake_session
+        mock_run_turn.side_effect = _fake_run_turn
+
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            event,
+            team_id=team_id,
+            channel=channel,
+            event_ts=thread_ts,
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+        )
+        while app._bg_tasks:  # pyright: ignore[reportPrivateUsage]
+            await asyncio.gather(
+                *list(app._bg_tasks),  # pyright: ignore[reportPrivateUsage]
+                return_exceptions=True,
+            )
+            await asyncio.sleep(0)
+
+    async with db_session_factory() as s:
+        orphaned = await list_orphaned_turns(s, platform="slack")
+        row = await get_live_thread_session(
+            s,
+            tenant_id=tenant_id,
+            platform="slack",
+            thread_id=thread_ts,
+            account_id=pre_principal.account_id,
+        )
+
+    assert orphaned == [], "the marker must be cleared on the success path"
+    assert row is not None
+    assert row.active_turn_channel_id is None, (
+        "active_turn_channel_id must be nulled alongside the rest of the marker on success"
+    )
+
+
+async def test_marker_is_written_with_channel_before_the_turn_runs(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """The turn marker (message ts + channel) is visible in the DB WHILE the
+    turn is running -- inspected from inside the fake run_turn, patched at
+    daimon.core.turn.run.run_turn (the name run_prepared_turn actually reads;
+    patching daimon.core.turn.driver.run_turn would rebind a name nothing
+    reads and the fake would never run)."""
+    from daimon.core.stores.identity import get_or_create_platform_principal
+
+    team_id = "T_MARKER_MID_TURN"
+    channel = "C_TEST"
+    thread_ts = "9000000045.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    async with db_session_factory() as s:
+        pre_principal = await get_or_create_platform_principal(
+            s, tenant_id=tenant_id, platform="slack", external_id="U_TEST_MARKER_MID"
+        )
+        await s.commit()
+
+    app, _ = _make_orchestrate_app(db_session_factory)
+
+    observed: dict[str, Any] = {}
+
+    async def _fake_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+        # Inspect DB state WHILE the turn is running -- before any terminal
+        # hook has a chance to clear the marker.
+        async with db_session_factory() as s:
+            row = await get_live_thread_session(
+                s,
+                tenant_id=tenant_id,
+                platform="slack",
+                thread_id=thread_ts,
+                account_id=pre_principal.account_id,
+            )
+        assert row is not None
+        observed["active_turn_message_id"] = row.active_turn_message_id
+        observed["active_turn_channel_id"] = row.active_turn_channel_id
+
+        state = TurnState(
+            content=[
+                ToolUseBlock(
+                    kind="tool_use", id="tu_mid", type="agent.tool_use", name="bash", input={}
+                ),
+                TextBlock(kind="text", text="Mid-turn."),
+            ]
+        )
+        await lifecycle.on_terminal_success(state)
+        return state
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": thread_ts,
+        "event_ts": thread_ts,
+        "channel": channel,
+        "user": "U_TEST_MARKER_MID",
+        "text": "<@U_BOT> hello",
+    }
+
+    _now = datetime.now(UTC)
+    _fake_session = BetaManagedAgentsSession(
+        outcome_evaluations=[],
+        id="sess-marker-mid-001",
+        agent=BetaManagedAgentsSessionAgent(
+            id="agent_test_id",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at=_now,
+        environment_id="env_test_id",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=_now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+    )
+
+    with (
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        patch("daimon.adapters.slack.app.deliver_session_outputs", new_callable=AsyncMock),
+    ):
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env.return_value = "env_test_id"
+        mock_create_session.return_value = _fake_session
+        mock_run_turn.side_effect = _fake_run_turn
+
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            event,
+            team_id=team_id,
+            channel=channel,
+            event_ts=thread_ts,
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+        )
+        while app._bg_tasks:  # pyright: ignore[reportPrivateUsage]
+            await asyncio.gather(
+                *list(app._bg_tasks),  # pyright: ignore[reportPrivateUsage]
+                return_exceptions=True,
+            )
+            await asyncio.sleep(0)
+
+    assert observed["active_turn_message_id"] == "1000000000.000001", (
+        "the marker's message ts must equal the status card's ts while the turn runs"
+    )
+    assert observed["active_turn_channel_id"] == channel, (
+        "the marker's channel must equal the mention's channel while the turn runs"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -2797,7 +2797,7 @@ async def test_run_thread_turn_bind_phase_ceiling_does_not_escape_handle_app_men
     """A `bind_session` ceiling breach (D-03/D-10) must surface through
     Slack's EXISTING generic `DaimonError` boundary in `_handle_app_mention`
     -- no exception escapes the background task. The status card now posts
-    BEFORE `bind_session` (D-02), so a bind-phase ceiling breach leaves
+    BEFORE `bind_session`, so a bind-phase ceiling breach leaves
     exactly two posts in the thread: the status card first, then the
     boundary's in-thread failure notice last. Pins that plan 19-03's new
     ceiling raise site lands in Slack's existing boundary with zero new
@@ -2863,7 +2863,7 @@ async def test_run_thread_turn_bind_phase_ceiling_does_not_escape_handle_app_men
         for req in reqs
     ]
     assert len(posts) == 2, (
-        "the status card posts before bind_session (D-02); a bind-phase ceiling "
+        "the status card posts before bind_session; a bind-phase ceiling "
         "breach must leave exactly two posts -- the card, then the failure notice"
     )
     first_body = posts[0].kwargs["json"]
@@ -3016,7 +3016,7 @@ async def test_run_thread_turn_pump_phase_ceiling_renders_terminal_error_in_thre
     assert "❌" in rendered_text, "a ceiling breach must render the terminal error emoji"
     assert CEILING_MESSAGE in rendered_text, (
         "the rendered card must carry the shared CEILING_MESSAGE text -- no new "
-        "Slack-specific ceiling copy may be introduced (D-07)"
+        "Slack-specific ceiling copy may be introduced"
     )
 
     async with db_session_factory() as s:
@@ -4195,7 +4195,7 @@ async def test_orchestrate_tenant_cap_when_in_thread_sheds_in_thread(
 
 
 # ---------------------------------------------------------------------------
-# Ceiling breach releases both concurrency slots (D-06, plan 20-06)
+# Ceiling breach releases both concurrency slots
 # ---------------------------------------------------------------------------
 
 

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -46,6 +46,7 @@ from daimon.core.ma_identity import derive_tenant_uuid
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.scope import ChannelScopeRef, DeploymentDefault
 from daimon.core.stores import tenant_ledger, usage_events
+from daimon.core.stores.domain import ThreadSessionRow
 from daimon.core.stores.scoped_config_write import set_fields
 from daimon.core.stores.slack_bot_tokens import get_slack_bot_token, upsert_slack_bot_token
 from daimon.core.stores.tenants import get_tenant
@@ -1452,11 +1453,22 @@ async def test_run_thread_turn_two_turns_same_session_chain_sweeps_serially(
         ) as mock_deliver_outputs,
     ):
         mock_get_session.return_value = None
-        # A real UUID, not a bare AsyncMock attribute -- the turn marker
-        # write/clear (mark_turn_active/clear_active_turn) now reads
-        # prepared.mapping_id and issues a real DB UPDATE against it.
-        fake_thread_session_row = MagicMock()
-        fake_thread_session_row.id = uuid.uuid4()
+        # The patched store returns the same validated Pydantic type the real
+        # store returns, so a field the production code reads is a real value
+        # or a loud failure, never an auto-generated mock attribute.
+        now = datetime.now(UTC)
+        fake_thread_session_row = ThreadSessionRow(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            platform="slack",
+            thread_id=thread_ts,
+            account_id=uuid.uuid4(),
+            ma_session_id="sess-chain-001",
+            watermark_message_id=None,
+            status="live",
+            created_at=now,
+            updated_at=now,
+        )
         mock_create_ts.return_value = fake_thread_session_row
         mock_resolve_agent.return_value = "agent_sweep_id"
         mock_resolve_env.return_value = "env_sweep_id"

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -18,7 +18,7 @@ import re
 import re as _re
 import uuid
 from collections.abc import Callable, Coroutine
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2847,6 +2847,156 @@ async def test_run_thread_turn_bind_phase_ceiling_does_not_escape_handle_app_men
     body = failure_posts[0].kwargs["json"]
     assert body["channel"] == channel
     assert body["thread_ts"] == thread_ts, "the failure notice must land in the mention's thread"
+
+
+async def test_run_thread_turn_pump_phase_ceiling_renders_terminal_error_in_thread(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """A pump-phase ceiling breach -- a TimeoutError inside run_prepared_turn's
+    own asyncio.wait_for, raised AFTER bind_session has already returned --
+    does NOT raise out of run_prepared_turn. It marks the mapping row dead,
+    calls lifecycle.on_terminal_failure directly (guarded by its own
+    try/except so a broken render hook cannot mask the ceiling error), and
+    returns a RunOutcome carrying state.error.kind == "ceiling". So this test
+    asserts a rendered terminal error card in-thread, not a boundary catch --
+    the bind-phase counterpart (raised from bind_session, unwinding through
+    _handle_app_mention's boundary) is already pinned above at
+    test_run_thread_turn_bind_phase_ceiling_does_not_escape_handle_app_mention.
+
+    A globally-past deadline cannot be used to force this breach:
+    _run_thread_turn threads ONE shared deadline into both bind_session and
+    run_prepared_turn, and remaining_s clamps to a small positive floor, so a
+    past deadline would breach at bind_session's own asyncio.wait_for before
+    run_prepared_turn is ever reached -- that would silently re-test the
+    bind-phase path instead of this one. Instead: turn_deadline is patched to
+    return a near-future deadline (2s -- survivable by the mocked bind) and
+    run_turn is patched to sleep past it (5s). The patch target is
+    daimon.core.turn.run.run_turn -- the module that IMPORTS the name and is
+    the one run_prepared_turn actually calls -- not the defining module
+    (daimon.core.turn's driver submodule); patching that one would rebind a
+    name nobody reads and the pump would never sleep.
+
+    Two pre-existing Slack behaviours a reader will trip on here, left alone
+    on purpose (not this plan's job to "fix"): Slack's watermark gate has no
+    state.error branch (unlike Discord's), so this breach DOES write a
+    watermark onto the row mark_dead just set to status='dead' -- functionally
+    inert, since dead rows are excluded from get_live_thread_session; and
+    on_terminal_failure sets final_ts to the status ts on its normal flush
+    path, which is why that watermark write fires at all.
+    """
+    from daimon.core.turn.ceiling import CEILING_MESSAGE
+
+    team_id = "T_PUMP_CEILING"
+    channel = "C_TEST"
+    thread_ts = "9000000045.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+
+    app, _ = _make_orchestrate_app(db_session_factory)
+
+    _now = datetime.now(UTC)
+    _fake_session = BetaManagedAgentsSession(
+        outcome_evaluations=[],
+        id="sess-pump-ceiling-001",
+        agent=BetaManagedAgentsSessionAgent(
+            id="agent_test_id",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at=_now,
+        environment_id="env_test_id",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=_now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+    )
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": thread_ts,
+        "event_ts": thread_ts,
+        "channel": channel,
+        "user": "U_TEST_PUMP_CEILING",
+        "text": "<@U_BOT> hello",
+    }
+
+    async def _sleepy_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+        await asyncio.sleep(5.0)
+        return TurnState(content=[TextBlock(kind="text", text="too late")])
+
+    with (
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+        patch("daimon.adapters.slack.app.turn_deadline") as mock_turn_deadline,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+    ):
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env.return_value = "env_test_id"
+        mock_create_session.return_value = _fake_session
+        mock_turn_deadline.side_effect = lambda *, now, **_: now + timedelta(seconds=2)
+        mock_run_turn.side_effect = _sleepy_run_turn
+
+        # No exception must escape -- the pump-phase breach returns a
+        # RunOutcome rather than raising.
+        await app._run_thread_turn(  # pyright: ignore[reportPrivateUsage]
+            event,
+            channel=channel,
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+            thread_id=thread_ts,
+            team_id=team_id,
+        )
+
+    update_calls = [
+        req
+        for (_, url), reqs in fake_slack_web_client.mock.requests.items()
+        if url == URL("https://slack.com/api/chat.update")
+        for req in reqs
+    ]
+    assert update_calls, (
+        "the pump-phase breach must render through chat.update against the "
+        "status card post_initial() already established -- not a new post"
+    )
+    last_blocks = update_calls[-1].kwargs["json"]["blocks"]
+    rendered_text = " ".join(
+        element.get("text", "")
+        for block in last_blocks
+        for element in block.get("elements", [block])
+        if isinstance(element, dict)
+    )
+    assert "❌" in rendered_text, "a ceiling breach must render the terminal error emoji"
+    assert CEILING_MESSAGE in rendered_text, (
+        "the rendered card must carry the shared CEILING_MESSAGE text -- no new "
+        "Slack-specific ceiling copy may be introduced (D-07)"
+    )
+
+    async with db_session_factory() as s:
+        orphaned = await list_orphaned_turns(s, platform="slack")
+    assert orphaned == [], (
+        "a ceilinged turn must not be swept as an orphan on the next boot -- the "
+        "marker must be cleared even though run_prepared_turn returns rather than raises"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/slack/tests/test_blockkit.py
+++ b/packages/adapters/slack/tests/test_blockkit.py
@@ -21,6 +21,7 @@ from daimon.adapters.slack.blockkit import (
     TurnPhase,
     _fmt_tokens,
     to_blocks,
+    to_interrupted_blocks,
     update,
 )
 
@@ -263,3 +264,36 @@ class TestToBlocks:
         assert _fmt_tokens(1500) == "1.5k", "1500 humanizes to 1.5k"
         assert _fmt_tokens(0) == "0", "zero renders as 0"
         assert _fmt_tokens(12000) == "12k", "whole-thousand strips trailing .0"
+
+
+# ---------------------------------------------------------------------------
+# to_interrupted_blocks() -- the boot sweep's frozen-card renderer
+# ---------------------------------------------------------------------------
+
+
+class TestToInterruptedBlocks:
+    def test_returns_exactly_one_section_block_with_mrkdwn_text(self) -> None:
+        blocks = to_interrupted_blocks()
+        assert len(blocks) == 1, "the frozen card is a single block, nothing else"
+        assert blocks[0]["type"] == "section", (
+            "the house pattern for a whole-card notice is section"
+        )
+        assert blocks[0]["text"]["type"] == "mrkdwn", "notice text must be mrkdwn"
+
+    def test_no_block_is_an_actions_block(self) -> None:
+        blocks = to_interrupted_blocks()
+        action_blocks = _find_blocks_by_type(blocks, "actions")
+        assert not action_blocks, "a dead turn must not offer a Cancel button"
+
+    def test_notice_text_is_character_identical_to_discord_copy(self) -> None:
+        # Literal, not imported from the Discord adapter -- import-linter's
+        # independence contract forbids cross-adapter imports, and the point
+        # of this test is that the two hand-kept literals stay in sync.
+        discord_copy = (
+            "❌ This turn was interrupted by a restart and cannot be "
+            "resumed. Nothing was lost on your side — mention me again to retry."
+        )
+        blocks = to_interrupted_blocks()
+        assert blocks[0]["text"]["text"] == discord_copy, (
+            "Slack's retirement copy must be byte-identical to Discord's"
+        )

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -4,17 +4,17 @@ Behavioral assertions — grouped by phase:
 
 Task 1 (debounce / registry / usage):
   - on_sse_event alone performs zero chat.postMessage and zero chat.update;
-    the following on_render posts immediately (D-12: flush rides the render
+    the following on_render posts immediately (flush rides the render
     tick, not the SSE consume path).
   - Two events plus two on_render ticks within 5s trigger NO chat.update
     (debounce window).
   - Events plus an on_render tick after 5s trigger exactly one chat.update
     (debounce elapsed).
-  - The first flush's registration rides post_initial() (D-02); a later
+  - The first flush's registration rides post_initial(); a later
     render-tick update does not re-register.
   - _apply_usage folds usage_totals into merged usage_in / usage_out / cost_str.
 
-on_render error propagation (D-12):
+on_render error propagation:
   - A failing chat.update surfaces out of on_render unswallowed -- the
     driver's per-tick render error policy is what handles it.
   - on_sse_event never raises for the identical scenario -- it performs no I/O.
@@ -196,7 +196,7 @@ async def test_on_sse_event_performs_no_io_then_on_render_posts_immediately(
 ) -> None:
     """on_sse_event alone performs zero chat-API I/O; a following on_render posts.
 
-    The flush moved off the SSE consume path (D-12): folding an event is a
+    The flush moved off the SSE consume path: folding an event is a
     local reducer call only, and the first chat.postMessage now happens on
     the next render tick.
     """
@@ -260,7 +260,7 @@ async def test_event_after_debounce_triggers_update(fake_slack_web_client: Any) 
 
 
 async def test_first_flush_registers_status_ts(fake_slack_web_client: Any) -> None:
-    """The first flush's registration rides post_initial() (D-02); a later
+    """The first flush's registration rides post_initial(); a later
     render-tick update must not re-register."""
     lc, cancel, registered, _ = _make_lifecycle(fake_slack_web_client)
 

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -243,6 +243,41 @@ async def test_first_flush_registers_status_ts(fake_slack_web_client: Any) -> No
 
 
 # ---------------------------------------------------------------------------
+# post_initial() / status_ts
+# ---------------------------------------------------------------------------
+
+
+async def test_post_initial_posts_the_card_and_registers_cancel_before_any_sse_event(
+    fake_slack_web_client: Any,
+) -> None:
+    """post_initial() alone posts the card and registers Cancel, with no prior SSE event."""
+    lc, cancel, registered, _ = _make_lifecycle(fake_slack_web_client)
+
+    await lc.post_initial()
+
+    assert _post_count(fake_slack_web_client) == 1, (
+        "post_initial() must post exactly one chat.postMessage with no SSE event required"
+    )
+    assert lc.status_ts == CHAT_OK_PAYLOAD["ts"], (
+        "status_ts must reflect the ts returned by the post"
+    )
+    assert len(registered) == 1, (
+        "the Cancel button must exist before the first SSE event, not after it"
+    )
+    ts, (reg_event, reg_author) = next(iter(registered.items()))
+    assert ts == lc.status_ts, "registered ts must match status_ts"
+    assert reg_event is cancel, "registered cancel event must be the one injected at construction"
+    assert reg_author == "U_AUTHOR", "registered author_id must match the constructor arg"
+
+
+async def test_status_ts_is_none_before_anything_is_posted(fake_slack_web_client: Any) -> None:
+    """A freshly constructed lifecycle reports status_ts as None."""
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+
+    assert lc.status_ts is None, "status_ts must be None before anything has been posted"
+
+
+# ---------------------------------------------------------------------------
 # Task 1: Usage footer
 # ---------------------------------------------------------------------------
 

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -3,11 +3,21 @@
 Behavioral assertions — grouped by phase:
 
 Task 1 (debounce / registry / usage):
-  - First SSE event triggers exactly one chat.postMessage and zero chat.update.
-  - Second SSE event within 5s triggers NO chat.update (debounce window).
-  - SSE event after 5s triggers exactly one chat.update (debounce elapsed).
-  - First flush registers status_ts in the injected registry as (cancel Event, author_id).
+  - on_sse_event alone performs zero chat.postMessage and zero chat.update;
+    the following on_render posts immediately (D-12: flush rides the render
+    tick, not the SSE consume path).
+  - Two events plus two on_render ticks within 5s trigger NO chat.update
+    (debounce window).
+  - Events plus an on_render tick after 5s trigger exactly one chat.update
+    (debounce elapsed).
+  - The first flush's registration rides post_initial() (D-02); a later
+    render-tick update does not re-register.
   - _apply_usage folds usage_totals into merged usage_in / usage_out / cost_str.
+
+on_render error propagation (D-12):
+  - A failing chat.update surfaces out of on_render unswallowed -- the
+    driver's per-tick render error policy is what handles it.
+  - on_sse_event never raises for the identical scenario -- it performs no I/O.
 
 Task 2 (terminal paths — replace-in-place, overflow, collapse, failure, deregister):
   - on_terminal_success with text replaces status message in place (chat.update on status_ts).
@@ -179,42 +189,62 @@ def _make_lifecycle(
 # ---------------------------------------------------------------------------
 
 
-async def test_first_sse_event_posts_immediately(fake_slack_web_client: Any) -> None:
-    """First SSE event triggers exactly one chat.postMessage and zero chat.update."""
+async def test_on_sse_event_performs_no_io_then_on_render_posts_immediately(
+    fake_slack_web_client: Any,
+) -> None:
+    """on_sse_event alone performs zero chat-API I/O; a following on_render posts.
+
+    The flush moved off the SSE consume path (D-12): folding an event is a
+    local reducer call only, and the first chat.postMessage now happens on
+    the next render tick.
+    """
     lc, *_ = _make_lifecycle(fake_slack_web_client)
 
     await lc.on_sse_event(_thinking_event())
 
-    assert _post_count(fake_slack_web_client) == 1, (
-        "first SSE event must trigger exactly one chat.postMessage (immediate flush)"
+    assert _post_count(fake_slack_web_client) == 0, (
+        "on_sse_event must perform zero chat.postMessage — the flush rides the render tick"
     )
     assert _update_count(fake_slack_web_client) == 0, (
-        "no chat.update on the first event — status message not yet established"
+        "on_sse_event must perform zero chat.update — no I/O on the SSE consume path"
+    )
+
+    await lc.on_render(TurnState())
+
+    assert _post_count(fake_slack_web_client) == 1, (
+        "the following render tick must trigger exactly one chat.postMessage (immediate flush)"
+    )
+    assert _update_count(fake_slack_web_client) == 0, (
+        "no chat.update on the first flush — status message not yet established"
     )
 
 
 async def test_second_event_within_debounce_no_update(fake_slack_web_client: Any) -> None:
-    """Second SSE event within 5s of the first triggers NO chat.update (debounce window)."""
+    """Two events plus two on_render ticks inside the debounce window produce one post, no update."""
     lc, *_ = _make_lifecycle(fake_slack_web_client)
 
     await lc.on_sse_event(_thinking_event())
+    await lc.on_render(TurnState())  # first render tick — immediate post, no debounce
     await lc.on_sse_event(_tool_event())  # within debounce window (no time elapsed)
+    await lc.on_render(TurnState())  # second render tick — still within debounce
 
     assert _post_count(fake_slack_web_client) == 1, (
-        "second event within debounce must not post a new message"
+        "second render tick within debounce must not post a new message"
     )
     assert _update_count(fake_slack_web_client) == 0, "no chat.update within the 5s debounce window"
 
 
 async def test_event_after_debounce_triggers_update(fake_slack_web_client: Any) -> None:
-    """SSE event after 5s debounce window triggers exactly one chat.update."""
+    """SSE events plus an on_render tick past the debounce window trigger one chat.update."""
     lc, *_ = _make_lifecycle(fake_slack_web_client)
 
-    await lc.on_sse_event(_thinking_event())  # initial post
+    await lc.on_sse_event(_thinking_event())
+    await lc.on_render(TurnState())  # initial post
     # Backdate _last_flush to simulate 6s elapsed (established idiom from Discord tests)
     lc._last_flush = time.monotonic() - 6.0  # pyright: ignore[reportPrivateUsage]  # backdating debounce
 
     await lc.on_sse_event(_tool_event())
+    await lc.on_render(TurnState())
 
     assert _post_count(fake_slack_web_client) == 1, "debounced update must NOT post a new message"
     assert _update_count(fake_slack_web_client) == 1, (
@@ -228,18 +258,76 @@ async def test_event_after_debounce_triggers_update(fake_slack_web_client: Any) 
 
 
 async def test_first_flush_registers_status_ts(fake_slack_web_client: Any) -> None:
-    """First flush registers status_ts with (cancel Event, author_id) in the registry."""
+    """The first flush's registration rides post_initial() (D-02); a later
+    render-tick update must not re-register."""
     lc, cancel, registered, _ = _make_lifecycle(fake_slack_web_client)
 
-    await lc.on_sse_event(_thinking_event())
+    await lc.post_initial()
 
-    assert len(registered) == 1, "exactly one registration after the first flush"
+    assert len(registered) == 1, "exactly one registration after post_initial()'s first flush"
     ts, (reg_event, reg_author) = next(iter(registered.items()))
     assert ts == "1000000000.000001", (
         "registered ts must match the ts from the chat.postMessage response"
     )
     assert reg_event is cancel, "registered cancel event must be the one injected at construction"
     assert reg_author == "U_AUTHOR", "registered author_id must match the constructor arg"
+
+    # A later render-tick update (debounce elapsed) must not add a second registration.
+    await lc.on_sse_event(_thinking_event())
+    lc._last_flush = time.monotonic() - 6.0  # pyright: ignore[reportPrivateUsage]  # backdating debounce
+    await lc.on_render(TurnState())
+
+    assert len(registered) == 1, "a debounced render-tick update must not add a second registration"
+
+
+# ---------------------------------------------------------------------------
+# on_render must not swallow adapter failures -- the driver's per-tick
+# render error policy is what handles them.
+# ---------------------------------------------------------------------------
+
+
+async def test_raising_chat_update_propagates_out_of_on_render(
+    fake_slack_web_client: Any,
+) -> None:
+    """A rate-limited/failing chat.update surfaces out of on_render -- the
+    adapter does not swallow it, so the driver's per-tick policy handles it."""
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+
+    await lc.on_sse_event(_thinking_event())
+    await lc.on_render(TurnState())  # first post — no update yet, succeeds
+    lc._last_flush = time.monotonic() - 6.0  # pyright: ignore[reportPrivateUsage]  # backdating debounce
+    await lc.on_sse_event(_tool_event())
+
+    _reset_slack_responses(fake_slack_web_client)
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": False, "error": "ratelimited"},
+    )
+
+    with pytest.raises(SlackApiError):
+        await lc.on_render(TurnState())
+
+
+async def test_on_sse_event_never_raises_for_the_same_scenario(
+    fake_slack_web_client: Any,
+) -> None:
+    """The cheap local tap performs no I/O, so a failing chat.update never
+    reaches it -- only the render tick can hit that failure."""
+    lc, *_ = _make_lifecycle(fake_slack_web_client)
+
+    await lc.on_sse_event(_thinking_event())
+    await lc.on_render(TurnState())
+    lc._last_flush = time.monotonic() - 6.0  # pyright: ignore[reportPrivateUsage]  # backdating debounce
+
+    _reset_slack_responses(fake_slack_web_client)
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": False, "error": "ratelimited"},
+    )
+
+    # Does not raise even though the next render tick would hit the failing
+    # update -- on_sse_event performs no I/O at all.
+    await lc.on_sse_event(_tool_event())
 
 
 # ---------------------------------------------------------------------------
@@ -333,7 +421,8 @@ async def test_terminal_success_replaces_status_in_place(fake_slack_web_client: 
     First chunk is placed via chat.update (not a new chat.postMessage), so final_ts = status_ts.
     """
     lc, *_ = _make_lifecycle(fake_slack_web_client)
-    await lc.on_sse_event(_thinking_event())  # initial post (1 postMessage)
+    await lc.post_initial()  # initial post (1 postMessage)
+    await lc.on_sse_event(_thinking_event())  # folds the thinking trail entry, no flush
 
     state = TurnState(content=[TextBlock(kind="text", text="The answer is 42.")])
     await lc.on_terminal_success(state)
@@ -362,6 +451,7 @@ async def test_terminal_success_overflow_posts_and_widens_final_ts(
 ) -> None:
     """Long text splits into overflow chunks posted via chat.postMessage; final_ts = LAST ts."""
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
     initial_posts = _post_count(fake_slack_web_client)
 
@@ -387,6 +477,7 @@ async def test_terminal_success_bounds_notification_text_on_long_answers(
     notifications, so it must never grow with the answer.
     """
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     long_text = "y" * 24000  # forces chunks at the 11800 block limit
@@ -427,6 +518,7 @@ async def test_terminal_success_tool_only_leaves_collapsed_done(
 ) -> None:
     """Tool-only turn (no final text after last ToolUseBlock) leaves the collapsed done; no overflow."""
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
     initial_posts = _post_count(fake_slack_web_client)
 
@@ -460,6 +552,7 @@ async def test_terminal_success_empty_content_shows_turn_cancelled(
 ) -> None:
     """Empty content (no blocks) triggers a chat.update with 'Turn cancelled.'."""
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState()  # completely empty
@@ -485,6 +578,7 @@ async def test_terminal_success_empty_content_shows_turn_cancelled(
 async def test_terminal_failure_does_not_raise(fake_slack_web_client: Any) -> None:
     """on_terminal_failure updates/posts error state and does NOT raise."""
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState()
@@ -511,6 +605,7 @@ async def test_deregister_called_in_terminal_success_finally(
 ) -> None:
     """deregister is invoked for status_ts in the on_terminal_success finally block."""
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState(content=[TextBlock(kind="text", text="Hello.")])
@@ -525,6 +620,7 @@ async def test_deregister_called_in_terminal_failure_finally(
 ) -> None:
     """deregister is invoked for status_ts in the on_terminal_failure finally block."""
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState()
@@ -583,6 +679,7 @@ async def test_terminal_success_flush_failure_repairs_status_message(
     """
     _stage_flush_failure_then_repair_ok(fake_slack_web_client, error="msg_too_long")
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState(content=[TextBlock(kind="text", text="The answer is 42.")])
@@ -621,6 +718,7 @@ async def test_terminal_success_swallows_repair_failure(
         repeat=True,
     )
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState(content=[TextBlock(kind="text", text="Hello.")])
@@ -686,6 +784,7 @@ async def test_terminal_success_overflow_failure_keeps_replaced_answer(
         repeat=True,
     )
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     long_text = "x" * 24000  # forces overflow chunks past the first update
@@ -709,6 +808,7 @@ async def test_terminal_failure_flush_failure_repairs_status_message(
     """on_terminal_failure's own flush failure gets the same repair treatment."""
     _stage_flush_failure_then_repair_ok(fake_slack_web_client, error="msg_too_long")
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     await lc.on_terminal_failure(TurnState(), RuntimeError("upstream blew up"))
@@ -750,6 +850,7 @@ async def test_terminal_success_transport_error_repairs_and_does_not_raise(
         repeat=True,
     )
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState(content=[TextBlock(kind="text", text="Hello.")])
@@ -783,6 +884,7 @@ async def test_terminal_failure_transport_error_in_flush_and_repair_does_not_rai
         repeat=True,
     )
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     await lc.on_terminal_failure(TurnState(), RuntimeError("upstream blew up"))
@@ -800,6 +902,7 @@ async def test_terminal_success_cancelled_collapse_repair_does_not_claim_an_answ
     """
     _stage_flush_failure_then_repair_ok(fake_slack_web_client, error="ratelimited")
     lc, _, _registered, deregistered = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     await lc.on_terminal_success(TurnState())  # empty content — cancelled path
@@ -825,6 +928,7 @@ async def test_terminal_success_flush_failure_reaches_sentry(
     monkeypatch.setattr(lifecycle_mod, "capture_exception_with_scope", captured.append)
     _stage_flush_failure_then_repair_ok(fake_slack_web_client, error="msg_too_long")
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState(content=[TextBlock(kind="text", text="Hello.")])
@@ -860,6 +964,7 @@ async def test_lifecycle_satisfies_turn_lifecycle_protocol(fake_slack_web_client
 async def test_terminal_success_appends_feedback_buttons(fake_slack_web_client: Any) -> None:
     """An answered turn carries the 👍/👎 vote buttons on the final message."""
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState(content=[TextBlock(kind="text", text="The answer is 42.")])
@@ -880,6 +985,7 @@ async def test_overflow_puts_feedback_buttons_on_last_chunk_only(
     message_id keys the same message the watermark does.
     """
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     long_text = "x" * 24000  # three chunks at _SLACK_LIMIT=11800
@@ -904,6 +1010,7 @@ async def test_overflow_puts_feedback_buttons_on_last_chunk_only(
 async def test_tool_only_turn_gets_no_feedback_buttons(fake_slack_web_client: Any) -> None:
     """A turn with no final answer text must not invite feedback on it."""
     lc, *_ = _make_lifecycle(fake_slack_web_client)
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
 
     state = TurnState(

--- a/packages/adapters/slack/tests/test_lifecycle.py
+++ b/packages/adapters/slack/tests/test_lifecycle.py
@@ -152,6 +152,7 @@ def _make_lifecycle(
     *,
     model_id: str = "claude-sonnet-4-6",
     agent_name: str = "test-agent",
+    adopt_status_ts: str | None = None,
 ) -> tuple[SlackTurnLifecycle, asyncio.Event, dict[str, tuple[asyncio.Event, str]], list[str]]:
     """Create a SlackTurnLifecycle with recorder callables for registry operations.
 
@@ -180,6 +181,7 @@ def _make_lifecycle(
         model_id=model_id,
         register=register,
         deregister=deregister,
+        adopt_status_ts=adopt_status_ts,
     )
     return lc, cancel, registered, deregistered
 
@@ -278,6 +280,124 @@ async def test_first_flush_registers_status_ts(fake_slack_web_client: Any) -> No
     await lc.on_render(TurnState())
 
     assert len(registered) == 1, "a debounced render-tick update must not add a second registration"
+
+
+# ---------------------------------------------------------------------------
+# Adopting construction path (dead-session recovery): the caller hands over
+# the pre-recovery card's ts instead of letting the lifecycle post a new one.
+# ---------------------------------------------------------------------------
+
+_ADOPTED_TS = "1111.1"
+
+
+async def test_status_ts_reports_the_adopted_ts_before_anything_is_posted(
+    fake_slack_web_client: Any,
+) -> None:
+    """An adopting lifecycle reports the adopted ts with no chat-API I/O.
+
+    The caller can read status_ts immediately after construction, before
+    the turn has rendered anything at all.
+    """
+    lc, *_ = _make_lifecycle(fake_slack_web_client, adopt_status_ts=_ADOPTED_TS)
+
+    assert lc.status_ts == _ADOPTED_TS, "status_ts must report the adopted ts immediately"
+    assert _post_count(fake_slack_web_client) == 0, (
+        "reading status_ts on an adopting lifecycle must not perform any chat-API I/O"
+    )
+
+
+async def test_an_adopting_lifecycle_updates_the_adopted_card_instead_of_posting_a_new_one(
+    fake_slack_web_client: Any,
+) -> None:
+    """An adopting lifecycle's first flush updates the adopted card, not a new one.
+
+    A recovered turn must not leave a second card behind: nothing would ever
+    finalise it, and the marker written against the pre-recovery mapping row
+    would address a card nobody is rendering into.
+    """
+    lc, *_ = _make_lifecycle(fake_slack_web_client, adopt_status_ts=_ADOPTED_TS)
+
+    await lc.on_sse_event(_thinking_event())
+    await lc.on_render(TurnState())
+
+    assert _post_count(fake_slack_web_client) == 0, (
+        "a recovered turn must not post a second status card"
+    )
+    assert _update_count(fake_slack_web_client) == 1, (
+        "an adopting lifecycle's first render tick must update, not post"
+    )
+    calls = fake_slack_web_client.mock.requests.get(("POST", _UPDATE_URL), [])
+    body = calls[-1].kwargs["json"]
+    assert body["ts"] == _ADOPTED_TS, "the update must target the adopted ts"
+    assert body["channel"] == "C_TEST", "the update must target the constructor's channel"
+
+
+async def test_an_adopting_lifecycles_first_render_tick_updates_without_waiting_out_the_debounce(
+    fake_slack_web_client: Any,
+) -> None:
+    """An adopting lifecycle's first render tick updates immediately, no debounce wait.
+
+    The debounce clock starts already satisfied against a monotonic clock, so
+    the very first flush after construction updates with no wait -- this test
+    pins that consequence with no debounce-window backdating of its own. If a
+    future change seeds the debounce clock from `time.monotonic()` at
+    construction instead of leaving it at its zero value, this goes red.
+    """
+    lc, *_ = _make_lifecycle(fake_slack_web_client, adopt_status_ts=_ADOPTED_TS)
+
+    await lc.on_sse_event(_thinking_event())
+    await lc.on_render(TurnState())
+
+    assert _update_count(fake_slack_web_client) == 1, (
+        "the first render tick on an adopting lifecycle must update immediately, "
+        "with no debounce wait -- if a future change seeds the debounce clock from "
+        "time.monotonic() at construction, this must fail"
+    )
+
+
+async def test_an_adopting_lifecycle_registers_no_cancel_entry_of_its_own(
+    fake_slack_web_client: Any,
+) -> None:
+    """An adopting lifecycle never registers a cancel entry of its own.
+
+    It never takes the first-post branch that registers -- the caller
+    handing over the ts owns rebinding the registry entry.
+    """
+    lc, _, registered, _ = _make_lifecycle(fake_slack_web_client, adopt_status_ts=_ADOPTED_TS)
+
+    await lc.on_sse_event(_thinking_event())
+    await lc.on_render(TurnState())
+
+    assert registered == {}, (
+        "an adopting lifecycle must not register anything -- the caller rebinds"
+    )
+
+
+async def test_a_terminal_success_on_an_adopting_lifecycle_replaces_the_adopted_card(
+    fake_slack_web_client: Any,
+) -> None:
+    """The terminal render on an adopting lifecycle lands on the adopted card.
+
+    This is the assertion that the answer ends up on the card the user has
+    been watching, not on a second, freshly-posted one.
+    """
+    lc, _, _registered, deregistered = _make_lifecycle(
+        fake_slack_web_client, adopt_status_ts=_ADOPTED_TS
+    )
+
+    state = TurnState(content=[TextBlock(kind="text", text="The answer is 42.")])
+    await lc.on_terminal_success(state)
+
+    assert _post_count(fake_slack_web_client) == 0, "a single chunk needs no overflow post"
+    calls = fake_slack_web_client.mock.requests.get(("POST", _UPDATE_URL), [])
+    assert calls, "terminal success on an adopting lifecycle must chat.update"
+    body = calls[-1].kwargs["json"]
+    assert body["ts"] == _ADOPTED_TS, "the terminal render must target the adopted ts"
+    assert "The answer is 42." in _block_text(body["blocks"]), (
+        "the answer must land on the adopted card, the one the user has been watching"
+    )
+    assert lc.final_ts == _ADOPTED_TS, "final_ts must equal the adopted ts"
+    assert deregistered == [_ADOPTED_TS], "the adopted ts must be deregistered on terminal success"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/slack/tests/test_lifecycle_snapshots.py
+++ b/packages/adapters/slack/tests/test_lifecycle_snapshots.py
@@ -76,8 +76,10 @@ async def test_thinking_tool_then_success_sequence(
     clock = _make_clock([100.0, 100.0, 106.0, 116.0])
     lc = _make_lifecycle(fake_slack_web_client, clock)
 
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
     await lc.on_sse_event(_tool_use_event("Bash"))
+    await lc.on_render(TurnState())
 
     state = TurnState(
         content=[TextBlock(kind="text", text="Here is the answer.")],
@@ -102,7 +104,9 @@ async def test_terminal_failure_sequence(
     clock = _make_clock([100.0, 100.0, 112.0])
     lc = _make_lifecycle(fake_slack_web_client, clock)
 
+    await lc.post_initial()
     await lc.on_sse_event(_thinking_event())
+    await lc.on_render(TurnState())
 
     state = TurnState(
         usage_totals=UsageTotals(

--- a/packages/adapters/slack/tests/test_orphaned_turns.py
+++ b/packages/adapters/slack/tests/test_orphaned_turns.py
@@ -1,0 +1,218 @@
+"""The boot sweep that lays to rest Slack turns whose process died mid-flight.
+
+Mirrors the intent of the Discord adapter's test_orphaned_turns.py, but the
+row-state coverage differs on purpose. Discord's third case is a reconnect
+that must not re-trigger the sweep -- that does not apply here (the sweep is
+spawned once from a straight-line statement in ``main()`` and cannot run
+twice in one process, see boot_sweep.py's docstring). It is replaced by two
+cases unique to Slack's per-tenant token model: an uninstalled workspace
+(no bot-token row) and a legacy row with no channel (every orphan already in
+production before the channel column shipped).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import yarl
+from cryptography.fernet import Fernet
+from daimon.adapters.slack.boot_sweep import retire_orphaned_turns
+from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.core.defaults.provisioning import provision_tenant
+from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+from daimon.core.stores.thread_sessions import (
+    create_thread_session,
+    list_orphaned_turns,
+    mark_turn_active,
+)
+from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_NOW = datetime(2026, 8, 29, 12, 0, 0, tzinfo=UTC)
+_UPDATE_URL = yarl.URL("https://slack.com/api/chat.update")
+_POST_URL = yarl.URL("https://slack.com/api/chat.postMessage")
+
+
+def _build_runtime(fernet_key: str, db_factory: async_sessionmaker[AsyncSession]) -> SlackRuntime:
+    settings = MagicMock()
+    settings.crypto.keys = (SecretStr(fernet_key),)
+    return SlackRuntime(
+        settings=settings,
+        anthropic=MagicMock(),
+        sessionmaker=db_factory,
+        billing_config=None,
+        http_client=MagicMock(spec=httpx.AsyncClient),
+        resolver_cache=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+        turn_deps=MagicMock(),  # pyright: ignore[reportArgumentType]  # stub, turn path not exercised
+    )
+
+
+async def _seed_orphan(
+    db_factory: async_sessionmaker[AsyncSession],
+    fernet_key: str,
+    *,
+    team_id: str,
+    thread_id: str = "1000.1",
+    channel_id: str | None = "C_TEST",
+    message_id: str = "1000000000.000001",
+    with_token: bool = True,
+) -> uuid.UUID:
+    """Seed one tenant with a mid-flight thread_sessions row.
+
+    ``with_token=False`` skips the ``slack_bot_tokens`` insert, reproducing an
+    uninstalled workspace. ``channel_id=None`` reproduces a legacy row from
+    before this phase's channel column existed.
+    """
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+    await provision_tenant(db_factory, platform="slack", workspace_id=team_id)
+    if with_token:
+        fernet = build_multifernet((fernet_key,))
+        async with db_factory() as s:
+            await upsert_slack_bot_token(
+                s, team_id=team_id, encrypted_token=encrypt_token(fernet, "xoxb-test")
+            )
+            await s.commit()
+    async with db_factory() as s:
+        row = await create_thread_session(
+            s,
+            tenant_id=tenant_id,
+            platform="slack",
+            thread_id=thread_id,
+            account_id=uuid.uuid4(),
+            ma_session_id="sesn_test",
+        )
+        await mark_turn_active(
+            s,
+            id=row.id,
+            active_turn_message_id=message_id,
+            active_turn_channel_id=channel_id,
+            now=_NOW,
+        )
+        await s.commit()
+    return row.id
+
+
+async def test_sweep_edits_the_frozen_card_and_clears_the_marker(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    fernet_key = Fernet.generate_key().decode()
+    await _seed_orphan(
+        db_session_factory,
+        fernet_key,
+        team_id="T_REACHABLE",
+        channel_id="C_REACHABLE",
+        message_id="1111.1",
+    )
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await retire_orphaned_turns(runtime, now=_NOW)
+
+    update_calls = fake_slack_web_client.mock.requests.get(("POST", _UPDATE_URL), [])
+    assert len(update_calls) == 1, "exactly one chat.update for the one seeded orphan"
+    body = update_calls[0].kwargs["json"]
+    assert body["channel"] == "C_REACHABLE", "must edit the row's own channel"
+    assert body["ts"] == "1111.1", "must edit the row's own message ts"
+    assert "interrupted" in body["blocks"][0]["text"]["text"], (
+        "the card must say the turn was interrupted"
+    )
+
+    post_calls = fake_slack_web_client.mock.requests.get(("POST", _POST_URL), [])
+    assert not post_calls, "D-09: the sweep edits in place, it never posts a new message"
+
+    assert await list_orphaned_turns(db_session, platform="slack") == [], (
+        "a retired turn must not be retired again on the next boot"
+    )
+
+
+async def test_sweep_clears_the_marker_when_the_card_is_unreachable(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    fernet_key = Fernet.generate_key().decode()
+    await _seed_orphan(db_session_factory, fernet_key, team_id="T_UNREACHABLE")
+    fake_slack_web_client.mock.clear()
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload={"ok": False, "error": "message_not_found"},
+        repeat=True,
+    )
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await retire_orphaned_turns(runtime, now=_NOW)  # must not raise
+
+    assert await list_orphaned_turns(db_session, platform="slack") == [], (
+        "a permanently unreachable card must not be retried on every boot"
+    )
+
+
+async def test_sweep_skips_the_api_call_and_still_clears_when_the_workspace_uninstalled(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    fernet_key = Fernet.generate_key().decode()
+    await _seed_orphan(db_session_factory, fernet_key, team_id="T_UNINSTALLED", with_token=False)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await retire_orphaned_turns(runtime, now=_NOW)
+
+    update_calls = fake_slack_web_client.mock.requests.get(("POST", _UPDATE_URL), [])
+    assert not update_calls, "an uninstalled workspace has no token to build a client from"
+    assert await list_orphaned_turns(db_session, platform="slack") == [], (
+        "the row must still clear so it is not retried forever"
+    )
+
+
+async def test_sweep_clears_a_legacy_row_with_no_channel_without_calling_slack(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    fernet_key = Fernet.generate_key().decode()
+    await _seed_orphan(db_session_factory, fernet_key, team_id="T_LEGACY", channel_id=None)
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await retire_orphaned_turns(runtime, now=_NOW)
+
+    update_calls = fake_slack_web_client.mock.requests.get(("POST", _UPDATE_URL), [])
+    assert not update_calls, "a NULL channel means there is nothing addressable to edit"
+    assert await list_orphaned_turns(db_session, platform="slack") == [], (
+        "a legacy pre-channel row must still clear without an API call"
+    )
+
+
+async def test_sweep_one_tenants_missing_token_does_not_stop_the_next_tenants_edit(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    fernet_key = Fernet.generate_key().decode()
+    await _seed_orphan(db_session_factory, fernet_key, team_id="T_NO_TOKEN", with_token=False)
+    await _seed_orphan(
+        db_session_factory,
+        fernet_key,
+        team_id="T_HAS_TOKEN",
+        channel_id="C_HAS_TOKEN",
+        message_id="2222.2",
+    )
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await retire_orphaned_turns(runtime, now=_NOW)
+
+    update_calls = fake_slack_web_client.mock.requests.get(("POST", _UPDATE_URL), [])
+    assert len(update_calls) == 1, "the reachable tenant's card must still be edited"
+    assert update_calls[0].kwargs["json"]["channel"] == "C_HAS_TOKEN", (
+        "one workspace's missing token must not divert the edit to another workspace"
+    )
+    assert await list_orphaned_turns(db_session, platform="slack") == [], (
+        "both tenants' rows must clear regardless of which one was reachable"
+    )

--- a/packages/adapters/slack/tests/test_orphaned_turns.py
+++ b/packages/adapters/slack/tests/test_orphaned_turns.py
@@ -129,7 +129,7 @@ async def test_sweep_edits_the_frozen_card_and_clears_the_marker(
     )
 
     post_calls = fake_slack_web_client.mock.requests.get(("POST", _POST_URL), [])
-    assert not post_calls, "D-09: the sweep edits in place, it never posts a new message"
+    assert not post_calls, "the sweep edits in place, it never posts a new message"
 
     assert await list_orphaned_turns(db_session, platform="slack") == [], (
         "a retired turn must not be retired again on the next boot"

--- a/packages/adapters/slack/tests/test_orphaned_turns.py
+++ b/packages/adapters/slack/tests/test_orphaned_turns.py
@@ -7,7 +7,9 @@ spawned once from a straight-line statement in ``main()`` and cannot run
 twice in one process, see boot_sweep.py's docstring). It is replaced by two
 cases unique to Slack's per-tenant token model: an uninstalled workspace
 (no bot-token row) and a legacy row with no channel (every orphan already in
-production before the channel column shipped).
+production before the channel column shipped). A further case covers the
+sweep's own compare-and-clear: a marker rewritten mid-sweep, by a turn
+admitted while the sweep was still running, must survive it.
 """
 
 from __future__ import annotations
@@ -33,6 +35,8 @@ from daimon.core.stores.thread_sessions import (
 )
 from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .conftest import CHAT_OK_PAYLOAD
 
 _NOW = datetime(2026, 8, 29, 12, 0, 0, tzinfo=UTC)
 _UPDATE_URL = yarl.URL("https://slack.com/api/chat.update")
@@ -215,4 +219,72 @@ async def test_sweep_one_tenants_missing_token_does_not_stop_the_next_tenants_ed
     )
     assert await list_orphaned_turns(db_session, platform="slack") == [], (
         "both tenants' rows must clear regardless of which one was reachable"
+    )
+
+
+async def test_sweep_leaves_a_marker_that_moved_while_the_sweep_was_running(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """A marker rewritten between the sweep's read and its clear must survive.
+
+    The sweep's orphan list is a snapshot taken once, up front. A marker
+    rewritten after that snapshot belongs to a turn a live process now owns
+    -- clearing it here would leave that turn unprotected against a second
+    crash, with no future sweep able to find it. This drives the interleave
+    through a callback on the fake Slack transport rather than patching the
+    sweep or the store: the fake is transport-level by construction, and a
+    patch-based interleave would prove nothing about the real code path.
+    """
+    fernet_key = Fernet.generate_key().decode()
+    row_id = await _seed_orphan(
+        db_session_factory,
+        fernet_key,
+        team_id="T_MOVED",
+        channel_id="C_MOVED",
+        message_id="3333.3",
+    )
+
+    async def _admit_a_fresh_turn_mid_sweep(url: yarl.URL, **kwargs: object) -> None:
+        # Fires from inside the sweep's own chat_update -- the exact window
+        # between the orphan read and the clear. Models a mention admitted
+        # while the sweep was still working: a live process writes a new
+        # marker on the same row before the sweep gets to clear it.
+        async with db_session_factory() as session:
+            await mark_turn_active(
+                session,
+                id=row_id,
+                active_turn_message_id="4444.4",
+                active_turn_channel_id="C_MOVED",
+                now=_NOW,
+            )
+            await session.commit()
+
+    fake_slack_web_client.mock.clear()
+    fake_slack_web_client.mock.post(  # pyright: ignore[reportUnknownMemberType]
+        str(_UPDATE_URL),
+        payload=CHAT_OK_PAYLOAD,
+        callback=_admit_a_fresh_turn_mid_sweep,
+        repeat=True,
+    )
+    runtime = _build_runtime(fernet_key, db_session_factory)
+
+    await retire_orphaned_turns(runtime, now=_NOW)
+
+    update_calls = fake_slack_web_client.mock.requests.get(("POST", _UPDATE_URL), [])
+    assert len(update_calls) == 1, "exactly one chat.update for the one seeded orphan"
+    assert update_calls[0].kwargs["json"]["ts"] == "3333.3", (
+        "the sweep must edit the ts it read at sweep start -- the frozen card, never the live one"
+    )
+
+    orphans = await list_orphaned_turns(db_session, platform="slack")
+    assert [o.id for o in orphans] == [row_id], (
+        "a marker written after the sweep's read belongs to a live turn and must survive the sweep"
+    )
+    assert orphans[0].active_turn_message_id == "4444.4", (
+        "the surviving marker must be the one the mid-sweep turn wrote, not the sweep's stale read"
+    )
+    assert orphans[0].active_turn_channel_id == "C_MOVED", (
+        "the conditional clear must null nothing at all here, not partially clear the row"
     )

--- a/packages/core/alembic/versions/0011_active_turn_channel.py
+++ b/packages/core/alembic/versions/0011_active_turn_channel.py
@@ -12,7 +12,7 @@ Discord, not just at migration time -- a Discord message id is globally
 addressable, so the Discord adapter never writes this column and its rows stay
 NULL for the life of the table.
 
-First-boot consequence (D-08): a Slack orphan row that already exists when
+First-boot consequence: a Slack orphan row that already exists when
 this migration lands carries NULL in this column too, since it predates the
 column entirely. The boot sweep must clear that row without attempting a
 `chat_update` call -- there is no channel to address.

--- a/packages/core/alembic/versions/0011_active_turn_channel.py
+++ b/packages/core/alembic/versions/0011_active_turn_channel.py
@@ -1,0 +1,40 @@
+"""Give the shared turn marker a channel, so a Slack boot sweep can find the frozen status card.
+
+Revision ID: 0011_active_turn_channel
+Revises: 0010_agent_mcp_credentials
+Create Date: 2026-08-29
+
+downgrade: safe
+
+Nullable with no backfill: a row with no marker has no channel to record, so
+every existing row is legitimately NULL here. NULL is also correct FOREVER for
+Discord, not just at migration time -- a Discord message id is globally
+addressable, so the Discord adapter never writes this column and its rows stay
+NULL for the life of the table.
+
+First-boot consequence (D-08): a Slack orphan row that already exists when
+this migration lands carries NULL in this column too, since it predates the
+column entirely. The boot sweep must clear that row without attempting a
+`chat_update` call -- there is no channel to address.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011_active_turn_channel"
+down_revision: str | None = "0010_agent_mcp_credentials"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "thread_sessions",
+        sa.Column("active_turn_channel_id", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("thread_sessions", "active_turn_channel_id")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -315,11 +315,14 @@ class ThreadSession(Base):
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'live'"))
     # Set while a turn is running, cleared when it reaches a terminal state.
     # Distinct from `status`, which is about the session mapping and stays
-    # 'live' on every healthy thread forever.
+    # 'live' on every healthy thread forever. Slack needs the channel because a
+    # Slack message is addressed by (channel, ts); Discord leaves it NULL since
+    # a Discord message id is globally addressable on its own.
     active_turn_message_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     active_turn_started_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    active_turn_channel_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -1091,8 +1091,12 @@ class SlackEventDedup(Base):
     event key. Dedup MUST be on this key, NOT envelope_id: reconnect redelivers
     the same logical event with a NEW envelope_id.
 
-    Unbounded for v1 (rows are tiny, no pruning job, no TTL, no delete
-    cost on the ack path).
+    Rows are pruned by age on a schedule: `daimon.core.slack_event_dedup_sweep`
+    deletes rows older than a 7-day retention window on every scheduler tick
+    (D-05). The ack path still pays no delete cost — pruning is out-of-band,
+    never per-turn (D-04). The window is chosen to outlive Slack's own
+    redelivery schedule by a wide margin, so a prune can never re-admit a
+    duplicate event.
 
     Private to `daimon.core.stores.**` per the import-linter ORM contract.
     """

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -1092,9 +1092,9 @@ class SlackEventDedup(Base):
     the same logical event with a NEW envelope_id.
 
     Rows are pruned by age on a schedule: `daimon.core.slack_event_dedup_sweep`
-    deletes rows older than a 7-day retention window on every scheduler tick
-    (D-05). The ack path still pays no delete cost — pruning is out-of-band,
-    never per-turn (D-04). The window is chosen to outlive Slack's own
+    deletes rows older than a 7-day retention window on every scheduler tick.
+    The ack path still pays no delete cost — pruning is out-of-band,
+    never per-turn. The window is chosen to outlive Slack's own
     redelivery schedule by a wide margin, so a prune can never re-admit a
     duplicate event.
 

--- a/packages/core/daimon/core/slack_event_dedup_sweep.py
+++ b/packages/core/daimon/core/slack_event_dedup_sweep.py
@@ -1,4 +1,4 @@
-"""Prune aged rows from the slack_event_dedup admission gate (D-05).
+"""Prune aged rows from the slack_event_dedup admission gate.
 
 A `slack_event_dedup` row exists only to suppress redelivery of an event
 Socket Mode has not yet been acked for. Slack's documented base retry
@@ -10,10 +10,10 @@ pessimistic 24-hour bound and roughly 1700x the actual ~6-minute one — it
 also doubles as a one-week forensic trail for "did we ever receive that
 event?". `_RETENTION` is a module constant, not a setting: `.env.example` is
 generated from the Settings models, and a knob with a 1700x margin is not
-worth that churn (D-05).
+worth that churn.
 
 Deleting a row here never recovers a crashed turn — pruning is deliberately
-out-of-band from any turn path, never per-turn (D-04).
+out-of-band from any turn path, never per-turn.
 
 Shell-only: opens one session, delegates the delete to the store's
 select-keys-then-delete helper, commits, and logs the count. `now` is

--- a/packages/core/daimon/core/slack_event_dedup_sweep.py
+++ b/packages/core/daimon/core/slack_event_dedup_sweep.py
@@ -1,0 +1,55 @@
+"""Prune aged rows from the slack_event_dedup admission gate (D-05).
+
+A `slack_event_dedup` row exists only to suppress redelivery of an event
+Socket Mode has not yet been acked for. Slack's documented base retry
+schedule is 3 retries over roughly 6 minutes; that extends to hourly retries
+for 24 hours only if the "Delayed Events" app setting is enabled, which
+daimon has not done (it is not in `docs/slack-app-manifest.yaml`). So
+`_RETENTION` only has to outlive that window, and 7 days is 7x the
+pessimistic 24-hour bound and roughly 1700x the actual ~6-minute one — it
+also doubles as a one-week forensic trail for "did we ever receive that
+event?". `_RETENTION` is a module constant, not a setting: `.env.example` is
+generated from the Settings models, and a knob with a 1700x margin is not
+worth that churn (D-05).
+
+Deleting a row here never recovers a crashed turn — pruning is deliberately
+out-of-band from any turn path, never per-turn (D-04).
+
+Shell-only: opens one session, delegates the delete to the store's
+select-keys-then-delete helper, commits, and logs the count. `now` is
+injected, never read from a clock inside this module, and there is no
+try/except here — the scheduler's call site owns the boundary catch, exactly
+as it does for the existing sweepers (`wizard_sweep.py`,
+`pending_file_sweeper.py`).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Final
+
+import structlog
+from daimon.core.stores.slack_event_dedup import delete_event_dedup_older_than
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_log = structlog.get_logger(__name__)
+
+# Not a setting — see the module docstring. A 1700x margin over the actual
+# redelivery bound is not worth a config knob, and .env.example is generated.
+_RETENTION: Final = timedelta(days=7)
+
+
+async def sweep_expired_slack_event_dedup(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    now: datetime,
+    limit: int = 500,
+) -> int:
+    """Delete up to `limit` slack_event_dedup rows older than `_RETENTION`.
+
+    Returns the number of rows deleted.
+    """
+    async with session_factory() as session, session.begin():
+        count = await delete_event_dedup_older_than(session, cutoff=now - _RETENTION, limit=limit)
+    _log.info("slack_event_dedup_sweep.expired", count=count)
+    return count

--- a/packages/core/daimon/core/stores/domain.py
+++ b/packages/core/daimon/core/stores/domain.py
@@ -178,6 +178,7 @@ class ThreadSessionRow(BaseModel):
     updated_at: datetime
     active_turn_message_id: str | None = None
     active_turn_started_at: datetime | None = None
+    active_turn_channel_id: str | None = None
 
 
 class GitHubOauthStateRow(BaseModel):

--- a/packages/core/daimon/core/stores/slack_event_dedup.py
+++ b/packages/core/daimon/core/stores/slack_event_dedup.py
@@ -10,10 +10,11 @@ the project's error-propagation rule.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, cast
 
 from daimon.core._models import SlackEventDedup
-from sqlalchemy import CursorResult, delete
+from sqlalchemy import CursorResult, delete, select, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -49,6 +50,42 @@ async def delete_event_dedup_for_team(session: AsyncSession, *, team_id: str) ->
     result = await session.execute(
         delete(SlackEventDedup).where(SlackEventDedup.team_id == team_id)
     )
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
+async def delete_event_dedup_older_than(
+    session: AsyncSession,
+    *,
+    cutoff: datetime,
+    limit: int = 500,
+) -> int:
+    """Delete up to `limit` slack_event_dedup rows created before `cutoff`.
+
+    Selects the target keys first with a `LIMIT`, then deletes by that key
+    set, so one sweep tick cannot lock the whole table (mirrors
+    `abandon_expired_wizard_sessions`). The primary key is the composite
+    (team_id, channel, event_ts), not a single id column, so the delete uses
+    a tuple `IN` over those three columns rather than an id list. Returns the
+    rowcount.
+    """
+    key_stmt = (
+        select(
+            SlackEventDedup.team_id,
+            SlackEventDedup.channel,
+            SlackEventDedup.event_ts,
+        )
+        .where(SlackEventDedup.created_at < cutoff)
+        .limit(limit)
+    )
+    keys = (await session.execute(key_stmt)).all()
+    if not keys:
+        return 0
+    stmt = delete(SlackEventDedup).where(
+        tuple_(SlackEventDedup.team_id, SlackEventDedup.channel, SlackEventDedup.event_ts).in_(keys)
+    )
+    result = await session.execute(stmt)
     rowcount = cast(CursorResult[Any], result).rowcount
     await session.flush()
     return rowcount

--- a/packages/core/daimon/core/stores/thread_sessions.py
+++ b/packages/core/daimon/core/stores/thread_sessions.py
@@ -24,10 +24,12 @@ from __future__ import annotations
 
 import uuid as _uuid
 from datetime import datetime
+from typing import Any, cast
 
 from daimon.core._models import ThreadSession
 from daimon.core.stores.domain import ThreadSessionRow
 from sqlalchemy import select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -202,6 +204,48 @@ async def clear_active_turn(
         )
     )
     await session.flush()
+
+
+async def clear_active_turn_if_message_id(
+    session: AsyncSession,
+    *,
+    id: _uuid.UUID,
+    expected_message_id: str,
+) -> bool:
+    """Clear the in-flight marker only if it still names the message the caller
+    read earlier. Returns whether it cleared.
+
+    For a reader that snapshotted the marker at some point in the past -- the
+    boot sweep -- and must not clobber a marker written since that snapshot.
+    `clear_active_turn` above stays unconditional and is still the right call
+    for callers that OWN the row: a turn's own terminal path wrote the marker
+    itself and is entitled to clear it outright, no comparison needed.
+
+    A `False` return is safe, not merely tolerated: the marker no longer
+    matching means a live process wrote a new one after the caller's read, and
+    that process will clear it on its own terminal path -- or crash, in which
+    case the next boot's sweep finds it. A skip can never strand a row. A NULL
+    marker never equals a string either, so a row that was already cleared
+    also returns `False` rather than raising.
+
+    The id predicate confines the write to the one row the caller named, so
+    two rows that happen to carry the same message id cannot be crossed.
+    """
+    result = await session.execute(
+        update(ThreadSession)
+        .where(
+            ThreadSession.id == id,
+            ThreadSession.active_turn_message_id == expected_message_id,
+        )
+        .values(
+            active_turn_message_id=None,
+            active_turn_started_at=None,
+            active_turn_channel_id=None,
+        )
+    )
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount == 1
 
 
 async def list_orphaned_turns(

--- a/packages/core/daimon/core/stores/thread_sessions.py
+++ b/packages/core/daimon/core/stores/thread_sessions.py
@@ -157,17 +157,27 @@ async def mark_turn_active(
     id: _uuid.UUID,
     active_turn_message_id: str,
     now: datetime,
+    active_turn_channel_id: str | None = None,
 ) -> None:
     """Record that a turn is running and which message is rendering it.
 
     Written once the embed exists and the mapping row is known. The pair is
     what lets a restarted process find embeds it can never finish -- the
     process holding them is gone, and nothing else knows they were mid-flight.
+
+    active_turn_channel_id is optional because a Discord message id is
+    globally addressable on its own, while a Slack message is identified by
+    (channel, ts). A caller that omits it stores NULL, which is the correct
+    reading for Discord.
     """
     await session.execute(
         update(ThreadSession)
         .where(ThreadSession.id == id)
-        .values(active_turn_message_id=active_turn_message_id, active_turn_started_at=now)
+        .values(
+            active_turn_message_id=active_turn_message_id,
+            active_turn_started_at=now,
+            active_turn_channel_id=active_turn_channel_id,
+        )
     )
     await session.flush()
 
@@ -177,11 +187,19 @@ async def clear_active_turn(
     *,
     id: _uuid.UUID,
 ) -> None:
-    """Clear the in-flight marker. Call on every terminal path, including failure."""
+    """Clear the in-flight marker. Call on every terminal path, including failure.
+
+    All three marker columns are cleared together so a cleared row carries no
+    dead channel id.
+    """
     await session.execute(
         update(ThreadSession)
         .where(ThreadSession.id == id)
-        .values(active_turn_message_id=None, active_turn_started_at=None)
+        .values(
+            active_turn_message_id=None,
+            active_turn_started_at=None,
+            active_turn_channel_id=None,
+        )
     )
     await session.flush()
 

--- a/packages/core/daimon/core/turn/run.py
+++ b/packages/core/daimon/core/turn/run.py
@@ -106,11 +106,13 @@ async def _mirror_cancel(cancel: asyncio.Event, fresh_cancel: asyncio.Event) -> 
     duration of the recovery turn (D-07(b)).
 
     The adapters' recovery lifecycles rebind their cancel affordance to
-    `fresh_cancel` (Discord's new `CancelView`, Slack's re-registration), but
-    only once their next flush lands -- a click on the ORIGINAL affordance in
-    the window between `fresh_cancel` being created and that rebind landing
-    would otherwise set an event nothing is watching. This task closes that
-    window (and also covers any future adapter that forgets to rebind).
+    `fresh_cancel`: Discord's new `CancelView` lands with the recovery
+    lifecycle's next flush, while the Slack adapter re-registers the adopted
+    card's entry eagerly, at construction -- a click on the ORIGINAL
+    affordance in the window between `fresh_cancel` being created and
+    whichever rebind lands would otherwise set an event nothing is watching.
+    This task closes that window (and also covers any future adapter that
+    forgets to rebind).
     """
     await cancel.wait()
     fresh_cancel.set()

--- a/packages/core/tests/stores/test_thread_sessions.py
+++ b/packages/core/tests/stores/test_thread_sessions.py
@@ -20,6 +20,7 @@ from daimon.core.stores.thread_sessions import (
     create_thread_session,
     get_latest_thread_session,
     get_live_thread_session,
+    get_thread_session_by_id,
     list_orphaned_turns,
     mark_dead,
     mark_turn_active,
@@ -497,3 +498,84 @@ async def test_orphan_listing_is_scoped_to_one_platform(
         "each adapter reaps only its own platform's turns"
     )
     assert len(await list_orphaned_turns(db_session, platform="slack")) == 1
+
+
+async def test_slack_marked_turn_lists_back_with_its_channel(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    """A Slack message is addressed by (channel, ts); the sweep needs the channel."""
+    row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id="1700000000.000100",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_slack_sweep",
+    )
+
+    await mark_turn_active(
+        db_session,
+        id=row.id,
+        active_turn_message_id="1700000000.000200",
+        active_turn_channel_id="C_SWEEP",
+        now=datetime.now(UTC),
+    )
+
+    orphans = await list_orphaned_turns(db_session, platform="slack")
+    assert [o.active_turn_channel_id for o in orphans] == ["C_SWEEP"], (
+        "the sweep cannot address a Slack message with chat_update without its channel"
+    )
+
+
+async def test_mark_turn_active_without_channel_defaults_to_none(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    """Discord's call site passes no channel; a Discord message id is globally addressable."""
+    row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="discord",
+        thread_id="discord-no-channel",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_discord_no_channel",
+    )
+
+    await mark_turn_active(
+        db_session, id=row.id, active_turn_message_id="msg-99", now=datetime.now(UTC)
+    )
+
+    orphans = await list_orphaned_turns(db_session, platform="discord")
+    assert orphans[0].active_turn_channel_id is None, (
+        "omitting the channel kwarg must store NULL, the correct reading for Discord"
+    )
+
+
+async def test_clear_active_turn_nulls_all_three_marker_columns(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id="1700000000.000300",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_slack_clear",
+    )
+    await mark_turn_active(
+        db_session,
+        id=row.id,
+        active_turn_message_id="1700000000.000400",
+        active_turn_channel_id="C_CLEAR",
+        now=datetime.now(UTC),
+    )
+
+    await clear_active_turn(db_session, id=row.id)
+
+    cleared = await get_thread_session_by_id(db_session, id=row.id)
+    assert cleared is not None, "the row itself must survive a clear, only the marker is reset"
+    assert cleared.active_turn_message_id is None, "cleared rows carry no dead message id"
+    assert cleared.active_turn_started_at is None, "cleared rows carry no dead start time"
+    assert cleared.active_turn_channel_id is None, "cleared rows carry no dead channel id"

--- a/packages/core/tests/stores/test_thread_sessions.py
+++ b/packages/core/tests/stores/test_thread_sessions.py
@@ -17,6 +17,7 @@ from daimon.core._models import ThreadSession
 from daimon.core.stores.domain import ThreadSessionRow
 from daimon.core.stores.thread_sessions import (
     clear_active_turn,
+    clear_active_turn_if_message_id,
     create_thread_session,
     get_latest_thread_session,
     get_live_thread_session,
@@ -579,3 +580,162 @@ async def test_clear_active_turn_nulls_all_three_marker_columns(
     assert cleared.active_turn_message_id is None, "cleared rows carry no dead message id"
     assert cleared.active_turn_started_at is None, "cleared rows carry no dead start time"
     assert cleared.active_turn_channel_id is None, "cleared rows carry no dead channel id"
+
+
+async def test_clear_active_turn_if_message_id_clears_when_the_marker_still_matches(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id="1700000000.000500",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_slack_conditional_match",
+    )
+    await mark_turn_active(
+        db_session,
+        id=row.id,
+        active_turn_message_id="5555.1",
+        active_turn_channel_id="C_MATCH",
+        now=datetime.now(UTC),
+    )
+
+    cleared = await clear_active_turn_if_message_id(
+        db_session, id=row.id, expected_message_id="5555.1"
+    )
+
+    assert cleared is True, "a marker that still names the caller's read must clear"
+    fetched = await get_thread_session_by_id(db_session, id=row.id)
+    assert fetched is not None, "the row itself must survive a clear"
+    assert fetched.active_turn_message_id is None, "a matched clear must null the message id"
+    assert fetched.active_turn_started_at is None, "a matched clear must null the start time"
+    assert fetched.active_turn_channel_id is None, "a matched clear must null the channel id"
+    assert await list_orphaned_turns(db_session, platform="slack") == [], (
+        "a cleared row must not be reported as an orphan"
+    )
+
+
+async def test_clear_active_turn_if_message_id_leaves_a_marker_that_moved(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id="1700000000.000600",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_slack_conditional_moved",
+    )
+    await mark_turn_active(
+        db_session,
+        id=row.id,
+        active_turn_message_id="6666.1",
+        active_turn_channel_id="C_FIRST",
+        now=datetime.now(UTC),
+    )
+    await mark_turn_active(
+        db_session,
+        id=row.id,
+        active_turn_message_id="6666.2",
+        active_turn_channel_id="C_SECOND",
+        now=datetime.now(UTC),
+    )
+
+    cleared = await clear_active_turn_if_message_id(
+        db_session, id=row.id, expected_message_id="6666.1"
+    )
+
+    assert cleared is False, (
+        "a marker written after the caller's read belongs to a live turn and must survive"
+    )
+    orphans = await list_orphaned_turns(db_session, platform="slack")
+    assert [o.id for o in orphans] == [row.id], "the row must still be listed as an orphan"
+    assert orphans[0].active_turn_message_id == "6666.2", (
+        "the second mark's message id must still be in place, untouched by the stale clear"
+    )
+    assert orphans[0].active_turn_channel_id == "C_SECOND", (
+        "the second mark's channel id must still be in place, untouched by the stale clear"
+    )
+
+
+async def test_clear_active_turn_if_message_id_is_a_no_op_on_an_already_cleared_row(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    row = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id="1700000000.000700",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_slack_conditional_already_cleared",
+    )
+    await mark_turn_active(
+        db_session,
+        id=row.id,
+        active_turn_message_id="7777.1",
+        active_turn_channel_id="C_ALREADY",
+        now=datetime.now(UTC),
+    )
+    await clear_active_turn(db_session, id=row.id)
+
+    cleared = await clear_active_turn_if_message_id(
+        db_session, id=row.id, expected_message_id="7777.1"
+    )
+
+    assert cleared is False, "a NULL marker never equals a string, so this must not raise or match"
+
+
+async def test_clear_active_turn_if_message_id_never_touches_another_row(
+    db_session: AsyncSession,
+    tenant_id: uuid.UUID,
+) -> None:
+    first = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id="1700000000.000800",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_slack_conditional_row_a",
+    )
+    second = await create_thread_session(
+        db_session,
+        tenant_id=tenant_id,
+        platform="slack",
+        thread_id="1700000000.000900",
+        account_id=uuid.uuid4(),
+        ma_session_id="sess_slack_conditional_row_b",
+    )
+    await mark_turn_active(
+        db_session,
+        id=first.id,
+        active_turn_message_id="8888.1",
+        active_turn_channel_id="C_ROW_A",
+        now=datetime.now(UTC),
+    )
+    await mark_turn_active(
+        db_session,
+        id=second.id,
+        active_turn_message_id="8888.1",
+        active_turn_channel_id="C_ROW_B",
+        now=datetime.now(UTC),
+    )
+
+    cleared = await clear_active_turn_if_message_id(
+        db_session, id=first.id, expected_message_id="8888.1"
+    )
+
+    assert cleared is True, "the named row, which genuinely matches, must clear"
+    orphans = await list_orphaned_turns(db_session, platform="slack")
+    assert [o.id for o in orphans] == [second.id], (
+        "the other row, sharing the same message id, must be untouched"
+    )
+    assert orphans[0].active_turn_message_id == "8888.1", (
+        "a colliding message id on a different row must not be nulled by the named row's clear"
+    )
+    assert orphans[0].active_turn_channel_id == "C_ROW_B", (
+        "the other row's channel id must also survive untouched"
+    )

--- a/packages/core/tests/test_slack_event_dedup.py
+++ b/packages/core/tests/test_slack_event_dedup.py
@@ -1,18 +1,33 @@
 """Real-Postgres round-trip tests for the slack_event_dedup store.
 
-Tests the three admission behaviors of insert_if_new:
+Covers both the admission gate and the TTL prune:
+
+`insert_if_new` (three tests):
 1. First insert on a fresh (team_id, channel, event_ts) triple → True.
 2. Second insert on the same triple → False (ON CONFLICT DO NOTHING, rowcount 0).
 3. Different event_ts for the same (team_id, channel) → True (distinct logical event).
 
 Dedup is on the logical key, NOT envelope_id: Slack Socket Mode reconnect redelivers
 the same logical event with a fresh envelope_id, so only the content triple matters.
+
+`delete_event_dedup_older_than` (four tests): rows strictly older than the cutoff
+are deleted; a row at or after the cutoff survives; `limit` caps one call's
+deletions; an empty table returns 0 without raising.
 """
 
 from __future__ import annotations
 
-from daimon.core.stores.slack_event_dedup import insert_if_new
+from datetime import UTC, datetime, timedelta
+
+from daimon.core._models import SlackEventDedup
+from daimon.core.stores.slack_event_dedup import (
+    delete_event_dedup_older_than,
+    insert_if_new,
+)
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+CUTOFF = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
 
 
 async def test_insert_if_new_first_insert_when_triple_is_new_returns_true(
@@ -42,3 +57,68 @@ async def test_insert_if_new_different_event_ts_when_same_team_and_channel_retur
         "a different event_ts for the same (team_id, channel) must return True — "
         "it is a distinct logical event"
     )
+
+
+async def test_delete_event_dedup_older_than_deletes_rows_strictly_before_cutoff(
+    db_session: AsyncSession,
+) -> None:
+    db_session.add(
+        SlackEventDedup(
+            team_id="T1",
+            channel="C1",
+            event_ts="1.1",
+            created_at=CUTOFF - timedelta(days=1),
+        )
+    )
+    await db_session.flush()
+
+    count = await delete_event_dedup_older_than(db_session, cutoff=CUTOFF)
+
+    assert count == 1, "a row strictly older than the cutoff must be deleted"
+    remaining = (await db_session.execute(select(SlackEventDedup))).scalars().all()
+    assert remaining == [], "the deleted row must no longer be present"
+
+
+async def test_delete_event_dedup_older_than_leaves_row_at_or_after_cutoff(
+    db_session: AsyncSession,
+) -> None:
+    db_session.add(SlackEventDedup(team_id="T1", channel="C1", event_ts="1.1", created_at=CUTOFF))
+    await db_session.flush()
+
+    count = await delete_event_dedup_older_than(db_session, cutoff=CUTOFF)
+
+    assert count == 0, (
+        "the prune must never delete a row Slack could still redeliver — a row at "
+        "or after the cutoff must survive"
+    )
+    remaining = (await db_session.execute(select(SlackEventDedup))).scalars().all()
+    assert len(remaining) == 1, "the surviving row must still be present"
+
+
+async def test_delete_event_dedup_older_than_limit_caps_one_calls_deletions(
+    db_session: AsyncSession,
+) -> None:
+    for i in range(3):
+        db_session.add(
+            SlackEventDedup(
+                team_id="T1",
+                channel="C1",
+                event_ts=f"{i}.1",
+                created_at=CUTOFF - timedelta(days=1),
+            )
+        )
+    await db_session.flush()
+
+    count = await delete_event_dedup_older_than(db_session, cutoff=CUTOFF, limit=2)
+
+    assert count == 2, "limit must cap the rowcount returned by one call"
+    remaining = (await db_session.execute(select(SlackEventDedup))).scalars().all()
+    assert len(remaining) == 1, "rows beyond the limit must survive this call"
+
+
+async def test_delete_event_dedup_older_than_empty_table_returns_zero(
+    db_session: AsyncSession,
+) -> None:
+    count = await delete_event_dedup_older_than(db_session, cutoff=CUTOFF)
+
+    assert count == 0, "an empty table must return 0 without raising"

--- a/packages/core/tests/test_slack_event_dedup_sweep.py
+++ b/packages/core/tests/test_slack_event_dedup_sweep.py
@@ -1,0 +1,100 @@
+"""Tests for daimon.core.slack_event_dedup_sweep."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from daimon.core._models import SlackEventDedup
+from daimon.core.slack_event_dedup_sweep import sweep_expired_slack_event_dedup
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=UTC)
+
+
+async def test_sweep_deletes_row_older_than_retention_window(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    db_session.add(
+        SlackEventDedup(
+            team_id="T1",
+            channel="C1",
+            event_ts="1.1",
+            created_at=NOW - timedelta(days=8),
+        )
+    )
+    await db_session.commit()
+
+    count = await sweep_expired_slack_event_dedup(db_session_factory, now=NOW)
+
+    assert count == 1, "a row older than the 7-day retention window must be deleted"
+
+
+async def test_sweep_leaves_row_inside_retention_window_untouched(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    db_session.add(
+        SlackEventDedup(
+            team_id="T1",
+            channel="C1",
+            event_ts="1.1",
+            created_at=NOW - timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+
+    count = await sweep_expired_slack_event_dedup(db_session_factory, now=NOW)
+
+    assert count == 0, "a row inside the retention window must survive"
+
+
+async def test_sweep_near_boundary_row_survives(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    db_session.add(
+        SlackEventDedup(
+            team_id="T1",
+            channel="C1",
+            event_ts="1.1",
+            created_at=NOW - timedelta(days=6, hours=23),
+        )
+    )
+    await db_session.commit()
+
+    count = await sweep_expired_slack_event_dedup(db_session_factory, now=NOW)
+
+    assert count == 0, (
+        "a row one hour inside the 7-day window must survive — the window must "
+        "stay comfortably wider than Slack's own worst-case 24-hour redelivery bound"
+    )
+
+
+async def test_sweep_outcome_changes_with_the_injected_now(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    db_session.add(
+        SlackEventDedup(
+            team_id="T1",
+            channel="C1",
+            event_ts="1.1",
+            created_at=NOW - timedelta(days=8),
+        )
+    )
+    await db_session.commit()
+
+    before_retention_elapsed = await sweep_expired_slack_event_dedup(
+        db_session_factory, now=NOW - timedelta(days=8)
+    )
+    after_retention_elapsed = await sweep_expired_slack_event_dedup(db_session_factory, now=NOW)
+
+    assert before_retention_elapsed == 0, (
+        "at the row's own creation instant, no clock has yet been read internally — "
+        "the row is not aged out"
+    )
+    assert after_retention_elapsed == 1, (
+        "the same seeded row is deleted once `now` moves past the retention window — "
+        "proving the outcome is decided by the injected `now`, not an internal clock read"
+    )


### PR DESCRIPTION
Brings Slack to parity with Discord on cross-process turn liveness. Before this, a Slack
turn whose process died left a card frozen on "thinking" forever: nothing recorded that the
turn existed, so no restart could find it, the mention was consumed for good, and the wedged
turn kept counting against the workspace's concurrency cap.

## What changed

**The turn marker learned which channel it lives in.** `thread_sessions` gains a nullable
`active_turn_channel_id`, threaded through `mark_turn_active` / `clear_active_turn`. Discord's
call sites are untouched and legitimately store NULL — it has a deployment-wide bot token and
doesn't need the channel to address an edit. Slack does.

**The status card now posts before the session binds.** A short timer races the first flush,
so a turn that wedges before any event still leaves the user a card and a working Cancel
button. `on_render` only updates from then on.

**A boot sweep retires orphans.** On start, every thread still carrying a marker gets its card
edited in place to a terminal "interrupted" state and its marker cleared, per tenant so a
workspace with several wedged threads decrypts its token once rather than once per row.

**The Block Kit flush moved off the SSE consume loop** onto the render tick, which is where
Discord already does it — the inline `chat_update` Retry-After stall dies with it.

**Dedup rows expire.** `(team_id, channel, event_ts)` rows were inserted before a turn and
never removed, so a mention eaten by a crashed turn could never be reprocessed. They now age
out via a bounded TTL prune wired into the scheduler's tick.

## The part worth reviewing closely

Verification caught a real hole in the first pass and it's the most subtle change here.
When a dead session triggers recovery, the turn driver creates a *new* mapping row. Slack was
building a fresh lifecycle for it, which posted a *second* status card — while the marker still
pointed at the first, now-abandoned one. Crash during a recovered turn and the next boot would
faithfully repair a card nobody was looking at, leaving the live one stranded forever. Exactly
the failure this branch exists to eliminate, in exactly the case it's named for.

The fix mirrors Discord's `adopt_message_ref`: `SlackTurnLifecycle` takes a keyword-only
`adopt_status_ts`, and `_recovery_lifecycle` seeds it from the pre-recovery card so the
recovered turn keeps editing the card the marker already names. The cancel registry entry is
rebound to the recovery cycle's fresh Event at the same time.

Separately, the boot sweep's clear is now a compare-and-clear: it only clears a marker that
still names the message the sweep read, so a turn admitted while the sweep was running keeps
its marker instead of being silently unprotected. Discord keeps the unconditional clear.

## Known limitation, deliberately out of scope

No marker exists between the card post and `mark_turn_active` — a window that spans the
session bind. A crash *there* still leaves an unfindable card. It's narrower than what this
branch closes but it's the same failure class, and it needs a design decision about how the
sweep represents "has a card, never bound a session" — currently an unrepresentable state.
Filed as a follow-up rather than patched under the wire.

## Verification

4968 passed, 4 skipped. pyright 0 errors, ruff clean, import-linter 6/6, repo lints clean.
`origin/main` is merged in and its Slack turn-isolation changes were confirmed not to disturb
the marker lifecycle, the recovery adoption, the cancel rebind, or the sweep.

Each behavioral change was mutation-tested: the fix was reverted, the new test confirmed
failing, then restored — so the tests are proving something rather than passing vacuously.
