### PR TITLE
feat(mcp): list files on Slack messages in the read tools

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -85,7 +85,9 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         pagination parameter — the other is rejected. Discord: at most 200
         messages per call; use before to fetch older messages. Slack: at most
         999 per call, and some workspaces cap a single call at 15 whatever
-        limit is asked for; use cursor to fetch the next page.
+        limit is asked for; use cursor to fetch the next page. Files on a
+        Slack message are listed in ``files``; each ``url`` is a fetchable
+        link that expires in about a day (curl it to read the bytes).
         """
         auth = await _auth(ctx)
         # MCP clients often send "" for an optional param they mean to omit —
@@ -120,7 +122,8 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         most 999 per page (some workspaces cap a page at 15 whatever limit is
         asked for). has_more=true means newer replies exist; pass the returned
         next_cursor as cursor to read them. before is Discord-only and cursor
-        is Slack-only.
+        is Slack-only. Files on a message are listed in ``files`` with a
+        fetchable ``url`` that expires in about a day.
         """
         auth = await _auth(ctx)
         before = before or None
@@ -143,7 +146,11 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         channel_id: str,
         message_id: str,
     ) -> MessageRow | SlackMessageRow:
-        """Fetch a single message by channel and message id (Slack: the message ts)."""
+        """Fetch a single message by channel and message id (Slack: the message ts).
+
+        Attached files come back in ``files`` (Slack) or ``attachments``
+        (Discord), each with a url you can fetch.
+        """
         auth = await _auth(ctx)
         if auth.platform == "slack":
             return await _slack_get_message_impl(

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_files.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_files.py
@@ -1,0 +1,80 @@
+"""Files on Slack messages, surfaced through the signed file proxy.
+
+A Slack ``url_private`` needs the workspace bot token, so handing it to the
+agent gives it nothing it can fetch. The Slack adapter solves this for the
+turn context by minting a signed, expiring token and pointing the agent at
+the MCP ``/slack/file/{token}`` route, which re-authenticates and streams
+the bytes. The read tools mint the same URLs here, with the same signer
+(``daimon.core.slack_file_token``) and the same secret the route verifies
+with, so a file the agent sees in ``read_thread`` is reachable exactly the
+way a file attached to the mention is.
+
+When the deployment has no public URL or no signing secret, the route is not
+mounted and no URL can be minted. Files are still listed, with ``url`` unset,
+so the agent knows a file exists rather than seeing a message with only text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.slack._models import SlackFileRow
+from daimon.core.slack_file_token import mint_file_token
+
+# Matches the Slack adapter's proxy-URL lifetime for files in the turn context.
+_FILE_URL_TTL_S = 24 * 3600
+
+# Slack keeps a placeholder entry for a deleted file or one hidden by the
+# workspace's retention limit; neither has bytes behind it.
+_UNREADABLE_MODES = frozenset({"tombstone", "hidden_by_limit"})
+
+
+@dataclass(frozen=True)
+class FileUrlMinter:
+    base_url: str
+    secret: str
+    team_id: str
+    now: int
+
+    def url(self, file_id: str) -> str:
+        token = mint_file_token(
+            team_id=self.team_id,
+            file_id=file_id,
+            exp=self.now + _FILE_URL_TTL_S,
+            secret=self.secret,
+        )
+        return f"{self.base_url.rstrip('/')}/slack/file/{token}"
+
+
+def file_url_minter(runtime: McpRuntime, *, team_id: str, now: int) -> FileUrlMinter | None:
+    """The minter for this deployment, or None when the proxy route is not mounted."""
+    base_url = runtime.settings.mcp.app_root_url
+    secret = runtime.settings.mcp.jwt_secret
+    if base_url is None or secret is None:
+        return None
+    return FileUrlMinter(
+        base_url=base_url, secret=secret.get_secret_value(), team_id=team_id, now=now
+    )
+
+
+def to_file_rows(
+    raw_files: list[dict[str, Any]], minter: FileUrlMinter | None
+) -> list[SlackFileRow]:
+    rows: list[SlackFileRow] = []
+    for f in raw_files:
+        file_id = f.get("id")
+        if not file_id or f.get("mode") in _UNREADABLE_MODES:
+            continue
+        size = f.get("size")
+        rows.append(
+            SlackFileRow(
+                id=str(file_id),
+                name=str(f.get("name") or f.get("title") or "file"),
+                mimetype=str(f.get("mimetype") or "unknown"),
+                size=int(size) if size is not None else None,
+                url=minter.url(str(file_id)) if minter is not None else None,
+            )
+        )
+    return rows

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
@@ -13,6 +13,17 @@ class SlackChannelRow(BaseModel):
     num_members: int | None = None
 
 
+class SlackFileRow(BaseModel):
+    """A file attached to a message. ``url`` is a signed, expiring link through
+    daimon's file proxy; unset when the deployment cannot mint one."""
+
+    id: str
+    name: str
+    mimetype: str
+    size: int | None = None
+    url: str | None = None
+
+
 class SlackMessageRow(BaseModel):
     ts: str
     user_id: str | None = None
@@ -20,6 +31,7 @@ class SlackMessageRow(BaseModel):
     text: str
     thread_ts: str | None = None
     reply_count: int | None = None
+    files: list[SlackFileRow] = []
 
 
 class SlackChannelResult(BaseModel):
@@ -46,6 +58,7 @@ class SlackSearchMatch(BaseModel):
     username: str | None = None
     text: str
     permalink: str | None = None
+    files: list[SlackFileRow] = []
 
 
 class SlackSearchResult(BaseModel):

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -28,6 +28,11 @@ from daimon.adapters.mcp.tools.slack._client import (
     slack_read_client,
     slack_web_client,
 )
+from daimon.adapters.mcp.tools.slack._files import (
+    FileUrlMinter,
+    file_url_minter,
+    to_file_rows,
+)
 from daimon.adapters.mcp.tools.slack._leak_policy import (
     DM_REDIRECT_MSG,
     get_destination,
@@ -129,7 +134,10 @@ async def _resolve_usernames(client: AsyncWebClient, user_ids: set[str]) -> dict
 
 
 def _to_message_rows(
-    raw_messages: list[dict[str, Any]], usernames: dict[str, str]
+    raw_messages: list[dict[str, Any]],
+    usernames: dict[str, str],
+    *,
+    files: FileUrlMinter | None,
 ) -> list[SlackMessageRow]:
     rows: list[SlackMessageRow] = []
     for msg in raw_messages:
@@ -142,6 +150,7 @@ def _to_message_rows(
                 text=str(msg.get("text", "")),
                 thread_ts=str(msg["thread_ts"]) if msg.get("thread_ts") else None,
                 reply_count=int(msg["reply_count"]) if msg.get("reply_count") else None,
+                files=to_file_rows(cast(list[dict[str, Any]], msg.get("files") or []), files),
             )
         )
     return rows
@@ -244,7 +253,12 @@ async def _slack_list_channels_impl(  # pyright: ignore[reportUnusedFunction]  #
 
 
 async def _fetch_channel_history(
-    client: AsyncWebClient, *, channel_id: str, limit: int, cursor: str | None
+    client: AsyncWebClient,
+    *,
+    channel_id: str,
+    limit: int,
+    cursor: str | None,
+    files: FileUrlMinter | None,
 ) -> SlackChannelResult:
     resp = await client.conversations_history(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
         channel=channel_id, limit=_bounded_page(limit), cursor=cursor
@@ -265,7 +279,9 @@ async def _fetch_channel_history(
     else:
         hint = None
     return SlackChannelResult(
-        messages=_to_message_rows(raw, usernames), next_cursor=next_cursor, hint=hint
+        messages=_to_message_rows(raw, usernames, files=files),
+        next_cursor=next_cursor,
+        hint=hint,
     )
 
 
@@ -280,13 +296,14 @@ async def _slack_read_channel_impl(  # pyright: ignore[reportUnusedFunction]  # 
     user_id = _require_slack_identity(auth)
     team_id = _require_team_id(auth)
     rc = await slack_read_client(runtime, team_id=team_id, slack_user_id=user_id)
+    files = file_url_minter(runtime, team_id=team_id, now=int(time.time()))
 
     if rc.runs_as_user:
         try:
             channel = await _channel_info(rc.client, channel_id=channel_id)
             await _gate_user_source(runtime, auth, channel=channel)
             return await _fetch_channel_history(
-                rc.client, channel_id=channel_id, limit=limit, cursor=cursor
+                rc.client, channel_id=channel_id, limit=limit, cursor=cursor, files=files
             )
         except SlackApiError as err:
             # Any not_in_channel from the user token (typically a public channel
@@ -303,7 +320,7 @@ async def _slack_read_channel_impl(  # pyright: ignore[reportUnusedFunction]  # 
         channel = await _channel_info(bot_client, channel_id=channel_id)
         await check_channel_access(bot_client, channel=channel, user_id=user_id)
         return await _fetch_channel_history(
-            bot_client, channel_id=channel_id, limit=limit, cursor=cursor
+            bot_client, channel_id=channel_id, limit=limit, cursor=cursor, files=files
         )
     except ToolError as terr:
         if rc.runs_as_user:
@@ -335,6 +352,7 @@ async def _fetch_thread_replies(
     thread_ts: str,
     limit: int,
     cursor: str | None,
+    files: FileUrlMinter | None,
 ) -> SlackThreadResult:
     resp = await client.conversations_replies(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
         channel=channel_id, ts=thread_ts, limit=_bounded_page(limit), cursor=cursor
@@ -374,7 +392,7 @@ async def _fetch_thread_replies(
     return SlackThreadResult(
         channel_id=channel_id,
         thread_ts=result_thread_ts,
-        messages=_to_message_rows(raw, usernames),
+        messages=_to_message_rows(raw, usernames, files=files),
         has_more=has_more,
         next_cursor=next_cursor,
         hint=hint,
@@ -393,13 +411,19 @@ async def _slack_read_thread_impl(  # pyright: ignore[reportUnusedFunction]  # r
     user_id = _require_slack_identity(auth)
     team_id = _require_team_id(auth)
     rc = await slack_read_client(runtime, team_id=team_id, slack_user_id=user_id)
+    files = file_url_minter(runtime, team_id=team_id, now=int(time.time()))
 
     if rc.runs_as_user:
         try:
             channel = await _channel_info(rc.client, channel_id=channel_id)
             await _gate_user_source(runtime, auth, channel=channel)
             return await _fetch_thread_replies(
-                rc.client, channel_id=channel_id, thread_ts=thread_ts, limit=limit, cursor=cursor
+                rc.client,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                limit=limit,
+                cursor=cursor,
+                files=files,
             )
         except SlackApiError as err:
             # Any not_in_channel from the user token (typically a public channel
@@ -416,7 +440,12 @@ async def _slack_read_thread_impl(  # pyright: ignore[reportUnusedFunction]  # r
         channel = await _channel_info(bot_client, channel_id=channel_id)
         await check_channel_access(bot_client, channel=channel, user_id=user_id)
         return await _fetch_thread_replies(
-            bot_client, channel_id=channel_id, thread_ts=thread_ts, limit=limit, cursor=cursor
+            bot_client,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            limit=limit,
+            cursor=cursor,
+            files=files,
         )
     except ToolError as terr:
         if rc.runs_as_user:
@@ -432,7 +461,7 @@ async def _slack_read_thread_impl(  # pyright: ignore[reportUnusedFunction]  # r
 
 
 async def _fetch_single_message(
-    client: AsyncWebClient, *, channel_id: str, message_id: str
+    client: AsyncWebClient, *, channel_id: str, message_id: str, files: FileUrlMinter | None
 ) -> SlackMessageRow:
     resp = await client.conversations_history(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
         channel=channel_id, latest=message_id, inclusive=True, limit=1
@@ -460,7 +489,7 @@ async def _fetch_single_message(
     if match is None:
         raise ToolError("message not found")
     usernames = await _resolve_usernames(client, _author_ids([match]))
-    return _to_message_rows([match], usernames)[0]
+    return _to_message_rows([match], usernames, files=files)[0]
 
 
 async def _slack_get_message_impl(  # pyright: ignore[reportUnusedFunction]  # registered by tools/channels.py
@@ -469,13 +498,14 @@ async def _slack_get_message_impl(  # pyright: ignore[reportUnusedFunction]  # r
     user_id = _require_slack_identity(auth)
     team_id = _require_team_id(auth)
     rc = await slack_read_client(runtime, team_id=team_id, slack_user_id=user_id)
+    files = file_url_minter(runtime, team_id=team_id, now=int(time.time()))
 
     if rc.runs_as_user:
         try:
             channel = await _channel_info(rc.client, channel_id=channel_id)
             await _gate_user_source(runtime, auth, channel=channel)
             return await _fetch_single_message(
-                rc.client, channel_id=channel_id, message_id=message_id
+                rc.client, channel_id=channel_id, message_id=message_id, files=files
             )
         except SlackApiError as err:
             # Any not_in_channel from the user token (typically a public channel
@@ -491,7 +521,9 @@ async def _slack_get_message_impl(  # pyright: ignore[reportUnusedFunction]  # r
     try:
         channel = await _channel_info(bot_client, channel_id=channel_id)
         await check_channel_access(bot_client, channel=channel, user_id=user_id)
-        return await _fetch_single_message(bot_client, channel_id=channel_id, message_id=message_id)
+        return await _fetch_single_message(
+            bot_client, channel_id=channel_id, message_id=message_id, files=files
+        )
     except ToolError as terr:
         if rc.runs_as_user:
             raise

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_search.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_search.py
@@ -20,6 +20,7 @@ from daimon.adapters.mcp.tools.slack._client import (
     build_connect_hint,
     slack_read_client,
 )
+from daimon.adapters.mcp.tools.slack._files import file_url_minter, to_file_rows
 from daimon.adapters.mcp.tools.slack._leak_policy import get_destination, is_dm_destination
 from daimon.adapters.mcp.tools.slack._models import SlackSearchMatch, SlackSearchResult
 from daimon.adapters.mcp.tools.slack._visibility import map_slack_api_error
@@ -52,6 +53,7 @@ async def _slack_search_messages_impl(  # pyright: ignore[reportUnusedFunction] 
     messages = cast(dict[str, Any], resp.get("messages") or {})
     raw_matches = cast(list[dict[str, Any]], messages.get("matches") or [])
     total = int(cast(dict[str, Any], messages.get("paging") or {}).get("total") or 0)
+    files = file_url_minter(runtime, team_id=team_id, now=int(time.time()))
     matches: list[SlackSearchMatch] = []
     for m in raw_matches:
         channel = cast(dict[str, Any], m.get("channel") or {})
@@ -65,6 +67,7 @@ async def _slack_search_messages_impl(  # pyright: ignore[reportUnusedFunction] 
                 username=str(m["username"]) if m.get("username") else None,
                 text=str(m.get("text", "")),
                 permalink=str(m["permalink"]) if m.get("permalink") else None,
+                files=to_file_rows(cast(list[dict[str, Any]], m.get("files") or []), files),
             )
         )
     return SlackSearchResult(matches=matches, total=total)

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -1467,7 +1467,12 @@
       }),
     }),
     'get_message': dict({
-      'description': 'Fetch a single message by channel and message id (Slack: the message ts).',
+      'description': '''
+        Fetch a single message by channel and message id (Slack: the message ts).
+        
+        Attached files come back in ``files`` (Slack) or ``attachments``
+        (Discord), each with a url you can fetch.
+      ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
@@ -2113,7 +2118,9 @@
         pagination parameter — the other is rejected. Discord: at most 200
         messages per call; use before to fetch older messages. Slack: at most
         999 per call, and some workspaces cap a single call at 15 whatever
-        limit is asked for; use cursor to fetch the next page.
+        limit is asked for; use cursor to fetch the next page. Files on a
+        Slack message are listed in ``files``; each ``url`` is a fetchable
+        link that expires in about a day (curl it to read the bytes).
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2164,7 +2171,8 @@
         most 999 per page (some workspaces cap a page at 15 whatever limit is
         asked for). has_more=true means newer replies exist; pass the returned
         next_cursor as cursor to read them. before is Discord-only and cursor
-        is Slack-only.
+        is Slack-only. Files on a message are listed in ``files`` with a
+        fetchable ``url`` that expires in about a day.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -33,6 +33,7 @@ from daimon.core.config import (
 )
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.scope import DeploymentDefault
+from daimon.core.slack_file_token import verify_file_token
 from daimon.core.stores.domain import Role
 from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
 from daimon.core.stores.slack_turn_contexts import create_slack_turn_context
@@ -66,7 +67,21 @@ def _auth(**overrides: object) -> AuthIdentity:
     return AuthIdentity(**base)  # type: ignore[arg-type]  # test kwargs are shape-correct
 
 
-def _build_settings(*, fernet_key: SecretStr, mintable: bool = False) -> Settings:
+_FILE_PROXY_SECRET = "file-proxy-secret"
+
+
+def _build_settings(
+    *, fernet_key: SecretStr, mintable: bool = False, file_proxy: bool = False
+) -> Settings:
+    if file_proxy:
+        mcp = McpSettings(
+            public_url=HttpUrl("https://mcp.example.com/mcp"),
+            jwt_secret=SecretStr(_FILE_PROXY_SECRET),
+        )
+    elif mintable:
+        mcp = McpSettings(public_url=HttpUrl("https://mcp.example.com/mcp"))
+    else:
+        mcp = McpSettings()
     return Settings(
         database=DatabaseSettings(
             url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon"),
@@ -77,9 +92,7 @@ def _build_settings(*, fernet_key: SecretStr, mintable: bool = False) -> Setting
         ),
         crypto=CryptoSettings(keys=(fernet_key,)),
         credentials=CredentialsSettings(google_sa_json=None),
-        mcp=McpSettings(public_url=HttpUrl("https://mcp.example.com/mcp"))
-        if mintable
-        else McpSettings(),
+        mcp=mcp,
         slack=(
             SlackSettings(signing_secret=SecretStr("shh-secret"), app_token=SecretStr("xapp-test"))
             if mintable
@@ -92,6 +105,7 @@ async def _make_runtime(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     *,
     mintable: bool = False,
+    file_proxy: bool = False,
 ) -> McpRuntime:
     fernet_key = SecretStr(Fernet.generate_key().decode("ascii"))
     fernet = build_multifernet((fernet_key.get_secret_value(),))
@@ -103,7 +117,7 @@ async def _make_runtime(
     return McpRuntime(
         session_factory=committing_sessionmaker,
         client=MagicMock(spec=AsyncAnthropic),
-        settings=_build_settings(fernet_key=fernet_key, mintable=mintable),
+        settings=_build_settings(fernet_key=fernet_key, mintable=mintable, file_proxy=file_proxy),
         deployment_default=DeploymentDefault(),
         fernet=fernet,
     )
@@ -1494,3 +1508,155 @@ async def test_read_thread_reply_ts_refetch_by_parent_keeps_the_cursor(
         cursors = _recorded_query(m, "/api/conversations.replies", "cursor")
     assert result.thread_ts == "1.0"
     assert cursors == ["CURSOR_3", "CURSOR_3"], "both lookups page from the same continuation"
+
+
+_CHART_FILE = {
+    "id": "F_CHART",
+    "name": "chart.png",
+    "mimetype": "image/png",
+    "size": 4096,
+    "url_private": "https://files.slack.com/files-pri/T_TEST-F_CHART/chart.png",
+}
+_TOMBSTONE_FILE = {"id": "F_GONE", "mode": "tombstone", "name": "gone.csv"}
+
+
+def _mock_public_channel(m: aioresponses) -> None:
+    m.get(  # pyright: ignore[reportUnknownMemberType]
+        _CONVERSATIONS_INFO,
+        payload={"ok": True, "channel": {"id": "C1", "name": "general", "is_private": False}},
+    )
+    m.get(_USERS_INFO, payload=_FULL_MEMBER)  # pyright: ignore[reportUnknownMemberType]
+
+
+@pytest.mark.asyncio
+async def test_read_channel_lists_files_with_a_proxy_url_the_route_would_accept(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_HISTORY,
+            payload={
+                "ok": True,
+                "messages": [
+                    {"ts": "1", "user": "U_A", "text": "see attached", "files": [_CHART_FILE]}
+                ],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
+
+    (row,) = result.messages
+    (file,) = row.files
+    assert (file.id, file.name, file.mimetype, file.size) == (
+        "F_CHART",
+        "chart.png",
+        "image/png",
+        4096,
+    )
+    assert file.url is not None and file.url.startswith("https://mcp.example.com/slack/file/"), (
+        "the url must point at the proxy route on the app root, not under /mcp"
+    )
+    token = file.url.rsplit("/", 1)[1]
+    ref = verify_file_token(
+        token, secret=_FILE_PROXY_SECRET, now=int(datetime.now(UTC).timestamp())
+    )
+    assert ref is not None, "the minted token must verify with the secret the route uses"
+    assert (ref.team_id, ref.file_id) == ("T_TEST", "F_CHART"), (
+        "the token must name the caller's workspace and this file, nothing else"
+    )
+    assert "url_private" not in file.model_dump_json(), "Slack's private url must not leak"
+
+
+@pytest.mark.asyncio
+async def test_read_channel_without_a_file_proxy_still_lists_files_with_no_url(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_HISTORY,
+            payload={
+                "ok": True,
+                "messages": [{"ts": "1", "user": "U_A", "text": "", "files": [_CHART_FILE]}],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        result = await _slack_read_channel_impl(runtime, auth, channel_id="C1", limit=50)
+
+    (file,) = result.messages[0].files
+    assert file.name == "chart.png" and file.url is None, (
+        "a deployment that cannot mint a link still tells the agent the file exists"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_thread_skips_tombstoned_files_and_keeps_readable_ones(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_REPLIES,
+            payload={
+                "ok": True,
+                "messages": [
+                    {"ts": "1.0", "user": "U_A", "text": "root", "thread_ts": "1.0"},
+                    {
+                        "ts": "2.0",
+                        "user": "U_A",
+                        "text": "two files",
+                        "thread_ts": "1.0",
+                        "files": [_TOMBSTONE_FILE, _CHART_FILE],
+                    },
+                ],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        result = await _slack_read_thread_impl(runtime, auth, thread_id="C1:1.0", limit=50)
+
+    root, reply = result.messages
+    assert root.files == [], "a message with no files reports an empty list, not a missing key"
+    assert [f.id for f in reply.files] == ["F_CHART"], (
+        "a deleted file's placeholder has no bytes behind it and must not be offered"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_message_returns_its_files(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    with aioresponses() as m:
+        _mock_public_channel(m)
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _CONVERSATIONS_HISTORY,
+            payload={
+                "ok": True,
+                "messages": [{"ts": "5.0", "user": "U_A", "text": "hit", "files": [_CHART_FILE]}],
+            },
+        )
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO,
+            payload={"ok": True, "user": {"id": "U_A", "profile": {"display_name": "alice"}}},
+        )
+        row = await _slack_get_message_impl(runtime, auth, channel_id="C1", message_id="5.0")
+
+    assert [f.name for f in row.files] == ["chart.png"]
+    assert row.files[0].url is not None

--- a/packages/adapters/mcp/tests/tools/test_slack_search.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_search.py
@@ -76,7 +76,9 @@ def _auth(**overrides: object) -> AuthIdentity:
     return AuthIdentity(**base)  # type: ignore[arg-type]  # test kwargs are shape-correct
 
 
-def _build_settings(*, fernet_key: SecretStr, mintable: bool = False) -> Settings:
+def _build_settings(
+    *, fernet_key: SecretStr, mintable: bool = False, file_proxy: bool = False
+) -> Settings:
     return Settings(
         database=DatabaseSettings(
             url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon"),
@@ -87,8 +89,11 @@ def _build_settings(*, fernet_key: SecretStr, mintable: bool = False) -> Setting
         ),
         crypto=CryptoSettings(keys=(fernet_key,)),
         credentials=CredentialsSettings(google_sa_json=None),
-        mcp=McpSettings(public_url=HttpUrl("https://mcp.example.com/mcp"))
-        if mintable
+        mcp=McpSettings(
+            public_url=HttpUrl("https://mcp.example.com/mcp"),
+            jwt_secret=SecretStr("file-proxy-secret") if file_proxy else None,
+        )
+        if (mintable or file_proxy)
         else McpSettings(),
         slack=(
             SlackSettings(signing_secret=SecretStr("shh-secret"), app_token=SecretStr("xapp-test"))
@@ -102,6 +107,7 @@ async def _make_runtime(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     *,
     mintable: bool = False,
+    file_proxy: bool = False,
 ) -> McpRuntime:
     fernet_key = SecretStr(Fernet.generate_key().decode("ascii"))
     fernet = build_multifernet((fernet_key.get_secret_value(),))
@@ -113,7 +119,7 @@ async def _make_runtime(
     return McpRuntime(
         session_factory=committing_sessionmaker,
         client=MagicMock(spec=AsyncAnthropic),
-        settings=_build_settings(fernet_key=fernet_key, mintable=mintable),
+        settings=_build_settings(fernet_key=fernet_key, mintable=mintable, file_proxy=file_proxy),
         deployment_default=DeploymentDefault(),
         fernet=fernet,
     )
@@ -272,3 +278,48 @@ async def test_dispatch_slack_search_rejects_discord_only_filters(
     async with Client(mcp) as client:
         with pytest.raises(ToolError, match="slack"):
             await client.call_tool("search_messages", {"content": "q", "author_ids": ["U1"]})
+
+
+@pytest.mark.asyncio
+async def test_search_matches_carry_files_with_proxy_urls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    await _seed_user_token(runtime, committing_sessionmaker)
+    await _seed_turn_context(committing_sessionmaker, auth, channel_id="C1")
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _SEARCH_MESSAGES,
+            payload={
+                "ok": True,
+                "messages": {
+                    "paging": {"count": 20, "total": 1, "page": 1, "pages": 1},
+                    "matches": [
+                        {
+                            "channel": {"id": "C1", "name": "general", "is_private": False},
+                            "ts": "1.0",
+                            "username": "alice",
+                            "text": "the report",
+                            "files": [
+                                {
+                                    "id": "F_REPORT",
+                                    "name": "report.csv",
+                                    "mimetype": "text/csv",
+                                    "size": 12,
+                                    "url_private": "https://files.slack.com/x",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        )
+        result = await _slack_search_messages_impl(runtime, auth, content="report", limit=10)
+
+    (match,) = result.matches
+    (file,) = match.files
+    assert file.name == "report.csv"
+    assert file.url is not None and file.url.startswith("https://mcp.example.com/slack/file/"), (
+        "a search hit's file must be fetchable the same way a read hit's is"
+    )


### PR DESCRIPTION
## Summary

Stacked on #145; merge that first and this diff shrinks to one commit.

The Slack read tools (`read_channel`, `read_thread`, `get_message`, `search_messages`) returned text only. Any file on those messages was dropped, so an agent reading history it was not mentioned in never learned a file existed. Files attached to the mention itself already reach the agent through the turn context; this closes the gap for everything the agent reads on its own.

Each Slack message row now carries `files`, one entry per attached file with id, name, mimetype, size and a `url`. A Slack `url_private` needs the bot token, so the `url` is a signed, expiring link through the MCP `/slack/file/{token}` route that the turn context already uses, minted with the same signer and the same `jwt_secret` the route verifies with. Fetching it gives the agent the bytes exactly as it does for a file on the mention.

## Behaviour worth knowing

- A deployment with no public URL or no `jwt_secret` cannot mount the proxy route. Files are still listed there, with `url` unset, so the agent knows a file exists instead of seeing a text-only message.
- Deleted files and files hidden by the workspace's retention limit come back from Slack as placeholders with no bytes behind them. They are skipped.
- The tool schema snapshot changes: `SlackMessageRow` and `SlackSearchMatch` gain `files`, and the read-tool docstrings mention it.
- Nothing changes for Discord rows, which already carry `attachments`.

## Testing

Transport-level `aioresponses` fakes against real Postgres. The new tests cover a file surfacing through `read_channel` with a url on the app root whose token verifies to the caller's workspace and that file id, the no-proxy deployment listing the file with no url, `read_thread` skipping a tombstone while keeping a readable file beside it, `get_message` returning its files, and a search hit carrying a fetchable url. One assertion pins that `url_private` never appears in the serialized row.

Not exercised against a live workspace. The proxy route itself is unchanged and keeps its existing tests.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally — mcp shard 840 passed; the three environmental failures noted on #145 are unchanged
- [x] `uv run pyright` passes locally (strict mode) — 0 errors
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)
