### PR TITLE
feat(mcp): Slack file posting, install link, and thread paging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,8 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_SLACK__CLIENT_SECRET=
 # Maximum number of agent turns a single tenant (Slack workspace) may have in flight at once. Caps one noisy workspace from starving others on the shared Anthropic key.
 # DAIMON_SLACK__MAX_CONCURRENT_TURNS_PER_TENANT=3
+# Messages requested per conversations.replies call when replaying thread history. Slack clamps this per workspace: an app commercially distributed outside the Marketplace gets 15 whatever it asks for, an internal-app install gets the full page up to 1000, which is also the largest value Slack accepts. Raising it costs a clamped workspace nothing.
+# DAIMON_SLACK__HISTORY_PAGE_LIMIT=200
 # Port for the Slack process's liveness endpoint. Must not collide with the mcp process (8080), the discord process (8081), or the scheduler process (8082) — all process groups share one host.
 # DAIMON_SLACK__HEALTH_PORT=8083
 

--- a/docs/slack-app-manifest.yaml
+++ b/docs/slack-app-manifest.yaml
@@ -6,7 +6,14 @@
 # 3. Basic Information → App-Level Tokens → generate one with `connections:write`
 #    → DAIMON_SLACK__APP_TOKEN. Signing secret and OAuth client id/secret are on
 #    the same page → DAIMON_SLACK__SIGNING_SECRET / __CLIENT_ID / __CLIENT_SECRET.
-# 4. Manage Distribution → activate public distribution (the install flow needs it).
+# 4. Manage Distribution → activate public distribution ONLY if this deployment
+#    serves workspaces other than your own; the install flow in step 5 reaches
+#    your own workspace without it. Slack caps conversations.history and
+#    conversations.replies at 15 objects per call and one call per minute for
+#    apps distributed outside the Marketplace. A deployment that stays internal
+#    to one workspace is not capped: daimon requests 200 messages per page by
+#    default (DAIMON_SLACK__HISTORY_PAGE_LIMIT, up to 1000), and a capped
+#    workspace silently answers with 15.
 # 5. Visit https://DAIMON_HOST/oauth/slack/install and install to your workspace.
 #    The bot token is stored encrypted in daimon's database by that callback —
 #    there is no env var for it.

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -22,6 +22,12 @@ lose thread previews and the upload buffers the whole payload in memory), and
 re-running the install flow. A workspace that has hit its Slack file-storage
 limit gets one in-thread notice and no deliveries until space is freed.
 
+Agents can also post a file deliberately, mid-turn, through the MCP
+`send_message` tool's `file_handles` argument. The text posts first and the
+files follow as replies under it, so a file always has a caption. This uses
+the same `files:write` scope, and a workspace without it gets a tool error
+naming the reinstall step instead of a silent drop.
+
 ### Per-user Slack access (optional)
 
 By default daimon reads only channels the bot is invited to. Members can

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/_file_handles.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/_file_handles.py
@@ -1,0 +1,53 @@
+"""Resolve ``send_message`` file handles into bytes, for either platform.
+
+A handle names a row staged in Postgres by ``create_file_upload_url`` and
+filled by a direct PUT from the agent's sandbox. Postgres rather than
+instance storage because the PUT and this read are separate HTTP requests
+and mcp runs several instances with no session affinity.
+
+The error strings surface the rejected handle so an agent can fix the call
+without inspecting structured tool output.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from daimon.core.stores.file_uploads import get_upload
+from fastmcp.exceptions import ToolError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+MAX_ATTACHMENTS_PER_MESSAGE: int = 10
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedUpload:
+    filename: str
+    content: bytes
+
+
+async def resolve_file_handles(
+    handles: list[str],
+    *,
+    session_factory: async_sessionmaker[AsyncSession],
+    tenant_id: uuid.UUID,
+) -> list[ResolvedUpload]:
+    if len(handles) > MAX_ATTACHMENTS_PER_MESSAGE:
+        raise ToolError(f"max {MAX_ATTACHMENTS_PER_MESSAGE} attachments per message")
+    resolved: list[ResolvedUpload] = []
+    for name in handles:
+        async with session_factory() as session:
+            upload = await get_upload(session, tenant_id=tenant_id, handle_id=name)
+        if upload is None:
+            raise ToolError(
+                f"file handle {name!r} not found — mint one with create_file_upload_url, "
+                f"or check the handle id"
+            )
+        if upload.content is None:
+            raise ToolError(
+                f"file handle {name!r} has no bytes yet — PUT the file to its "
+                f"upload_url before posting it"
+            )
+        resolved.append(ResolvedUpload(filename=upload.display_filename, content=upload.content))
+    return resolved

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -110,22 +110,29 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         thread_id: str,
         limit: int = 50,
         before: str | None = None,
+        cursor: str | None = None,
     ) -> ReadThreadResult | SlackThreadResult:
         """Read messages from a thread, oldest-first.
 
         Discord: thread_id is the thread's channel id; use before for older messages.
-        Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is rejected — Slack threads read one page of at most 999
-        messages from the thread root, some workspaces cap that page at 15
-        whatever limit is asked for, and has_more=true means the newest
-        replies were not returned.
+        Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456).
+        Pages start at the thread root and run towards the newest reply, at
+        most 999 per page (some workspaces cap a page at 15 whatever limit is
+        asked for). has_more=true means newer replies exist; pass the returned
+        next_cursor as cursor to read them. before is Discord-only and cursor
+        is Slack-only.
         """
         auth = await _auth(ctx)
         before = before or None
+        cursor = cursor or None
         if auth.platform == "slack":
             if before is not None:
-                raise ToolError("before is Discord-only — slack read_thread has no pagination")
-            return await _slack_read_thread_impl(runtime, auth, thread_id=thread_id, limit=limit)
+                raise ToolError("before is Discord-only — slack read_thread pages with cursor")
+            return await _slack_read_thread_impl(
+                runtime, auth, thread_id=thread_id, limit=limit, cursor=cursor
+            )
+        if cursor is not None:
+            raise ToolError("cursor is Slack-only — discord read_thread pages with before")
         return await _read_thread_impl(
             runtime, auth, thread_id=thread_id, limit=limit, before=before
         )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -83,8 +83,9 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
         For threads use read_thread. Each platform takes only its own
         pagination parameter — the other is rejected. Discord: at most 200
-        messages per call; use before to fetch older messages. Slack: use
-        cursor to fetch the next page; at most 15 messages are returned.
+        messages per call; use before to fetch older messages. Slack: at most
+        999 per call, and some workspaces cap a single call at 15 whatever
+        limit is asked for; use cursor to fetch the next page.
         """
         auth = await _auth(ctx)
         # MCP clients often send "" for an optional param they mean to omit —
@@ -114,9 +115,10 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
         Discord: thread_id is the thread's channel id; use before for older messages.
         Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is rejected — Slack threads read one page of at most 15 messages
-        from the thread root, and has_more=true means the newest replies were
-        not returned.
+        before is rejected — Slack threads read one page of at most 999
+        messages from the thread root, some workspaces cap that page at 15
+        whatever limit is asked for, and has_more=true means the newest
+        replies were not returned.
         """
         auth = await _auth(ctx)
         before = before or None

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -250,15 +250,16 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         To post a file you made in your sandbox, call
         ``create_file_upload_url`` first and PUT the bytes to the URL it
         returns — never base64 a file into a tool argument. Combined
-        cap of 10 attachments per message. Both FILES paragraphs are
-        Discord-only for now — Slack file posting needs a scope this
-        install does not have.
+        cap of 10 attachments per message.
 
         Slack: ``channel_id`` may be ``channel_id:thread_ts`` (e.g.
         ``C0123456789:1717171717.123456``) to post into a thread. Content is
         sent as-is — nothing is escaped, so ``<@U…>`` mentions work — and is
         capped at 12,000 characters. daimon must already be in the channel
-        (a member can run ``/invite @daimon``).
+        (a member can run ``/invite @daimon``). ``file_handles`` works;
+        ``attachments`` by url does not (there is no Slack CDN to fetch from).
+        Files post as replies under the message, so ``content`` cannot be
+        empty when files are given — use it as the caption.
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_send.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_send.py
@@ -10,6 +10,10 @@ import aiohttp
 import discord
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools._file_handles import (
+    MAX_ATTACHMENTS_PER_MESSAGE,
+    resolve_file_handles,
+)
 from daimon.adapters.mcp.tools.discord._client import (
     _require_bot_token,  # pyright: ignore[reportPrivateUsage]
     _require_discord_identity,  # pyright: ignore[reportPrivateUsage]
@@ -27,13 +31,11 @@ from daimon.adapters.mcp.tools.discord._visibility import (
     _check_send_permission,  # pyright: ignore[reportPrivateUsage]
     _ensure_thread_parent_cached,  # pyright: ignore[reportPrivateUsage]
 )
-from daimon.core.stores.file_uploads import get_upload
 from fastmcp.exceptions import ToolError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 # Discord uses MiB, not MB, for the per-attachment cap.
 _DISCORD_ATTACHMENT_MAX_BYTES: int = 25 * 1024 * 1024
-_MAX_ATTACHMENTS_PER_MESSAGE: int = 10
 
 # SSRF guard: attachment fetches are restricted to Discord's CDN hosts. A bare
 # https scheme check is insufficient — an attacker-supplied https URL can
@@ -72,7 +74,7 @@ async def _fetch_attachment(session: aiohttp.ClientSession, url: str) -> bytes:
 async def _build_files(
     specs: list[dict[str, str]], *, session: aiohttp.ClientSession
 ) -> list[discord.File]:
-    if len(specs) > _MAX_ATTACHMENTS_PER_MESSAGE:
+    if len(specs) > MAX_ATTACHMENTS_PER_MESSAGE:
         raise ToolError("max 10 attachments per message")
     files: list[discord.File] = []
     for spec in specs:
@@ -87,34 +89,13 @@ async def _build_files_from_handles(
     session_factory: async_sessionmaker[AsyncSession],
     tenant_id: uuid.UUID,
 ) -> list[discord.File]:
-    """Resolve file handles into discord.File attachments.
-
-    Handles name rows staged in Postgres by ``create_file_upload_url``, which
-    the agent's sandbox filled with a direct PUT. Postgres rather than instance
-    storage because the PUT and this read are separate HTTP requests and mcp
-    runs several instances with no session affinity.
-
-    The error string must surface the rejected handle so an agent can fix the
-    call without inspecting structured tool output.
-    """
-    if len(filenames) > _MAX_ATTACHMENTS_PER_MESSAGE:
-        raise ToolError("max 10 attachments per message")
-    files: list[discord.File] = []
-    for name in filenames:
-        async with session_factory() as session:
-            upload = await get_upload(session, tenant_id=tenant_id, handle_id=name)
-        if upload is None:
-            raise ToolError(
-                f"file handle {name!r} not found — mint one with create_file_upload_url, "
-                f"or check the handle id"
-            )
-        if upload.content is None:
-            raise ToolError(
-                f"file handle {name!r} has no bytes yet — PUT the file to its "
-                f"upload_url before posting it"
-            )
-        files.append(discord.File(fp=io.BytesIO(upload.content), filename=upload.display_filename))
-    return files
+    """Resolve file handles into discord.File attachments."""
+    uploads = await resolve_file_handles(
+        filenames, session_factory=session_factory, tenant_id=tenant_id
+    )
+    return [
+        discord.File(fp=io.BytesIO(upload.content), filename=upload.filename) for upload in uploads
+    ]
 
 
 async def _send_message_impl(  # pyright: ignore[reportUnusedFunction]
@@ -134,7 +115,7 @@ async def _send_message_impl(  # pyright: ignore[reportUnusedFunction]
     total_attachments = (len(attachments) if attachments else 0) + (
         len(file_handles) if file_handles else 0
     )
-    if total_attachments > _MAX_ATTACHMENTS_PER_MESSAGE:
+    if total_attachments > MAX_ATTACHMENTS_PER_MESSAGE:
         raise ToolError("max 10 attachments per message")
 
     files: list[discord.File] = []

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/github_app.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/github_app.py
@@ -2,10 +2,11 @@
 
 Makes an existing GitHub App installation reachable from chat. A link button
 carries a URL and no custom id, so nothing dispatches it in the bot process
-and no request state is created anywhere — Discord opens the URL directly.
-This tool introduces no credential-request row, no minted token, no expiry,
-and no dynamic item; see ``tools/discord/_app_install_button.py`` for the
-posting path this delegates to.
+and no request state is created anywhere — the chat client opens the URL
+directly. This tool introduces no credential-request row, no minted token,
+no expiry, and no dynamic item; see ``tools/discord/_app_install_button.py``
+and ``tools/slack/_app_install_button.py`` for the posting paths this
+delegates to.
 
 Ungated deliberately: posting a link has no blast radius inside daimon, and
 GitHub itself enforces who may install an App on a given account or
@@ -20,6 +21,9 @@ from daimon.adapters.mcp.tools._ctx import _auth  # pyright: ignore[reportPrivat
 from daimon.adapters.mcp.tools.discord import (
     _post_app_install_button_impl,  # pyright: ignore[reportPrivateUsage]
 )
+from daimon.adapters.mcp.tools.slack._app_install_button import (
+    _post_slack_app_install_button_impl,  # pyright: ignore[reportPrivateUsage]
+)
 from daimon.core.github_app_auth import build_app_install_url
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
@@ -29,8 +33,8 @@ from pydantic import BaseModel, ConfigDict
 class PostAppInstallLinkResult(BaseModel):
     """Result of posting the GitHub App install-link button.
 
