### PR TITLE
feat(mcp): re-post Slack files through send_message attachments

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -23,10 +23,12 @@ re-running the install flow. A workspace that has hit its Slack file-storage
 limit gets one in-thread notice and no deliveries until space is freed.
 
 Agents can also post a file deliberately, mid-turn, through the MCP
-`send_message` tool's `file_handles` argument. The text posts first and the
-files follow as replies under it, so a file always has a caption. This uses
-the same `files:write` scope, and a workspace without it gets a tool error
-naming the reinstall step instead of a silent drop.
+`send_message` tool: `file_handles` for a file the agent produced, or
+`attachments` with a file link from one of the read tools to re-post a file
+already in the workspace. The text posts first and the files follow as
+replies under it, so a file always has a caption. This uses the same
+`files:write` scope, and a workspace without it gets a tool error naming the
+reinstall step instead of a silent drop.
 
 ### Per-user Slack access (optional)
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/channels.py
@@ -254,9 +254,11 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         paragraphs above together or you will conclude, wrongly, that you
         should hand a file back "in your reply" and silently deliver nothing.
 
-        ``attachments=[{url, filename}]`` fetches over https, restricted to
-        Discord's own CDN hosts — an arbitrary external URL will be refused
-        (<=25 MiB each). ``file_handles=[handle_id, ...]`` references any
+        ``attachments=[{url, filename}]`` re-posts a file that is already in
+        the chat: on Discord a url on Discord's own CDN (<=25 MiB each), on
+        Slack a file ``url`` from read_thread / read_channel / get_message /
+        search_messages (<=20 MiB each). An arbitrary external URL is
+        refused on both. ``file_handles=[handle_id, ...]`` references any
         file daimon is already holding — this is how you post a file
         you produced yourself, not only output from a built-in tool. Any
         tool that stores a file and returns a handle works here (e.g.
@@ -270,10 +272,9 @@ def register_channel_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         ``C0123456789:1717171717.123456``) to post into a thread. Content is
         sent as-is — nothing is escaped, so ``<@U…>`` mentions work — and is
         capped at 12,000 characters. daimon must already be in the channel
-        (a member can run ``/invite @daimon``). ``file_handles`` works;
-        ``attachments`` by url does not (there is no Slack CDN to fetch from).
-        Files post as replies under the message, so ``content`` cannot be
-        empty when files are given — use it as the caption.
+        (a member can run ``/invite @daimon``). Files post as replies under
+        the message, so ``content`` cannot be empty when files are given —
+        use it as the caption.
         """
         auth = await _auth(ctx)
         if auth.platform == "slack":

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_send.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_send.py
@@ -28,15 +28,31 @@ carry no `shares` block, so reading the ts back would need a `files.info`
 poll with no bound on when the share appears. Two calls with a known ts beat
 one call with a guessed one. The cost is that an upload failure leaves the
 text already posted; the error says so, so the agent does not re-send it.
+
+``attachments`` on Slack take the signed ``/slack/file/{token}`` links the
+read tools hand out, never a raw ``url_private`` (the agent is never shown
+one, and could not fetch it without the bot token anyway). The token is
+verified with the same secret the proxy route uses and must name the
+caller's own workspace, so a link minted for one install cannot relay a
+file into another. Authorization is inherited from the read that produced
+the link: the requester could see that message, so they may re-post its
+file.
 """
 
 from __future__ import annotations
 
+import time
 from typing import Any, cast
 
