### PR TITLE
fix(defaults): stop telling Slack agents the credential buttons are Discord-only

### DIFF
--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -78,9 +78,9 @@ it goes through `/agent-setup` or the `daimon agents archive` CLI command.
 `request_env_credential`, `request_mcp_credential`, and
 `request_repo_binding` post a single-use, expiring button in the thread;
 clicking it opens a private modal where the user enters the value, so it
-never enters channel history or the session log. All three are Discord-only
-today — on Slack, credential entry and repo binding go through
-`/agent-setup` instead.
+never enters channel history or the session log. They work the same way on
+Discord and Slack, so on either platform post the button rather than
+sending the user to `/agent-setup`.
 
 If a user pastes a token or secret in chat anyway: acknowledge that you saw
 it, call no tool with it, and tell them to rotate it immediately — it is


### PR DESCRIPTION
Asked on Slack to set up an auth-required MCP server, the seeded agent refuses the token and sends the user to `/agent-setup` instead of posting the `request_mcp_credential` button. The tools are tagged for both platforms and the Slack click handler shipped in #99, but the `workspace-setup` skill still carries the pre-#99 paragraph saying all three `request_*` tools are Discord-only. The agent follows that paragraph to the letter.

The paragraph now says the buttons work the same on both platforms.

Text-only change to `defaults/skills/workspace-setup/SKILL.md`. `packages/core/tests/defaults/test_defaults_dir.py` passes. Needs a `daimon defaults apply` after merge; existing sessions keep the old skill text until recreated.