-    A link button returns no signal when clicked — Discord opens the URL
-    itself, and nothing dispatches back to daimon. This result reports only
+    A link button returns no signal when clicked — the chat client opens the
+    URL itself, and nothing dispatches back to daimon. This result reports only
     that the invitation was posted: it carries no field named or meaning
     installed, success, completed, connected, or verified.
     """
@@ -49,8 +53,6 @@ async def _post_app_install_link_impl(
     channel_id: str,
     purpose: str,
 ) -> PostAppInstallLinkResult:
-    if auth.platform == "slack":
-        raise ToolError("post_github_app_install_link is not supported on Slack yet")
     if auth.platform_user_id is None:
         raise ToolError("posting the install link requires a platform-bound identity")
     slug = runtime.settings.github.app_slug
@@ -59,13 +61,12 @@ async def _post_app_install_link_impl(
             "this deployment has no GitHub App install link configured — "
             "an operator must set DAIMON_GITHUB__APP_SLUG"
         )
-    message_id = await _post_app_install_button_impl(
-        runtime,
-        auth,
-        channel_id=channel_id,
-        slug=slug,
-        purpose=purpose,
+    post = (
+        _post_slack_app_install_button_impl
+        if auth.platform == "slack"
+        else _post_app_install_button_impl
     )
+    message_id = await post(runtime, auth, channel_id=channel_id, slug=slug, purpose=purpose)
     return PostAppInstallLinkResult(
         channel_id=channel_id,
         message_id=message_id,
@@ -74,7 +75,7 @@ async def _post_app_install_link_impl(
 
 
 def register_github_app_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
-    @mcp.tool(tags={"discord"})  # pyright: ignore[reportArgumentType]
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def post_github_app_install_link(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         channel_id: str,
@@ -86,7 +87,9 @@ def register_github_app_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         and has no token to paste, or when a sync failed because the repo is
         not readable. Posts a button in the thread; clicking it opens the
         install page on GitHub, where the user chooses which repositories to
-        grant access to.
+        grant access to. Slack: ``channel_id`` may be ``channel_id:thread_ts``
+        to post into the thread you were invoked from; ``message_id`` is the
+        posted message's ts.
 
         This tool CANNOT tell whether the install happened — a link button
         gives no signal back. After the user says they installed it, verify

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/media.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/media.py
@@ -6,8 +6,8 @@
 
 Agent-produced files cannot travel as a tool argument — the model would have to
 emit the whole file as base64 — so ``create_file_upload_url`` mints a one-time
-URL the sandbox PUTs to, and the bytes land in Postgres. Discord
-``send_message`` resolves them via the ``file_handles`` parameter.
+URL the sandbox PUTs to, and the bytes land in Postgres. ``send_message``
+resolves them via the ``file_handles`` parameter on both platforms.
 """
 
 from __future__ import annotations
@@ -166,10 +166,10 @@ def register_upload_tool(mcp: FastMCP, *, runtime: McpRuntime) -> None:
         title: str,
         mime_type: str,
     ) -> str:
-        """Attach, post, send, or share a file in Discord — step 1 of 2.
+        """Attach, post, send, or share a file in the chat — step 1 of 2.
 
         This is the ONLY way to put a file you produced (a chart, a table, an
-        image, a data file) into Discord as an attachment. Your reply text
+        image, a data file) into Discord or Slack as an attachment. Your reply text
         delivers itself; a file never does. Reading a file, or copying it to
         /mnt/session/outputs/, does not send it anywhere.
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_app_install_button.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_app_install_button.py
@@ -1,0 +1,103 @@
+"""Post the GitHub App install-page link as a Slack link button.
+
+Posted from the MCP process. Like its Discord sibling
+(`tools/discord/_app_install_button.py`) and unlike the credential button,
+this button carries a ``url`` and no ``action_id`` value the bot process
+dispatches — Slack opens the URL itself when it is clicked. Nothing here
+creates a request row, a minted token, an expiry, or a handler, and nothing
+should.
+
+Reuses the send path's target and visibility discipline: the composite
+``channel_id:thread_ts`` form lands the button in the thread the request was
+made from, and the requester must be able to see the channel before
+anything is posted.
+
+The install URL comes from `daimon.core.github_app_auth` — the single place
+it is constructed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.slack._client import (
+    _require_slack_identity,  # pyright: ignore[reportPrivateUsage]
+    _require_team_id,  # pyright: ignore[reportPrivateUsage]
+    slack_web_client,
+)
+from daimon.adapters.mcp.tools.slack._send import (
+    _split_send_target,  # pyright: ignore[reportPrivateUsage]
+    _validate_channel_access,  # pyright: ignore[reportPrivateUsage]
+    _validate_thread_target,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.slack._visibility import map_slack_api_error
+from daimon.core.github_app_auth import build_app_install_url
+from fastmcp.exceptions import ToolError
+from slack_sdk.errors import SlackApiError
+
+# Slack renders a button whose action_id it has never seen as a no-op click
+# with a warning; a url button still needs one to be a valid element.
+_ACTION_ID = "daimon_github_app_install_link"
+
+
+def _build_message_text(*, requester_platform_user_id: str, purpose: str) -> str:
+    """The message body, in Slack mrkdwn (single-asterisk bold, `<@U…>` mention)."""
+    return (
+        f"<@{requester_platform_user_id}> wants to reach a private GitHub repository "
+        f"({purpose}) — installing the GitHub App grants read access to the "
+        "repositories you choose, so skill sync and repo cloning can reach them "
+        "without anyone pasting a token.\n"
+        "Click the button below to open the install page on GitHub."
+    )
+
+
+async def _post_slack_app_install_button_impl(  # pyright: ignore[reportUnusedFunction]
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    slug: str,
+    purpose: str,
+) -> str:
+    """Post the App install link as a Slack link button. Returns the sent message ts."""
+    requester_id = _require_slack_identity(auth)
+    team_id = _require_team_id(auth)
+    target_channel_id, thread_ts = _split_send_target(channel_id)
+    client = await slack_web_client(runtime, team_id=team_id)
+
+    await _validate_channel_access(client, channel_id=target_channel_id, requester_id=requester_id)
+    if thread_ts is not None:
+        await _validate_thread_target(client, channel_id=target_channel_id, thread_ts=thread_ts)
+
+    text = _build_message_text(requester_platform_user_id=requester_id, purpose=purpose)
+    post_kwargs: dict[str, Any] = {
+        "channel": target_channel_id,
+        "text": text,
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": _ACTION_ID,
+                        "url": build_app_install_url(slug),
+                        "text": {"type": "plain_text", "text": "Install the GitHub App"},
+                    }
+                ],
+            },
+        ],
+    }
+    if thread_ts is not None:
+        post_kwargs["thread_ts"] = thread_ts
+    try:
+        sent = await client.chat_postMessage(**post_kwargs)  # pyright: ignore[reportUnknownMemberType, reportArgumentType]  # slack_sdk **kwargs: Unknown
+    except SlackApiError as err:
+        mapped = map_slack_api_error(err)
+        if mapped is not None:
+            raise mapped from err
+        code = str(err.response.get("error", "slack_api_error"))  # pyright: ignore[reportUnknownArgumentType, reportUnknownMemberType]  # slack_sdk response is dict-like
+        raise ToolError(f"posting to the channel failed ({code})") from err
+    return str(cast(dict[str, Any], sent.data)["ts"])  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]  # slack_sdk response is dict-like

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_client.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_client.py
@@ -41,9 +41,10 @@ def _build_retry_handlers() -> list[AsyncRetryHandler]:
     """Retry handlers for every AsyncWebClient built here.
 
     slack_sdk defaults to connection-error retries only, so a 429 reaches the