+import httpx
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
-from daimon.adapters.mcp.tools._file_handles import ResolvedUpload, resolve_file_handles
+from daimon.adapters.mcp.slack_file_proxy import fetch_slack_file
+from daimon.adapters.mcp.tools._file_handles import (
+    MAX_ATTACHMENTS_PER_MESSAGE,
+    ResolvedUpload,
+    resolve_file_handles,
+)
 from daimon.adapters.mcp.tools.slack._client import (
     _require_slack_identity,  # pyright: ignore[reportPrivateUsage]
     _require_team_id,  # pyright: ignore[reportPrivateUsage]
@@ -47,6 +63,8 @@ from daimon.adapters.mcp.tools.slack._visibility import (
     check_channel_access,
     map_slack_api_error,
 )
+from daimon.core.output_delivery import MAX_BYTES_PER_FILE
+from daimon.core.slack_file_token import SlackFileRef, verify_file_token
 from fastmcp.exceptions import ToolError
 from slack_sdk.errors import SlackApiError, SlackRequestError
 from slack_sdk.web.async_client import AsyncWebClient
@@ -66,10 +84,17 @@ _OVER_LENGTH_MSG = (
     "(thread replies work well for parts)"
 )
 _NOT_IN_CHANNEL_MSG = "daimon isn't in that channel — ask a member to /invite @daimon"
-_ATTACHMENTS_UNSUPPORTED_MSG = (
-    "attachments by url are Discord-only — on Slack, upload the file with "
-    "create_file_upload_url and pass its handle in file_handles"
+_ATTACHMENT_NOT_A_FILE_LINK_MSG = (
+    "on Slack an attachment url must be a file link from read_thread, read_channel, "
+    "get_message or search_messages (…/slack/file/<token>) — to post a file you made "
+    "yourself, use create_file_upload_url and file_handles"
 )
+_ATTACHMENT_LINK_REJECTED_MSG = (
+    "that file link has expired or belongs to another workspace — read the message "
+    "again to get a fresh one"
+)
+_ATTACHMENT_TOO_LARGE_MSG = f"attachment exceeds {MAX_BYTES_PER_FILE // (1024 * 1024)} MiB"
+_TOO_MANY_FILES_MSG = f"max {MAX_ATTACHMENTS_PER_MESSAGE} attachments per message"
 _FILES_NEED_CONTENT_MSG = (
     "Slack attaches files to a message, so content cannot be empty when "
     "file_handles is given — pass a short caption"
@@ -162,6 +187,48 @@ async def _post_message(
     return cast(dict[str, Any], resp.data)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]  # slack_sdk response is dict-like
 
 
+def _resolve_attachment_ref(runtime: McpRuntime, *, url: str, team_id: str) -> SlackFileRef:
+    """Verify a proxy link and return the file it names, refusing anything else."""
+    base_url = runtime.settings.mcp.app_root_url
+    secret = runtime.settings.mcp.jwt_secret
+    if base_url is None or secret is None:
+        raise ToolError(
+            "this deployment has no public URL configured, so file links cannot be "
+            "resolved — use create_file_upload_url and file_handles instead"
+        )
+    prefix = f"{base_url.rstrip('/')}/slack/file/"
+    if not url.startswith(prefix):
+        raise ToolError(_ATTACHMENT_NOT_A_FILE_LINK_MSG)
+    token = url[len(prefix) :].split("?", 1)[0]
+    ref = verify_file_token(token, secret=secret.get_secret_value(), now=int(time.time()))
+    if ref is None or ref.team_id != team_id:
+        raise ToolError(_ATTACHMENT_LINK_REJECTED_MSG)
+    return ref
+
+
+async def _fetch_attachments(
+    http_client: httpx.AsyncClient,
+    *,
+    bot_token: str,
+    specs: list[dict[str, str]],
+    refs: list[SlackFileRef],
+) -> list[ResolvedUpload]:
+    uploads: list[ResolvedUpload] = []
+    for spec, ref in zip(specs, refs, strict=True):
+        try:
+            content, _, fetched_name = await fetch_slack_file(
+                http_client, bot_token=bot_token, file_id=ref.file_id
+            )
+        except httpx.HTTPError as exc:
+            raise ToolError(f"failed to fetch attachment {ref.file_id!r}: {exc}") from exc
+        if len(content) > MAX_BYTES_PER_FILE:
+            raise ToolError(_ATTACHMENT_TOO_LARGE_MSG)
+        uploads.append(
+            ResolvedUpload(filename=spec.get("filename") or fetched_name, content=content)
+        )
+    return uploads
+
+
 async def _upload_files(
     client: AsyncWebClient,
     *,
@@ -205,27 +272,50 @@ async def _slack_send_message_impl(  # pyright: ignore[reportUnusedFunction]  # 
     content: str,
     attachments: list[dict[str, str]] | None,
     file_handles: list[str] | None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> SlackMessageRow:
-    if attachments:
-        raise ToolError(_ATTACHMENTS_UNSUPPORTED_MSG)
     if len(content) > _MAX_CONTENT_CHARS:
         raise ToolError(_OVER_LENGTH_MSG)
-    uploads: list[ResolvedUpload] = []
-    if file_handles:
-        if not content.strip():
-            raise ToolError(_FILES_NEED_CONTENT_MSG)
-        uploads = await resolve_file_handles(
-            file_handles, session_factory=runtime.session_factory, tenant_id=auth.tenant_id
-        )
+    if (len(attachments or []) + len(file_handles or [])) > MAX_ATTACHMENTS_PER_MESSAGE:
+        raise ToolError(_TOO_MANY_FILES_MSG)
+    if (attachments or file_handles) and not content.strip():
+        raise ToolError(_FILES_NEED_CONTENT_MSG)
 
     target_channel_id, thread_ts = _split_send_target(channel_id)
     requester_id = _require_slack_identity(auth)
     team_id = _require_team_id(auth)
-    client = await slack_web_client(runtime, team_id=team_id)
 
+    # Everything that can be checked without a network call goes first, so a
+    # bad handle or a stale link costs nothing and posts nothing.
+    refs = [
+        _resolve_attachment_ref(runtime, url=spec.get("url", ""), team_id=team_id)
+        for spec in (attachments or [])
+    ]
+    uploads: list[ResolvedUpload] = []
+    if file_handles:
+        uploads.extend(
+            await resolve_file_handles(
+                file_handles, session_factory=runtime.session_factory, tenant_id=auth.tenant_id
+            )
+        )
+
+    client = await slack_web_client(runtime, team_id=team_id)
     await _validate_channel_access(client, channel_id=target_channel_id, requester_id=requester_id)
     if thread_ts is not None:
         await _validate_thread_target(client, channel_id=target_channel_id, thread_ts=thread_ts)
+
+    if refs:
+        bot_token = str(client.token)
+        if http_client is not None:
+            fetched = await _fetch_attachments(
+                http_client, bot_token=bot_token, specs=attachments or [], refs=refs
+            )
+        else:
+            async with httpx.AsyncClient(timeout=30.0) as owned_client:
+                fetched = await _fetch_attachments(
+                    owned_client, bot_token=bot_token, specs=attachments or [], refs=refs
+                )
+        uploads = fetched + uploads
 
     resp = await _post_message(
         client, channel_id=target_channel_id, content=content, thread_ts=thread_ts

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2614,9 +2614,11 @@
         paragraphs above together or you will conclude, wrongly, that you
         should hand a file back "in your reply" and silently deliver nothing.
         
-        ``attachments=[{url, filename}]`` fetches over https, restricted to
-        Discord's own CDN hosts — an arbitrary external URL will be refused
-        (<=25 MiB each). ``file_handles=[handle_id, ...]`` references any
+        ``attachments=[{url, filename}]`` re-posts a file that is already in
+        the chat: on Discord a url on Discord's own CDN (<=25 MiB each), on
+        Slack a file ``url`` from read_thread / read_channel / get_message /
+        search_messages (<=20 MiB each). An arbitrary external URL is
+        refused on both. ``file_handles=[handle_id, ...]`` references any
         file daimon is already holding — this is how you post a file
         you produced yourself, not only output from a built-in tool. Any
         tool that stores a file and returns a handle works here (e.g.
@@ -2630,10 +2632,9 @@
         ``C0123456789:1717171717.123456``) to post into a thread. Content is
         sent as-is — nothing is escaped, so ``<@U…>`` mentions work — and is
         capped at 12,000 characters. daimon must already be in the channel
-        (a member can run ``/invite @daimon``). ``file_handles`` works;
-        ``attachments`` by url does not (there is no Slack CDN to fetch from).
-        Files post as replies under the message, so ``content`` cannot be
-        empty when files are given — use it as the caption.
+        (a member can run ``/invite @daimon``). Files post as replies under
+        the message, so ``content`` cannot be empty when files are given —
+        use it as the caption.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/tools/test_slack_send.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_send.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 from aioresponses import aioresponses
 from anthropic import AsyncAnthropic
@@ -31,7 +32,9 @@ from daimon.core.config import (
     Settings,
 )
 from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.output_delivery import MAX_BYTES_PER_FILE
 from daimon.core.scope import DeploymentDefault
+from daimon.core.slack_file_token import mint_file_token
 from daimon.core.stores.domain import Role
 from daimon.core.stores.file_uploads import create_upload, store_upload_content
 from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
@@ -67,7 +70,18 @@ def _auth(**overrides: object) -> AuthIdentity:
     return AuthIdentity(**base)  # type: ignore[arg-type]  # test kwargs are shape-correct
 
 
-def _build_settings(*, fernet_key: SecretStr) -> Settings:
+_FILE_PROXY_SECRET = "file-proxy-secret"
+_APP_ROOT = "https://mcp.example.com"
+
+
+def _build_settings(*, fernet_key: SecretStr, file_proxy: bool = False) -> Settings:
+    mcp = (
+        McpSettings(
+            public_url=HttpUrl(f"{_APP_ROOT}/mcp"), jwt_secret=SecretStr(_FILE_PROXY_SECRET)
+        )
+        if file_proxy
+        else McpSettings()
+    )
     return Settings(
         database=DatabaseSettings(
             url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon"),
@@ -78,13 +92,15 @@ def _build_settings(*, fernet_key: SecretStr) -> Settings:
         ),
         crypto=CryptoSettings(keys=(fernet_key,)),
         credentials=CredentialsSettings(google_sa_json=None),
-        mcp=McpSettings(),
+        mcp=mcp,
         slack=None,
     )
 
 
 async def _make_runtime(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    file_proxy: bool = False,
 ) -> McpRuntime:
     fernet_key = SecretStr(Fernet.generate_key().decode("ascii"))
     fernet = build_multifernet((fernet_key.get_secret_value(),))
@@ -96,7 +112,7 @@ async def _make_runtime(
     return McpRuntime(
         session_factory=committing_sessionmaker,
         client=MagicMock(spec=AsyncAnthropic),
-        settings=_build_settings(fernet_key=fernet_key),
+        settings=_build_settings(fernet_key=fernet_key, file_proxy=file_proxy),
         deployment_default=DeploymentDefault(),
         fernet=fernet,
     )
@@ -470,14 +486,48 @@ async def test_send_message_over_12000_chars_refused_with_zero_api_calls(
         assert m.requests == {}, "an over-length call must cost zero Slack API calls"
 
 
+def _file_link(*, team_id: str = "T_TEST", file_id: str = "F_CHART", exp_offset: int = 3600) -> str:
+    token = mint_file_token(
+        team_id=team_id,
+        file_id=file_id,
+        exp=int(datetime.now(UTC).timestamp()) + exp_offset,
+        secret=_FILE_PROXY_SECRET,
+    )
+    return f"{_APP_ROOT}/slack/file/{token}"
+
+
+def _slack_file_transport(payload: bytes, *, seen: list[str] | None = None) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer xoxb-secret", (
+            "the fetch must authenticate with the workspace bot token"
+        )
+        if seen is not None:
+            seen.append(str(request.url))
+        if request.url.path.endswith("/files.info"):
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "file": {
+                        "url_private_download": "https://files.slack.com/F_CHART/dl",
+                        "mimetype": "image/png",
+                        "name": "original.png",
+                    },
+                },
+            )
+        return httpx.Response(200, content=payload)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
 @pytest.mark.asyncio
-async def test_send_message_attachments_by_url_refused_pointing_at_file_handles_no_api_calls(
+async def test_send_message_external_url_attachment_refused_naming_file_links_no_api_calls(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
-    runtime = await _make_runtime(committing_sessionmaker)
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
     auth = _auth()
     with aioresponses() as m:
-        with pytest.raises(ToolError, match="file_handles"):
+        with pytest.raises(ToolError, match="slack/file"):
             await _slack_send_message_impl(
                 runtime,
                 auth,
@@ -485,6 +535,124 @@ async def test_send_message_attachments_by_url_refused_pointing_at_file_handles_
                 content="hi",
                 attachments=[{"url": "https://example.com/f.png", "filename": "f.png"}],
                 file_handles=None,
+            )
+        assert m.requests == {}
+
+
+@pytest.mark.asyncio
+async def test_send_message_file_link_for_another_workspace_refused_no_api_calls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="another workspace"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content="hi",
+                attachments=[{"url": _file_link(team_id="T_OTHER"), "filename": "f.png"}],
+                file_handles=None,
+            )
+        assert m.requests == {}, "a link minted for another install must relay nothing"
+
+
+@pytest.mark.asyncio
+async def test_send_message_expired_file_link_refused_no_api_calls(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="expired"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content="hi",
+                attachments=[{"url": _file_link(exp_offset=-1), "filename": "f.png"}],
+                file_handles=None,
+            )
+        assert m.requests == {}
+
+
+@pytest.mark.asyncio
+async def test_send_message_file_link_attachment_is_fetched_with_the_bot_token_and_reposted(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    payload = bytes(range(256)) * 4
+    seen: list[str] = []
+    http_client = _slack_file_transport(payload, seen=seen)
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        m.post(  # pyright: ignore[reportUnknownMemberType]
+            _CHAT_POST_MESSAGE, payload={"ok": True, "ts": "1700000001.000100"}
+        )
+        _mock_upload_flow(m)
+        row = await _slack_send_message_impl(
+            runtime,
+            auth,
+            channel_id="C1",
+            content="reposting",
+            attachments=[{"url": _file_link(), "filename": "chart.png"}],
+            file_handles=None,
+            http_client=http_client,
+        )
+        get_url = _recorded(m, "getUploadURLExternal")
+        upload = _recorded(m, "files.slack.com")
+    await http_client.aclose()
+
+    assert row.ts == "1700000001.000100"
+    assert any("file=F_CHART" in url for url in seen), "the fetch names the file from the token"
+    assert upload[0][1]["data"] == payload, "fetched bytes must reach the upload byte-identical"
+    assert get_url[0][1]["params"]["filename"] == "chart.png", (
+        "the caller's filename wins over the original upload name"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_oversized_file_link_refused_before_posting(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    http_client = _slack_file_transport(b"x" * (MAX_BYTES_PER_FILE + 1))
+    with aioresponses() as m:
+        _mock_public_channel_access(m)
+        with pytest.raises(ToolError, match="MiB"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content="big",
+                attachments=[{"url": _file_link(), "filename": "big.bin"}],
+                file_handles=None,
+                http_client=http_client,
+            )
+        assert _POST_KEY not in m.requests, (
+            "an oversized file must be refused before the text posts"
+        )
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_send_message_links_and_handles_share_the_ten_file_cap(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    runtime = await _make_runtime(committing_sessionmaker, file_proxy=True)
+    auth = _auth()
+    with aioresponses() as m:
+        with pytest.raises(ToolError, match="max 10"):
+            await _slack_send_message_impl(
+                runtime,
+                auth,
+                channel_id="C1",
+                content="too many",
+                attachments=[{"url": _file_link(), "filename": "f.png"}] * 6,
+                file_handles=["h"] * 5,
             )
         assert m.requests == {}
 


### PR DESCRIPTION
## Summary

Stacked on #146 (which is stacked on #145); merge those first and this diff shrinks to one commit.

`send_message`'s `attachments` argument was refused outright on Slack. An agent that found a file in a thread could describe it but not move it anywhere. This makes `attachments` work on Slack the way it does on Discord: re-post a file the bot can already see.

On Slack the agent never holds a `url_private`, only the signed `/slack/file/{token}` links the read tools emit since #146, so those are what `attachments` accept. The token is verified with the same `jwt_secret` the proxy route uses and must name the caller's own workspace, so a link minted for one install cannot relay a file into another. Authorization is inherited from the read that produced the link: the requester could see that message, so they may re-post its file. The bytes come through the proxy route's own fetcher with the bot token and go out in the same `files_upload_v2` call as any file handles.

## Behaviour worth knowing

- An arbitrary external https url is refused on Slack, as it is on Discord. The refusal names the read tools whose file links are accepted and points at `file_handles` for a file the agent made itself.
- A link that has expired or was minted for another workspace is refused before any Slack call. The message says to read the message again for a fresh link.
- Attachments over 20 MiB (the Slack adapter's own delivery cap) and more than ten files across `attachments` plus `file_handles` are refused before the text posts.
- A deployment with no public URL or `jwt_secret` has no file links to resolve and says so.
- The caller's `filename` wins over the file's original name, matching Discord.

## Testing

Slack Web API calls are faked with `aioresponses`; the file fetch runs through `httpx.MockTransport` injected via the impl's `http_client` parameter, the same way the proxy fetcher's own tests do it. New tests cover the external-url refusal, a foreign-workspace link, an expired link, the happy path (bot token on the fetch, file id from the token, bytes reaching the upload byte-identical, caller filename winning), an oversized file refused before the text posts, and the shared ten-file cap. Each refusal asserts zero Slack requests.

Not run against a live workspace.

## Checklist

- [x] Tests added or updated for any behavior change
- [x] `uv run pytest` passes locally — mcp shard 845 passed; the three environmental failures noted on #145 are unchanged
- [x] `uv run pyright` passes locally (strict mode) — 0 errors
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)