-    tool caller as a bare error. Slack caps non-Marketplace apps at one
-    ``conversations.history``/``conversations.replies`` call per minute, which
-    the model-facing read tools trip easily. Duplicated from the Slack
+    tool caller as a bare error. Slack caps apps commercially distributed
+    outside the Marketplace at one ``conversations.history``/
+    ``conversations.replies`` call per minute, which the model-facing read
+    tools trip easily. Duplicated from the Slack
     adapter's ``build_retry_handlers`` — adapters must not import each other.
     """
     return [*async_default_handlers(), AsyncRateLimitErrorRetryHandler()]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
@@ -33,6 +33,8 @@ class SlackThreadResult(BaseModel):
     thread_ts: str
     messages: list[SlackMessageRow]
     has_more: bool
+    next_cursor: str | None = None
+    hint: str | None = None
 
 
 class SlackSearchMatch(BaseModel):

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -329,13 +329,17 @@ def _split_thread_id(thread_id: str) -> tuple[str, str]:
 
 
 async def _fetch_thread_replies(
-    client: AsyncWebClient, *, channel_id: str, thread_ts: str, limit: int
+    client: AsyncWebClient,
+    *,
+    channel_id: str,
+    thread_ts: str,
+    limit: int,
+    cursor: str | None,
 ) -> SlackThreadResult:
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-        channel=channel_id, ts=thread_ts, limit=_bounded_page(limit)
+        channel=channel_id, ts=thread_ts, limit=_bounded_page(limit), cursor=cursor
     )
     raw = cast(list[dict[str, Any]], resp["messages"])  # already oldest-first
-    has_more = bool(resp.get("has_more"))
     result_thread_ts = thread_ts
 
     # A reply's ts identifies its thread, matching how send treats a thread
@@ -346,10 +350,25 @@ async def _fetch_thread_replies(
         if parent_ts and str(parent_ts) != thread_ts:
             result_thread_ts = str(parent_ts)
             resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-                channel=channel_id, ts=result_thread_ts, limit=_bounded_page(limit)
+                channel=channel_id,
+                ts=result_thread_ts,
+                limit=_bounded_page(limit),
+                cursor=cursor,
             )
             raw = cast(list[dict[str, Any]], resp["messages"])
-            has_more = bool(resp.get("has_more"))
+
+    # Replies page oldest-first, so the continuation reaches NEWER messages.
+    # has_more stays the authority: Slack can send a next_cursor that only
+    # points past the end, and (rarely) report has_more without a cursor.
+    has_more = bool(resp.get("has_more"))
+    metadata = cast(dict[str, Any], resp.get("response_metadata") or {})
+    next_cursor = (str(metadata.get("next_cursor") or "") or None) if has_more else None
+    if next_cursor is not None:
+        hint = f"more replies available — pass cursor={next_cursor} to read newer messages"
+    elif has_more:
+        hint = "more replies exist, but Slack returned no continuation cursor"
+    else:
+        hint = None
 
     usernames = await _resolve_usernames(client, _author_ids(raw))
     return SlackThreadResult(
@@ -357,11 +376,18 @@ async def _fetch_thread_replies(
         thread_ts=result_thread_ts,
         messages=_to_message_rows(raw, usernames),
         has_more=has_more,
+        next_cursor=next_cursor,
+        hint=hint,
     )
 
 
 async def _slack_read_thread_impl(  # pyright: ignore[reportUnusedFunction]  # registered by tools/channels.py
-    runtime: McpRuntime, auth: AuthIdentity, *, thread_id: str, limit: int
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    thread_id: str,
+    limit: int,
+    cursor: str | None = None,
 ) -> SlackThreadResult:
     channel_id, thread_ts = _split_thread_id(thread_id)
     user_id = _require_slack_identity(auth)
@@ -373,7 +399,7 @@ async def _slack_read_thread_impl(  # pyright: ignore[reportUnusedFunction]  # r
             channel = await _channel_info(rc.client, channel_id=channel_id)
             await _gate_user_source(runtime, auth, channel=channel)
             return await _fetch_thread_replies(
-                rc.client, channel_id=channel_id, thread_ts=thread_ts, limit=limit
+                rc.client, channel_id=channel_id, thread_ts=thread_ts, limit=limit, cursor=cursor
             )
         except SlackApiError as err:
             # Any not_in_channel from the user token (typically a public channel
@@ -390,7 +416,7 @@ async def _slack_read_thread_impl(  # pyright: ignore[reportUnusedFunction]  # r
         channel = await _channel_info(bot_client, channel_id=channel_id)
         await check_channel_access(bot_client, channel=channel, user_id=user_id)
         return await _fetch_thread_replies(
-            bot_client, channel_id=channel_id, thread_ts=thread_ts, limit=limit
+            bot_client, channel_id=channel_id, thread_ts=thread_ts, limit=limit, cursor=cursor
         )
     except ToolError as terr:
         if rc.runs_as_user:

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -50,11 +50,18 @@ from fastmcp.exceptions import ToolError
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
-# Slack's ceiling for non-Marketplace apps on conversations.history and
-# conversations.replies: at most 15 objects per call and one call per minute.
-# Larger limits are clamped server-side, so asking for more only misleads the
-# caller about how much of the channel or thread they were shown.
-_HISTORY_LIMIT_CAP = 15
+# Largest ``limit`` conversations.history accepts; conversations.replies takes
+# 1000 but one ceiling keeps both reads on the same bound. Above it Slack
+# answers ``invalid_limit`` rather than clamping, unlike the per-workspace
+# 15-object clamp, which it applies silently and reports through ``has_more``.
+_HISTORY_PAGE_CEILING = 999
+
+# Page size for the replies lookup that locates one message by ts.
+_MESSAGE_LOOKUP_PAGE = 200
+
+
+def _bounded_page(limit: int) -> int:
+    return max(1, min(limit, _HISTORY_PAGE_CEILING))
 
 
 def _reraise_mapped(err: SlackApiError, *, as_user: bool = False) -> ToolError:
@@ -240,7 +247,7 @@ async def _fetch_channel_history(
     client: AsyncWebClient, *, channel_id: str, limit: int, cursor: str | None
 ) -> SlackChannelResult:
     resp = await client.conversations_history(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-        channel=channel_id, limit=max(1, min(limit, _HISTORY_LIMIT_CAP)), cursor=cursor
+        channel=channel_id, limit=_bounded_page(limit), cursor=cursor
     )
     raw = cast(list[dict[str, Any]], resp["messages"])
     raw.reverse()  # Slack returns newest-first; tools return oldest-first
@@ -325,7 +332,7 @@ async def _fetch_thread_replies(
     client: AsyncWebClient, *, channel_id: str, thread_ts: str, limit: int
 ) -> SlackThreadResult:
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-        channel=channel_id, ts=thread_ts, limit=max(1, min(limit, _HISTORY_LIMIT_CAP))
+        channel=channel_id, ts=thread_ts, limit=_bounded_page(limit)
     )
     raw = cast(list[dict[str, Any]], resp["messages"])  # already oldest-first
     has_more = bool(resp.get("has_more"))
@@ -339,9 +346,7 @@ async def _fetch_thread_replies(
         if parent_ts and str(parent_ts) != thread_ts:
             result_thread_ts = str(parent_ts)
             resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-                channel=channel_id,
-                ts=result_thread_ts,
-                limit=max(1, min(limit, _HISTORY_LIMIT_CAP)),
+                channel=channel_id, ts=result_thread_ts, limit=_bounded_page(limit)
             )
             raw = cast(list[dict[str, Any]], resp["messages"])
             has_more = bool(resp.get("has_more"))
@@ -417,7 +422,7 @@ async def _fetch_single_message(
         # mapping (or an opaque raw SlackApiError).
         try:
             resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-                channel=channel_id, ts=message_id, limit=_HISTORY_LIMIT_CAP
+                channel=channel_id, ts=message_id, limit=_MESSAGE_LOOKUP_PAGE
             )
         except SlackApiError as err:
             error_code = _slack_error_code(err)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_send.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_send.py
@@ -18,6 +18,16 @@ it, and posts the message at the channel root instead of erroring — so the
 post itself can never surface a bad thread target; only a pre-flight check
 can. The composite `channel_id:thread_ts` form is how a caller aims a reply
 at a specific thread.
+
+Files ride as a second step: the text posts first, then every handle goes
+up in one `files_upload_v2` call threaded under that text (or under the
+target thread, which is the same place when the caller aimed at one). Slack
+has no single call that posts text plus files AND returns the message ts —
+`files.completeUploadExternal` shares asynchronously and its file objects
+carry no `shares` block, so reading the ts back would need a `files.info`
+poll with no bound on when the share appears. Two calls with a known ts beat
+one call with a guessed one. The cost is that an upload failure leaves the
+text already posted; the error says so, so the agent does not re-send it.
 """
 
 from __future__ import annotations
@@ -26,6 +36,7 @@ from typing import Any, cast
 
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools._file_handles import ResolvedUpload, resolve_file_handles
 from daimon.adapters.mcp.tools.slack._client import (
     _require_slack_identity,  # pyright: ignore[reportPrivateUsage]
     _require_team_id,  # pyright: ignore[reportPrivateUsage]
@@ -37,7 +48,7 @@ from daimon.adapters.mcp.tools.slack._visibility import (
     map_slack_api_error,
 )
 from fastmcp.exceptions import ToolError
-from slack_sdk.errors import SlackApiError
+from slack_sdk.errors import SlackApiError, SlackRequestError
 from slack_sdk.web.async_client import AsyncWebClient
 
 # Slack's {"type": "markdown"} block cap is 12,000 CHARACTERS (not bytes);
@@ -55,10 +66,19 @@ _OVER_LENGTH_MSG = (
     "(thread replies work well for parts)"
 )
 _NOT_IN_CHANNEL_MSG = "daimon isn't in that channel — ask a member to /invite @daimon"
-_FILES_UNSUPPORTED_MSG = (
-    "file posting is not available on Slack yet — this workspace's bot token "
-    "has no files:write scope"
+_ATTACHMENTS_UNSUPPORTED_MSG = (
+    "attachments by url are Discord-only — on Slack, upload the file with "
+    "create_file_upload_url and pass its handle in file_handles"
 )
+_FILES_NEED_CONTENT_MSG = (
+    "Slack attaches files to a message, so content cannot be empty when "
+    "file_handles is given — pass a short caption"
+)
+_MISSING_FILES_SCOPE_MSG = (
+    "this workspace's daimon install has no files:write scope — a workspace "
+    "admin must reinstall daimon from the install link before files can be posted"
+)
+_UPLOAD_FAILED_SUFFIX = " — the message text was already posted, do not send it again"
 _THREAD_NOT_FOUND_MSG = "that thread does not exist — check the thread_ts and try again"
 
 
@@ -142,6 +162,41 @@ async def _post_message(
     return cast(dict[str, Any], resp.data)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]  # slack_sdk response is dict-like
 
 
+async def _upload_files(
+    client: AsyncWebClient,
+    *,
+    channel_id: str,
+    thread_ts: str,
+    uploads: list[ResolvedUpload],
+) -> None:
+    try:
+        # No content_type: files_upload_v2 forwards it into the
+        # files.completeUploadExternal query string, where it is a silent
+        # no-op — Slack derives the preview from the filename extension.
+        await client.files_upload_v2(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
+            channel=channel_id,
+            thread_ts=thread_ts,
+            file_uploads=[
+                {"content": upload.content, "filename": upload.filename, "title": upload.filename}
+                for upload in uploads
+            ],
+        )
+    except SlackApiError as err:
+        code = _slack_error_code(err)
+        if code == "missing_scope":
+            raise ToolError(_MISSING_FILES_SCOPE_MSG + _UPLOAD_FAILED_SUFFIX) from err
+        if code == "not_in_channel":
+            raise ToolError(_NOT_IN_CHANNEL_MSG + _UPLOAD_FAILED_SUFFIX) from err
+        mapped = map_slack_api_error(err)
+        if mapped is not None:
+            raise ToolError(str(mapped) + _UPLOAD_FAILED_SUFFIX) from err
+        raise ToolError(f"file upload failed ({code}){_UPLOAD_FAILED_SUFFIX}") from err
+    except SlackRequestError as err:
+        # The middle leg of the upload flow is a plain HTTP PUT to
+        # files.slack.com; a non-200 there surfaces as this, not as an API error.
+        raise ToolError(f"file upload failed ({err}){_UPLOAD_FAILED_SUFFIX}") from err
+
+
 async def _slack_send_message_impl(  # pyright: ignore[reportUnusedFunction]  # registered by tools/channels.py
     runtime: McpRuntime,
     auth: AuthIdentity,
@@ -151,10 +206,17 @@ async def _slack_send_message_impl(  # pyright: ignore[reportUnusedFunction]  # 
     attachments: list[dict[str, str]] | None,
     file_handles: list[str] | None,
 ) -> SlackMessageRow:
-    if attachments or file_handles:
-        raise ToolError(_FILES_UNSUPPORTED_MSG)
+    if attachments:
+        raise ToolError(_ATTACHMENTS_UNSUPPORTED_MSG)
     if len(content) > _MAX_CONTENT_CHARS:
         raise ToolError(_OVER_LENGTH_MSG)
+    uploads: list[ResolvedUpload] = []
+    if file_handles:
+        if not content.strip():
+            raise ToolError(_FILES_NEED_CONTENT_MSG)
+        uploads = await resolve_file_handles(
+            file_handles, session_factory=runtime.session_factory, tenant_id=auth.tenant_id
+        )
 
     target_channel_id, thread_ts = _split_send_target(channel_id)
     requester_id = _require_slack_identity(auth)
@@ -168,6 +230,13 @@ async def _slack_send_message_impl(  # pyright: ignore[reportUnusedFunction]  # 
     resp = await _post_message(
         client, channel_id=target_channel_id, content=content, thread_ts=thread_ts
     )
+    if uploads:
+        await _upload_files(
+            client,
+            channel_id=target_channel_id,
+            thread_ts=thread_ts or str(resp["ts"]),
+            uploads=uploads,
+        )
     message = cast(dict[str, Any], resp.get("message") or {})
     response_thread_ts = message.get("thread_ts")
     response_user_id = message.get("user")

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -999,10 +999,10 @@
     }),
     'create_file_upload_url': dict({
       'description': '''
-        Attach, post, send, or share a file in Discord — step 1 of 2.
+        Attach, post, send, or share a file in the chat — step 1 of 2.
         
         This is the ONLY way to put a file you produced (a chart, a table, an
-        image, a data file) into Discord as an attachment. Your reply text
+        image, a data file) into Discord or Slack as an attachment. Your reply text
         delivers itself; a file never does. Reading a file, or copying it to
         /mnt/session/outputs/, does not send it anywhere.
         
@@ -2602,15 +2602,16 @@
         To post a file you made in your sandbox, call
         ``create_file_upload_url`` first and PUT the bytes to the URL it
         returns — never base64 a file into a tool argument. Combined
-        cap of 10 attachments per message. Both FILES paragraphs are
-        Discord-only for now — Slack file posting needs a scope this
-        install does not have.
+        cap of 10 attachments per message.
         
         Slack: ``channel_id`` may be ``channel_id:thread_ts`` (e.g.
         ``C0123456789:1717171717.123456``) to post into a thread. Content is
         sent as-is — nothing is escaped, so ``<@U…>`` mentions work — and is
         capped at 12,000 characters. daimon must already be in the channel
-        (a member can run ``/invite @daimon``).
+        (a member can run ``/invite @daimon``). ``file_handles`` works;
+        ``attachments`` by url does not (there is no Slack CDN to fetch from).
+        Files post as replies under the message, so ``content`` cannot be
+        empty when files are given — use it as the caption.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2159,16 +2159,28 @@
         Read messages from a thread, oldest-first.
         
         Discord: thread_id is the thread's channel id; use before for older messages.
-        Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is rejected — Slack threads read one page of at most 999
-        messages from the thread root, some workspaces cap that page at 15
-        whatever limit is asked for, and has_more=true means the newest
-        replies were not returned.
+        Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456).
+        Pages start at the thread root and run towards the newest reply, at
+        most 999 per page (some workspaces cap a page at 15 whatever limit is
+        asked for). has_more=true means newer replies exist; pass the returned
+        next_cursor as cursor to read them. before is Discord-only and cursor
+        is Slack-only.
       ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
           'before': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+          'cursor': dict({
             'anyOf': list([
               dict({
                 'type': 'string',

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2109,8 +2109,9 @@
         
         For threads use read_thread. Each platform takes only its own
         pagination parameter — the other is rejected. Discord: at most 200
-        messages per call; use before to fetch older messages. Slack: use
-        cursor to fetch the next page; at most 15 messages are returned.
+        messages per call; use before to fetch older messages. Slack: at most
+        999 per call, and some workspaces cap a single call at 15 whatever
+        limit is asked for; use cursor to fetch the next page.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2157,9 +2158,10 @@
         
         Discord: thread_id is the thread's channel id; use before for older messages.
         Slack: thread_id is channel_id:thread_ts (e.g. C0123456789:1717171717.123456);
-        before is rejected — Slack threads read one page of at most 15 messages
-        from the thread root, and has_more=true means the newest replies were
-        not returned.
+        before is rejected — Slack threads read one page of at most 999
+        messages from the thread root, some workspaces cap that page at 15
+        whatever limit is asked for, and has_more=true means the newest
+        replies were not returned.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -1901,7 +1901,9 @@
         and has no token to paste, or when a sync failed because the repo is
         not readable. Posts a button in the thread; clicking it opens the
         install page on GitHub, where the user chooses which repositories to
-        grant access to.
+        grant access to. Slack: ``channel_id`` may be ``channel_id:thread_ts``
+        to post into the thread you were invoked from; ``message_id`` is the
+        posted message's ts.
         
         This tool CANNOT tell whether the install happened — a link button
         gives no signal back. After the user says they installed it, verify

--- a/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
+++ b/packages/adapters/mcp/tests/tools/test_channels_dispatch.py
@@ -523,7 +523,7 @@ async def test_read_thread_slack_caller_rejects_discord_before_param(
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
     """A Slack caller passing before to read_thread gets a ToolError — Slack
-    threads have no pagination, so dropping it would replay page 1 as a sweep."""
+    threads page with cursor, so dropping it would replay page 1 as a sweep."""
     tenant = await make_tenant(db_session, platform="slack", workspace_id="slack-thread-before")
     account = await make_account(db_session, tenant=tenant)
     await make_platform_principal(
@@ -548,6 +548,40 @@ async def test_read_thread_slack_caller_rejects_discord_before_param(
     output_text = _output_text(call_result)
     assert "before is Discord-only" in output_text, (
         f"Slack caller's before param must be rejected, not dropped; got {output_text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_thread_discord_caller_rejects_slack_cursor_param(
+    db_session: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A Discord caller passing Slack's cursor to read_thread gets a ToolError,
+    not a silent first page."""
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="discord-thread-cursor")
+    account = await make_account(db_session, tenant=tenant)
+    await make_platform_principal(
+        db_session,
+        platform="discord",
+        external_id="U_DISCORD_CALLER",
+        tenant=tenant,
+        account=account,
+    )
+    await db_session.commit()
+    token = mint_jwt(account_id=account.id, secret=_SECRET, now=dt.datetime.now(dt.UTC))
+    app = _make_app(sessionmaker)
+
+    call_result = await _call_tool(
+        app,
+        token=token,
+        tool_name="read_thread",
+        arguments={"thread_id": "123", "cursor": "CURSOR_1"},
+    )
+
+    assert call_result.get("isError") is True
+    output_text = _output_text(call_result)
+    assert "cursor is Slack-only" in output_text, (
+        f"Discord caller's cursor param must be rejected, not dropped; got {output_text!r}"
     )
 
 

--- a/packages/adapters/mcp/tests/tools/test_github_app.py
+++ b/packages/adapters/mcp/tests/tools/test_github_app.py
@@ -4,7 +4,8 @@ The install-URL builder's own unit test lives in core's tree
 (``packages/core/tests/test_github_app_auth.py``); these tests cover the
 tool and the posting path only. Discord REST calls are faked at transport
 level via the sibling ``conftest.py``'s ``patch_discord_http`` (same trick
-``test_credential_requests.py`` uses), never via method-level mocks.
+``test_credential_requests.py`` uses), never via method-level mocks. The
+Slack posting path is covered in ``test_slack_app_install_button.py``.
 """
 
 from __future__ import annotations
@@ -278,25 +279,6 @@ async def test_result_model_has_no_success_shaped_field() -> None:
         name for name in field_names if any(word in name.lower() for word in forbidden_words)
     }
     assert not offending, f"result model must carry no success-shaped field, found {offending}"
-
-
-# ---------------------------------------------------------------------------
-# 3. Slack caller is rejected
-# ---------------------------------------------------------------------------
-
-
-async def test_post_app_install_link_rejects_slack_caller(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    runtime = _runtime()
-    auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
-    captured = _outbound_request_count(monkeypatch)
-
-    with pytest.raises(ToolError, match="not supported on Slack"):
-        await _post_app_install_link_impl(
-            runtime, auth, channel_id="222", purpose="reading a private repo"
-        )
-    assert captured == [], "a rejected slack call must post nothing"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/mcp/tests/tools/test_slack_app_install_button.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_app_install_button.py
@@ -1,0 +1,195 @@
+"""Tests for tools/slack/_app_install_button.py, driven through the shared
+post_github_app_install_link impl so the platform dispatch is exercised too.
+
+Slack Web API calls are faked at transport level with aioresponses, the same
+way the Slack send tests do it.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from aioresponses import aioresponses
+from anthropic import AsyncAnthropic
+from cryptography.fernet import Fernet
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.github_app import (
+    _post_app_install_link_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.config import (
+    AnthropicSettings,
+    CredentialsSettings,
+    CryptoSettings,
+    DatabaseSettings,
+    GithubSettings,
+    McpSettings,
+    Settings,
+)
+from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.domain import Role
+from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+from fastmcp.exceptions import ToolError
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from yarl import URL
+
+_CONVERSATIONS_INFO = re.compile(r"https://slack\.com/api/conversations\.info.*")
+_CONVERSATIONS_REPLIES = re.compile(r"https://slack\.com/api/conversations\.replies.*")
+_USERS_INFO = re.compile(r"https://slack\.com/api/users\.info.*")
+_CHAT_POST_MESSAGE = "https://slack.com/api/chat.postMessage"
+_POST_KEY = ("POST", URL(_CHAT_POST_MESSAGE))
+
+_FULL_MEMBER = {"ok": True, "user": {"id": "U_CALLER", "is_restricted": False}}
+_INSTALL_URL = "https://github.com/apps/acme-daimon/installations/new"
+
+pytestmark = pytest.mark.asyncio
+
+
+def _auth() -> AuthIdentity:
+    return AuthIdentity(
+        account_id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+        role=Role.USER,
+        platform="slack",
+        external_id="T_TEST",
+        platform_user_id="U_CALLER",
+    )
+
+
+async def _make_runtime(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> McpRuntime:
+    fernet_key = SecretStr(Fernet.generate_key().decode("ascii"))
+    fernet = build_multifernet((fernet_key.get_secret_value(),))
+    async with committing_sessionmaker() as session:
+        await upsert_slack_bot_token(
+            session, team_id="T_TEST", encrypted_token=encrypt_token(fernet, "xoxb-secret")
+        )
+        await session.commit()
+    settings = Settings(
+        database=DatabaseSettings(
+            url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon"),
+        ),
+        anthropic=AnthropicSettings(
+            api_key=SecretStr("sk-test"),
+            base_url=HttpUrl("https://api.anthropic.com"),
+        ),
+        crypto=CryptoSettings(keys=(fernet_key,)),
+        credentials=CredentialsSettings(google_sa_json=None),
+        mcp=McpSettings(),
+        github=GithubSettings(app_slug="acme-daimon"),
+        slack=None,
+    )
+    return McpRuntime(
+        session_factory=committing_sessionmaker,
+        client=MagicMock(spec=AsyncAnthropic),
+        settings=settings,
+        deployment_default=DeploymentDefault(),
+        fernet=fernet,
+    )
+
+
+def _mock_public_channel_access(m: aioresponses) -> None:
+    m.get(  # pyright: ignore[reportUnknownMemberType]
+        _CONVERSATIONS_INFO,
+        payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+    )
+    m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+
+
+def _post_body(m: aioresponses) -> dict[str, Any]:
+    return m.requests[_POST_KEY][0].kwargs["json"]  # type: ignore[no-any-return]
+
+
+def _only_button(body: dict[str, Any]) -> dict[str, Any]:
+    actions = [b for b in body["blocks"] if b["type"] == "actions"]
+    assert len(actions) == 1, "exactly one actions block must be posted"
+    elements = actions[0]["elements"]
+    assert len(elements) == 1, "exactly one button must be posted"
+    return elements[0]
+
+
+async def test_slack_caller_posts_a_url_button_carrying_the_install_url(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(_CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000001.000100"})  # pyright: ignore[reportUnknownMemberType]
+        result = await _post_app_install_link_impl(
+            runtime, _auth(), channel_id="C1", purpose="reading a private repo"
+        )
+        body = _post_body(m)
+
+    assert result.message_id == "1700000001.000100", "message_id is the posted ts on Slack"
+    assert result.channel_id == "C1"
+    assert result.install_url == _INSTALL_URL
+    button = _only_button(body)
+    assert button["url"] == _INSTALL_URL, "the button opens the built install URL"
+    assert "value" not in button, "a url button carries nothing for the bot process to dispatch"
+    assert "<@U_CALLER>" in body["text"], "the notification text names the requester"
+    assert "thread_ts" not in body, "a bare channel target posts at the channel root"
+
+
+async def test_slack_composite_target_validates_the_thread_and_posts_into_it(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={"ok": True, "messages": [{"ts": "1700000000.000001", "text": "root"}]},
+        )
+        m.post(_CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000002.000100"})  # pyright: ignore[reportUnknownMemberType]
+        await _post_app_install_link_impl(
+            runtime,
+            _auth(),
+            channel_id="C1:1700000000.000001",
+            purpose="reading a private repo",
+        )
+        body = _post_body(m)
+
+    assert body["channel"] == "C1"
+    assert body["thread_ts"] == "1700000000.000001", "the button lands in the requested thread"
+
+
+async def test_slack_nonexistent_thread_target_posts_nothing(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.get(_CONVERSATIONS_REPLIES, payload={"ok": False, "error": "thread_not_found"})  # pyright: ignore[reportUnknownMemberType]
+        with pytest.raises(ToolError, match="does not exist"):
+            await _post_app_install_link_impl(
+                runtime, _auth(), channel_id="C1:9.9", purpose="reading a private repo"
+            )
+        assert _POST_KEY not in m.requests, "a bad thread target must post nothing"
+
+
+async def test_slack_private_channel_nonmember_posts_nothing(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "secret", "is_private": True}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            re.compile(r"https://slack\.com/api/conversations\.members.*"),
+            payload={"ok": True, "members": ["U_SOMEONE_ELSE"]},
+        )
+        with pytest.raises(ToolError):
+            await _post_app_install_link_impl(
+                runtime, _auth(), channel_id="C1", purpose="reading a private repo"
+            )
+        assert _POST_KEY not in m.requests, "the requester must be able to see the channel"

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -1134,13 +1134,15 @@ def _recorded_limit(m: aioresponses, path: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_read_channel_clamps_limit_to_the_slack_page_cap(
+async def test_read_channel_passes_the_requested_limit_through(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
-    """A caller asking for 50 gets a request Slack will honour, not silently clamp.
+    """A caller asking for 50 has 50 requested of Slack.
 
-    Non-Marketplace apps receive at most 15 objects per conversations.history
-    call; the shared tool default of 50 is meaningful on Discord only.
+    Slack clamps the value per workspace — 15 for an app commercially
+    distributed outside the Marketplace, the full page for an internal-app
+    install. Clamping in our own code would hold the second class to the
+    first's ceiling.
     """
     runtime = await _make_runtime(committing_sessionmaker)
     auth = _auth()
@@ -1153,7 +1155,7 @@ async def test_read_channel_clamps_limit_to_the_slack_page_cap(
         m.get(_CONVERSATIONS_HISTORY, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
         await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
         limit = _recorded_limit(m, "/api/conversations.history")
-    assert limit == "15"
+    assert limit == "50"
 
 
 @pytest.mark.asyncio
@@ -1314,7 +1316,44 @@ async def test_read_channel_raises_limit_floor_to_one(
 
 
 @pytest.mark.asyncio
-async def test_read_thread_clamps_limit_to_the_slack_page_cap(
+async def test_read_channel_caps_limit_at_the_slack_maximum(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Above 999 Slack answers invalid_limit instead of clamping, so we clamp there."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(_CONVERSATIONS_HISTORY, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
+        await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=5000)
+        limit = _recorded_limit(m, "/api/conversations.history")
+    assert limit == "999"
+
+
+@pytest.mark.asyncio
+async def test_read_thread_caps_limit_at_the_slack_maximum(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(_CONVERSATIONS_REPLIES, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
+        await _slack_read_thread_impl(runtime, auth, thread_id="C1:1.0", limit=5000)
+        limit = _recorded_limit(m, "/api/conversations.replies")
+    assert limit == "999"
+
+
+@pytest.mark.asyncio
+async def test_read_thread_passes_the_requested_limit_through(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
     runtime = await _make_runtime(committing_sessionmaker)
@@ -1331,5 +1370,5 @@ async def test_read_thread_clamps_limit_to_the_slack_page_cap(
         )
         result = await _slack_read_thread_impl(runtime, auth, thread_id="C1:1.0", limit=50)
         limit = _recorded_limit(m, "/api/conversations.replies")
-    assert limit == "15"
+    assert limit == "50"
     assert result.has_more is True, "truncation must reach the caller"

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -1372,3 +1372,125 @@ async def test_read_thread_passes_the_requested_limit_through(
         limit = _recorded_limit(m, "/api/conversations.replies")
     assert limit == "50"
     assert result.has_more is True, "truncation must reach the caller"
+
+
+def _recorded_query(m: aioresponses, path: str, key: str) -> list[str | None]:
+    """One query-param value per recorded call to a Slack read method, in call order."""
+    return [
+        url.query.get(key)
+        for (method, url), _ in m.requests.items()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        if method == "GET" and url.path == path
+    ]
+
+
+@pytest.mark.asyncio
+async def test_read_thread_forwards_the_cursor_to_conversations_replies(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(_CONVERSATIONS_REPLIES, payload={"ok": True, "messages": []})  # pyright: ignore[reportUnknownMemberType]
+        result = await _slack_read_thread_impl(
+            runtime, auth, thread_id="C1:1.0", limit=50, cursor="CURSOR_2"
+        )
+        cursors = _recorded_query(m, "/api/conversations.replies", "cursor")
+    assert cursors == ["CURSOR_2"], "the continuation must reach Slack, not replay page one"
+    assert result.next_cursor is None and result.hint is None
+
+
+@pytest.mark.asyncio
+async def test_read_thread_has_more_returns_next_cursor_and_a_hint_naming_it(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "has_more": True,
+                "response_metadata": {"next_cursor": "CURSOR_NEXT"},
+                "messages": [{"ts": "1.0", "user": "U_A", "text": "root", "thread_ts": "1.0"}],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        result = await _slack_read_thread_impl(runtime, auth, thread_id="C1:1.0", limit=1)
+    assert result.has_more is True
+    assert result.next_cursor == "CURSOR_NEXT"
+    assert result.hint is not None and "cursor=CURSOR_NEXT" in result.hint, (
+        "the hint must hand the agent the exact argument to pass next"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_thread_has_more_without_a_cursor_says_so_instead_of_claiming_done(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={"ok": True, "has_more": True, "messages": []},
+        )
+        result = await _slack_read_thread_impl(runtime, auth, thread_id="C1:1.0", limit=1)
+    assert result.has_more is True and result.next_cursor is None
+    assert result.hint is not None and "no continuation cursor" in result.hint
+
+
+@pytest.mark.asyncio
+async def test_read_thread_reply_ts_refetch_by_parent_keeps_the_cursor(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_INFO,
+            payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+        )
+        m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "messages": [{"ts": "2.0", "user": "U_B", "text": "reply", "thread_ts": "1.0"}],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "messages": [{"ts": "1.0", "user": "U_A", "text": "root", "thread_ts": "1.0"}],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        result = await _slack_read_thread_impl(
+            runtime, auth, thread_id="C1:2.0", limit=50, cursor="CURSOR_3"
+        )
+        cursors = _recorded_query(m, "/api/conversations.replies", "cursor")
+    assert result.thread_ts == "1.0"
+    assert cursors == ["CURSOR_3", "CURSOR_3"], "both lookups page from the same continuation"

--- a/packages/adapters/mcp/tests/tools/test_slack_send.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_send.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import re
 import uuid
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -30,7 +33,9 @@ from daimon.core.config import (
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.domain import Role
+from daimon.core.stores.file_uploads import create_upload, store_upload_content
 from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+from daimon.testing.factories import make_tenant
 from fastmcp.exceptions import ToolError
 from pydantic import HttpUrl, PostgresDsn, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -42,6 +47,9 @@ _CONVERSATIONS_MEMBERS = re.compile(r"https://slack\.com/api/conversations\.memb
 _USERS_INFO = re.compile(r"https://slack\.com/api/users\.info.*")
 _CHAT_POST_MESSAGE = "https://slack.com/api/chat.postMessage"
 _POST_KEY = ("POST", URL(_CHAT_POST_MESSAGE))
+_GET_UPLOAD_URL = re.compile(r"https://slack\.com/api/files\.getUploadURLExternal.*")
+_UPLOAD = re.compile(r"https://files\.slack\.com/upload/v1/.*")
+_COMPLETE_UPLOAD = re.compile(r"https://slack\.com/api/files\.completeUploadExternal.*")
 
 _FULL_MEMBER = {"ok": True, "user": {"id": "U_CALLER", "is_restricted": False}}
 
@@ -105,6 +113,69 @@ def _mock_public_channel_access(m: aioresponses) -> None:
 def _post_body(m: aioresponses) -> dict[str, object]:
     posts = m.requests[_POST_KEY]
     return posts[0].kwargs["json"]  # type: ignore[no-any-return]
+
+
+def _recorded(m: aioresponses, path_fragment: str) -> list[tuple[URL, dict[str, Any]]]:
+    """Every recorded (url, kwargs) whose url contains the fragment, in call order."""
+    return [
+        (url, call.kwargs)  # pyright: ignore[reportUnknownMemberType]
+        for (_, url), calls in m.requests.items()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        if path_fragment in str(url)
+        for call in calls  # pyright: ignore[reportUnknownVariableType]
+    ]
+
+
+def _mock_upload_flow(m: aioresponses) -> None:
+    m.post(  # pyright: ignore[reportUnknownMemberType]
+        _GET_UPLOAD_URL,
+        payload={
+            "ok": True,
+            "file_id": "F1",
+            "upload_url": "https://files.slack.com/upload/v1/ABC",
+        },
+    )
+    m.post(_UPLOAD, status=200, body="OK", content_type="text/plain")  # pyright: ignore[reportUnknownMemberType]
+    m.post(  # pyright: ignore[reportUnknownMemberType]
+        _COMPLETE_UPLOAD, payload={"ok": True, "files": [{"id": "F1", "title": "chart.png"}]}
+    )
+
+
+async def _stage_uploads(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: uuid.UUID,
+    payloads: list[bytes],
+) -> list[str]:
+    """Mint and fill upload rows for the caller's tenant, creating the tenant."""
+    now = datetime.now(UTC)
+    handles: list[str] = []
+    async with committing_sessionmaker() as session:
+        await make_tenant(session, platform="slack", workspace_id="T_TEST", id=tenant_id)
+        for payload in payloads:
+            row, token = await create_upload(
+                session,
+                tenant_id=tenant_id,
+                title="chart",
+                display_filename="chart.png",
+                content_type="image/png",
+                now=now,
+            )
+            await store_upload_content(session, upload_token=token, data=payload, now=now)
+            handles.append(row.id)
+        await session.commit()
+    return handles
+
+
+async def _stage_upload(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: uuid.UUID,
+    payload: bytes,
+) -> str:
+    (handle,) = await _stage_uploads(
+        committing_sessionmaker, tenant_id=tenant_id, payloads=[payload]
+    )
+    return handle
 
 
 @pytest.mark.asyncio
@@ -400,13 +471,13 @@ async def test_send_message_over_12000_chars_refused_with_zero_api_calls(
 
 
 @pytest.mark.asyncio
-async def test_send_message_attachments_refused_naming_files_write_no_api_calls(
+async def test_send_message_attachments_by_url_refused_pointing_at_file_handles_no_api_calls(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
     runtime = await _make_runtime(committing_sessionmaker)
     auth = _auth()
     with aioresponses() as m:
-        with pytest.raises(ToolError, match="files:write"):
+        with pytest.raises(ToolError, match="file_handles"):
             await _slack_send_message_impl(
                 runtime,
                 auth,
@@ -419,22 +490,195 @@ async def test_send_message_attachments_refused_naming_files_write_no_api_calls(
 
 
 @pytest.mark.asyncio
-async def test_send_message_file_handles_refused_naming_files_write_no_api_calls(
+async def test_send_message_file_handles_with_empty_content_refused_no_api_calls(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
     runtime = await _make_runtime(committing_sessionmaker)
     auth = _auth()
     with aioresponses() as m:
-        with pytest.raises(ToolError, match="files:write"):
+        with pytest.raises(ToolError, match="caption"):
             await _slack_send_message_impl(
                 runtime,
                 auth,
                 channel_id="C1",
-                content="hi",
+                content="   ",
                 attachments=None,
                 file_handles=["handle_1"],
             )
         assert m.requests == {}
+
+
+@pytest.mark.asyncio
+async def test_send_message_unknown_file_handle_refused_naming_it_no_api_calls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="nope.png"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content="here",
+                attachments=None,
+                file_handles=["nope.png"],
+            )
+        assert m.requests == {}, "a bad handle must be caught before the text is posted"
+
+
+@pytest.mark.asyncio
+async def test_send_message_file_handles_post_text_then_upload_threaded_under_it(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    payload = bytes(range(256)) * 4
+    handle = await _stage_upload(committing_sessionmaker, tenant_id=auth.tenant_id, payload=payload)
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000001.000100"}
+        )
+        _mock_upload_flow(m)
+        row = await _slack_send_message_impl(
+            runtime,
+            auth,
+            channel_id="C1",
+            content="the chart",
+            attachments=None,
+            file_handles=[handle],
+        )
+        get_url = _recorded(m, "getUploadURLExternal")
+        upload = _recorded(m, "files.slack.com")
+        complete = _recorded(m, "completeUploadExternal")
+
+    assert row.ts == "1700000001.000100", "the returned row is the text message"
+    assert len(get_url) == 1 and len(upload) == 1 and len(complete) == 1, (
+        "one file must run the 3-request upload flow exactly once"
+    )
+    assert get_url[0][1]["params"]["filename"] == "chart.png", (
+        "the upload row's display filename must name the Slack file"
+    )
+    assert upload[0][1]["data"] == payload, "uploaded bytes must reach Slack byte-identical"
+    complete_params = complete[0][1]["params"]
+    assert complete_params["channel_id"] == "C1"
+    assert complete_params["thread_ts"] == "1700000001.000100", (
+        "a channel-root post threads its files under the text it just posted"
+    )
+    assert "content_type" not in get_url[0][1]["params"]
+
+
+@pytest.mark.asyncio
+async def test_send_message_file_handles_into_thread_target_upload_uses_that_thread(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    handle = await _stage_upload(committing_sessionmaker, tenant_id=auth.tenant_id, payload=b"x")
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={"ok": True, "messages": [{"ts": "1700000000.000001", "text": "root"}]},
+        )
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE,
+            payload={
+                "ok": True,
+                "ts": "1700000002.000100",
+                "message": {"thread_ts": "1700000000.000001"},
+            },
+        )
+        _mock_upload_flow(m)
+        row = await _slack_send_message_impl(
+            runtime,
+            auth,
+            channel_id="C1:1700000000.000001",
+            content="the chart",
+            attachments=None,
+            file_handles=[handle],
+        )
+        complete_params = _recorded(m, "completeUploadExternal")[0][1]["params"]
+
+    assert row.thread_ts == "1700000000.000001"
+    assert complete_params["thread_ts"] == "1700000000.000001", (
+        "files aimed at a thread land in that thread, not under the new reply"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_two_file_handles_share_one_completion_call(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    first, second = await _stage_uploads(
+        committing_sessionmaker, tenant_id=auth.tenant_id, payloads=[b"a", b"b"]
+    )
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000001.000100"}
+        )
+        for file_id in ("F1", "F2"):
+            m.post(  # pyright: ignore[reportUnknownMemberType]
+                _GET_UPLOAD_URL,
+                payload={
+                    "ok": True,
+                    "file_id": file_id,
+                    "upload_url": f"https://files.slack.com/upload/v1/{file_id}",
+                },
+            )
+            m.post(_UPLOAD, status=200, body="OK", content_type="text/plain")  # pyright: ignore[reportUnknownMemberType]
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _COMPLETE_UPLOAD,
+            payload={"ok": True, "files": [{"id": "F1"}, {"id": "F2"}]},
+        )
+        await _slack_send_message_impl(
+            runtime,
+            auth,
+            channel_id="C1",
+            content="two charts",
+            attachments=None,
+            file_handles=[first, second],
+        )
+        complete = _recorded(m, "completeUploadExternal")
+
+    assert len(complete) == 1, "several files complete in one call, so they share one message"
+    completed_ids = [f["id"] for f in json.loads(complete[0][1]["params"]["files"])]
+    assert completed_ids == ["F1", "F2"]
+
+
+@pytest.mark.asyncio
+async def test_send_message_missing_files_scope_names_reinstall_and_the_already_posted_text(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    handle = await _stage_upload(committing_sessionmaker, tenant_id=auth.tenant_id, payload=b"x")
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000001.000100"}
+        )
+        m.post(_GET_UPLOAD_URL, payload={"ok": False, "error": "missing_scope"})  # pyright: ignore[reportUnknownMemberType]
+        with pytest.raises(ToolError) as excinfo:
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content="the chart",
+                attachments=None,
+                file_handles=[handle],
+            )
+        assert len(m.requests[_POST_KEY]) == 1, "the text goes out before the upload is tried"
+
+    message = str(excinfo.value)
+    assert "files:write" in message and "reinstall" in message, (
+        "a scope-less install must be told what to fix, not shown a raw error code"
+    )
+    assert "already posted" in message, "the agent must learn the text landed, or it re-sends it"
 
 
 @pytest.mark.asyncio

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -1035,6 +1035,7 @@ class SlackApp:
             "SlackApp._orchestrate requires slack settings (entrypoint validates at boot)"
         )
         cap = self.runtime.settings.slack.max_concurrent_turns_per_tenant
+        page_limit = self.runtime.settings.slack.history_page_limit
         count = self._inflight.get(tenant_id, 0)
         if not should_admit_turn(current_in_flight=count, cap=cap):
             # The rejection below is an ephemeral — it appears in no channel
@@ -1092,6 +1093,7 @@ class SlackApp:
                 tenant_id=tenant_id,
                 thread_id=thread_id,
                 team_id=team_id,
+                page_limit=page_limit,
                 files=_collect_files([event]),
             )
             # Drain loop: new events may arrive during the drain turn; they land
@@ -1138,6 +1140,7 @@ class SlackApp:
                             thread_id=thread_id,
                             content_override=_compose_queued_content(user_events),
                             team_id=team_id,
+                            page_limit=page_limit,
                             # Merge files from ALL of this author's queued events,
                             # in first-seen order — user_events[0] alone would
                             # silently drop files on their later mentions.
@@ -1190,6 +1193,7 @@ class SlackApp:
         tenant_id: uuid.UUID,
         thread_id: str,
         team_id: str,
+        page_limit: int,
         content_override: str | None = None,
         files: list[SlackFile] | None = None,
     ) -> None:
@@ -1468,6 +1472,7 @@ class SlackApp:
                     user_query=user_text,
                     author_id=author_id,
                     proxy=proxy_ctx,
+                    page_limit=page_limit,
                 )
             elif watermark is not None:
                 # Continuation: replay only messages since the last watermark.
@@ -1479,6 +1484,7 @@ class SlackApp:
                     user_query=user_text,
                     author_id=author_id,
                     proxy=proxy_ctx,
+                    page_limit=page_limit,
                 )
             else:
                 # Reused session with no watermark (prior turn's final_ts was None).
@@ -1542,6 +1548,7 @@ class SlackApp:
                     user_query=user_text,
                     author_id=author_id,
                     proxy=proxy_ctx,
+                    page_limit=page_limit,
                 )
                 if synthetic_prefix:
                     full_message = synthetic_prefix + "\n" + full_message

--- a/packages/adapters/slack/daimon/adapters/slack/context.py
+++ b/packages/adapters/slack/daimon/adapters/slack/context.py
@@ -8,9 +8,9 @@ Mirrors ``packages/adapters/discord/daimon/adapters/discord/context.py``:
 - ``build_context_xml``: first-turn fetch, one page from the thread root.
 - ``build_delta_xml``: continuation fetch, delta since the watermark timestamp.
 
-Both fetch a single page. Slack caps non-Marketplace apps at
-``THREAD_PAGE_LIMIT`` objects per ``conversations.replies`` call and one call
-per minute, so paginating inside a turn is not viable; when Slack reports
+Both fetch a single page. A workspace whose app is commercially distributed
+outside the Marketplace answers with at most 15 objects and allows one call per
+minute, so paginating inside a turn is not viable there; when Slack reports
 ``has_more`` the block is marked ``truncated="true"`` so the model knows the
 window is partial.
 
@@ -27,11 +27,13 @@ from daimon.adapters.slack.attachments import ProxyUrlContext, build_proxy_url
 from daimon.adapters.slack.vision import SlackFile
 from slack_sdk.web.async_client import AsyncWebClient
 
-# Slack's ceiling for non-Marketplace apps on conversations.replies (both the
-# default and the maximum accepted value of ``limit``; larger values are clamped
-# server-side). Socket Mode apps cannot list on the Marketplace, so daimon is
-# always in this class.
-THREAD_PAGE_LIMIT = 15
+# Messages requested per ``conversations.replies`` call. Slack clamps ``limit``
+# server-side rather than erroring: a workspace whose app is commercially
+# distributed outside the Marketplace returns 15 however much we ask for, an
+# internal-app install returns the full page. Asking for the real page size is
+# what lets the second class replay a deep thread; ``has_more`` reports which
+# class answered.
+DEFAULT_PAGE_LIMIT = 200
 
 
 def _open_tag(name: str, *, truncated: bool) -> str:
@@ -92,23 +94,24 @@ async def build_context_xml(
     user_query: str,
     author_id: str = "",
     proxy: ProxyUrlContext | None = None,
+    page_limit: int = DEFAULT_PAGE_LIMIT,
 ) -> str:
     """Build XML context from thread history for the first turn.
 
-    Fetches one page of ``THREAD_PAGE_LIMIT`` messages via
+    Fetches one page of ``page_limit`` messages via
     ``conversations.replies``. Returns a string with a
     ``<context>/<thread_history>`` block containing the replayed messages
     followed by a ``<user_query>`` element.
 
     Window: ``conversations.replies`` always returns oldest-first from the
     thread root, and ``oldest``/``latest`` only filter, so the newest window
-    cannot be requested in one call. A thread longer than one page therefore
-    replays the root and the first replies, and the block carries
-    ``truncated="true"`` so the model knows the recent tail is missing.
-    Discord's equivalent replays 100 messages; the gap is Slack's rate policy.
+    cannot be requested in one call. A thread longer than the page the
+    workspace grants therefore replays the root and the first replies, and the
+    block carries ``truncated="true"`` so the model knows the recent tail is
+    missing.
     """
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]
-        channel=channel, ts=thread_ts, limit=THREAD_PAGE_LIMIT
+        channel=channel, ts=thread_ts, limit=page_limit
     )
     messages = cast(list[dict[str, Any]], resp["messages"])  # pyright: ignore[reportUnknownVariableType]
     truncated = bool(resp.get("has_more"))  # pyright: ignore[reportUnknownMemberType]
@@ -137,6 +140,7 @@ async def build_delta_xml(
     user_query: str,
     author_id: str = "",
     proxy: ProxyUrlContext | None = None,
+    page_limit: int = DEFAULT_PAGE_LIMIT,
 ) -> str:
     """Build XML context for a continuation turn (delta since watermark).
 
@@ -145,15 +149,15 @@ async def build_delta_xml(
     ``build_delta_xml``'s ``after_message_id`` path).  Returns a string with a
     ``<context>/<thread_delta>`` block and a ``<user_query>`` element.
 
-    One page of ``THREAD_PAGE_LIMIT`` messages, oldest-first from the
-    watermark; a delta longer than that is marked ``truncated="true"``.
+    One page of ``page_limit`` messages, oldest-first from the watermark; a
+    delta longer than that is marked ``truncated="true"``.
     """
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]
         channel=channel,
         ts=thread_ts,
         oldest=watermark_ts,
         inclusive=False,
-        limit=THREAD_PAGE_LIMIT,
+        limit=page_limit,
     )
     messages = cast(list[dict[str, Any]], resp["messages"])  # pyright: ignore[reportUnknownVariableType]
     truncated = bool(resp.get("has_more"))  # pyright: ignore[reportUnknownMemberType]

--- a/packages/adapters/slack/daimon/adapters/slack/interactions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/interactions.py
@@ -24,11 +24,12 @@ def build_retry_handlers() -> list[AsyncRetryHandler]:
     """Retry handlers for every AsyncWebClient we construct.
 
     slack_sdk's default is connection-error retries only, so a 429 surfaces
-    immediately as ``SlackApiError``. Slack caps non-Marketplace apps at one
-    ``conversations.history``/``conversations.replies`` call per minute, and
-    the listener boundary posts nothing on failure, so an unretried 429 reads
-    as a dead bot. ``AsyncRateLimitErrorRetryHandler`` honours ``Retry-After``;
-    its default single retry is deliberate, since that wait can be 60s.
+    immediately as ``SlackApiError``. Slack caps apps commercially distributed
+    outside the Marketplace at one ``conversations.history``/
+    ``conversations.replies`` call per minute, and the listener boundary posts
+    nothing on failure, so an unretried 429 reads as a dead bot.
+    ``AsyncRateLimitErrorRetryHandler`` honours ``Retry-After``; its default
+    single retry is deliberate, since that wait can be 60s.
     """
     return [*async_default_handlers(), AsyncRateLimitErrorRetryHandler()]
 

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -28,7 +28,7 @@ import aiohttp
 import httpx
 import pytest
 import structlog.testing
-from anthropic import AsyncAnthropic
+from anthropic import AsyncAnthropic, NotFoundError
 from anthropic.types.beta import (
     BetaManagedAgentsModelConfig,
     BetaManagedAgentsSession,
@@ -40,7 +40,7 @@ from cryptography.fernet import Fernet
 from daimon.adapters.slack.app import SlackApp
 from daimon.adapters.slack.runtime import SlackRuntime, build_turn_deps
 from daimon.core.defaults.provisioning import provision_tenant
-from daimon.core.errors import DaimonError
+from daimon.core.errors import DaimonError, TurnError
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.ma_identity import derive_tenant_uuid
 from daimon.core.ma_resolver import new_resolver_cache
@@ -161,6 +161,7 @@ def _make_app(
     else:
         settings.crypto.keys = ()
     settings.slack.max_concurrent_turns_per_tenant = 3
+    settings.slack.history_page_limit = 200
 
     if sessionmaker is None:
         # Provide a factory that returns an AsyncMock context manager when
@@ -736,6 +737,7 @@ def _make_orchestrate_app(
     settings = MagicMock()
     settings.crypto.keys = (SecretStr(crypto_key),) if crypto_key is not None else ()
     settings.slack.max_concurrent_turns_per_tenant = max_concurrent_turns_per_tenant
+    settings.slack.history_page_limit = 200
     settings.mcp.public_url = None
     # app_root_url=None short-circuits _maybe_post_connect_nudge (Task 11) — these
     # orchestration tests don't exercise the connect-nudge flow.
@@ -1036,6 +1038,10 @@ async def test_orchestrate_continuation_when_live_session_exists_calls_build_del
         f"build_delta_xml must be called with watermark_ts={prior_watermark!r}, "
         f"got {call_kwargs.get('watermark_ts')!r}"
     )
+    assert call_kwargs.get("page_limit") == 200, (
+        "the configured page size must reach the replay call; hardcoding the "
+        "clamped ceiling denies unclamped workspaces their depth"
+    )
 
     # Assert watermark was updated in the DB.
     async with db_session_factory() as s:
@@ -1049,6 +1055,138 @@ async def test_orchestrate_continuation_when_live_session_exists_calls_build_del
     assert row is not None, "thread_sessions row must still exist"
     assert row.watermark_message_id != prior_watermark, (
         "watermark must be updated after the continuation turn"
+    )
+
+
+async def test_dead_session_reseed_requests_the_configured_page_size(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    """The recovery re-seed replays history with the same page size as the first turn.
+
+    The setting is deliberately not 200 here: the reseed call falling back to
+    the module default would otherwise be indistinguishable from honouring it.
+    """
+    from daimon.core.stores.identity import get_or_create_platform_principal
+
+    team_id = "T_ORCH_80_RESEED"
+    channel = "C_TEST"
+    thread_ts = "9000000003.000001"
+    tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+    await provision_tenant(
+        db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+    )
+    async with db_session_factory() as s:
+        principal = await get_or_create_platform_principal(
+            s, tenant_id=tenant_id, platform="slack", external_id="U_TEST_RESEED"
+        )
+        await create_thread_session(
+            s,
+            tenant_id=tenant_id,
+            platform="slack",
+            thread_id=thread_ts,
+            account_id=principal.account_id,
+            ma_session_id="sess-reseed-dead",
+            watermark_message_id=None,
+        )
+        await s.commit()
+
+    app, _ = _make_orchestrate_app(db_session_factory)
+    app.runtime.settings.slack.history_page_limit = 350
+
+    dead = TurnState(
+        error=TurnError(
+            kind="upstream",
+            message="session gone",
+            cause=NotFoundError(
+                "session gone",
+                response=httpx.Response(404, request=httpx.Request("POST", "https://ma.test")),
+                body=None,
+            ),
+        ),
+    )
+    outcomes = iter([dead, None])
+
+    async def _fake_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+        if (state := next(outcomes)) is not None:
+            return state
+        ok = TurnState(content=[TextBlock(kind="text", text="Recovered!")])
+        await lifecycle.on_terminal_success(ok)
+        return ok
+
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "ts": "9000000003.000002",
+        "thread_ts": thread_ts,
+        "event_ts": "9000000003.000002",
+        "channel": channel,
+        "user": "U_TEST_RESEED",
+        "text": "<@U_BOT> still there?",
+    }
+
+    _now = datetime.now(UTC)
+    _fake_session = BetaManagedAgentsSession(
+        outcome_evaluations=[],
+        id="sess-reseed-fresh",
+        agent=BetaManagedAgentsSessionAgent(
+            id="agent_test_id",
+            mcp_servers=[],
+            model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+            name="test-agent",
+            skills=[],
+            tools=[],
+            type="agent",
+            version=1,
+        ),
+        created_at=_now,
+        environment_id="env_test_id",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=_now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+    )
+
+    with (
+        patch(
+            "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+        ) as mock_resolve_agent,
+        patch(
+            "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+        ) as mock_resolve_env,
+        patch(
+            "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+        patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+    ):
+        mock_resolve_agent.return_value = "agent_test_id"
+        mock_resolve_env.return_value = "env_test_id"
+        mock_create_session.return_value = _fake_session
+        mock_run_turn.side_effect = _fake_run_turn
+
+        await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+            event,
+            team_id=team_id,
+            channel=channel,
+            event_ts="9000000003.000002",
+            web_client=fake_slack_web_client.client,
+            tenant_id=tenant_id,
+        )
+
+    assert mock_run_turn.await_count == 2, "the dead session must be recovered exactly once"
+    requested = [
+        str(url.query["limit"])
+        for (method, url), _ in fake_slack_web_client.mock.requests.items()
+        if method == "GET" and url.path == "/api/conversations.replies"
+    ]
+    assert requested == ["350"], (
+        "the re-seed after recovery is the only history replay on a reused session, "
+        f"and it must carry the configured page size; saw {requested}"
     )
 
 
@@ -3614,6 +3752,7 @@ async def test_run_thread_turn_pump_phase_ceiling_renders_terminal_error_in_thre
             tenant_id=tenant_id,
             thread_id=thread_ts,
             team_id=team_id,
+            page_limit=200,
         )
 
     update_calls = [

--- a/packages/adapters/slack/tests/test_context.py
+++ b/packages/adapters/slack/tests/test_context.py
@@ -13,7 +13,12 @@ import re
 
 from aioresponses import aioresponses as AioResponsesMock
 from daimon.adapters.slack.attachments import ProxyUrlContext
-from daimon.adapters.slack.context import _render_message, build_context_xml, build_delta_xml
+from daimon.adapters.slack.context import (
+    DEFAULT_PAGE_LIMIT,
+    _render_message,
+    build_context_xml,
+    build_delta_xml,
+)
 from daimon.core.slack_file_token import verify_file_token
 from slack_sdk.web.async_client import AsyncWebClient
 
@@ -37,16 +42,34 @@ def _replies_request_params(mock: AioResponsesMock) -> dict[str, str]:
     return calls[0]
 
 
+def _messages(count: int) -> list[dict[str, str]]:
+    return [{"user": "U1", "text": f"msg {i}", "ts": f"{100 + i}.0"} for i in range(count)]
+
+
 def _fifteen_messages() -> list[dict[str, str]]:
-    return [{"user": "U1", "text": f"msg {i}", "ts": f"{100 + i}.0"} for i in range(15)]
+    return _messages(15)
 
 
-async def test_build_context_xml_requests_the_slack_page_cap() -> None:
-    """The first-turn replay asks for exactly the 15 messages Slack will return.
+def _clamped_to_fifteen(total: int) -> dict[str, object]:
+    """Response a capped workspace sends however large a limit it was asked for.
 
-    Non-Marketplace apps get at most 15 objects per conversations.replies call;
-    asking for more is silently clamped, so the request must state the real
-    ceiling rather than a number the API ignores.
+    Slack clamps ``limit`` server-side rather than erroring, which is why a
+    request for 100 returned 15 unnoticed before. Tests that echo back the
+    requested limit cannot tell the two workspace classes apart.
+    """
+    return {
+        "ok": True,
+        "messages": _messages(min(15, total)),
+        "has_more": total > 15,
+    }
+
+
+async def test_build_context_xml_requests_the_full_page_size() -> None:
+    """The first-turn replay asks for the page size the settings name.
+
+    Slack clamps the value server-side per workspace: a capped install gets 15
+    back whatever we ask for, an exempt one gets the full page. Hardcoding the
+    capped ceiling in the request denies exempt installs their depth.
     """
     with AioResponsesMock() as mock:
         mock.get(
@@ -54,12 +77,73 @@ async def test_build_context_xml_requests_the_slack_page_cap() -> None:
             payload={"ok": True, "messages": _fifteen_messages(), "has_more": False},
         )
         client = _make_client()
+        await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
+        params = _replies_request_params(mock)
+
+    assert params["limit"] == str(DEFAULT_PAGE_LIMIT)
+
+
+async def test_build_context_xml_requests_an_explicit_page_limit() -> None:
+    """A caller-supplied page size reaches the API call."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": _fifteen_messages(), "has_more": False},
+        )
+        client = _make_client()
+        await build_context_xml(
+            client, channel="C1", thread_ts="100.0", user_query="hi", page_limit=50
+        )
+        params = _replies_request_params(mock)
+
+    assert params["limit"] == "50"
+
+
+async def test_build_delta_xml_requests_the_full_page_size() -> None:
+    """The continuation delta asks for the same page size as the first turn."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": _fifteen_messages(), "has_more": False},
+        )
+        client = _make_client()
+        await build_delta_xml(
+            client, channel="C1", thread_ts="100.0", watermark_ts="99.0", user_query="hi"
+        )
+        params = _replies_request_params(mock)
+
+    assert params["limit"] == str(DEFAULT_PAGE_LIMIT)
+
+
+async def test_build_context_xml_replays_a_page_wider_than_the_capped_ceiling() -> None:
+    """An unclamped workspace replays everything Slack returns, not the first 15."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": _messages(40), "has_more": False},
+        )
+        client = _make_client()
+        xml = await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
+
+    assert xml.count("<message ") == 40, "every returned message reaches the model"
+    assert "<thread_history>" in xml, "a complete window carries no truncation marker"
+
+
+async def test_build_context_xml_flags_truncation_when_the_workspace_clamps() -> None:
+    """A capped workspace asked for a full page still reports a partial window.
+
+    The request states the full page size; the workspace returns 15 with
+    ``has_more``. The model must be told the tail is absent.
+    """
+    with AioResponsesMock() as mock:
+        mock.get(_REPLIES_PATTERN, payload=_clamped_to_fifteen(total=200))
+        client = _make_client()
         xml = await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
         params = _replies_request_params(mock)
 
-    assert params["limit"] == "15"
-    assert xml.count("<message ") == 15, "every returned message reaches the model"
-    assert "<thread_history>" in xml, "a complete window carries no truncation marker"
+    assert params["limit"] == str(DEFAULT_PAGE_LIMIT), "we asked for the full page"
+    assert xml.count("<message ") == 15, "the workspace clamped the response"
+    assert '<thread_history truncated="true">' in xml
 
 
 async def test_build_context_xml_marks_thread_history_truncated_when_slack_has_more() -> None:

--- a/packages/adapters/slack/tests/test_turn_context.py
+++ b/packages/adapters/slack/tests/test_turn_context.py
@@ -75,6 +75,7 @@ def _make_orchestrate_app(
     settings = MagicMock()
     settings.crypto.keys = ()
     settings.slack.max_concurrent_turns_per_tenant = 3
+    settings.slack.history_page_limit = 200
     settings.mcp.public_url = None
     # app_root_url=None short-circuits _maybe_post_connect_nudge (Task 11) — these
     # turn-context tests don't exercise the connect-nudge flow.

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -226,6 +226,19 @@ class SlackSettings(BaseModel):
             "starving others on the shared Anthropic key."
         ),
     )
+    history_page_limit: int = Field(
+        default=200,
+        ge=1,
+        le=1000,
+        description=(
+            "Messages requested per conversations.replies call when replaying "
+            "thread history. Slack clamps this per workspace: an app "
+            "commercially distributed outside the Marketplace gets 15 whatever "
+            "it asks for, an internal-app install gets the full page up to "
+            "1000, which is also the largest value Slack accepts. Raising it "
+            "costs a clamped workspace nothing."
+        ),
+    )
     health_port: int = Field(
         default=8083,
         description=(

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -575,3 +575,59 @@ def test_slack_settings_max_concurrent_turns_per_tenant_defaults_to_3(
     assert settings.slack.max_concurrent_turns_per_tenant == 3, (
         "max_concurrent_turns_per_tenant must default to 3 (STURN-06 per-tenant cap)"
     )
+
+
+def test_slack_settings_history_page_limit_defaults_to_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The requested conversations.replies page size defaults above the capped ceiling.
+
+    Slack clamps the value per workspace, so a default of 200 costs a capped
+    install nothing and gives an internal-app install the depth it is entitled
+    to.
+    """
+    monkeypatch.setenv("DAIMON_DATABASE__URL", "postgresql+asyncpg://u:p@h/d")
+    monkeypatch.setenv("DAIMON_ANTHROPIC__API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_SLACK__SIGNING_SECRET", "s" * 32)
+    monkeypatch.setenv("DAIMON_SLACK__APP_TOKEN", "xapp-test")
+    settings = load_settings(_env_file=None)
+    assert settings.slack is not None, "slack block must be present when DAIMON_SLACK__* are set"
+    assert settings.slack.history_page_limit == 200, (
+        "history_page_limit must default to 200 so unclamped workspaces replay deep threads"
+    )
+
+
+def test_slack_settings_history_page_limit_overrides_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator on an unclamped workspace can raise the page size to Slack's maximum."""
+    monkeypatch.setenv("DAIMON_DATABASE__URL", "postgresql+asyncpg://u:p@h/d")
+    monkeypatch.setenv("DAIMON_ANTHROPIC__API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_SLACK__SIGNING_SECRET", "s" * 32)
+    monkeypatch.setenv("DAIMON_SLACK__APP_TOKEN", "xapp-test")
+    monkeypatch.setenv("DAIMON_SLACK__HISTORY_PAGE_LIMIT", "1000")
+    settings = load_settings(_env_file=None)
+    assert settings.slack is not None
+    assert settings.slack.history_page_limit == 1000, (
+        "DAIMON_SLACK__HISTORY_PAGE_LIMIT must override the default page size"
+    )
+
+
+def test_slack_settings_history_page_limit_rejects_zero() -> None:
+    """A page size Slack would refuse fails at boot, not on the first mention.
+
+    conversations.replies answers ``invalid_limit`` for 0 and for anything above
+    1000, and the listener boundary posts nothing on failure, so an unbounded
+    field would turn a typo in .env into a workspace-wide silent bot.
+    """
+    from daimon.core.config import SlackSettings
+
+    with pytest.raises(ValidationError):
+        SlackSettings(signing_secret="s" * 32, app_token="xapp-test", history_page_limit=0)
+
+
+def test_slack_settings_history_page_limit_rejects_above_slack_maximum() -> None:
+    from daimon.core.config import SlackSettings
+
+    with pytest.raises(ValidationError):
+        SlackSettings(signing_secret="s" * 32, app_token="xapp-test", history_page_limit=1001)

--- a/tests/parity/drivers/slack_driver.py
+++ b/tests/parity/drivers/slack_driver.py
@@ -153,6 +153,7 @@ class SlackDriver:
         settings = MagicMock()
         settings.crypto.keys = (SecretStr(fernet_key),)
         settings.slack.max_concurrent_turns_per_tenant = 100
+        settings.slack.history_page_limit = 200
         settings.mcp.public_url = None
         settings.mcp.app_root_url = None
         settings.mcp.jwt_secret = None


### PR DESCRIPTION
## Summary

Four Slack gaps in the agent-facing MCP tool surface, each of which Discord already had. Until now an agent talking to a Slack workspace could produce a chart and have no way to hand it over, could not offer the GitHub App install page from chat, and could not read a thread past its first page.

**`send_message` posts file handles on Slack.** The refusal blamed a missing `files:write` scope, but the manifest has carried that scope since post-turn output delivery landed. The text posts first and the handles go up in one `files_upload_v2` call threaded under it. Slack's completion call shares asynchronously and returns no message ts, so a single combined post would leave the tool guessing at the ts it reports; two calls with a known ts beat one call with a guessed one. The cost is that an upload failure leaves the text already posted, and the error says so outright so the agent does not re-send it. Handle resolution moved into a module both platforms share. Attachments by url stay Discord-only (there is no Slack CDN to fetch from) and the refusal points at `file_handles`. A workspace whose install predates the scope gets an error naming the reinstall step. `create_file_upload_url` loses its Discord-specific wording, since untagged tools were already visible to Slack callers.

**`post_github_app_install_link` works on Slack.** A url button needs no bot-side handler any more than the Discord link button does. The posting path is a sibling of the Slack credential button that reuses the send path's target and visibility checks, and the composite `channel_id:thread_ts` target lands it in the thread the request came from. `message_id` is the posted ts.

**`read_thread` pages on Slack.** `has_more` said newer replies existed but nothing let the agent fetch them. `conversations.replies` pages oldest-first with a cursor, so the result carries `next_cursor` and a hint naming the exact argument to pass next, the same shape `read_channel` already returns. `cursor` is Slack-only and `before` Discord-only; each platform rejects the other's parameter rather than silently replaying page one.

**Page size.** Includes the earlier `fix/slack-history-page-size` commit, which the cursor work builds on: `conversations.history` and `conversations.replies` request the workspace's real page size instead of a hard-coded 15.

## Behaviour changes worth knowing

- On Slack, `content` cannot be empty when `file_handles` is given. Files land as replies under the text, so an empty caption has nothing to attach to. The error says to pass a short caption.
- The tool schema snapshot changes for `send_message`, `read_thread`, `create_file_upload_url` and `post_github_app_install_link` docstrings, plus the new `cursor` parameter.
- Production still needs the pending reinstall that grants `files:write` before file posting works there. Until then the tool returns the reinstall error rather than a silent drop.

## Testing

Slack Web API calls are faked at transport level with `aioresponses`, including the three-request upload flow, against real Postgres rows staged through `create_upload` / `store_upload_content`. New tests cover: bytes reaching Slack unaltered, root-target files threading under the posted text, thread-target files staying in that thread, several handles completing in one call, `missing_scope` naming the reinstall and the already-posted text, the bad-handle and empty-caption refusals making zero API calls, the install button's url and thread placement, and the cursor reaching `conversations.replies` on both the direct and refetch-by-parent paths.

Not tested against a live workspace. The `files.completeUploadExternal` thread placement is asserted on the request Slack receives, not on what Slack renders.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally — 4987 passed, 6 skipped. Three failures are environmental and fail identically on `main` in the same shell: `test_mcp_settings_both_unset_by_default` (a sourced `.env` sets the JWT secret) and two notebook-host chown tests macOS refuses.
- [x] `uv run pyright` passes locally (strict mode) — 0 errors
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts) — 6 kept, 0 broken
