### PR TITLE
feat(mcp): OAuth hub mounts and a Claude Code plugin to reach every daimon a person can see

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,8 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_HUB__DISCORD_CLIENT_ID=
 # Discord OAuth app client secret for the /discord/mcp login mount. (secret)
 # DAIMON_HUB__DISCORD_CLIENT_SECRET=
+# Redirect URI patterns an MCP client may register with the hub login mounts (wildcards allowed). Defaults cover coding agents on loopback and claude.ai; widen only for a client you operate.
+# DAIMON_HUB__ALLOWED_CLIENT_REDIRECT_URIS=['http://localhost:*', 'http://127.0.0.1:*', 'https://claude.ai/*', 'https://claude.com/*']
 # Base64url 32-byte key that signs hub login tokens. Required when any hub mount is configured, and rejected at boot unless it decodes to exactly 32 bytes. Generate with Fernet.generate_key(). (secret)
 # DAIMON_HUB__JWT_SIGNING_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,18 @@ DAIMON_ANTHROPIC__API_KEY=
 # How long an uploaded bundle object is retained on the Files API before deletion. Deletion is performed by the scheduler's pending-file sweeper, not by this process directly — a deployment running no scheduler will never reclaim these objects.
 # DAIMON_MCP__BUNDLE_TTL_DAYS=90
 
+# === Hub (optional) ===
+# Slack OAuth app client ID for the /slack/mcp login mount.
+# DAIMON_HUB__SLACK_CLIENT_ID=
+# Slack OAuth app client secret for the /slack/mcp login mount. (secret)
+# DAIMON_HUB__SLACK_CLIENT_SECRET=
+# Discord OAuth app client ID for the /discord/mcp login mount.
+# DAIMON_HUB__DISCORD_CLIENT_ID=
+# Discord OAuth app client secret for the /discord/mcp login mount. (secret)
+# DAIMON_HUB__DISCORD_CLIENT_SECRET=
+# Base64url 32-byte key that signs hub login tokens. Required when any hub mount is configured. Generate with Fernet.generate_key(). (secret)
+# DAIMON_HUB__JWT_SIGNING_KEY=
+
 # === Discord (optional) ===
 # Discord bot token. Required to run the Discord adapter. (required to run the Discord adapter; secret)
 # DAIMON_DISCORD__BOT_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,7 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_HUB__DISCORD_CLIENT_ID=
 # Discord OAuth app client secret for the /discord/mcp login mount. (secret)
 # DAIMON_HUB__DISCORD_CLIENT_SECRET=
-# Base64url 32-byte key that signs hub login tokens. Required when any hub mount is configured. Generate with Fernet.generate_key(). (secret)
+# Base64url 32-byte key that signs hub login tokens. Required when any hub mount is configured, and rejected at boot unless it decodes to exactly 32 bytes. Generate with Fernet.generate_key(). (secret)
 # DAIMON_HUB__JWT_SIGNING_KEY=
 
 # === Discord (optional) ===

--- a/.env.example
+++ b/.env.example
@@ -41,11 +41,11 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_MCP__BUNDLE_TTL_DAYS=90
 
 # === Hub (optional) ===
-# Slack OAuth app client ID for the /slack/mcp login mount.
+# Slack OAuth app client ID for the /slack/mcp login mount. Register <DAIMON_MCP__PUBLIC_URL origin>/slack/auth/callback as a redirect URL on the Slack app.
 # DAIMON_HUB__SLACK_CLIENT_ID=
 # Slack OAuth app client secret for the /slack/mcp login mount. (secret)
 # DAIMON_HUB__SLACK_CLIENT_SECRET=
-# Discord OAuth app client ID for the /discord/mcp login mount.
+# Discord OAuth app client ID for the /discord/mcp login mount. Register <DAIMON_MCP__PUBLIC_URL origin>/discord/auth/callback as a redirect URI on the Discord app.
 # DAIMON_HUB__DISCORD_CLIENT_ID=
 # Discord OAuth app client secret for the /discord/mcp login mount. (secret)
 # DAIMON_HUB__DISCORD_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -164,8 +164,25 @@ lifetime, and image-embedding controls.
 Coding-agent clients such as Claude Code connect through the plugin in
 [`plugin/`](plugin/) instead of a per-agent token: it logs in via Slack or
 Discord OAuth and reaches every daimon install the logged-in person belongs
-to. This needs `DAIMON_HUB__*` configured on the server in addition to the
-settings above.
+to.
+
+#### Hub login mounts
+
+Each platform's mount needs its own OAuth app, plus `DAIMON_HUB__*`,
+`DAIMON_CRYPTO__KEYS` (the login state is encrypted at rest) and
+`DAIMON_MCP__PUBLIC_URL` (the mounts derive their public base URL from it) on
+the server. Register these redirect URIs on the OAuth apps, where the origin
+is `DAIMON_MCP__PUBLIC_URL` without the trailing `/mcp`:
+
+- Slack: `{origin}/slack/auth/callback`
+- Discord: `{origin}/discord/auth/callback`
+
+The Discord app requests the `identify` and `guilds` scopes, enough to learn
+who logged in and which servers they are in. The Slack app requests user
+scopes (`users:read`, `channels:history`, `groups:history`, `channels:read`,
+`groups:read`, `im:history`, `mpim:history`, `im:read`, `mpim:read`,
+`search:read`) so a daimon reads Slack as the person asking and never sees a
+channel they cannot.
 
 ### 2. Create the Discord application
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ stored objects, so configure a bucket lifecycle rule for the retention period
 your deployment requires. See `.env.example` for the optional region, URL
 lifetime, and image-embedding controls.
 
+Coding-agent clients such as Claude Code connect through the plugin in
+[`plugin/`](plugin/) instead of a per-agent token: it logs in via Slack or
+Discord OAuth and reaches every daimon install the logged-in person belongs
+to. This needs `DAIMON_HUB__*` configured on the server in addition to the
+settings above.
+
 ### 2. Create the Discord application
 
 1. Create an application in the

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ scopes (`users:read`, `channels:history`, `groups:history`, `channels:read`,
 `search:read`) so a daimon reads Slack as the person asking and never sees a
 channel they cannot.
 
+A login reaches only workspaces where daimon is installed and ready, checked
+on every call. Membership itself is re-read when the login token is issued or
+refreshed: a Slack token stops working the moment its user leaves the
+workspace, while someone removed from a Discord server keeps that server's
+daimons until their Discord token expires. `DAIMON_HUB__ALLOWED_CLIENT_REDIRECT_URIS`
+limits which clients may complete a login; the default covers coding agents
+on loopback and claude.ai.
+
 ### 2. Create the Discord application
 
 1. Create an application in the

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/app.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/app.py
@@ -85,6 +85,7 @@ def _providers(
                     session_factory=sessionmaker,
                     client_storage=hub_kv_for(hub_kv, platform="slack"),
                     jwt_signing_key=signing_key,
+                    allowed_client_redirect_uris=hub.allowed_client_redirect_uris,
                 ),
             )
         )
@@ -100,6 +101,7 @@ def _providers(
                     session_factory=sessionmaker,
                     client_storage=hub_kv_for(hub_kv, platform="discord"),
                     jwt_signing_key=signing_key,
+                    allowed_client_redirect_uris=hub.allowed_client_redirect_uris,
                 ),
             )
         )

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/app.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/app.py
@@ -56,7 +56,7 @@ def build_hub_app(
             "Call list_daimons first; every other tool takes a daimon_id from that list."
         ),
     )
-    mcp.add_middleware(HubIdentityMiddleware())
+    mcp.add_middleware(HubIdentityMiddleware(platform))
     mcp.add_middleware(MaErrorMiddleware())
     register_hub_tools(mcp, runtime, billing_config=billing_config)
     return mcp

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/app.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/app.py
@@ -22,7 +22,7 @@ from cryptography.fernet import MultiFernet
 from daimon.adapters.mcp.hub.discord_provider import DaimonDiscordProvider
 from daimon.adapters.mcp.hub.identity import HubIdentityMiddleware
 from daimon.adapters.mcp.hub.slack_provider import SlackHubProvider
-from daimon.adapters.mcp.hub.storage import asyncpg_dsn, build_hub_kv
+from daimon.adapters.mcp.hub.storage import asyncpg_dsn, build_hub_kv_base, hub_kv_for
 from daimon.adapters.mcp.middleware.ma_errors import MaErrorMiddleware
 from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools.hub import register_hub_tools
@@ -32,6 +32,7 @@ from daimon.core.errors import BootstrapError
 from daimon.core.stores.domain import Platform
 from fastmcp import FastMCP
 from fastmcp.server.auth.auth import AuthProvider
+from key_value.aio.protocols import AsyncKeyValue
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.applications import Starlette
 from starlette.routing import Mount
@@ -66,11 +67,10 @@ def _providers(
     *,
     settings: Settings,
     sessionmaker: async_sessionmaker[AsyncSession],
-    fernet: MultiFernet,
+    hub_kv: AsyncKeyValue,
     signing_key: bytes,
     app_root_url: str,
 ) -> list[tuple[Platform, AuthProvider]]:
-    dsn = asyncpg_dsn(str(settings.database.url))
     out: list[tuple[Platform, AuthProvider]] = []
     hub = settings.hub
     if hub.slack_configured:
@@ -83,7 +83,7 @@ def _providers(
                     client_secret=hub.slack_client_secret.get_secret_value(),
                     base_url=f"{app_root_url}/slack",
                     session_factory=sessionmaker,
-                    client_storage=build_hub_kv(database_url=dsn, fernet=fernet, platform="slack"),
+                    client_storage=hub_kv_for(hub_kv, platform="slack"),
                     jwt_signing_key=signing_key,
                 ),
             )
@@ -98,9 +98,7 @@ def _providers(
                     client_secret=hub.discord_client_secret.get_secret_value(),
                     base_url=f"{app_root_url}/discord",
                     session_factory=sessionmaker,
-                    client_storage=build_hub_kv(
-                        database_url=dsn, fernet=fernet, platform="discord"
-                    ),
+                    client_storage=hub_kv_for(hub_kv, platform="discord"),
                     jwt_signing_key=signing_key,
                 ),
             )
@@ -132,12 +130,15 @@ def mount_hub_apps(
         raise BootstrapError("DAIMON_MCP__PUBLIC_URL is required when a hub mount is configured")
 
     signing_key = hub.jwt_signing_key.get_secret_value().encode()
+    kv_store, hub_kv = build_hub_kv_base(
+        database_url=asyncpg_dsn(str(settings.database.url)), fernet=fernet
+    )
     sub_apps: list[Starlette] = []
     mounted: list[str] = []
     for platform, provider in _providers(
         settings=settings,
         sessionmaker=sessionmaker,
-        fernet=fernet,
+        hub_kv=hub_kv,
         signing_key=signing_key,
         app_root_url=app_root_url,
     ):
@@ -160,6 +161,7 @@ def mount_hub_apps(
     async def chained(a: Starlette) -> AsyncIterator[Any]:
         async with AsyncExitStack() as stack:
             state = await stack.enter_async_context(parent_lifespan(a))
+            await stack.enter_async_context(kv_store)
             for sub in sub_apps:
                 await stack.enter_async_context(sub.router.lifespan_context(sub))
             yield state

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/app.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/app.py
@@ -1,0 +1,168 @@
+"""Assemble and mount the per-platform hub apps.
+
+Each platform gets its own ``FastMCP`` with its own OAuth proxy as ``auth``,
+so a Slack login token is never evaluated by the Discord proxy and vice versa.
+Both share the runtime with the JWT-verified app at ``/mcp``.
+
+Mounting is more than ``Mount()``: Starlette does not run a sub-app's
+lifespan, and RFC 8414 discovery for ``https://host/discord/mcp`` is fetched
+from ``https://host/.well-known/oauth-authorization-server/discord``, at the
+origin root. ``mount_hub_apps`` therefore chains the sub-app lifespans into the
+parent's and re-roots each provider's well-known routes on the parent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any
+
+import structlog
+from cryptography.fernet import MultiFernet
+from daimon.adapters.mcp.hub.discord_provider import DaimonDiscordProvider
+from daimon.adapters.mcp.hub.identity import HubIdentityMiddleware
+from daimon.adapters.mcp.hub.slack_provider import SlackHubProvider
+from daimon.adapters.mcp.hub.storage import asyncpg_dsn, build_hub_kv
+from daimon.adapters.mcp.middleware.ma_errors import MaErrorMiddleware
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.hub import register_hub_tools
+from daimon.core.billing import BillingConfig
+from daimon.core.config import Settings
+from daimon.core.errors import BootstrapError
+from daimon.core.stores.domain import Platform
+from fastmcp import FastMCP
+from fastmcp.server.auth.auth import AuthProvider
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+log = structlog.get_logger(__name__)
+
+HUB_MCP_PATH = "/mcp"
+
+
+def build_hub_app(
+    *,
+    platform: Platform,
+    runtime: McpRuntime,
+    auth: AuthProvider,
+    billing_config: BillingConfig | None,
+) -> FastMCP:
+    mcp = FastMCP(
+        name=f"daimon-{platform}",
+        auth=auth,
+        instructions=(
+            f"Every daimon reachable here lives in a {platform.title()} workspace. "
+            "Call list_daimons first; every other tool takes a daimon_id from that list."
+        ),
+    )
+    mcp.add_middleware(HubIdentityMiddleware())
+    mcp.add_middleware(MaErrorMiddleware())
+    register_hub_tools(mcp, runtime, billing_config=billing_config)
+    return mcp
+
+
+def _providers(
+    *,
+    settings: Settings,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    fernet: MultiFernet,
+    signing_key: bytes,
+    app_root_url: str,
+) -> list[tuple[Platform, AuthProvider]]:
+    dsn = asyncpg_dsn(str(settings.database.url))
+    out: list[tuple[Platform, AuthProvider]] = []
+    hub = settings.hub
+    if hub.slack_configured:
+        assert hub.slack_client_id is not None and hub.slack_client_secret is not None
+        out.append(
+            (
+                "slack",
+                SlackHubProvider(
+                    client_id=hub.slack_client_id,
+                    client_secret=hub.slack_client_secret.get_secret_value(),
+                    base_url=f"{app_root_url}/slack",
+                    session_factory=sessionmaker,
+                    client_storage=build_hub_kv(database_url=dsn, fernet=fernet, platform="slack"),
+                    jwt_signing_key=signing_key,
+                ),
+            )
+        )
+    if hub.discord_configured:
+        assert hub.discord_client_id is not None and hub.discord_client_secret is not None
+        out.append(
+            (
+                "discord",
+                DaimonDiscordProvider(
+                    client_id=hub.discord_client_id,
+                    client_secret=hub.discord_client_secret.get_secret_value(),
+                    base_url=f"{app_root_url}/discord",
+                    session_factory=sessionmaker,
+                    client_storage=build_hub_kv(
+                        database_url=dsn, fernet=fernet, platform="discord"
+                    ),
+                    jwt_signing_key=signing_key,
+                ),
+            )
+        )
+    return out
+
+
+def mount_hub_apps(
+    app: Starlette,
+    *,
+    settings: Settings,
+    runtime: McpRuntime,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    billing_config: BillingConfig | None,
+    fernet: MultiFernet | None,
+) -> list[str]:
+    """Mount configured hub apps on ``app``. Returns the platforms mounted."""
+    hub = settings.hub
+    if not (hub.slack_configured or hub.discord_configured):
+        return []
+    if hub.jwt_signing_key is None:
+        raise BootstrapError(
+            "DAIMON_HUB__JWT_SIGNING_KEY is required when a hub mount is configured"
+        )
+    if fernet is None:
+        raise BootstrapError("DAIMON_CRYPTO__KEYS is required when a hub mount is configured")
+    app_root_url = settings.mcp.app_root_url
+    if app_root_url is None:
+        raise BootstrapError("DAIMON_MCP__PUBLIC_URL is required when a hub mount is configured")
+
+    signing_key = hub.jwt_signing_key.get_secret_value().encode()
+    sub_apps: list[Starlette] = []
+    mounted: list[str] = []
+    for platform, provider in _providers(
+        settings=settings,
+        sessionmaker=sessionmaker,
+        fernet=fernet,
+        signing_key=signing_key,
+        app_root_url=app_root_url,
+    ):
+        mcp = build_hub_app(
+            platform=platform, runtime=runtime, auth=provider, billing_config=billing_config
+        )
+        sub_app = mcp.http_app(path=HUB_MCP_PATH, stateless_http=True, json_response=True)
+        for route in provider.get_well_known_routes(mcp_path=HUB_MCP_PATH):
+            app.router.routes.append(route)
+        app.router.routes.append(Mount(f"/{platform}", app=sub_app))
+        sub_apps.append(sub_app)
+        mounted.append(platform)
+        log.info(
+            "hub.mounted", platform=platform, endpoint=f"{app_root_url}/{platform}{HUB_MCP_PATH}"
+        )
+
+    parent_lifespan = app.router.lifespan_context
+
+    @asynccontextmanager
+    async def chained(a: Starlette) -> AsyncIterator[Any]:
+        async with AsyncExitStack() as stack:
+            state = await stack.enter_async_context(parent_lifespan(a))
+            for sub in sub_apps:
+                await stack.enter_async_context(sub.router.lifespan_context(sub))
+            yield state
+
+    app.router.lifespan_context = chained
+    return mounted

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/claims.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/claims.py
@@ -1,0 +1,71 @@
+"""Wire shape of the tenant map a hub login bakes into its token.
+
+The OAuth proxy embeds whatever ``_extract_upstream_claims`` returns under the
+``upstream_claims`` key of the issued JWT and surfaces it again as
+``AccessToken.claims["upstream_claims"]`` on every request. Both providers
+encode with ``encode_hub_claims``; the middleware decodes with
+``decode_hub_claims``. Anything malformed decodes to ``None`` so a token from
+an older deployment fails closed rather than half-parsing.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from typing import Any, cast, get_args
+
+from daimon.adapters.mcp.hub.identity import HubIdentity
+from daimon.core.hub_identity import HubTenant
+from daimon.core.stores.domain import Platform
+
+UPSTREAM_CLAIMS_KEY = "upstream_claims"
+_PLATFORMS: frozenset[str] = frozenset(get_args(Platform))
+
+
+def encode_hub_claims(
+    *, platform: Platform, platform_user_id: str, tenants: Sequence[HubTenant]
+) -> dict[str, Any]:
+    return {
+        "platform": platform,
+        "platform_user_id": platform_user_id,
+        "tenants": [
+            {
+                "tenant_id": str(t.tenant_id),
+                "account_id": str(t.account_id),
+                "workspace_id": t.workspace_id,
+                "workspace_name": t.workspace_name,
+            }
+            for t in tenants
+        ],
+    }
+
+
+def decode_hub_claims(claims: Mapping[str, Any]) -> HubIdentity | None:
+    raw = claims.get(UPSTREAM_CLAIMS_KEY)
+    if not isinstance(raw, Mapping):
+        return None
+    raw = cast("Mapping[str, Any]", raw)
+    platform = raw.get("platform")
+    user = raw.get("platform_user_id")
+    tenants_raw = raw.get("tenants")
+    if platform not in _PLATFORMS or not isinstance(user, str) or not isinstance(tenants_raw, list):
+        return None
+    tenants: list[HubTenant] = []
+    for entry in cast("list[object]", tenants_raw):
+        if not isinstance(entry, Mapping):
+            return None
+        entry = cast("Mapping[str, Any]", entry)
+        try:
+            tenants.append(
+                HubTenant(
+                    tenant_id=uuid.UUID(str(entry["tenant_id"])),
+                    account_id=uuid.UUID(str(entry["account_id"])),
+                    workspace_id=str(entry["workspace_id"]),
+                    workspace_name=str(entry["workspace_name"]),
+                )
+            )
+        except (KeyError, ValueError):
+            return None
+    return HubIdentity(
+        platform=cast(Platform, platform), platform_user_id=user, tenants=tuple(tenants)
+    )

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/claims.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/claims.py
@@ -6,6 +6,15 @@ The OAuth proxy embeds whatever ``_extract_upstream_claims`` returns under the
 encode with ``encode_hub_claims``; the middleware decodes with
 ``decode_hub_claims``. Anything malformed decodes to ``None`` so a token from
 an older deployment fails closed rather than half-parsing.
+
+The tenant map is a snapshot taken when the token is issued or refreshed. The
+hub tools re-check each tenant's readiness against the database on every
+call, so an uninstall or archive takes effect immediately; workspace
+*membership* is only as fresh as the token. On Slack that is per request,
+because the token verifier's ``auth.test`` fails the moment the user leaves
+the workspace. On Discord the token is validated but guild membership is
+re-read only on refresh, so a removed member keeps a guild's daimons for at
+most the access token's upstream lifetime.
 """
 
 from __future__ import annotations

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/discord_provider.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/discord_provider.py
@@ -51,6 +51,7 @@ class DaimonDiscordProvider(DiscordProvider):
         session_factory: async_sessionmaker[AsyncSession],
         client_storage: AsyncKeyValue,
         jwt_signing_key: bytes,
+        allowed_client_redirect_uris: list[str],
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         super().__init__(
@@ -60,6 +61,7 @@ class DaimonDiscordProvider(DiscordProvider):
             required_scopes=_SCOPES,
             client_storage=client_storage,
             jwt_signing_key=jwt_signing_key,
+            allowed_client_redirect_uris=allowed_client_redirect_uris,
             http_client=http_client,
         )
         self._session_factory = session_factory

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/discord_provider.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/discord_provider.py
@@ -1,0 +1,78 @@
+"""Discord login for the /discord/mcp hub mount.
+
+Built on FastMCP's ``DiscordProvider``. The one addition that matters is
+``_extract_upstream_claims``: the proxy calls it once per code exchange (and
+again on refresh) with Discord's raw token response, and embeds the return
+value in the token it issues. That is where the user's guilds are fetched,
+intersected with installed tenants, and turned into the tenant map every hub
+tool reads. Fetching here rather than per request means one Discord call per
+login instead of one per tool call.
+
+The consent cookie name carries a platform suffix because the Slack proxy
+shares this origin and both would otherwise write the same ``__Host-`` cookie
+at ``path=/``, invalidating each other's in-flight authorizations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from daimon.adapters.mcp.hub.claims import encode_hub_claims
+from daimon.core.hub_identity import resolve_hub_tenants
+from fastmcp.server.auth.providers.discord import DiscordProvider
+from key_value.aio.protocols import AsyncKeyValue
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+DISCORD_API = "https://discord.com/api/v10"
+_SCOPES = ["identify", "guilds"]
+
+
+async def fetch_discord_workspaces(
+    http: httpx.AsyncClient, *, access_token: str
+) -> tuple[str, list[tuple[str, str]]]:
+    """Return ``(user_id, [(guild_id, guild_name), ...])`` for the token's user."""
+    headers = {"Authorization": f"Bearer {access_token}"}
+    me = await http.get(f"{DISCORD_API}/users/@me", headers=headers)
+    me.raise_for_status()
+    guilds = await http.get(f"{DISCORD_API}/users/@me/guilds", headers=headers)
+    guilds.raise_for_status()
+    user_id = str(me.json()["id"])
+    return user_id, [(str(g["id"]), str(g["name"])) for g in guilds.json()]
+
+
+class DaimonDiscordProvider(DiscordProvider):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        base_url: str,
+        session_factory: async_sessionmaker[AsyncSession],
+        client_storage: AsyncKeyValue,
+        jwt_signing_key: bytes,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(
+            client_id=client_id,
+            client_secret=client_secret,
+            base_url=base_url,
+            required_scopes=_SCOPES,
+            client_storage=client_storage,
+            jwt_signing_key=jwt_signing_key,
+            http_client=http_client,
+        )
+        self._session_factory = session_factory
+        self._http = http_client or httpx.AsyncClient(timeout=10.0)
+
+    async def _extract_upstream_claims(self, idp_tokens: dict[str, Any]) -> dict[str, Any] | None:
+        user_id, guilds = await fetch_discord_workspaces(
+            self._http, access_token=str(idp_tokens["access_token"])
+        )
+        tenants = await resolve_hub_tenants(
+            self._session_factory, platform="discord", platform_user_id=user_id, workspaces=guilds
+        )
+        return encode_hub_claims(platform="discord", platform_user_id=user_id, tenants=tenants)
+
+    def _cookie_name(self, base_name: str) -> str:
+        return super()._cookie_name(f"{base_name}_DISCORD")

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/identity.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/identity.py
@@ -35,6 +35,17 @@ class HubIdentity:
 
 
 class HubIdentityMiddleware(Middleware):
+    """Decode the login claims into request state for the mount's platform.
+
+    Both mounts sign with the same key, so a Slack login token verifies
+    against the Discord proxy's signature check too; only the issuer and
+    audience separate them. Comparing the claims' platform to the mount's is
+    the second, independent layer behind that check.
+    """
+
+    def __init__(self, platform: Platform) -> None:
+        self.platform = platform
+
     async def on_request(self, context: MiddlewareContext, call_next: CallNext) -> object:
         from daimon.adapters.mcp.hub.claims import decode_hub_claims
 
@@ -44,6 +55,8 @@ class HubIdentityMiddleware(Middleware):
         identity = decode_hub_claims(token.claims)
         if identity is None:
             raise AuthorizationError("token carries no hub identity")
+        if identity.platform != self.platform:
+            raise AuthorizationError("token was issued for another platform")
         fastmcp_ctx = context.fastmcp_context
         if fastmcp_ctx is None:
             raise AuthorizationError("missing fastmcp context on request")

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/identity.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/identity.py
@@ -1,0 +1,58 @@
+"""Request identity for the hub mounts.
+
+Unlike ``AuthIdentity``, a hub caller is not one account: they are one
+platform user who may act in several tenants. Tool code picks the tenant per
+call (from the daimon being addressed) and only then builds an
+``AuthIdentity`` for the existing agent-chat implementation functions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from daimon.core.hub_identity import HubTenant
+from daimon.core.stores.domain import Platform
+from fastmcp import Context
+from fastmcp.exceptions import AuthorizationError, ToolError
+from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+
+HUB_AUTH_STATE_KEY = "hub_auth"
+
+
+@dataclass(frozen=True, kw_only=True)
+class HubIdentity:
+    platform: Platform
+    platform_user_id: str
+    tenants: tuple[HubTenant, ...]
+
+    def tenant(self, tenant_id: uuid.UUID) -> HubTenant | None:
+        for t in self.tenants:
+            if t.tenant_id == tenant_id:
+                return t
+        return None
+
+
+class HubIdentityMiddleware(Middleware):
+    async def on_request(self, context: MiddlewareContext, call_next: CallNext) -> object:
+        from daimon.adapters.mcp.hub.claims import decode_hub_claims
+
+        token = get_access_token()
+        if token is None:
+            raise AuthorizationError("missing access token")
+        identity = decode_hub_claims(token.claims)
+        if identity is None:
+            raise AuthorizationError("token carries no hub identity")
+        fastmcp_ctx = context.fastmcp_context
+        if fastmcp_ctx is None:
+            raise AuthorizationError("missing fastmcp context on request")
+        await fastmcp_ctx.set_state(HUB_AUTH_STATE_KEY, identity, serializable=False)
+        return await call_next(context)
+
+
+async def _hub_auth(ctx: Context) -> HubIdentity:  # pyright: ignore[reportUnusedFunction]
+    identity = await ctx.get_state(HUB_AUTH_STATE_KEY)
+    if not isinstance(identity, HubIdentity):
+        raise ToolError("internal: missing hub auth context")
+    return identity

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/slack_provider.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/slack_provider.py
@@ -115,6 +115,7 @@ class SlackHubProvider(OAuthProxy):
         session_factory: async_sessionmaker[AsyncSession],
         client_storage: AsyncKeyValue,
         jwt_signing_key: bytes,
+        allowed_client_redirect_uris: list[str],
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._http = http_client or httpx.AsyncClient(timeout=10.0)
@@ -128,6 +129,7 @@ class SlackHubProvider(OAuthProxy):
             forward_pkce=False,
             client_storage=client_storage,
             jwt_signing_key=jwt_signing_key,
+            allowed_client_redirect_uris=allowed_client_redirect_uris,
             fallback_access_token_expiry_seconds=_FALLBACK_EXPIRY_S,
         )
         self._session_factory = session_factory

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/slack_provider.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/slack_provider.py
@@ -1,0 +1,164 @@
+"""Slack login for the /slack/mcp hub mount.
+
+FastMCP has no Slack provider, and Slack's OAuth differs from the generic
+proxy in three ways this module absorbs:
+
+- The authorize endpoint takes ``user_scope`` for a user (xoxp) grant;
+  ``scope`` would request bot scopes and install the app again.
+- ``oauth.v2.access`` returns the user token under ``authed_user.access_token``.
+  The proxy reads ``access_token`` at the top level, so the token client here
+  performs the exchange itself and lifts the user token up.
+- Slack does not support PKCE, so it is not forwarded upstream.
+
+``_extract_upstream_claims`` runs once per exchange with the lifted response,
+which already carries ``team.id``, ``team.name`` and ``authed_user.id``; no
+second Slack call is needed to build the tenant map. The verifier runs
+``auth.test`` per request so a token revoked upstream stops working
+immediately rather than at the next refresh (non-rotating Slack tokens never
+refresh).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import httpx
+from daimon.adapters.mcp.hub.claims import encode_hub_claims
+from daimon.core.hub_identity import resolve_hub_tenants
+from daimon.core.slack_oauth import SLACK_USER_SCOPES
+from fastmcp.server.auth import AccessToken, TokenVerifier
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from key_value.aio.protocols import AsyncKeyValue
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
+SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access"
+SLACK_AUTH_TEST_URL = "https://slack.com/api/auth.test"
+# Non-rotating xoxp tokens carry no expiry; cap the issued login at 30 days.
+_FALLBACK_EXPIRY_S = 30 * 24 * 60 * 60
+
+
+class SlackTokenVerifier(TokenVerifier):
+    def __init__(self, *, http_client: httpx.AsyncClient | None = None) -> None:
+        super().__init__()
+        self._http = http_client or httpx.AsyncClient(timeout=10.0)
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        response = await self._http.post(
+            SLACK_AUTH_TEST_URL, headers={"Authorization": f"Bearer {token}"}
+        )
+        if response.status_code != 200:
+            return None
+        body = response.json()
+        if not body.get("ok"):
+            return None
+        return AccessToken(
+            token=token,
+            client_id="slack",
+            scopes=[],
+            expires_at=None,
+            claims={"sub": str(body["user_id"]), "team_id": str(body["team_id"])},
+        )
+
+
+class _SlackTokenClient:
+    """Stand-in for authlib's client: only ``fetch_token`` is ever called on the exchange path."""
+
+    def __init__(self, *, http: httpx.AsyncClient, client_id: str, client_secret: str) -> None:
+        self._http = http
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    async def fetch_token(
+        self, *, url: str, code: str, redirect_uri: str, **_: Any
+    ) -> dict[str, Any]:
+        response = await self._http.post(
+            url,
+            data={
+                "code": code,
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "redirect_uri": redirect_uri,
+            },
+        )
+        response.raise_for_status()
+        payload: dict[str, Any] = response.json()
+        if not payload.get("ok"):
+            raise ValueError(f"slack exchange failed: {payload.get('error', 'unknown_error')}")
+        if payload.get("is_enterprise_install"):
+            raise ValueError("Enterprise Grid installs are not supported")
+        authed_user: dict[str, Any] = payload.get("authed_user") or {}
+        if "access_token" not in authed_user:
+            raise ValueError("slack exchange returned no user token")
+        lifted: dict[str, Any] = {
+            "access_token": authed_user["access_token"],
+            "token_type": "bearer",
+            "scope": authed_user.get("scope", ""),
+            "team": payload.get("team") or {},
+            "authed_user": {"id": authed_user.get("id")},
+        }
+        if authed_user.get("expires_in") is not None:
+            lifted["expires_in"] = int(authed_user["expires_in"])
+        if authed_user.get("refresh_token"):
+            lifted["refresh_token"] = authed_user["refresh_token"]
+        return lifted
+
+
+class SlackHubProvider(OAuthProxy):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        base_url: str,
+        session_factory: async_sessionmaker[AsyncSession],
+        client_storage: AsyncKeyValue,
+        jwt_signing_key: bytes,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._http = http_client or httpx.AsyncClient(timeout=10.0)
+        super().__init__(
+            upstream_authorization_endpoint=SLACK_AUTHORIZE_URL,
+            upstream_token_endpoint=SLACK_TOKEN_URL,
+            upstream_client_id=client_id,
+            upstream_client_secret=client_secret,
+            token_verifier=SlackTokenVerifier(http_client=self._http),
+            base_url=base_url,
+            forward_pkce=False,
+            client_storage=client_storage,
+            jwt_signing_key=jwt_signing_key,
+            fallback_access_token_expiry_seconds=_FALLBACK_EXPIRY_S,
+        )
+        self._session_factory = session_factory
+
+    def _build_upstream_authorize_url(self, txn_id: str, transaction: dict[str, Any]) -> str:
+        url = super()._build_upstream_authorize_url(txn_id, transaction)
+        parts = urlsplit(url)
+        query = [(k, v) for k, v in parse_qsl(parts.query) if k != "scope"]
+        query.append(("user_scope", ",".join(SLACK_USER_SCOPES)))
+        return urlunsplit(parts._replace(query=urlencode(query)))
+
+    def _create_upstream_oauth_client(self) -> Any:  # pyright: ignore[reportIncompatibleMethodOverride]
+        secret = self._upstream_client_secret
+        return _SlackTokenClient(
+            http=self._http,
+            client_id=self._upstream_client_id,
+            client_secret=secret.get_secret_value() if secret is not None else "",
+        )
+
+    async def _extract_upstream_claims(self, idp_tokens: dict[str, Any]) -> dict[str, Any] | None:
+        team: dict[str, Any] = idp_tokens.get("team") or {}
+        authed_user: dict[str, Any] = idp_tokens.get("authed_user") or {}
+        team_id = str(team["id"])
+        user_id = str(authed_user["id"])
+        tenants = await resolve_hub_tenants(
+            self._session_factory,
+            platform="slack",
+            platform_user_id=user_id,
+            workspaces=[(team_id, str(team.get("name") or team_id))],
+        )
+        return encode_hub_claims(platform="slack", platform_user_id=user_id, tenants=tenants)
+
+    def _cookie_name(self, base_name: str) -> str:
+        return super()._cookie_name(f"{base_name}_SLACK")

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/storage.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/storage.py
@@ -3,14 +3,15 @@
 ``OAuthProxy`` keeps dynamic client registrations, in-flight transactions,
 authorization codes, and upstream tokens in an ``AsyncKeyValue``. Its default
 is an on-disk store under the process home, which neither survives a redeploy
-nor is shared between replicas. This builder gives each platform the same
-Postgres table with a distinct collection prefix, so a Discord client id can
-never be looked up by the Slack proxy, and encrypts every value with the
+nor is shared between replicas. Both platforms therefore share one Postgres
+table, each behind its own collection prefix, so a Discord client id can never
+be looked up by the Slack proxy, and every value is encrypted with the
 deployment's credential keys because upstream access tokens live here.
 
 The store speaks asyncpg directly and owns its own pool; it cannot reuse the
-SQLAlchemy engine. ``auto_create`` is off because the table belongs to Alembic
-(``0012_hub_oauth_kv``).
+SQLAlchemy engine. One store serves both platforms so the deployment holds one
+pool, and the caller closes it at shutdown. ``auto_create`` is off because the
+table belongs to Alembic (``0013_hub_oauth_kv``).
 """
 
 from __future__ import annotations
@@ -30,7 +31,18 @@ def asyncpg_dsn(sqlalchemy_url: str) -> str:
     return sqlalchemy_url.replace("postgresql+asyncpg://", "postgresql://", 1)
 
 
-def build_hub_kv(*, database_url: str, fernet: MultiFernet, platform: Platform) -> AsyncKeyValue:
+def build_hub_kv_base(
+    *, database_url: str, fernet: MultiFernet
+) -> tuple[PostgreSQLStore, AsyncKeyValue]:
+    """Return the pool-owning store and the encrypted view the platforms share.
+
+    The store comes back alongside its wrapper because only it can close the
+    asyncpg pool; the wrappers do not expose it.
+    """
     store = PostgreSQLStore(url=database_url, table_name=HUB_KV_TABLE, auto_create=False)
-    encrypted = FernetEncryptionWrapper(store, fernet=fernet, raise_on_decryption_error=False)
-    return PrefixCollectionsWrapper(encrypted, prefix=platform)
+    return store, FernetEncryptionWrapper(store, fernet=fernet, raise_on_decryption_error=False)
+
+
+def hub_kv_for(base: AsyncKeyValue, *, platform: Platform) -> AsyncKeyValue:
+    """Namespace ``base`` so one platform's collections cannot be read as another's."""
+    return PrefixCollectionsWrapper(base, prefix=platform)

--- a/packages/adapters/mcp/daimon/adapters/mcp/hub/storage.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/hub/storage.py
@@ -1,0 +1,36 @@
+"""Persistent state for the hub login proxies.
+
+``OAuthProxy`` keeps dynamic client registrations, in-flight transactions,
+authorization codes, and upstream tokens in an ``AsyncKeyValue``. Its default
+is an on-disk store under the process home, which neither survives a redeploy
+nor is shared between replicas. This builder gives each platform the same
+Postgres table with a distinct collection prefix, so a Discord client id can
+never be looked up by the Slack proxy, and encrypts every value with the
+deployment's credential keys because upstream access tokens live here.
+
+The store speaks asyncpg directly and owns its own pool; it cannot reuse the
+SQLAlchemy engine. ``auto_create`` is off because the table belongs to Alembic
+(``0012_hub_oauth_kv``).
+"""
+
+from __future__ import annotations
+
+from cryptography.fernet import MultiFernet
+from daimon.core.stores.domain import Platform
+from key_value.aio.protocols import AsyncKeyValue
+from key_value.aio.stores.postgresql import PostgreSQLStore
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+from key_value.aio.wrappers.prefix_collections import PrefixCollectionsWrapper
+
+HUB_KV_TABLE = "hub_oauth_kv"
+
+
+def asyncpg_dsn(sqlalchemy_url: str) -> str:
+    """Drop the ``+asyncpg`` driver marker; asyncpg wants a plain postgresql:// DSN."""
+    return sqlalchemy_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def build_hub_kv(*, database_url: str, fernet: MultiFernet, platform: Platform) -> AsyncKeyValue:
+    store = PostgreSQLStore(url=database_url, table_name=HUB_KV_TABLE, auto_create=False)
+    encrypted = FernetEncryptionWrapper(store, fernet=fernet, raise_on_decryption_error=False)
+    return PrefixCollectionsWrapper(encrypted, prefix=platform)

--- a/packages/adapters/mcp/daimon/adapters/mcp/server.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/server.py
@@ -20,6 +20,7 @@ from daimon.adapters.mcp.artifacts import build_artifact_store
 from daimon.adapters.mcp.auth.verifier import DaimonJWTVerifier
 from daimon.adapters.mcp.bundles import build_bundles_route
 from daimon.adapters.mcp.checkout import billing_cancel, billing_success, build_checkout_route
+from daimon.adapters.mcp.hub.app import mount_hub_apps
 from daimon.adapters.mcp.middleware.ma_errors import MaErrorMiddleware
 from daimon.adapters.mcp.middleware.mcp_identity import (
     ClaimResolver,
@@ -392,6 +393,15 @@ def create_mcp_app(
             )
     else:
         log.info("slack oauth disabled", reason="no slack settings or crypto keys")
+
+    mount_hub_apps(
+        app,
+        settings=effective_settings,
+        runtime=runtime,
+        sessionmaker=effective_sessionmaker,
+        billing_config=effective_billing_config,
+        fernet=fernet,
+    )
 
     # GitHub App clone-auth: App-clone boots with only app_id +
     # app_private_key — no webhook required. The /webhooks/github mount is

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/_ctx.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/_ctx.py
@@ -39,16 +39,19 @@ def _require_admin(auth: AuthIdentity) -> None:  # pyright: ignore[reportUnusedF
         )
 
 
-async def _check_admission(  # pyright: ignore[reportUnusedFunction]
-    ctx: Context,
+async def _admit(  # pyright: ignore[reportUnusedFunction]
+    auth: AuthIdentity,
     *,
     sessionmaker: async_sessionmaker[AsyncSession],
     billing_config: BillingConfig | None,
     tool_name: str,
 ) -> AuthIdentity:
-    """Shared admission gate for the billed media and agent-chat turn tools.
+    """Balance and cap gate for an already-resolved identity.
 
-    Resolves the caller's identity, then:
+    ``_check_admission`` wraps this for tools whose identity is the request's
+    own; the hub mounts call it directly because their identity is chosen per
+    call from the daimon being addressed.
+
     - ``platform_user_id is None`` is the trusted, fully-unbilled path:
       CLI-only/internal operator tokens run with no balance/cap checks, no
       usage row, no debit. This is intentional, not an oversight — never add
@@ -58,7 +61,6 @@ async def _check_admission(  # pyright: ignore[reportUnusedFunction]
       a deny event carrying only ids (tenant/user/tool/gate) — never prompt
       content or raw Gemini text (Pitfall 9).
     """
-    auth = await _auth(ctx)
     if auth.platform_user_id is None:
         return auth
 
@@ -95,3 +97,19 @@ async def _check_admission(  # pyright: ignore[reportUnusedFunction]
         )
 
     return auth
+
+
+async def _check_admission(  # pyright: ignore[reportUnusedFunction]
+    ctx: Context,
+    *,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    billing_config: BillingConfig | None,
+    tool_name: str,
+) -> AuthIdentity:
+    """Shared admission gate for the billed media and agent-chat turn tools. See ``_admit``."""
+    return await _admit(
+        await _auth(ctx),
+        sessionmaker=sessionmaker,
+        billing_config=billing_config,
+        tool_name=tool_name,
+    )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -127,6 +127,9 @@ class AgentDescription(BaseModel):
     skill_names: list[str]
     repo_url: str | None
     environment_name: str | None
+    platform: str | None = None
+    workspace_id: str | None = None
+    workspace: str | None = None
 
 
 class AskResult(BaseModel):
@@ -278,6 +281,8 @@ async def _describe_agent_impl(
         skill_names=skill_names,
         repo_url=repo_url,
         environment_name=env_name,
+        platform=auth.platform,
+        workspace_id=auth.external_id,
     )
 
 
@@ -736,16 +741,21 @@ async def _ask_impl(
     auth: AuthIdentity,
     message: str,
     *,
+    handle: str | None = None,
     timeout_seconds: float = 120.0,
     poll_interval_seconds: float = 1.0,
     clock: Callable[[], float] = monotonic,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     now: Callable[[], dt.datetime] = lambda: dt.datetime.now(dt.UTC),
 ) -> AskResult:
-    """Start a turn, wait boundedly for idle, and return its final reply."""
+    """Start a turn (or continue one given ``handle``), wait boundedly for idle, and
+    return its final reply."""
     turn_started_at = now()
-    started = await _start_turn_impl(runtime, auth, message)
-    handle = started["handle"]
+    if handle is None:
+        started = await _start_turn_impl(runtime, auth, message)
+        handle = started["handle"]
+    else:
+        await _continue_turn_impl(runtime, auth, handle, message)
     deadline = clock() + timeout_seconds
 
     while True:
@@ -886,12 +896,15 @@ def register_agent_chat_tools(
         return await _start_turn_impl(runtime, auth, message, bundle)
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
-    async def ask(ctx: Context, message: str) -> AskResult:  # pyright: ignore[reportUnusedFunction]
+    async def ask(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context, message: str, handle: str | None = None
+    ) -> AskResult:
         """Ask one question and wait for the final answer and any chart images. Starts a
         persistent turn, waits up to about 120 seconds for idle, and
         returns the final text plus a resumable handle. Chart images are
         embedded by default; short-lived download links are added when private
-        artifact storage is configured.
+        artifact storage is configured. Pass ``handle`` from a previous result to
+        continue that conversation instead of starting a new one.
         """
         auth = await _check_admission(
             ctx,
@@ -900,7 +913,7 @@ def register_agent_chat_tools(
             tool_name="ask",
         )
         return _ask_tool_result(  # type: ignore[return-value]
-            await _ask_impl(runtime, auth, message)
+            await _ask_impl(runtime, auth, message, handle=handle)
         )
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -749,13 +749,21 @@ async def _ask_impl(
     now: Callable[[], dt.datetime] = lambda: dt.datetime.now(dt.UTC),
 ) -> AskResult:
     """Start a turn (or continue one given ``handle``), wait boundedly for idle, and
-    return its final reply."""
-    turn_started_at = now()
+    return its final reply.
+
+    The reply is read from THIS turn's side of the boundary the send
+    returned. That matters most on the resume path: a resumable session is
+    already idle, and the agent only picks up the new message a moment after
+    the send is acknowledged, so an unfiltered "newest agent.message" read on
+    the first poll would hand back the previous turn's answer.
+    """
     if handle is None:
-        started = await _start_turn_impl(runtime, auth, message)
-        handle = started["handle"]
+        started = await _start_turn_impl(runtime, auth, message, now=now)
     else:
-        await _continue_turn_impl(runtime, auth, handle, message)
+        started = await _continue_turn_impl(runtime, auth, handle, message, now=now)
+    handle = started["handle"]
+    turn_event_id = started["turn_event_id"]
+    turn_started_at = dt.datetime.fromisoformat(started["turn_started_at"])
     deadline = clock() + timeout_seconds
 
     while True:
@@ -773,8 +781,19 @@ async def _ask_impl(
             page: str | None = None
             final_text: str | None = None
             for _ in range(_MAX_EVENT_PAGES):
-                events = await _list_events_impl(runtime, auth, handle, page, 100, "desc")
+                events = await _list_events_impl(
+                    runtime,
+                    auth,
+                    handle,
+                    page,
+                    100,
+                    "desc",
+                    created_at_gte=turn_started_at.isoformat(),
+                    types=["agent.message"],
+                )
                 for event in events.items:
+                    if event.id == turn_event_id:
+                        continue
                     final_text = _agent_message_text(event)
                     if final_text is not None:
                         break

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/hub.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/hub.py
@@ -1,0 +1,224 @@
+"""Tool surface for the hub mounts: every daimon a logged-in person can reach.
+
+A hub caller is one platform user across several tenants, so no tool here
+takes a bare agent name: names are unique only within a tenant and two guilds
+can both have a ``helper``. ``list_daimons`` hands out the derived per-agent
+UUID as ``id`` and every other tool takes it back as ``daimon_id``. Resolution
+walks only the caller's own tenants, so an id from anywhere else is
+indistinguishable from a nonexistent one.
+
+Once a daimon is resolved the tool builds an ordinary ``AuthIdentity`` for the
+caller's account in that tenant and hands off to the agent-chat implementation
+functions. That is what makes a hub turn run with the person's channel
+visibility and bill the right tenant, exactly as a per-agent token does.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from anthropic.types.beta import BetaManagedAgentsAgent
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.hub.identity import (
+    HubIdentity,
+    _hub_auth,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools._ctx import _admit  # pyright: ignore[reportPrivateUsage]
+from daimon.adapters.mcp.tools._pagination import Page
+from daimon.adapters.mcp.tools.agent_chat import (
+    AgentDescription,
+    _ask_impl,  # pyright: ignore[reportPrivateUsage]
+    _ask_tool_result,  # pyright: ignore[reportPrivateUsage]
+    _continue_turn_impl,  # pyright: ignore[reportPrivateUsage]
+    _describe_agent_impl,  # pyright: ignore[reportPrivateUsage]
+    _get_session_impl,  # pyright: ignore[reportPrivateUsage]
+    _list_events_impl,  # pyright: ignore[reportPrivateUsage]
+    _list_sessions_impl,  # pyright: ignore[reportPrivateUsage]
+    _start_turn_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.adapters.mcp.tools.sessions import SessionEventOut, SessionInfo
+from daimon.core.billing import BillingConfig
+from daimon.core.defaults.ma_index import list_agents_by_tenant
+from daimon.core.hub_identity import HubTenant
+from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.stores.accounts import get_account_with_tenant
+from daimon.core.stores.domain import Role
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.tools import ToolResult
+from pydantic import BaseModel
+
+_NOT_FOUND = "daimon not found"
+
+
+class DaimonSummary(BaseModel):
+    model_config = {"frozen": True}
+
+    id: str
+    name: str
+    platform: str
+    workspace_id: str
+    workspace: str
+    role_summary: str
+    skill_names: list[str]
+
+
+def _summary(tenant: HubTenant, hub: HubIdentity, agent: BetaManagedAgentsAgent) -> DaimonSummary:
+    return DaimonSummary(
+        id=str(derive_agent_uuid(tenant_id=tenant.tenant_id, ma_agent_id=str(agent.id))),
+        name=agent.name,
+        platform=hub.platform,
+        workspace_id=tenant.workspace_id,
+        workspace=tenant.workspace_name,
+        role_summary=(agent.system or "")[:200],
+        skill_names=[sk.skill_id for sk in agent.skills],
+    )
+
+
+async def _list_daimons_impl(runtime: McpRuntime, hub: HubIdentity) -> list[DaimonSummary]:
+    out: list[DaimonSummary] = []
+    for tenant in hub.tenants:
+        for agent in await list_agents_by_tenant(runtime.client, tenant_id=tenant.tenant_id):
+            out.append(_summary(tenant, hub, agent))
+    out.sort(key=lambda d: (d.workspace.lower(), d.name.lower()))
+    return out
+
+
+async def _resolve_daimon(
+    runtime: McpRuntime, hub: HubIdentity, daimon_id: str
+) -> tuple[HubTenant, BetaManagedAgentsAgent]:
+    try:
+        wanted = uuid.UUID(daimon_id)
+    except ValueError as e:
+        raise ToolError(_NOT_FOUND) from e
+    for tenant in hub.tenants:
+        for agent in await list_agents_by_tenant(runtime.client, tenant_id=tenant.tenant_id):
+            if derive_agent_uuid(tenant_id=tenant.tenant_id, ma_agent_id=str(agent.id)) == wanted:
+                return tenant, agent
+    raise ToolError(_NOT_FOUND)
+
+
+async def _auth_for(
+    runtime: McpRuntime, hub: HubIdentity, tenant: HubTenant, agent: BetaManagedAgentsAgent
+) -> AuthIdentity:
+    """Identity for the caller's account in ``tenant``. Never admin: the hub has no admin tools."""
+    async with runtime.session_factory() as session:
+        row = await get_account_with_tenant(session, account_id=tenant.account_id)
+    if row is None:
+        raise ToolError(_NOT_FOUND)
+    return AuthIdentity(
+        account_id=tenant.account_id,
+        tenant_id=tenant.tenant_id,
+        role=Role.USER if row.role is not Role.ADMIN else Role.ADMIN,
+        platform=hub.platform,
+        external_id=tenant.workspace_id,
+        agent_id=derive_agent_uuid(tenant_id=tenant.tenant_id, ma_agent_id=str(agent.id)),
+        platform_user_id=hub.platform_user_id,
+        is_admin=False,
+    )
+
+
+async def _identity(
+    runtime: McpRuntime, ctx: Context, daimon_id: str
+) -> tuple[HubTenant, AuthIdentity]:
+    hub = await _hub_auth(ctx)
+    tenant, agent = await _resolve_daimon(runtime, hub, daimon_id)
+    return tenant, await _auth_for(runtime, hub, tenant, agent)
+
+
+def register_hub_tools(
+    mcp: FastMCP, runtime: McpRuntime, *, billing_config: BillingConfig | None
+) -> None:
+    async def _admitted(ctx: Context, daimon_id: str, tool_name: str) -> AuthIdentity:
+        _, auth = await _identity(runtime, ctx, daimon_id)
+        return await _admit(
+            auth,
+            sessionmaker=runtime.session_factory,
+            billing_config=billing_config,
+            tool_name=tool_name,
+        )
+
+    @mcp.tool
+    async def list_daimons(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+    ) -> list[DaimonSummary]:
+        """List every daimon you can reach on this platform, across all your workspaces.
+
+        Call this first. ``id`` is what every other tool takes as ``daimon_id``;
+        ``workspace`` tells you which Slack workspace or Discord server the daimon
+        lives in. Two daimons may share a ``name`` in different workspaces.
+        """
+        return await _list_daimons_impl(runtime, await _hub_auth(ctx))
+
+    @mcp.tool
+    async def describe_daimon(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context, daimon_id: str
+    ) -> AgentDescription:
+        """Describe one daimon: role, skills, repo, environment, platform and workspace."""
+        tenant, auth = await _identity(runtime, ctx, daimon_id)
+        base = await _describe_agent_impl(runtime, auth)
+        return base.model_copy(update={"workspace": tenant.workspace_name})
+
+    @mcp.tool
+    async def ask(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context, daimon_id: str, message: str, handle: str | None = None
+    ) -> ToolResult:
+        """Ask a daimon one question and wait up to about two minutes for its answer.
+
+        Runs as you, in that daimon's workspace: it reads only what you can see
+        and spends that workspace's credit. Pass ``handle`` from a previous
+        result to continue the same conversation. On timeout the error carries
+        the handle; resume with it rather than asking again.
+        """
+        auth = await _admitted(ctx, daimon_id, "ask")
+        return _ask_tool_result(await _ask_impl(runtime, auth, message, handle=handle))
+
+    @mcp.tool
+    async def start_turn(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context, daimon_id: str, message: str
+    ) -> dict[str, str]:
+        """Start a turn without waiting.
+
+        Returns ``{"handle": ...}`` for polling with ``get_session``.
+        """
+        auth = await _admitted(ctx, daimon_id, "start_turn")
+        return await _start_turn_impl(runtime, auth, message)
+
+    @mcp.tool
+    async def continue_turn(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context, daimon_id: str, handle: str, message: str
+    ) -> dict[str, str]:
+        """Send a follow-up on an existing session without waiting."""
+        auth = await _admitted(ctx, daimon_id, "continue_turn")
+        return await _continue_turn_impl(runtime, auth, handle, message)
+
+    @mcp.tool
+    async def get_session(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context, daimon_id: str, handle: str
+    ) -> SessionInfo:
+        """Status of one session. Poll until ``idle`` before reading ``list_events``."""
+        _, auth = await _identity(runtime, ctx, daimon_id)
+        return await _get_session_impl(runtime, auth, handle)
+
+    @mcp.tool
+    async def list_events(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        daimon_id: str,
+        handle: str,
+        page: str | None = None,
+        limit: int | None = None,
+        order: Literal["asc", "desc"] | None = None,
+    ) -> Page[SessionEventOut]:
+        """A session's transcript. The daimon's reply is in ``agent.message`` events."""
+        _, auth = await _identity(runtime, ctx, daimon_id)
+        return await _list_events_impl(runtime, auth, handle, page, limit, order)
+
+    @mcp.tool
+    async def list_my_sessions(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context, daimon_id: str
+    ) -> list[SessionInfo]:
+        """Sessions you have with this daimon, for resuming with ``handle``."""
+        _, auth = await _identity(runtime, ctx, daimon_id)
+        return await _list_sessions_impl(runtime, auth)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/hub.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/hub.py
@@ -50,7 +50,7 @@ from daimon.adapters.mcp.tools.agent_chat import (
 )
 from daimon.adapters.mcp.tools.sessions import SessionEventOut, SessionInfo
 from daimon.core.billing import BillingConfig
-from daimon.core.defaults.ma_index import list_agents_by_tenant
+from daimon.core.defaults.ma_index import list_agents_by_tenants
 from daimon.core.defaults.metadata import MA_METADATA_KEY_ACCOUNT
 from daimon.core.hub_identity import HubTenant
 from daimon.core.ma_identity import derive_agent_uuid
@@ -90,11 +90,19 @@ def _summary(tenant: HubTenant, hub: HubIdentity, agent: BetaManagedAgentsAgent)
     )
 
 
+async def _agents_by_tenant(
+    runtime: McpRuntime, hub: HubIdentity
+) -> list[tuple[HubTenant, list[BetaManagedAgentsAgent]]]:
+    by_id = await list_agents_by_tenants(
+        runtime.client, tenant_ids=[t.tenant_id for t in hub.tenants]
+    )
+    return [(tenant, by_id[tenant.tenant_id]) for tenant in hub.tenants]
+
+
 async def _list_daimons_impl(runtime: McpRuntime, hub: HubIdentity) -> list[DaimonSummary]:
     out: list[DaimonSummary] = []
-    for tenant in hub.tenants:
-        for agent in await list_agents_by_tenant(runtime.client, tenant_id=tenant.tenant_id):
-            out.append(_summary(tenant, hub, agent))
+    for tenant, agents in await _agents_by_tenant(runtime, hub):
+        out.extend(_summary(tenant, hub, agent) for agent in agents)
     out.sort(key=lambda d: (d.workspace.lower(), d.name.lower()))
     return out
 
@@ -106,8 +114,8 @@ async def _resolve_daimon(
         wanted = uuid.UUID(daimon_id)
     except ValueError as e:
         raise ToolError(_NOT_FOUND) from e
-    for tenant in hub.tenants:
-        for agent in await list_agents_by_tenant(runtime.client, tenant_id=tenant.tenant_id):
+    for tenant, agents in await _agents_by_tenant(runtime, hub):
+        for agent in agents:
             if derive_agent_uuid(tenant_id=tenant.tenant_id, ma_agent_id=str(agent.id)) == wanted:
                 return tenant, agent
     raise ToolError(_NOT_FOUND)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/hub.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/hub.py
@@ -11,6 +11,16 @@ Once a daimon is resolved the tool builds an ordinary ``AuthIdentity`` for the
 caller's account in that tenant and hands off to the agent-chat implementation
 functions. That is what makes a hub turn run with the person's channel
 visibility and bill the right tenant, exactly as a per-agent token does.
+
+Session handles are scoped one step tighter than on the per-agent surface.
+There, the token *is* the agent, so "the agent's sessions" and "the caller's
+sessions" coincide. Here every member of a workspace shares one daimon, so a
+handle is only usable by the account that created the session: the
+``daimon_account`` metadata ``create_session`` stamps on every session is
+compared to the caller's account before any read or continuation, and
+``list_my_sessions`` filters on it. Channel threads driven by the chat
+adapters carry the thread starter's account, so they are invisible to
+everyone else through the hub.
 """
 
 from __future__ import annotations
@@ -18,7 +28,7 @@ from __future__ import annotations
 import uuid
 from typing import Literal
 
-from anthropic.types.beta import BetaManagedAgentsAgent
+from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsSession
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.hub.identity import (
     HubIdentity,
@@ -35,22 +45,25 @@ from daimon.adapters.mcp.tools.agent_chat import (
     _describe_agent_impl,  # pyright: ignore[reportPrivateUsage]
     _get_session_impl,  # pyright: ignore[reportPrivateUsage]
     _list_events_impl,  # pyright: ignore[reportPrivateUsage]
-    _list_sessions_impl,  # pyright: ignore[reportPrivateUsage]
     _start_turn_impl,  # pyright: ignore[reportPrivateUsage]
+    _verify_agent_owns_session,  # pyright: ignore[reportPrivateUsage]
 )
 from daimon.adapters.mcp.tools.sessions import SessionEventOut, SessionInfo
 from daimon.core.billing import BillingConfig
 from daimon.core.defaults.ma_index import list_agents_by_tenant
+from daimon.core.defaults.metadata import MA_METADATA_KEY_ACCOUNT
 from daimon.core.hub_identity import HubTenant
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.stores.accounts import get_account_with_tenant
 from daimon.core.stores.domain import Role
+from daimon.core.stores.tenants import get_tenant
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel
 
 _NOT_FOUND = "daimon not found"
+_SESSION_NOT_FOUND = "session not found"
 
 
 class DaimonSummary(BaseModel):
@@ -103,15 +116,30 @@ async def _resolve_daimon(
 async def _auth_for(
     runtime: McpRuntime, hub: HubIdentity, tenant: HubTenant, agent: BetaManagedAgentsAgent
 ) -> AuthIdentity:
-    """Identity for the caller's account in ``tenant``. Never admin: the hub has no admin tools."""
+    """Identity for the caller's account in ``tenant``.
+
+    ``role`` and ``is_admin`` are both pinned to the non-admin value rather
+    than copied from the account row: the hub registers no admin tools, and
+    every admin gate in the codebase expects the pair to agree.
+
+    The tenant's readiness is re-checked here rather than trusted from the
+    login-time claims, so a workspace that uninstalls daimon or is archived
+    stops being reachable on the next call instead of when the token expires.
+    """
     async with runtime.session_factory() as session:
         row = await get_account_with_tenant(session, account_id=tenant.account_id)
-    if row is None:
+        live = await get_tenant(session, tenant.tenant_id)
+    if (
+        row is None
+        or live is None
+        or live.archived_at is not None
+        or live.provision_status != "ready"
+    ):
         raise ToolError(_NOT_FOUND)
     return AuthIdentity(
         account_id=tenant.account_id,
         tenant_id=tenant.tenant_id,
-        role=Role.USER if row.role is not Role.ADMIN else Role.ADMIN,
+        role=Role.USER,
         platform=hub.platform,
         external_id=tenant.workspace_id,
         agent_id=derive_agent_uuid(tenant_id=tenant.tenant_id, ma_agent_id=str(agent.id)),
@@ -122,17 +150,44 @@ async def _auth_for(
 
 async def _identity(
     runtime: McpRuntime, ctx: Context, daimon_id: str
-) -> tuple[HubTenant, AuthIdentity]:
+) -> tuple[HubTenant, BetaManagedAgentsAgent, AuthIdentity]:
     hub = await _hub_auth(ctx)
     tenant, agent = await _resolve_daimon(runtime, hub, daimon_id)
-    return tenant, await _auth_for(runtime, hub, tenant, agent)
+    return tenant, agent, await _auth_for(runtime, hub, tenant, agent)
+
+
+def _owned_by(session: BetaManagedAgentsSession, auth: AuthIdentity) -> bool:
+    return session.metadata.get(MA_METADATA_KEY_ACCOUNT) == str(auth.account_id)
+
+
+async def _verify_account_owns_session(
+    runtime: McpRuntime, auth: AuthIdentity, handle: str
+) -> None:
+    """Reject a handle unless the caller's account created the session.
+
+    Same message as an unknown handle, so a session's existence is not leaked
+    to other members of the workspace.
+    """
+    session = await _verify_agent_owns_session(runtime, auth, handle)
+    if not _owned_by(session, auth):
+        raise ToolError(_SESSION_NOT_FOUND)
+
+
+async def _list_my_sessions_impl(
+    runtime: McpRuntime, auth: AuthIdentity, agent: BetaManagedAgentsAgent
+) -> list[SessionInfo]:
+    out: list[SessionInfo] = []
+    async for session in runtime.client.beta.sessions.list(agent_id=str(agent.id)):
+        if _owned_by(session, auth):
+            out.append(SessionInfo.from_ma(session))
+    return out
 
 
 def register_hub_tools(
     mcp: FastMCP, runtime: McpRuntime, *, billing_config: BillingConfig | None
 ) -> None:
     async def _admitted(ctx: Context, daimon_id: str, tool_name: str) -> AuthIdentity:
-        _, auth = await _identity(runtime, ctx, daimon_id)
+        _, _, auth = await _identity(runtime, ctx, daimon_id)
         return await _admit(
             auth,
             sessionmaker=runtime.session_factory,
@@ -157,7 +212,7 @@ def register_hub_tools(
         ctx: Context, daimon_id: str
     ) -> AgentDescription:
         """Describe one daimon: role, skills, repo, environment, platform and workspace."""
-        tenant, auth = await _identity(runtime, ctx, daimon_id)
+        tenant, _, auth = await _identity(runtime, ctx, daimon_id)
         base = await _describe_agent_impl(runtime, auth)
         return base.model_copy(update={"workspace": tenant.workspace_name})
 
@@ -173,6 +228,8 @@ def register_hub_tools(
         the handle; resume with it rather than asking again.
         """
         auth = await _admitted(ctx, daimon_id, "ask")
+        if handle is not None:
+            await _verify_account_owns_session(runtime, auth, handle)
         return _ask_tool_result(await _ask_impl(runtime, auth, message, handle=handle))
 
     @mcp.tool
@@ -192,6 +249,7 @@ def register_hub_tools(
     ) -> dict[str, str]:
         """Send a follow-up on an existing session without waiting."""
         auth = await _admitted(ctx, daimon_id, "continue_turn")
+        await _verify_account_owns_session(runtime, auth, handle)
         return await _continue_turn_impl(runtime, auth, handle, message)
 
     @mcp.tool
@@ -199,7 +257,8 @@ def register_hub_tools(
         ctx: Context, daimon_id: str, handle: str
     ) -> SessionInfo:
         """Status of one session. Poll until ``idle`` before reading ``list_events``."""
-        _, auth = await _identity(runtime, ctx, daimon_id)
+        _, _, auth = await _identity(runtime, ctx, daimon_id)
+        await _verify_account_owns_session(runtime, auth, handle)
         return await _get_session_impl(runtime, auth, handle)
 
     @mcp.tool
@@ -212,13 +271,18 @@ def register_hub_tools(
         order: Literal["asc", "desc"] | None = None,
     ) -> Page[SessionEventOut]:
         """A session's transcript. The daimon's reply is in ``agent.message`` events."""
-        _, auth = await _identity(runtime, ctx, daimon_id)
+        _, _, auth = await _identity(runtime, ctx, daimon_id)
+        await _verify_account_owns_session(runtime, auth, handle)
         return await _list_events_impl(runtime, auth, handle, page, limit, order)
 
     @mcp.tool
     async def list_my_sessions(  # pyright: ignore[reportUnusedFunction]
         ctx: Context, daimon_id: str
     ) -> list[SessionInfo]:
-        """Sessions you have with this daimon, for resuming with ``handle``."""
-        _, auth = await _identity(runtime, ctx, daimon_id)
-        return await _list_sessions_impl(runtime, auth)
+        """Sessions you started with this daimon, for resuming with ``handle``.
+
+        Other people's conversations with the same daimon are not listed and
+        their handles are not accepted.
+        """
+        _, agent, auth = await _identity(runtime, ctx, daimon_id)
+        return await _list_my_sessions_impl(runtime, auth, agent)

--- a/packages/adapters/mcp/pyproject.toml
+++ b/packages/adapters/mcp/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "google-genai>=2.5,<3",
     "imageio-ffmpeg>=0.6",
     "slack-sdk>=3.42,<4",
+    "py-key-value-aio[postgresql]>=0.4.4",
 ]
 
 [project.optional-dependencies]

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -1,4 +1,219 @@
 # serializer version: 1
+# name: test_rendered_hub_tool_schema_matches_snapshot
+  dict({
+    'instructions': 'Every daimon reachable here lives in a Discord workspace. Call list_daimons first; every other tool takes a daimon_id from that list.',
+    'tools': dict({
+      'ask': dict({
+        'description': '''
+          Ask a daimon one question and wait up to about two minutes for its answer.
+          
+          Runs as you, in that daimon's workspace: it reads only what you can see
+          and spends that workspace's credit. Pass ``handle`` from a previous
+          result to continue the same conversation. On timeout the error carries
+          the handle; resume with it rather than asking again.
+        ''',
+        'parameters': dict({
+          'additionalProperties': False,
+          'properties': dict({
+            'daimon_id': dict({
+              'type': 'string',
+            }),
+            'handle': dict({
+              'anyOf': list([
+                dict({
+                  'type': 'string',
+                }),
+                dict({
+                  'type': 'null',
+                }),
+              ]),
+              'default': None,
+            }),
+            'message': dict({
+              'type': 'string',
+            }),
+          }),
+          'required': list([
+            'daimon_id',
+            'message',
+          ]),
+          'type': 'object',
+        }),
+      }),
+      'continue_turn': dict({
+        'description': 'Send a follow-up on an existing session without waiting.',
+        'parameters': dict({
+          'additionalProperties': False,
+          'properties': dict({
+            'daimon_id': dict({
+              'type': 'string',
+            }),
+            'handle': dict({
+              'type': 'string',
+            }),
+            'message': dict({
+              'type': 'string',
+            }),
+          }),
+          'required': list([
+            'daimon_id',
+            'handle',
+            'message',
+          ]),
+          'type': 'object',
+        }),
+      }),
+      'describe_daimon': dict({
+        'description': 'Describe one daimon: role, skills, repo, environment, platform and workspace.',
+        'parameters': dict({
+          'additionalProperties': False,
+          'properties': dict({
+            'daimon_id': dict({
+              'type': 'string',
+            }),
+          }),
+          'required': list([
+            'daimon_id',
+          ]),
+          'type': 'object',
+        }),
+      }),
+      'get_session': dict({
+        'description': 'Status of one session. Poll until ``idle`` before reading ``list_events``.',
+        'parameters': dict({
+          'additionalProperties': False,
+          'properties': dict({
+            'daimon_id': dict({
+              'type': 'string',
+            }),
+            'handle': dict({
+              'type': 'string',
+            }),
+          }),
+          'required': list([
+            'daimon_id',
+            'handle',
+          ]),
+          'type': 'object',
+        }),
+      }),
+      'list_daimons': dict({
+        'description': '''
+          List every daimon you can reach on this platform, across all your workspaces.
+          
+          Call this first. ``id`` is what every other tool takes as ``daimon_id``;
+          ``workspace`` tells you which Slack workspace or Discord server the daimon
+          lives in. Two daimons may share a ``name`` in different workspaces.
+        ''',
+        'parameters': dict({
+          'additionalProperties': False,
+          'properties': dict({
+          }),
+          'type': 'object',
+        }),
+      }),
+      'list_events': dict({
+        'description': "A session's transcript. The daimon's reply is in ``agent.message`` events.",
+        'parameters': dict({
+          'additionalProperties': False,
+          'properties': dict({
+            'daimon_id': dict({
+              'type': 'string',
+            }),
+            'handle': dict({
+              'type': 'string',
+            }),
+            'limit': dict({
+              'anyOf': list([
+                dict({
+                  'type': 'integer',
+                }),
+                dict({
+                  'type': 'null',
+                }),
+              ]),
+              'default': None,
+            }),
+            'order': dict({
+              'anyOf': list([
+                dict({
+                  'enum': list([
+                    'asc',
+                    'desc',
+                  ]),
+                  'type': 'string',
+                }),
+                dict({
+                  'type': 'null',
+                }),
+              ]),
+              'default': None,
+            }),
+            'page': dict({
+              'anyOf': list([
+                dict({
+                  'type': 'string',
+                }),
+                dict({
+                  'type': 'null',
+                }),
+              ]),
+              'default': None,
+            }),
+          }),
+          'required': list([
+            'daimon_id',
+            'handle',
+          ]),
+          'type': 'object',
+        }),
+      }),
+      'list_my_sessions': dict({
+        'description': '''
+          Sessions you started with this daimon, for resuming with ``handle``.
+          
+          Other people's conversations with the same daimon are not listed and
+          their handles are not accepted.
+        ''',
+        'parameters': dict({
+          'additionalProperties': False,
+          'properties': dict({
+            'daimon_id': dict({
+              'type': 'string',
+            }),
+          }),
+          'required': list([
+            'daimon_id',
+          ]),
+          'type': 'object',
+        }),
+      }),
+      'start_turn': dict({
+        'description': '''
+          Start a turn without waiting.
+          
+          Returns ``{"handle": ...}`` for polling with ``get_session``.
+        ''',
+        'parameters': dict({
+          'additionalProperties': False,
+          'properties': dict({
+            'daimon_id': dict({
+              'type': 'string',
+            }),
+            'message': dict({
+              'type': 'string',
+            }),
+          }),
+          'required': list([
+            'daimon_id',
+            'message',
+          ]),
+          'type': 'object',
+        }),
+      }),
+    }),
+  })
+# ---
 # name: test_rendered_tool_schema_matches_snapshot
   dict({
     'archive_agent': dict({

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -64,11 +64,23 @@
         persistent turn, waits up to about 120 seconds for idle, and
         returns the final text plus a resumable handle. Chart images are
         embedded by default; short-lived download links are added when private
-        artifact storage is configured.
+        artifact storage is configured. Pass ``handle`` from a previous result to
+        continue that conversation instead of starting a new one.
       ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
+          'handle': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
           'message': dict({
             'type': 'string',
           }),

--- a/packages/adapters/mcp/tests/hub/conftest.py
+++ b/packages/adapters/mcp/tests/hub/conftest.py
@@ -1,0 +1,32 @@
+"""Make parent test helpers (conftest, factories) importable from hub/ tests.
+
+Without __init__.py in the test directories (removed to avoid pluggy plugin
+registration collision with packages/core/tests), the hub/ subdirectory
+needs the parent tests/ directory on sys.path for absolute imports.
+
+Because packages/core/tests also has a ``factories`` module on sys.path
+(added by core's conftest), we must insert the MCP tests directory first
+AND invalidate any cached ``factories`` so the MCP-local version wins.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+_parent = str(Path(__file__).resolve().parent.parent)
+if _parent not in sys.path:
+    sys.path.insert(0, _parent)
+else:
+    # Ensure it's at the front so MCP's factories shadows core's.
+    sys.path.remove(_parent)
+    sys.path.insert(0, _parent)
+
+# Invalidate cached ``factories`` module from core/tests so the MCP-local
+# version is found on next import.
+if "factories" in sys.modules:
+    _cached = sys.modules["factories"]
+    if _cached.__file__ and "adapters/mcp" not in _cached.__file__:
+        del sys.modules["factories"]
+        importlib.invalidate_caches()

--- a/packages/adapters/mcp/tests/hub/conftest.py
+++ b/packages/adapters/mcp/tests/hub/conftest.py
@@ -1,8 +1,7 @@
 """Make parent test helpers (conftest, factories) importable from hub/ tests.
 
-Without __init__.py in the test directories (removed to avoid pluggy plugin
-registration collision with packages/core/tests), the hub/ subdirectory
-needs the parent tests/ directory on sys.path for absolute imports.
+The parent ``tests/`` directory has no ``__init__.py``, so ``factories`` is
+only importable once that directory is on sys.path.
 
 Because packages/core/tests also has a ``factories`` module on sys.path
 (added by core's conftest), we must insert the MCP tests directory first

--- a/packages/adapters/mcp/tests/hub/test_app.py
+++ b/packages/adapters/mcp/tests/hub/test_app.py
@@ -1,0 +1,192 @@
+"""Hub apps mount beside /mcp, expose only hub tools, and stay absent when unconfigured."""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+from daimon.adapters.mcp.hub.app import build_hub_app, mount_hub_apps
+from daimon.adapters.mcp.hub.claims import encode_hub_claims
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.server import create_mcp_app
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    HubSettings,
+    McpSettings,
+    Settings,
+)
+from daimon.core.defaults.loader import DeploymentDefault
+from daimon.core.hub_identity import HubTenant
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.applications import Starlette
+
+pytestmark = pytest.mark.asyncio
+
+_HUB_TOOLS = {
+    "list_daimons",
+    "describe_daimon",
+    "ask",
+    "start_turn",
+    "continue_turn",
+    "get_session",
+    "list_events",
+    "list_my_sessions",
+}
+
+
+def _settings(hub: HubSettings | None = None) -> Settings:
+    return Settings(
+        database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+        anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+        mcp=McpSettings(
+            public_url=HttpUrl("https://t.example.com/mcp"), jwt_secret=SecretStr("x" * 32)
+        ),
+        hub=hub or HubSettings(),
+    )
+
+
+def _runtime(sessionmaker: Any) -> McpRuntime:
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda _r, _m: list_response([]))
+    return McpRuntime(
+        session_factory=sessionmaker,
+        client=build_fake_anthropic(router.dispatch),
+        settings=_settings(),
+        deployment_default=DeploymentDefault(environment_name=None),
+    )
+
+
+@asynccontextmanager
+async def _lifespan(app: Starlette):
+    async with app.router.lifespan_context(app):
+        yield
+
+
+async def _tools_list(app: Starlette, path: str, token: str) -> set[str]:
+    async with (
+        _lifespan(app),
+        httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c,
+    ):
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+        init = await c.post(
+            path,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "t", "version": "0"},
+                },
+            },
+        )
+        assert init.status_code == 200, init.text
+        assert "mcp-session-id" not in init.headers, (
+            f"hub app must be stateless, got session {init.headers['mcp-session-id']!r}"
+        )
+        resp = await c.post(
+            path,
+            headers=headers,
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+        assert resp.headers["content-type"].startswith("application/json"), (
+            f"expected JSON response, got {resp.headers['content-type']!r}"
+        )
+        return {t["name"] for t in resp.json()["result"]["tools"]}
+
+
+async def test_hub_app_lists_exactly_the_hub_tools(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant = HubTenant(
+        tenant_id=uuid.uuid4(), account_id=uuid.uuid4(), workspace_id="g1", workspace_name="PyMC"
+    )
+    claims = encode_hub_claims(platform="discord", platform_user_id="u1", tenants=[tenant])
+    auth = StaticTokenVerifier(
+        tokens={"tok": {"sub": "u1", "client_id": "c", "upstream_claims": claims}}
+    )
+    mcp = build_hub_app(
+        platform="discord", runtime=_runtime(sessionmaker), auth=auth, billing_config=None
+    )
+
+    names = await _tools_list(
+        mcp.http_app(path="/mcp", stateless_http=True, json_response=True), "/mcp", "tok"
+    )
+
+    assert names == _HUB_TOOLS, f"hub surface drifted: {sorted(names)}"
+
+
+async def test_unconfigured_hub_mounts_nothing(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    app = create_mcp_app(
+        settings=_settings(),
+        sessionmaker=sessionmaker,
+        auth=StaticTokenVerifier(tokens={}),
+        anthropic=_runtime(sessionmaker).client,
+    )
+    paths = {getattr(r, "path", None) for r in app.router.routes}
+    assert "/slack" not in paths and "/discord" not in paths, f"got {paths!r}"
+
+
+async def test_mount_hub_apps_requires_signing_key_and_crypto(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    from daimon.core.errors import BootstrapError
+
+    hub = HubSettings(discord_client_id="id", discord_client_secret=SecretStr("s"))
+    app = Starlette()
+    with pytest.raises(BootstrapError, match="JWT_SIGNING_KEY"):
+        mount_hub_apps(
+            app,
+            settings=_settings(hub),
+            runtime=_runtime(sessionmaker),
+            sessionmaker=sessionmaker,
+            billing_config=None,
+            fernet=None,
+        )
+
+
+async def test_mount_hub_apps_adds_mount_and_root_well_known_routes(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    from cryptography.fernet import Fernet, MultiFernet
+
+    key = Fernet.generate_key()
+    hub = HubSettings(
+        discord_client_id="id",
+        discord_client_secret=SecretStr("s"),
+        jwt_signing_key=SecretStr(key.decode()),
+    )
+    app = Starlette()
+    mounted = mount_hub_apps(
+        app,
+        settings=_settings(hub),
+        runtime=_runtime(sessionmaker),
+        sessionmaker=sessionmaker,
+        billing_config=None,
+        fernet=MultiFernet([Fernet(key)]),
+    )
+
+    assert mounted == ["discord"], f"got {mounted!r}"
+    paths = {getattr(r, "path", None) for r in app.router.routes}
+    assert "/discord" in paths, f"mount missing: {paths!r}"
+    assert "/.well-known/oauth-authorization-server/discord" in paths, (
+        f"path-aware discovery route missing: {paths!r}"
+    )
+    assert "/.well-known/oauth-protected-resource/discord/mcp" in paths, (
+        f"resource metadata route missing: {paths!r}"
+    )

--- a/packages/adapters/mcp/tests/hub/test_app.py
+++ b/packages/adapters/mcp/tests/hub/test_app.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 import pytest
+from cryptography.fernet import Fernet, MultiFernet
 from daimon.adapters.mcp.hub.app import build_hub_app, mount_hub_apps
 from daimon.adapters.mcp.hub.claims import encode_hub_claims
 from daimon.adapters.mcp.runtime import McpRuntime
@@ -20,6 +21,7 @@ from daimon.core.config import (
     Settings,
 )
 from daimon.core.defaults.loader import DeploymentDefault
+from daimon.core.errors import BootstrapError
 from daimon.core.hub_identity import HubTenant
 from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
@@ -41,14 +43,25 @@ _HUB_TOOLS = {
 }
 
 
-def _settings(hub: HubSettings | None = None) -> Settings:
+def _settings(
+    hub: HubSettings | None = None, *, public_url: str | None = "https://t.example.com/mcp"
+) -> Settings:
     return Settings(
         database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
         anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
         mcp=McpSettings(
-            public_url=HttpUrl("https://t.example.com/mcp"), jwt_secret=SecretStr("x" * 32)
+            public_url=HttpUrl(public_url) if public_url is not None else None,
+            jwt_secret=SecretStr("x" * 32),
         ),
         hub=hub or HubSettings(),
+    )
+
+
+def _discord_hub(*, signing_key: str | None = None) -> HubSettings:
+    return HubSettings(
+        discord_client_id="id",
+        discord_client_secret=SecretStr("s"),
+        jwt_signing_key=SecretStr(signing_key) if signing_key is not None else None,
     )
 
 
@@ -142,14 +155,27 @@ async def test_unconfigured_hub_mounts_nothing(
     assert "/slack" not in paths and "/discord" not in paths, f"got {paths!r}"
 
 
-async def test_mount_hub_apps_requires_signing_key_and_crypto(
+async def test_mount_hub_apps_requires_a_signing_key(
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
-    from daimon.core.errors import BootstrapError
-
-    hub = HubSettings(discord_client_id="id", discord_client_secret=SecretStr("s"))
     app = Starlette()
-    with pytest.raises(BootstrapError, match="JWT_SIGNING_KEY"):
+    with pytest.raises(BootstrapError, match="DAIMON_HUB__JWT_SIGNING_KEY"):
+        mount_hub_apps(
+            app,
+            settings=_settings(_discord_hub()),
+            runtime=_runtime(sessionmaker),
+            sessionmaker=sessionmaker,
+            billing_config=None,
+            fernet=None,
+        )
+
+
+async def test_mount_hub_apps_requires_crypto_keys(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    hub = _discord_hub(signing_key=Fernet.generate_key().decode())
+    app = Starlette()
+    with pytest.raises(BootstrapError, match="DAIMON_CRYPTO__KEYS"):
         mount_hub_apps(
             app,
             settings=_settings(hub),
@@ -160,17 +186,28 @@ async def test_mount_hub_apps_requires_signing_key_and_crypto(
         )
 
 
+async def test_mount_hub_apps_requires_a_public_url(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    key = Fernet.generate_key()
+    hub = _discord_hub(signing_key=key.decode())
+    app = Starlette()
+    with pytest.raises(BootstrapError, match="DAIMON_MCP__PUBLIC_URL"):
+        mount_hub_apps(
+            app,
+            settings=_settings(hub, public_url=None),
+            runtime=_runtime(sessionmaker),
+            sessionmaker=sessionmaker,
+            billing_config=None,
+            fernet=MultiFernet([Fernet(key)]),
+        )
+
+
 async def test_mount_hub_apps_adds_mount_and_root_well_known_routes(
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
-    from cryptography.fernet import Fernet, MultiFernet
-
     key = Fernet.generate_key()
-    hub = HubSettings(
-        discord_client_id="id",
-        discord_client_secret=SecretStr("s"),
-        jwt_signing_key=SecretStr(key.decode()),
-    )
+    hub = _discord_hub(signing_key=key.decode())
     app = Starlette()
     mounted = mount_hub_apps(
         app,

--- a/packages/adapters/mcp/tests/hub/test_discord_provider.py
+++ b/packages/adapters/mcp/tests/hub/test_discord_provider.py
@@ -1,0 +1,88 @@
+"""Discord login resolves the user's guilds to installed tenants at exchange time."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from daimon.adapters.mcp.hub.discord_provider import DaimonDiscordProvider, fetch_discord_workspaces
+from daimon.testing.factories import make_tenant
+from key_value.aio.stores.memory import MemoryStore
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+def _discord_http(*, user_id: str, guilds: list[tuple[str, str]]) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer upstream-tok", request.headers
+        if request.url.path == "/api/v10/users/@me":
+            return httpx.Response(200, json={"id": user_id, "username": "j"})
+        if request.url.path == "/api/v10/users/@me/guilds":
+            return httpx.Response(200, json=[{"id": g, "name": n} for g, n in guilds])
+        return httpx.Response(404)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://discord.com")
+
+
+async def test_fetch_discord_workspaces_returns_user_and_guilds() -> None:
+    http = _discord_http(user_id="u1", guilds=[("g1", "PyMC"), ("g2", "Bayes")])
+    user, guilds = await fetch_discord_workspaces(http, access_token="upstream-tok")
+    assert user == "u1", f"got {user!r}"
+    assert guilds == [("g1", "PyMC"), ("g2", "Bayes")], f"got {guilds!r}"
+
+
+def _provider(
+    session_factory: async_sessionmaker[AsyncSession], http: httpx.AsyncClient
+) -> DaimonDiscordProvider:
+    return DaimonDiscordProvider(
+        client_id="cid",
+        client_secret="csecret",
+        base_url="https://example.test/discord",
+        session_factory=session_factory,
+        client_storage=MemoryStore(),
+        jwt_signing_key=b"0" * 32,
+        http_client=http,
+    )
+
+
+async def test_extract_upstream_claims_bakes_tenant_map(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    installed = await make_tenant(db_session, platform="discord", workspace_id="g1")
+    await db_session.commit()
+    provider = _provider(
+        db_session_factory, _discord_http(user_id="u1", guilds=[("g1", "PyMC"), ("g9", "Nope")])
+    )
+
+    claims = await provider._extract_upstream_claims({"access_token": "upstream-tok"})  # pyright: ignore[reportPrivateUsage]
+
+    assert claims is not None, "claims must be produced for a successful exchange"
+    assert claims["platform"] == "discord" and claims["platform_user_id"] == "u1", f"got {claims!r}"
+    assert [t["tenant_id"] for t in claims["tenants"]] == [str(installed.id)], (
+        f"got {claims['tenants']!r}"
+    )
+    assert claims["tenants"][0]["workspace_name"] == "PyMC"
+
+
+async def test_extract_upstream_claims_with_no_shared_guilds_yields_empty_tenants(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    provider = _provider(db_session_factory, _discord_http(user_id="u1", guilds=[("g9", "Nope")]))
+    claims = await provider._extract_upstream_claims({"access_token": "upstream-tok"})  # pyright: ignore[reportPrivateUsage]
+    assert claims is not None and claims["tenants"] == [], (
+        f"login must succeed with no tenants, got {claims!r}"
+    )
+
+
+async def test_cookie_name_is_platform_specific(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    provider = _provider(db_session_factory, _discord_http(user_id="u1", guilds=[]))
+    assert provider._cookie_name("MCP_CONSENT_BINDING").endswith("MCP_CONSENT_BINDING_DISCORD"), (  # pyright: ignore[reportPrivateUsage]
+        "consent cookie must not collide with the slack proxy on the same origin"
+    )
+
+
+async def test_requests_guilds_scope(db_session_factory: async_sessionmaker[AsyncSession]) -> None:
+    provider = _provider(db_session_factory, _discord_http(user_id="u1", guilds=[]))
+    assert "guilds" in (provider.required_scopes or []), f"got {provider.required_scopes!r}"

--- a/packages/adapters/mcp/tests/hub/test_discord_provider.py
+++ b/packages/adapters/mcp/tests/hub/test_discord_provider.py
@@ -41,6 +41,7 @@ def _provider(
         session_factory=session_factory,
         client_storage=MemoryStore(),
         jwt_signing_key=b"0" * 32,
+        allowed_client_redirect_uris=["http://localhost:*"],
         http_client=http,
     )
 

--- a/packages/adapters/mcp/tests/hub/test_identity.py
+++ b/packages/adapters/mcp/tests/hub/test_identity.py
@@ -1,0 +1,159 @@
+"""HubIdentityMiddleware turns proxy token claims into a HubIdentity in request state."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import uuid
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+from daimon.adapters.mcp.hub.claims import decode_hub_claims, encode_hub_claims
+from daimon.adapters.mcp.hub.identity import HubIdentity, HubIdentityMiddleware, _hub_auth
+from daimon.core.hub_identity import HubTenant
+from fastmcp import Context, FastMCP
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from starlette.types import ASGIApp, Message
+
+pytestmark = pytest.mark.asyncio
+
+_TENANT = HubTenant(
+    tenant_id=uuid.uuid4(), account_id=uuid.uuid4(), workspace_id="g1", workspace_name="PyMC"
+)
+
+
+def test_claims_round_trip() -> None:
+    claims = encode_hub_claims(platform="discord", platform_user_id="u1", tenants=[_TENANT])
+    identity = decode_hub_claims({"sub": "u1", "upstream_claims": claims})
+    assert identity == HubIdentity(platform="discord", platform_user_id="u1", tenants=(_TENANT,)), (
+        f"round trip changed the identity: {identity!r}"
+    )
+
+
+def test_decode_returns_none_without_upstream_claims() -> None:
+    assert decode_hub_claims({"sub": "u1"}) is None, "missing upstream_claims must decode to None"
+
+
+def test_decode_returns_none_on_malformed_tenant() -> None:
+    bad = {"platform": "discord", "platform_user_id": "u1", "tenants": [{"tenant_id": "nope"}]}
+    assert decode_hub_claims({"upstream_claims": bad}) is None, "malformed tenant must fail closed"
+
+
+def _app_with_tokens(tokens: dict[str, dict[str, object]]) -> FastMCP:
+    mcp = FastMCP(name="hub-test", auth=StaticTokenVerifier(tokens=tokens))
+    mcp.add_middleware(HubIdentityMiddleware())
+
+    @mcp.tool
+    async def whoami(ctx: Context) -> str:  # pyright: ignore[reportUnusedFunction]
+        return (await _hub_auth(ctx)).platform_user_id
+
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# HTTP harness (FastMCP's in-memory Client transport does not support auth;
+# same pattern as tests/tools/test_agent_chat.py:200-283).
+# ---------------------------------------------------------------------------
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
+    send_q: asyncio.Queue[Message] = asyncio.Queue()
+    recv_q: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await recv_q.get()
+
+    async def send(message: Message) -> None:
+        await send_q.put(message)
+
+    async def run() -> None:
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+
+    task = asyncio.create_task(run())
+    await recv_q.put({"type": "lifespan.startup"})
+    msg = await send_q.get()
+    assert msg["type"] == "lifespan.startup.complete", msg
+    try:
+        yield
+    finally:
+        await recv_q.put({"type": "lifespan.shutdown"})
+        msg = await send_q.get()
+        assert msg["type"] == "lifespan.shutdown.complete", msg
+        await task
+
+
+def _parse_jsonrpc(resp: httpx.Response) -> dict[str, object]:
+    ct = resp.headers.get("content-type", "")
+    if "text/event-stream" in ct:
+        for line in resp.text.splitlines():
+            if line.startswith("data: "):
+                return json.loads(line[6:])  # type: ignore[return-value]
+        raise AssertionError(f"No data line in SSE: {resp.text!r}")
+    return resp.json()  # type: ignore[return-value]
+
+
+async def _call_whoami_via_http(app: ASGIApp, token: str) -> dict[str, object]:
+    """Initialize an MCP HTTP session and call tools/call for whoami; return the JSON-RPC result."""
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        init_resp = await c.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0"},
+                },
+            },
+            headers=headers,
+        )
+        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
+        session_id = init_resp.headers.get("mcp-session-id")
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+        call_resp = await c.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "whoami", "arguments": {}},
+            },
+            headers=headers,
+        )
+        assert call_resp.status_code == 200, f"tools/call failed: {call_resp.text}"
+        return _parse_jsonrpc(call_resp)
+
+
+async def test_middleware_exposes_identity_to_tools() -> None:
+    claims = encode_hub_claims(platform="slack", platform_user_id="U1", tenants=[_TENANT])
+    mcp = _app_with_tokens({"tok": {"sub": "U1", "client_id": "c", "upstream_claims": claims}})
+    result = await _call_whoami_via_http(mcp.http_app(), "tok")
+    payload = result.get("result", result)
+    assert isinstance(payload, dict), f"unexpected tools/call shape: {result!r}"
+    assert not payload.get("isError"), (
+        f"whoami should succeed for a hub-claims token; got {payload!r}"
+    )
+    content = payload.get("content") or []
+    text = content[0]["text"] if content else None  # type: ignore[index]
+    assert text == "U1", f"tool must see the login identity, got {payload!r}"
+
+
+async def test_middleware_rejects_token_without_hub_claims() -> None:
+    mcp = _app_with_tokens({"tok": {"sub": "U1", "client_id": "c"}})
+    result = await _call_whoami_via_http(mcp.http_app(), "tok")
+    # The middleware raises AuthorizationError before the tool is dispatched, so
+    # the request fails at the JSON-RPC level rather than surfacing as a tool
+    # result with isError=True.
+    assert "error" in result, f"token without hub claims must be rejected; got {result!r}"

--- a/packages/adapters/mcp/tests/hub/test_identity.py
+++ b/packages/adapters/mcp/tests/hub/test_identity.py
@@ -10,12 +10,16 @@ from collections.abc import AsyncIterator
 
 import httpx
 import pytest
+from daimon.adapters.mcp.hub.app import build_hub_app
 from daimon.adapters.mcp.hub.claims import decode_hub_claims, encode_hub_claims
 from daimon.adapters.mcp.hub.identity import HubIdentity, HubIdentityMiddleware, _hub_auth
 from daimon.core.hub_identity import HubTenant
 from fastmcp import Context, FastMCP
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.types import ASGIApp, Message
+
+from .test_app import _runtime
 
 pytestmark = pytest.mark.asyncio
 
@@ -43,7 +47,7 @@ def test_decode_returns_none_on_malformed_tenant() -> None:
 
 def _app_with_tokens(tokens: dict[str, dict[str, object]]) -> FastMCP:
     mcp = FastMCP(name="hub-test", auth=StaticTokenVerifier(tokens=tokens))
-    mcp.add_middleware(HubIdentityMiddleware())
+    mcp.add_middleware(HubIdentityMiddleware("slack"))
 
     @mcp.tool
     async def whoami(ctx: Context) -> str:  # pyright: ignore[reportUnusedFunction]
@@ -95,8 +99,8 @@ def _parse_jsonrpc(resp: httpx.Response) -> dict[str, object]:
     return resp.json()  # type: ignore[return-value]
 
 
-async def _call_whoami_via_http(app: ASGIApp, token: str) -> dict[str, object]:
-    """Initialize an MCP HTTP session and call tools/call for whoami; return the JSON-RPC result."""
+async def _call_tool_via_http(app: ASGIApp, token: str, tool: str = "whoami") -> dict[str, object]:
+    """Initialize an MCP HTTP session and call ``tool``; return the JSON-RPC result."""
     headers = {
         "Accept": "application/json, text/event-stream",
         "Content-Type": "application/json",
@@ -128,7 +132,7 @@ async def _call_whoami_via_http(app: ASGIApp, token: str) -> dict[str, object]:
                 "jsonrpc": "2.0",
                 "id": 2,
                 "method": "tools/call",
-                "params": {"name": "whoami", "arguments": {}},
+                "params": {"name": tool, "arguments": {}},
             },
             headers=headers,
         )
@@ -139,7 +143,7 @@ async def _call_whoami_via_http(app: ASGIApp, token: str) -> dict[str, object]:
 async def test_middleware_exposes_identity_to_tools() -> None:
     claims = encode_hub_claims(platform="slack", platform_user_id="U1", tenants=[_TENANT])
     mcp = _app_with_tokens({"tok": {"sub": "U1", "client_id": "c", "upstream_claims": claims}})
-    result = await _call_whoami_via_http(mcp.http_app(), "tok")
+    result = await _call_tool_via_http(mcp.http_app(), "tok")
     payload = result.get("result", result)
     assert isinstance(payload, dict), f"unexpected tools/call shape: {result!r}"
     assert not payload.get("isError"), (
@@ -152,8 +156,32 @@ async def test_middleware_exposes_identity_to_tools() -> None:
 
 async def test_middleware_rejects_token_without_hub_claims() -> None:
     mcp = _app_with_tokens({"tok": {"sub": "U1", "client_id": "c"}})
-    result = await _call_whoami_via_http(mcp.http_app(), "tok")
+    result = await _call_tool_via_http(mcp.http_app(), "tok")
     # The middleware raises AuthorizationError before the tool is dispatched, so
     # the request fails at the JSON-RPC level rather than surfacing as a tool
     # result with isError=True.
     assert "error" in result, f"token without hub claims must be rejected; got {result!r}"
+
+
+async def test_middleware_rejects_a_token_issued_for_another_platform(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    claims = encode_hub_claims(platform="slack", platform_user_id="U1", tenants=[_TENANT])
+    auth = StaticTokenVerifier(
+        tokens={"tok": {"sub": "U1", "client_id": "c", "upstream_claims": claims}}
+    )
+    mcp = build_hub_app(
+        platform="discord", runtime=_runtime(sessionmaker), auth=auth, billing_config=None
+    )
+
+    result = await _call_tool_via_http(
+        mcp.http_app(path="/mcp", stateless_http=True, json_response=True),
+        "tok",
+        tool="list_daimons",
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict), f"unexpected tools/call shape: {result!r}"
+    assert payload.get("isError"), (
+        f"a Slack login must not be accepted by the Discord mount: {result!r}"
+    )

--- a/packages/adapters/mcp/tests/hub/test_no_token_in_logs.py
+++ b/packages/adapters/mcp/tests/hub/test_no_token_in_logs.py
@@ -4,106 +4,21 @@ from __future__ import annotations
 
 import logging
 import uuid
-from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
 import pytest
 from daimon.adapters.mcp.hub.app import build_hub_app
 from daimon.adapters.mcp.hub.claims import encode_hub_claims
-from daimon.adapters.mcp.runtime import McpRuntime
-from daimon.core.config import (
-    AnthropicSettings,
-    DatabaseSettings,
-    HubSettings,
-    McpSettings,
-    Settings,
-)
-from daimon.core.defaults.loader import DeploymentDefault
 from daimon.core.hub_identity import HubTenant
-from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
-from pydantic import HttpUrl, PostgresDsn, SecretStr
 from starlette.applications import Starlette
+
+from .test_app import _lifespan, _runtime, _tools_list
 
 pytestmark = pytest.mark.asyncio
 
 SENTINEL = "hub-sentinel-upstream-token-DO-NOT-LOG"
-
-# _settings, _runtime, _lifespan and _tools_list are mirrored from
-# tests/hub/test_app.py rather than imported: hub/ carries an __init__.py
-# (unlike its sibling test dirs), so under --import-mode=importlib pytest
-# resolves that module as "hub.test_app" and never registers a bare
-# "test_app" name for `from test_app import ...` to find, even when this
-# whole directory is collected together. Keep these in sync with test_app.py
-# if it changes.
-
-
-def _settings() -> Settings:
-    return Settings(
-        database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
-        anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
-        mcp=McpSettings(
-            public_url=HttpUrl("https://t.example.com/mcp"), jwt_secret=SecretStr("x" * 32)
-        ),
-        hub=HubSettings(),
-    )
-
-
-def _runtime(sessionmaker: Any) -> McpRuntime:
-    router = MARouter()
-    router.add("GET", r"/v1/agents", lambda _r, _m: list_response([]))
-    return McpRuntime(
-        session_factory=sessionmaker,
-        client=build_fake_anthropic(router.dispatch),
-        settings=_settings(),
-        deployment_default=DeploymentDefault(environment_name=None),
-    )
-
-
-@asynccontextmanager
-async def _lifespan(app: Starlette):
-    async with app.router.lifespan_context(app):
-        yield
-
-
-async def _tools_list(app: Starlette, path: str, token: str) -> set[str]:
-    async with (
-        _lifespan(app),
-        httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c,
-    ):
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/json, text/event-stream",
-            "Content-Type": "application/json",
-        }
-        init = await c.post(
-            path,
-            headers=headers,
-            json={
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": "2025-06-18",
-                    "capabilities": {},
-                    "clientInfo": {"name": "t", "version": "0"},
-                },
-            },
-        )
-        assert init.status_code == 200, init.text
-        assert "mcp-session-id" not in init.headers, (
-            f"hub app must be stateless, got session {init.headers['mcp-session-id']!r}"
-        )
-        resp = await c.post(
-            path,
-            headers=headers,
-            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
-        )
-        assert resp.headers["content-type"].startswith("application/json"), (
-            f"expected JSON response, got {resp.headers['content-type']!r}"
-        )
-        return {t["name"] for t in resp.json()["result"]["tools"]}
 
 
 async def _call_list_daimons(app: Starlette, path: str, token: str) -> list[dict[str, Any]]:

--- a/packages/adapters/mcp/tests/hub/test_no_token_in_logs.py
+++ b/packages/adapters/mcp/tests/hub/test_no_token_in_logs.py
@@ -1,0 +1,181 @@
+"""Neither the upstream token nor the login claims reach a log line on a hub call."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+from daimon.adapters.mcp.hub.app import build_hub_app
+from daimon.adapters.mcp.hub.claims import encode_hub_claims
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    HubSettings,
+    McpSettings,
+    Settings,
+)
+from daimon.core.defaults.loader import DeploymentDefault
+from daimon.core.hub_identity import HubTenant
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from starlette.applications import Starlette
+
+pytestmark = pytest.mark.asyncio
+
+SENTINEL = "hub-sentinel-upstream-token-DO-NOT-LOG"
+
+# _settings, _runtime, _lifespan and _tools_list are mirrored from
+# tests/hub/test_app.py rather than imported: hub/ carries an __init__.py
+# (unlike its sibling test dirs), so under --import-mode=importlib pytest
+# resolves that module as "hub.test_app" and never registers a bare
+# "test_app" name for `from test_app import ...` to find, even when this
+# whole directory is collected together. Keep these in sync with test_app.py
+# if it changes.
+
+
+def _settings() -> Settings:
+    return Settings(
+        database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+        anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+        mcp=McpSettings(
+            public_url=HttpUrl("https://t.example.com/mcp"), jwt_secret=SecretStr("x" * 32)
+        ),
+        hub=HubSettings(),
+    )
+
+
+def _runtime(sessionmaker: Any) -> McpRuntime:
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda _r, _m: list_response([]))
+    return McpRuntime(
+        session_factory=sessionmaker,
+        client=build_fake_anthropic(router.dispatch),
+        settings=_settings(),
+        deployment_default=DeploymentDefault(environment_name=None),
+    )
+
+
+@asynccontextmanager
+async def _lifespan(app: Starlette):
+    async with app.router.lifespan_context(app):
+        yield
+
+
+async def _tools_list(app: Starlette, path: str, token: str) -> set[str]:
+    async with (
+        _lifespan(app),
+        httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c,
+    ):
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+        init = await c.post(
+            path,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "t", "version": "0"},
+                },
+            },
+        )
+        assert init.status_code == 200, init.text
+        assert "mcp-session-id" not in init.headers, (
+            f"hub app must be stateless, got session {init.headers['mcp-session-id']!r}"
+        )
+        resp = await c.post(
+            path,
+            headers=headers,
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+        assert resp.headers["content-type"].startswith("application/json"), (
+            f"expected JSON response, got {resp.headers['content-type']!r}"
+        )
+        return {t["name"] for t in resp.json()["result"]["tools"]}
+
+
+async def _call_list_daimons(app: Starlette, path: str, token: str) -> list[dict[str, Any]]:
+    """Actually invoke the ``list_daimons`` tool (not just list its schema), so log
+    output from tool execution -- not merely the initialize/tools-list handshake
+    -- is captured too."""
+    async with (
+        _lifespan(app),
+        httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c,
+    ):
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+        init = await c.post(
+            path,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "t", "version": "0"},
+                },
+            },
+        )
+        assert init.status_code == 200, init.text
+        resp = await c.post(
+            path,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "list_daimons", "arguments": {}},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        result = payload.get("result", payload)
+        assert isinstance(result, dict) and not result.get("isError"), (
+            f"list_daimons call failed: {result!r}"
+        )
+        structured = result.get("structuredContent") or {}
+        items = structured.get("result", structured) if isinstance(structured, dict) else structured
+        return items if isinstance(items, list) else []
+
+
+async def test_hub_call_never_logs_the_bearer_token(
+    sessionmaker: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    tenant = HubTenant(
+        tenant_id=uuid.uuid4(), account_id=uuid.uuid4(), workspace_id="g1", workspace_name="PyMC"
+    )
+    claims = encode_hub_claims(platform="discord", platform_user_id="u1", tenants=[tenant])
+    auth = StaticTokenVerifier(
+        tokens={SENTINEL: {"sub": "u1", "client_id": "c", "upstream_claims": claims}}
+    )
+    mcp = build_hub_app(
+        platform="discord", runtime=_runtime(sessionmaker), auth=auth, billing_config=None
+    )
+    caplog.set_level(logging.DEBUG)
+
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+    names = await _tools_list(app, "/mcp", SENTINEL)
+    daimons = await _call_list_daimons(app, "/mcp", SENTINEL)
+
+    assert "list_daimons" in names, f"expected list_daimons among hub tools, got {names!r}"
+    assert daimons == [], f"empty tenant should list no daimons, got {daimons!r}"
+    assert SENTINEL not in caplog.text, "bearer token must never be logged"
+    for record in caplog.records:
+        assert SENTINEL not in record.getMessage() and SENTINEL not in repr(record.args), record

--- a/packages/adapters/mcp/tests/hub/test_no_token_in_logs.py
+++ b/packages/adapters/mcp/tests/hub/test_no_token_in_logs.py
@@ -18,7 +18,8 @@ from .test_app import _lifespan, _runtime, _tools_list
 
 pytestmark = pytest.mark.asyncio
 
-SENTINEL = "hub-sentinel-upstream-token-DO-NOT-LOG"
+TOKEN_SENTINEL = "hub-sentinel-upstream-token-DO-NOT-LOG"
+CLAIMS_SENTINEL = "hub-sentinel-workspace"
 
 
 async def _call_list_daimons(app: Starlette, path: str, token: str) -> list[dict[str, Any]]:
@@ -70,15 +71,18 @@ async def _call_list_daimons(app: Starlette, path: str, token: str) -> list[dict
         return items if isinstance(items, list) else []
 
 
-async def test_hub_call_never_logs_the_bearer_token(
-    sessionmaker: Any, caplog: pytest.LogCaptureFixture
+async def test_hub_call_logs_neither_the_bearer_token_nor_the_login_claims(
+    sessionmaker: Any, caplog: pytest.LogCaptureFixture, capfd: pytest.CaptureFixture[str]
 ) -> None:
     tenant = HubTenant(
-        tenant_id=uuid.uuid4(), account_id=uuid.uuid4(), workspace_id="g1", workspace_name="PyMC"
+        tenant_id=uuid.uuid4(),
+        account_id=uuid.uuid4(),
+        workspace_id="g1",
+        workspace_name=CLAIMS_SENTINEL,
     )
     claims = encode_hub_claims(platform="discord", platform_user_id="u1", tenants=[tenant])
     auth = StaticTokenVerifier(
-        tokens={SENTINEL: {"sub": "u1", "client_id": "c", "upstream_claims": claims}}
+        tokens={TOKEN_SENTINEL: {"sub": "u1", "client_id": "c", "upstream_claims": claims}}
     )
     mcp = build_hub_app(
         platform="discord", runtime=_runtime(sessionmaker), auth=auth, billing_config=None
@@ -86,11 +90,23 @@ async def test_hub_call_never_logs_the_bearer_token(
     caplog.set_level(logging.DEBUG)
 
     app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
-    names = await _tools_list(app, "/mcp", SENTINEL)
-    daimons = await _call_list_daimons(app, "/mcp", SENTINEL)
+    names = await _tools_list(app, "/mcp", TOKEN_SENTINEL)
+    daimons = await _call_list_daimons(app, "/mcp", TOKEN_SENTINEL)
+    # daimon's structlog uses PrintLoggerFactory, so its own lines land on the
+    # process's stdout and never reach the stdlib logging caplog reads.
+    captured = capfd.readouterr()
+    printed = captured.out + captured.err
 
     assert "list_daimons" in names, f"expected list_daimons among hub tools, got {names!r}"
     assert daimons == [], f"empty tenant should list no daimons, got {daimons!r}"
-    assert SENTINEL not in caplog.text, "bearer token must never be logged"
+    for haystack, where in ((caplog.text, "stdlib logs"), (printed, "stdout")):
+        assert TOKEN_SENTINEL not in haystack, (
+            f"bearer token must never be logged; found in {where}"
+        )
+        assert CLAIMS_SENTINEL not in haystack, (
+            f"login claims must never be logged; found in {where}"
+        )
     for record in caplog.records:
-        assert SENTINEL not in record.getMessage() and SENTINEL not in repr(record.args), record
+        assert TOKEN_SENTINEL not in record.getMessage() and TOKEN_SENTINEL not in repr(
+            record.args
+        ), record

--- a/packages/adapters/mcp/tests/hub/test_slack_provider.py
+++ b/packages/adapters/mcp/tests/hub/test_slack_provider.py
@@ -46,6 +46,7 @@ def _provider(
         session_factory=session_factory,
         client_storage=MemoryStore(),
         jwt_signing_key=b"0" * 32,
+        allowed_client_redirect_uris=["http://localhost:*"],
         http_client=http,
     )
 

--- a/packages/adapters/mcp/tests/hub/test_slack_provider.py
+++ b/packages/adapters/mcp/tests/hub/test_slack_provider.py
@@ -1,0 +1,128 @@
+"""Slack login: user_scope on authorize, user token lifted from authed_user, tenant map baked in."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from daimon.adapters.mcp.hub.slack_provider import SlackHubProvider, SlackTokenVerifier
+from daimon.core.slack_oauth import SLACK_USER_SCOPES
+from daimon.testing.factories import make_tenant
+from key_value.aio.stores.memory import MemoryStore
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+_EXCHANGE_OK = {
+    "ok": True,
+    "team": {"id": "T1", "name": "Acme"},
+    "authed_user": {"id": "U1", "access_token": "xoxp-user", "scope": "channels:read"},
+}
+
+
+def _slack_http(
+    exchange: dict[str, object], *, auth_test: dict[str, object] | None = None
+) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/oauth.v2.access":
+            return httpx.Response(200, json=exchange)
+        if request.url.path == "/api/auth.test":
+            return httpx.Response(
+                200, json=auth_test or {"ok": True, "user_id": "U1", "team_id": "T1"}
+            )
+        return httpx.Response(404)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://slack.com")
+
+
+def _provider(
+    session_factory: async_sessionmaker[AsyncSession], http: httpx.AsyncClient
+) -> SlackHubProvider:
+    return SlackHubProvider(
+        client_id="cid",
+        client_secret="csecret",
+        base_url="https://example.test/slack",
+        session_factory=session_factory,
+        client_storage=MemoryStore(),
+        jwt_signing_key=b"0" * 32,
+        http_client=http,
+    )
+
+
+async def test_authorize_url_uses_user_scope_not_scope(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    provider = _provider(db_session_factory, _slack_http(_EXCHANGE_OK))
+    url = provider._build_upstream_authorize_url(
+        "txn", {"scopes": [], "client_redirect_uri": "http://localhost/cb"}
+    )  # pyright: ignore[reportPrivateUsage]
+    qs = parse_qs(urlparse(url).query)
+    assert "scope" not in qs, f"bot scope must not be requested, got {qs!r}"
+    assert qs["user_scope"] == [",".join(SLACK_USER_SCOPES)], f"got {qs.get('user_scope')!r}"
+    assert qs["redirect_uri"] == ["https://example.test/slack/auth/callback"], (
+        f"got {qs.get('redirect_uri')!r}"
+    )
+
+
+async def test_token_client_lifts_user_token_to_top_level(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    provider = _provider(db_session_factory, _slack_http(_EXCHANGE_OK))
+    client = provider._create_upstream_oauth_client()  # pyright: ignore[reportPrivateUsage]
+    tokens = await client.fetch_token(
+        url="https://slack.com/api/oauth.v2.access", code="c", redirect_uri="r"
+    )
+    assert tokens["access_token"] == "xoxp-user", f"got {tokens!r}"
+    assert tokens["team"] == {"id": "T1", "name": "Acme"} and tokens["authed_user"]["id"] == "U1"
+    assert "expires_in" not in tokens, "non-rotating slack tokens must not claim an expiry"
+
+
+async def test_token_client_rejects_enterprise_install(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    provider = _provider(
+        db_session_factory, _slack_http({**_EXCHANGE_OK, "is_enterprise_install": True})
+    )
+    client = provider._create_upstream_oauth_client()  # pyright: ignore[reportPrivateUsage]
+    with pytest.raises(ValueError, match="Enterprise Grid"):
+        await client.fetch_token(
+            url="https://slack.com/api/oauth.v2.access", code="c", redirect_uri="r"
+        )
+
+
+async def test_extract_upstream_claims_bakes_single_tenant(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="T1")
+    await db_session.commit()
+    provider = _provider(db_session_factory, _slack_http(_EXCHANGE_OK))
+    claims = await provider._extract_upstream_claims(  # pyright: ignore[reportPrivateUsage]
+        {
+            "access_token": "xoxp-user",
+            "team": {"id": "T1", "name": "Acme"},
+            "authed_user": {"id": "U1"},
+        }
+    )
+    assert claims is not None and [t["tenant_id"] for t in claims["tenants"]] == [str(tenant.id)], (
+        f"got {claims!r}"
+    )
+    assert claims["tenants"][0]["workspace_name"] == "Acme" and claims["platform_user_id"] == "U1"
+
+
+async def test_verifier_accepts_live_token_and_rejects_dead_one() -> None:
+    live = SlackTokenVerifier(http_client=_slack_http(_EXCHANGE_OK))
+    token = await live.verify_token("xoxp-user")
+    assert token is not None and token.claims["sub"] == "U1", f"got {token!r}"
+
+    dead = SlackTokenVerifier(
+        http_client=_slack_http(_EXCHANGE_OK, auth_test={"ok": False, "error": "invalid_auth"})
+    )
+    assert await dead.verify_token("xoxp-user") is None, "revoked token must fail verification"
+
+
+async def test_cookie_name_is_platform_specific(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    provider = _provider(db_session_factory, _slack_http(_EXCHANGE_OK))
+    assert provider._cookie_name("MCP_CONSENT_BINDING").endswith("MCP_CONSENT_BINDING_SLACK")  # pyright: ignore[reportPrivateUsage]

--- a/packages/adapters/mcp/tests/hub/test_storage.py
+++ b/packages/adapters/mcp/tests/hub/test_storage.py
@@ -1,0 +1,45 @@
+"""The hub key-value store isolates platforms by collection prefix and encrypts values at rest."""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet, MultiFernet
+from daimon.adapters.mcp.hub.storage import asyncpg_dsn, build_hub_kv
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+
+def test_asyncpg_dsn_strips_sqlalchemy_driver() -> None:
+    assert asyncpg_dsn("postgresql+asyncpg://u:p@h:5432/d") == "postgresql://u:p@h:5432/d"
+    assert asyncpg_dsn("postgresql://u:p@h/d") == "postgresql://u:p@h/d"
+
+
+async def test_platforms_share_the_table_but_not_keys(
+    db_engine: AsyncEngine, db_session: AsyncSession, test_schema: str
+) -> None:
+    fernet = MultiFernet([Fernet(Fernet.generate_key())])
+    dsn = asyncpg_dsn(str(db_engine.url.render_as_string(hide_password=False)))
+    dsn = f"{dsn}?options=-csearch_path%3D{test_schema}"
+    slack = build_hub_kv(database_url=dsn, fernet=fernet, platform="slack")
+    discord = build_hub_kv(database_url=dsn, fernet=fernet, platform="discord")
+
+    await slack.put("k", {"v": "slack"}, collection="mcp-oauth-proxy-clients")
+    await discord.put("k", {"v": "discord"}, collection="mcp-oauth-proxy-clients")
+
+    assert await slack.get("k", collection="mcp-oauth-proxy-clients") == {"v": "slack"}
+    assert await discord.get("k", collection="mcp-oauth-proxy-clients") == {"v": "discord"}
+
+    rows = (
+        await db_session.execute(
+            text("SELECT collection, value::text FROM hub_oauth_kv ORDER BY collection")
+        )
+    ).all()
+    assert [r[0] for r in rows] == [
+        "discord__mcp-oauth-proxy-clients",
+        "slack__mcp-oauth-proxy-clients",
+    ], f"got {rows!r}"
+    assert all("slack" not in r[1] and "discord" not in r[1] for r in rows), (
+        f"values must be encrypted at rest, got {rows!r}"
+    )

--- a/packages/adapters/mcp/tests/hub/test_storage.py
+++ b/packages/adapters/mcp/tests/hub/test_storage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 from cryptography.fernet import Fernet, MultiFernet
-from daimon.adapters.mcp.hub.storage import asyncpg_dsn, build_hub_kv
+from daimon.adapters.mcp.hub.storage import asyncpg_dsn, build_hub_kv_base, hub_kv_for
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -22,14 +22,16 @@ async def test_platforms_share_the_table_but_not_keys(
     fernet = MultiFernet([Fernet(Fernet.generate_key())])
     dsn = asyncpg_dsn(str(db_engine.url.render_as_string(hide_password=False)))
     dsn = f"{dsn}?options=-csearch_path%3D{test_schema}"
-    slack = build_hub_kv(database_url=dsn, fernet=fernet, platform="slack")
-    discord = build_hub_kv(database_url=dsn, fernet=fernet, platform="discord")
+    store, base = build_hub_kv_base(database_url=dsn, fernet=fernet)
+    slack = hub_kv_for(base, platform="slack")
+    discord = hub_kv_for(base, platform="discord")
 
-    await slack.put("k", {"v": "slack"}, collection="mcp-oauth-proxy-clients")
-    await discord.put("k", {"v": "discord"}, collection="mcp-oauth-proxy-clients")
+    async with store:
+        await slack.put("k", {"v": "slack"}, collection="mcp-oauth-proxy-clients")
+        await discord.put("k", {"v": "discord"}, collection="mcp-oauth-proxy-clients")
 
-    assert await slack.get("k", collection="mcp-oauth-proxy-clients") == {"v": "slack"}
-    assert await discord.get("k", collection="mcp-oauth-proxy-clients") == {"v": "discord"}
+        assert await slack.get("k", collection="mcp-oauth-proxy-clients") == {"v": "slack"}
+        assert await discord.get("k", collection="mcp-oauth-proxy-clients") == {"v": "discord"}
 
     rows = (
         await db_session.execute(

--- a/packages/adapters/mcp/tests/hub/test_tool_wrappers.py
+++ b/packages/adapters/mcp/tests/hub/test_tool_wrappers.py
@@ -1,0 +1,286 @@
+"""The thin per-tool wrappers in register_hub_tools resolve, delegate, and reject
+foreign daimon ids the same way ask does -- driven over the wire, not called directly."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+from anthropic.types.beta import BetaManagedAgentsSession
+from daimon.adapters.mcp.hub.app import build_hub_app
+from daimon.adapters.mcp.hub.claims import encode_hub_claims
+from daimon.core.hub_identity import HubTenant
+from daimon.core.ma_identity import derive_agent_uuid
+from daimon.testing.factories import make_platform_principal, make_tenant
+from daimon.testing.ma import build_fake_anthropic, list_response, session_response
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .test_turn_parity import AGENT_ID, _call_tool, _runtime, build_turn_router
+
+pytestmark = pytest.mark.asyncio
+
+_TOKEN = "tok"
+_HANDLE = "ses_wrap_001"
+
+
+def _foreign_daimon_id() -> str:
+    """A well-formed daimon_id derived from a tenant that isn't in the caller's
+    HubIdentity -- indistinguishable from a nonexistent one to _resolve_daimon."""
+    return str(derive_agent_uuid(tenant_id=uuid.uuid4(), ma_agent_id=AGENT_ID))
+
+
+def _session_payload(session_id: str) -> dict[str, Any]:
+    return BetaManagedAgentsSession.model_validate(
+        {
+            "id": session_id,
+            "type": "session",
+            "agent": {
+                "id": AGENT_ID,
+                "name": "test-agent",
+                "version": 1,
+                "type": "agent",
+                "model": {"id": "claude-sonnet-4-6"},
+                "mcp_servers": [],
+                "skills": [],
+                "tools": [],
+            },
+            "archived_at": None,
+            "created_at": "2026-06-23T00:00:00Z",
+            "updated_at": "2026-06-23T00:00:00Z",
+            "outcome_evaluations": [],
+            "environment_id": "env_parity_test",
+            "metadata": {},
+            "resources": [],
+            "stats": {},
+            "status": "idle",
+            "title": None,
+            "usage": {},
+            "vault_ids": [],
+        }
+    ).model_dump(mode="json")
+
+
+async def _hub_app(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> tuple[Any, str, HubTenant]:
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="g1")
+    principal = await make_platform_principal(
+        db_session, platform="discord", external_id="u1", tenant=tenant
+    )
+    await db_session.commit()
+
+    hub_tenant = HubTenant(
+        tenant_id=tenant.id,
+        account_id=principal.account_id,
+        workspace_id="g1",
+        workspace_name="PyMC",
+    )
+    claims = encode_hub_claims(platform="discord", platform_user_id="u1", tenants=[hub_tenant])
+    auth = StaticTokenVerifier(
+        tokens={_TOKEN: {"sub": "u1", "client_id": "c", "upstream_claims": claims}}
+    )
+
+    router = build_turn_router(str(tenant.id))
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)$",
+        lambda _r, m: session_response(session_id=m.group(1), status="idle", agent_id=AGENT_ID),
+    )
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)/events$",
+        lambda _r, _m: httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "sevt_wrap_msg",
+                        "type": "agent.message",
+                        "content": [{"type": "text", "text": "hi"}],
+                    }
+                ],
+                "next_page": None,
+            },
+        ),
+    )
+    router.add(
+        "GET",
+        r"/v1/sessions$",
+        lambda _r, _m: list_response([_session_payload("ses_a"), _session_payload("ses_b")]),
+    )
+    runtime = _runtime(build_fake_anthropic(router.dispatch), db_session_factory)
+    mcp = build_hub_app(platform="discord", runtime=runtime, auth=auth, billing_config=None)
+    daimon_id = str(derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=AGENT_ID))
+    return mcp, daimon_id, hub_tenant
+
+
+async def test_describe_daimon_returns_the_platform_and_workspace_the_caller_addressed(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    mcp, daimon_id, hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app, "/mcp", _TOKEN, name="describe_daimon", arguments={"daimon_id": daimon_id}
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and not payload.get("isError"), (
+        f"describe_daimon call failed: {payload!r}"
+    )
+    described = payload.get("structuredContent") or {}
+    assert described.get("platform") == "discord", f"got {described!r}"
+    assert described.get("workspace_id") == hub_tenant.workspace_id, f"got {described!r}"
+    assert described.get("workspace") == hub_tenant.workspace_name, f"got {described!r}"
+
+
+async def test_describe_daimon_rejects_a_daimon_id_outside_the_callers_tenants(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    mcp, _daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app,
+        "/mcp",
+        _TOKEN,
+        name="describe_daimon",
+        arguments={"daimon_id": _foreign_daimon_id()},
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and payload.get("isError"), (
+        f"describe_daimon must reject a daimon_id outside the caller's tenants, got {payload!r}"
+    )
+    assert "daimon not found" in str(payload.get("content")), f"got {payload!r}"
+
+
+async def test_get_session_returns_the_session_status(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    mcp, daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app,
+        "/mcp",
+        _TOKEN,
+        name="get_session",
+        arguments={"daimon_id": daimon_id, "handle": _HANDLE},
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and not payload.get("isError"), (
+        f"get_session call failed: {payload!r}"
+    )
+    info = payload.get("structuredContent") or {}
+    assert info.get("id") == _HANDLE, f"got {info!r}"
+    assert info.get("status") == "idle", f"got {info!r}"
+
+
+async def test_get_session_rejects_a_daimon_id_outside_the_callers_tenants(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    mcp, _daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app,
+        "/mcp",
+        _TOKEN,
+        name="get_session",
+        arguments={"daimon_id": _foreign_daimon_id(), "handle": _HANDLE},
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and payload.get("isError"), (
+        f"get_session must reject a daimon_id outside the caller's tenants, got {payload!r}"
+    )
+    assert "daimon not found" in str(payload.get("content")), f"got {payload!r}"
+
+
+async def test_list_events_returns_the_sessions_transcript(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    mcp, daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app,
+        "/mcp",
+        _TOKEN,
+        name="list_events",
+        arguments={"daimon_id": daimon_id, "handle": _HANDLE},
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and not payload.get("isError"), (
+        f"list_events call failed: {payload!r}"
+    )
+    page = payload.get("structuredContent") or {}
+    items = page.get("items") or []
+    assert any(item.get("type") == "agent.message" for item in items), f"got {items!r}"
+
+
+async def test_list_events_rejects_a_daimon_id_outside_the_callers_tenants(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    mcp, _daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app,
+        "/mcp",
+        _TOKEN,
+        name="list_events",
+        arguments={"daimon_id": _foreign_daimon_id(), "handle": _HANDLE},
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and payload.get("isError"), (
+        f"list_events must reject a daimon_id outside the caller's tenants, got {payload!r}"
+    )
+    assert "daimon not found" in str(payload.get("content")), f"got {payload!r}"
+
+
+async def test_list_my_sessions_returns_the_callers_sessions(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    mcp, daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app, "/mcp", _TOKEN, name="list_my_sessions", arguments={"daimon_id": daimon_id}
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and not payload.get("isError"), (
+        f"list_my_sessions call failed: {payload!r}"
+    )
+    structured = payload.get("structuredContent") or {}
+    sessions = structured.get("result", structured) if isinstance(structured, dict) else structured
+    assert {s["id"] for s in sessions} == {"ses_a", "ses_b"}, f"got {sessions!r}"
+
+
+async def test_list_my_sessions_rejects_a_daimon_id_outside_the_callers_tenants(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    mcp, _daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app,
+        "/mcp",
+        _TOKEN,
+        name="list_my_sessions",
+        arguments={"daimon_id": _foreign_daimon_id()},
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and payload.get("isError"), (
+        f"list_my_sessions must reject a daimon_id outside the caller's tenants, got {payload!r}"
+    )
+    assert "daimon not found" in str(payload.get("content")), f"got {payload!r}"

--- a/packages/adapters/mcp/tests/hub/test_tool_wrappers.py
+++ b/packages/adapters/mcp/tests/hub/test_tool_wrappers.py
@@ -4,6 +4,7 @@ foreign daimon ids the same way ask does -- driven over the wire, not called dir
 from __future__ import annotations
 
 import uuid
+from decimal import Decimal
 from typing import Any
 
 import httpx
@@ -11,9 +12,10 @@ import pytest
 from anthropic.types.beta import BetaManagedAgentsSession
 from daimon.adapters.mcp.hub.app import build_hub_app
 from daimon.adapters.mcp.hub.claims import encode_hub_claims
+from daimon.core.defaults.metadata import MA_METADATA_KEY_ACCOUNT
 from daimon.core.hub_identity import HubTenant
 from daimon.core.ma_identity import derive_agent_uuid
-from daimon.testing.factories import make_platform_principal, make_tenant
+from daimon.testing.factories import make_ledger_entry, make_platform_principal, make_tenant
 from daimon.testing.ma import build_fake_anthropic, list_response, session_response
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -24,6 +26,8 @@ pytestmark = pytest.mark.asyncio
 
 _TOKEN = "tok"
 _HANDLE = "ses_wrap_001"
+_THEIR_HANDLE = "ses_theirs"
+_OTHER_ACCOUNT = str(uuid.uuid4())
 
 
 def _foreign_daimon_id() -> str:
@@ -32,7 +36,7 @@ def _foreign_daimon_id() -> str:
     return str(derive_agent_uuid(tenant_id=uuid.uuid4(), ma_agent_id=AGENT_ID))
 
 
-def _session_payload(session_id: str) -> dict[str, Any]:
+def _session_payload(session_id: str, *, account_id: str) -> dict[str, Any]:
     return BetaManagedAgentsSession.model_validate(
         {
             "id": session_id,
@@ -52,7 +56,7 @@ def _session_payload(session_id: str) -> dict[str, Any]:
             "updated_at": "2026-06-23T00:00:00Z",
             "outcome_evaluations": [],
             "environment_id": "env_parity_test",
-            "metadata": {},
+            "metadata": {MA_METADATA_KEY_ACCOUNT: account_id},
             "resources": [],
             "stats": {},
             "status": "idle",
@@ -64,12 +68,17 @@ def _session_payload(session_id: str) -> dict[str, Any]:
 
 
 async def _hub_app(
-    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    *,
+    funded: bool = True,
 ) -> tuple[Any, str, HubTenant]:
     tenant = await make_tenant(db_session, platform="discord", workspace_id="g1")
     principal = await make_platform_principal(
         db_session, platform="discord", external_id="u1", tenant=tenant
     )
+    if funded:
+        await make_ledger_entry(db_session, tenant=tenant, delta_usd=Decimal("10"))
     await db_session.commit()
 
     hub_tenant = HubTenant(
@@ -83,11 +92,21 @@ async def _hub_app(
         tokens={_TOKEN: {"sub": "u1", "client_id": "c", "upstream_claims": claims}}
     )
 
+    mine = str(principal.account_id)
+
+    def _owner(session_id: str) -> str:
+        return _OTHER_ACCOUNT if session_id == _THEIR_HANDLE else mine
+
     router = build_turn_router(str(tenant.id))
     router.add(
         "GET",
         r"/v1/sessions/([^/]+)$",
-        lambda _r, m: session_response(session_id=m.group(1), status="idle", agent_id=AGENT_ID),
+        lambda _r, m: session_response(
+            session_id=m.group(1),
+            status="idle",
+            agent_id=AGENT_ID,
+            metadata={MA_METADATA_KEY_ACCOUNT: _owner(m.group(1))},
+        ),
     )
     router.add(
         "GET",
@@ -109,7 +128,13 @@ async def _hub_app(
     router.add(
         "GET",
         r"/v1/sessions$",
-        lambda _r, _m: list_response([_session_payload("ses_a"), _session_payload("ses_b")]),
+        lambda _r, _m: list_response(
+            [
+                _session_payload("ses_a", account_id=mine),
+                _session_payload(_THEIR_HANDLE, account_id=_OTHER_ACCOUNT),
+                _session_payload("ses_b", account_id=mine),
+            ]
+        ),
     )
     runtime = _runtime(build_fake_anthropic(router.dispatch), db_session_factory)
     mcp = build_hub_app(platform="discord", runtime=runtime, auth=auth, billing_config=None)
@@ -262,7 +287,9 @@ async def test_list_my_sessions_returns_the_callers_sessions(
     )
     structured = payload.get("structuredContent") or {}
     sessions = structured.get("result", structured) if isinstance(structured, dict) else structured
-    assert {s["id"] for s in sessions} == {"ses_a", "ses_b"}, f"got {sessions!r}"
+    assert {s["id"] for s in sessions} == {"ses_a", "ses_b"}, (
+        f"another member's session must not be listed as the caller's: {sessions!r}"
+    )
 
 
 async def test_list_my_sessions_rejects_a_daimon_id_outside_the_callers_tenants(
@@ -284,3 +311,56 @@ async def test_list_my_sessions_rejects_a_daimon_id_outside_the_callers_tenants(
         f"list_my_sessions must reject a daimon_id outside the caller's tenants, got {payload!r}"
     )
     assert "daimon not found" in str(payload.get("content")), f"got {payload!r}"
+
+
+@pytest.mark.parametrize(
+    ("tool", "arguments"),
+    [
+        ("get_session", {"handle": _THEIR_HANDLE}),
+        ("list_events", {"handle": _THEIR_HANDLE}),
+        ("continue_turn", {"handle": _THEIR_HANDLE, "message": "hi"}),
+        ("ask", {"handle": _THEIR_HANDLE, "message": "hi"}),
+    ],
+)
+async def test_handle_started_by_another_account_is_indistinguishable_from_unknown(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    tool: str,
+    arguments: dict[str, str],
+) -> None:
+    """Every workspace member shares the daimon, so agent ownership alone would let one
+    member read or continue another's conversation. The account check closes that, with
+    the same message as a nonexistent handle."""
+    mcp, daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+
+    result = await _call_tool(
+        app, "/mcp", _TOKEN, name=tool, arguments={"daimon_id": daimon_id, **arguments}
+    )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and payload.get("isError"), (
+        f"{tool} must reject a handle another account started, got {payload!r}"
+    )
+    assert "session not found" in str(payload.get("content")), f"got {payload!r}"
+
+
+@pytest.mark.parametrize("tool", ["ask", "start_turn", "continue_turn"])
+async def test_billed_tools_are_refused_before_the_turn_when_the_workspace_has_no_credit(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession], tool: str
+) -> None:
+    """The hub path runs the same balance gate as the per-agent tools; a depleted
+    workspace is turned away before any session is created or continued."""
+    mcp, daimon_id, _hub_tenant = await _hub_app(db_session, db_session_factory, funded=False)
+    app = mcp.http_app(path="/mcp", stateless_http=True, json_response=True)
+    arguments: dict[str, str] = {"daimon_id": daimon_id, "message": "hi"}
+    if tool == "continue_turn":
+        arguments["handle"] = _HANDLE
+
+    result = await _call_tool(app, "/mcp", _TOKEN, name=tool, arguments=arguments)
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and payload.get("isError"), (
+        f"{tool} must be refused for a workspace with no credit, got {payload!r}"
+    )
+    assert "credit is depleted" in str(payload.get("content")), f"got {payload!r}"

--- a/packages/adapters/mcp/tests/hub/test_tools.py
+++ b/packages/adapters/mcp/tests/hub/test_tools.py
@@ -41,7 +41,11 @@ def _runtime(client: AsyncAnthropic, session_factory: Any) -> McpRuntime:
     )
 
 
-def _agents_router(agents_by_tenant: dict[uuid.UUID, list[tuple[str, str]]]) -> MARouter:
+def _agents_router(
+    agents_by_tenant: dict[uuid.UUID, list[tuple[str, str]]],
+    listings: list[str] | None = None,
+) -> MARouter:
+    """``listings`` collects one entry per GET /v1/agents page request when given."""
     router = MARouter()
     payload = [
         make_ma_agent(
@@ -53,7 +57,13 @@ def _agents_router(agents_by_tenant: dict[uuid.UUID, list[tuple[str, str]]]) -> 
         for tid, agents in agents_by_tenant.items()
         for ma_id, name in agents
     ]
-    router.add("GET", r"/v1/agents", lambda _r, _m: list_response(payload))
+
+    def _list(_r: Any, _m: Any) -> Any:
+        if listings is not None:
+            listings.append("agents.list")
+        return list_response(payload)
+
+    router.add("GET", r"/v1/agents", _list)
     return router
 
 
@@ -98,6 +108,30 @@ async def test_list_daimons_spans_every_tenant_and_disambiguates_same_names(
         str(derive_agent_uuid(tenant_id=t2.tenant_id, ma_agent_id="ag_2")),
     }, f"ids must be the derived per-agent UUIDs, got {[d.id for d in daimons]!r}"
     assert daimons[0].platform == "discord" and daimons[0].role_summary.startswith("Answers ops")
+
+
+async def test_list_daimons_pages_the_org_once_however_many_tenants_the_caller_has(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    """The org agent listing is the expensive call; a login spanning several workspaces
+    must not pay for it once per workspace."""
+    hub = await _two_tenant_hub(db_session)
+    listings: list[str] = []
+    router = _agents_router(
+        {
+            hub.tenants[0].tenant_id: [("ag_1", "helper")],
+            hub.tenants[1].tenant_id: [("ag_2", "ops")],
+        },
+        listings,
+    )
+    runtime = _runtime(build_fake_anthropic(router.dispatch), db_session_factory)
+
+    daimons = await _list_daimons_impl(runtime, hub)
+
+    assert len(daimons) == 2, f"got {daimons!r}"
+    assert listings == ["agents.list"], (
+        f"expected one org listing for two tenants, got {len(listings)}"
+    )
 
 
 async def test_resolve_daimon_rejects_ids_outside_the_callers_tenants(

--- a/packages/adapters/mcp/tests/hub/test_tools.py
+++ b/packages/adapters/mcp/tests/hub/test_tools.py
@@ -21,9 +21,7 @@ from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.stores.domain import Role
 from daimon.testing.factories import make_platform_principal, make_tenant
 from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
-from factories import (
-    make_ma_agent,  # tests/tools/conftest.py sys.path shim; copy that shim into tests/hub/conftest.py
-)
+from factories import make_ma_agent
 from fastmcp.exceptions import ToolError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 

--- a/packages/adapters/mcp/tests/hub/test_tools.py
+++ b/packages/adapters/mcp/tests/hub/test_tools.py
@@ -1,0 +1,136 @@
+"""Hub tools address daimons by derived UUID and act as the caller's account in that tenant."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from anthropic import AsyncAnthropic
+from daimon.adapters.mcp.hub.identity import HubIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.hub import (  # pyright: ignore[reportPrivateUsage]
+    _auth_for,
+    _list_daimons_impl,
+    _resolve_daimon,
+)
+from daimon.core.defaults.loader import DeploymentDefault
+from daimon.core.hub_identity import HubTenant
+from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.stores.domain import Role
+from daimon.testing.factories import make_platform_principal, make_tenant
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from factories import (
+    make_ma_agent,  # tests/tools/conftest.py sys.path shim; copy that shim into tests/hub/conftest.py
+)
+from fastmcp.exceptions import ToolError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+def _runtime(client: AsyncAnthropic, session_factory: Any) -> McpRuntime:
+    settings = MagicMock()
+    settings.mcp.public_url = None
+    settings.mcp.jwt_secret = None
+    settings.github.fallback_pat = None
+    return McpRuntime(
+        session_factory=session_factory,
+        client=client,  # type: ignore[arg-type]
+        settings=settings,  # type: ignore[arg-type]
+        deployment_default=DeploymentDefault(environment_name="production"),
+    )
+
+
+def _agents_router(agents_by_tenant: dict[uuid.UUID, list[tuple[str, str]]]) -> MARouter:
+    router = MARouter()
+    payload = [
+        make_ma_agent(
+            id=ma_id,
+            name=name,
+            system="Answers ops questions",
+            metadata={"daimon_tenant": str(tid), "daimon_name": name},
+        ).model_dump(mode="json")
+        for tid, agents in agents_by_tenant.items()
+        for ma_id, name in agents
+    ]
+    router.add("GET", r"/v1/agents", lambda _r, _m: list_response(payload))
+    return router
+
+
+async def _two_tenant_hub(db_session: AsyncSession) -> HubIdentity:
+    t1 = await make_tenant(db_session, platform="discord", workspace_id="g1")
+    t2 = await make_tenant(db_session, platform="discord", workspace_id="g2")
+    p1 = await make_platform_principal(db_session, platform="discord", external_id="u1", tenant=t1)
+    p2 = await make_platform_principal(db_session, platform="discord", external_id="u1", tenant=t2)
+    await db_session.commit()
+    return HubIdentity(
+        platform="discord",
+        platform_user_id="u1",
+        tenants=(
+            HubTenant(
+                tenant_id=t1.id, account_id=p1.account_id, workspace_id="g1", workspace_name="PyMC"
+            ),
+            HubTenant(
+                tenant_id=t2.id, account_id=p2.account_id, workspace_id="g2", workspace_name="Bayes"
+            ),
+        ),
+    )
+
+
+async def test_list_daimons_spans_every_tenant_and_disambiguates_same_names(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    hub = await _two_tenant_hub(db_session)
+    t1, t2 = hub.tenants
+    client = build_fake_anthropic(
+        _agents_router(
+            {t1.tenant_id: [("ag_1", "helper")], t2.tenant_id: [("ag_2", "helper")]}
+        ).dispatch
+    )
+
+    daimons = await _list_daimons_impl(_runtime(client, db_session_factory), hub)
+
+    assert [(d.name, d.workspace) for d in daimons] == [("helper", "Bayes"), ("helper", "PyMC")], (
+        f"got {daimons!r}"
+    )
+    assert {d.id for d in daimons} == {
+        str(derive_agent_uuid(tenant_id=t1.tenant_id, ma_agent_id="ag_1")),
+        str(derive_agent_uuid(tenant_id=t2.tenant_id, ma_agent_id="ag_2")),
+    }, f"ids must be the derived per-agent UUIDs, got {[d.id for d in daimons]!r}"
+    assert daimons[0].platform == "discord" and daimons[0].role_summary.startswith("Answers ops")
+
+
+async def test_resolve_daimon_rejects_ids_outside_the_callers_tenants(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    hub = await _two_tenant_hub(db_session)
+    t1, _ = hub.tenants
+    client = build_fake_anthropic(_agents_router({t1.tenant_id: [("ag_1", "helper")]}).dispatch)
+    runtime = _runtime(client, db_session_factory)
+
+    foreign = derive_agent_uuid(tenant_id=uuid.uuid4(), ma_agent_id="ag_1")
+    with pytest.raises(ToolError, match="daimon not found"):
+        await _resolve_daimon(runtime, hub, str(foreign))
+    with pytest.raises(ToolError, match="daimon not found"):
+        await _resolve_daimon(runtime, hub, "not-a-uuid")
+
+
+async def test_auth_for_acts_as_the_callers_account_in_that_tenant(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    hub = await _two_tenant_hub(db_session)
+    t1, _ = hub.tenants
+    client = build_fake_anthropic(_agents_router({t1.tenant_id: [("ag_1", "helper")]}).dispatch)
+    runtime = _runtime(client, db_session_factory)
+
+    tenant, agent = await _resolve_daimon(
+        runtime, hub, str(derive_agent_uuid(tenant_id=t1.tenant_id, ma_agent_id="ag_1"))
+    )
+    auth = await _auth_for(runtime, hub, tenant, agent)
+
+    assert auth.account_id == t1.account_id and auth.tenant_id == t1.tenant_id, f"got {auth!r}"
+    assert auth.agent_id == derive_agent_uuid(tenant_id=t1.tenant_id, ma_agent_id="ag_1")
+    assert auth.platform == "discord" and auth.platform_user_id == "u1" and auth.external_id == "g1"
+    assert auth.role is Role.USER and auth.is_admin is False, "hub identities never carry admin"

--- a/packages/adapters/mcp/tests/hub/test_turn_parity.py
+++ b/packages/adapters/mcp/tests/hub/test_turn_parity.py
@@ -1,0 +1,388 @@
+"""A hub ask bills the same usage event a chat turn does, against the addressed tenant."""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import (
+    BetaEnvironment,
+    BetaManagedAgentsAgent,
+    BetaManagedAgentsSession,
+)
+from anthropic.types.beta.beta_managed_agents_model_config import BetaManagedAgentsModelConfig
+from anthropic.types.beta.sessions.beta_managed_agents_agent_message_event import (
+    BetaManagedAgentsAgentMessageEvent,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_session_end_turn import (
+    BetaManagedAgentsSessionEndTurn,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_session_status_idle_event import (
+    BetaManagedAgentsSessionStatusIdleEvent,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_span_model_request_end_event import (
+    BetaManagedAgentsSpanModelRequestEndEvent,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_span_model_usage import (
+    BetaManagedAgentsSpanModelUsage,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_text_block import (
+    BetaManagedAgentsTextBlock,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_user_message_event import (
+    BetaManagedAgentsUserMessageEvent,
+)
+from daimon.adapters.mcp.hub.app import build_hub_app
+from daimon.adapters.mcp.hub.claims import encode_hub_claims
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    HubSettings,
+    McpSettings,
+    Settings,
+)
+from daimon.core.defaults.loader import DeploymentDefault
+from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
+from daimon.core.hub_identity import HubTenant
+from daimon.core.ma_identity import derive_agent_uuid
+from daimon.testing.factories import make_ledger_entry, make_platform_principal, make_tenant
+from daimon.testing.ma import (
+    EMPTY_CLOUD_CONFIG,
+    MARouter,
+    build_fake_anthropic,
+    list_response,
+    send_events_response,
+    session_response,
+    sse_response,
+)
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from pydantic import PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.applications import Starlette
+
+pytestmark = pytest.mark.asyncio
+
+_TOKEN = "tok"
+
+# build_turn_router and its constants are copied from tests/parity/conftest.py
+# (repo root) rather than imported: this suite runs under
+# `--import-mode=importlib` and, collected on its own (`pytest
+# packages/adapters/mcp/tests/hub`), never gives pytest a reason to add the
+# repo root to sys.path, so `from tests.parity.conftest import ...` is not
+# resolvable here. Keep this in sync with the original if it changes.
+AGENT_TEXT = "Hello from the agent!"
+AGENT_ID = "ag_parity_test"
+ENV_ID = "env_parity_test"
+MODEL_ID = "claude-sonnet-4-6"
+
+
+def build_turn_router(
+    tenant_id_str: str,
+    *,
+    agent_id: str = AGENT_ID,
+    env_id: str = ENV_ID,
+    model_id: str = MODEL_ID,
+    agent_text: str = AGENT_TEXT,
+    usage_event_id: str = "evt_parity_usage",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+) -> MARouter:
+    """Build a MARouter handling agent/environment resolution + a turn SSE stream.
+
+    Copied verbatim from ``tests/parity/conftest.py`` -- see the module
+    docstring above for why this isn't an import.
+    """
+    agent_item = BetaManagedAgentsAgent(
+        id=agent_id,
+        type="agent",
+        name="test-agent",
+        model=BetaManagedAgentsModelConfig(id=model_id),
+        metadata={
+            MA_METADATA_KEY_TENANT: tenant_id_str,
+            MA_METADATA_KEY_NAME: "test-agent",
+        },
+        description=None,
+        created_at="2026-06-14T00:00:00Z",  # pyright: ignore[reportArgumentType]
+        updated_at="2026-06-14T00:00:00Z",  # pyright: ignore[reportArgumentType]
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system=None,
+    ).model_dump(mode="json")
+
+    env_item = BetaEnvironment(
+        id=env_id,
+        type="environment",
+        name="test-env",
+        config=EMPTY_CLOUD_CONFIG,
+        metadata={
+            MA_METADATA_KEY_TENANT: tenant_id_str,
+            MA_METADATA_KEY_NAME: "test-env",
+        },
+        description="",
+        created_at="2026-06-14T00:00:00Z",
+        updated_at="2026-06-14T00:00:00Z",
+    ).model_dump(mode="json")
+
+    now = datetime.now(UTC)
+    agent_message_event = BetaManagedAgentsAgentMessageEvent(
+        id="evt_parity_msg",
+        type="agent.message",
+        processed_at=now,
+        content=[BetaManagedAgentsTextBlock(type="text", text=agent_text)],
+    ).model_dump(mode="json")
+
+    model_request_end_event = BetaManagedAgentsSpanModelRequestEndEvent(
+        id=usage_event_id,
+        is_error=False,
+        model_request_start_id="start_parity",
+        model_usage=BetaManagedAgentsSpanModelUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        ),
+        processed_at=now,
+        type="span.model_request_end",
+    ).model_dump(mode="json")
+
+    idle_event = BetaManagedAgentsSessionStatusIdleEvent(
+        id="evt_parity_idle",
+        type="session.status_idle",
+        processed_at=now,
+        stop_reason=BetaManagedAgentsSessionEndTurn(type="end_turn"),
+    ).model_dump(mode="json")
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([agent_item]))
+    router.add(
+        "GET",
+        r"/v1/agents/[^/]+",
+        lambda req, _m: httpx.Response(200, json=agent_item),
+    )
+    router.add("GET", r"/v1/environments", lambda req, _m: list_response([env_item]))
+    router.add(
+        "GET",
+        r"/v1/environments/[^/]+",
+        lambda req, _m: httpx.Response(200, json=env_item),
+    )
+    router.add(
+        "POST",
+        r"/v1/sessions/[^/]+/events",
+        lambda req, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_hub_boundary",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="hello")],
+                    type="user.message",
+                    processed_at=datetime(2026, 9, 6, tzinfo=UTC),
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add(
+        "GET",
+        r"/v1/sessions/[^/]+/events/stream",
+        lambda req, _m: sse_response([agent_message_event, model_request_end_event, idle_event]),
+    )
+    return router
+
+
+def _runtime(client: AsyncAnthropic, session_factory: Any) -> McpRuntime:
+    """Mirrors ``test_tools._runtime`` but pins ``environment_name`` to
+    ``"test-env"``, matching the environment tag ``build_turn_router`` bakes into
+    its fake MA data. ``test_tools._runtime``'s ``"production"`` default is fine
+    over there because none of those tests drive environment resolution; this
+    one runs a real turn through ``_ask_impl``, which does.
+    """
+    settings = Settings(
+        database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+        anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+        mcp=McpSettings(public_url=None, jwt_secret=None),
+        hub=HubSettings(),
+    )
+    return McpRuntime(
+        session_factory=session_factory,
+        client=client,  # type: ignore[arg-type]
+        settings=settings,
+        deployment_default=DeploymentDefault(environment_name="test-env"),
+    )
+
+
+@asynccontextmanager
+async def _lifespan(app: Starlette):
+    async with app.router.lifespan_context(app):
+        yield
+
+
+async def _call_tool(
+    app: Starlette, path: str, token: str, *, name: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Drive one MCP tool call over HTTP through the real hub app, auth middleware included."""
+    async with (
+        _lifespan(app),
+        httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c,
+    ):
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+        init = await c.post(
+            path,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "t", "version": "0"},
+                },
+            },
+        )
+        assert init.status_code == 200, init.text
+        resp = await c.post(
+            path,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()  # type: ignore[return-value]
+
+
+def _fake_session_for(kwargs: dict[str, Any]) -> BetaManagedAgentsSession:
+    """A ``BetaManagedAgentsSession`` shaped like ``create_session``'s real return.
+
+    Same shape ``tests/tools/test_agent_chat.py::_make_fake_session`` builds
+    (~line 116), except ``agent.id`` is pinned to ``AGENT_ID`` so
+    ``_verify_agent_owns_session``'s ownership check passes.
+    """
+    return BetaManagedAgentsSession.model_validate(
+        {
+            "id": "ses_hub_parity",
+            "type": "session",
+            "agent": {
+                "id": AGENT_ID,
+                "name": "test-agent",
+                "version": 1,
+                "type": "agent",
+                "model": {"id": "claude-sonnet-4-6"},
+                "mcp_servers": [],
+                "skills": [],
+                "tools": [],
+            },
+            "archived_at": None,
+            "created_at": "2026-06-23T00:00:00Z",
+            "updated_at": "2026-06-23T00:00:00Z",
+            "outcome_evaluations": [],
+            "environment_id": "env_parity_test",
+            "metadata": {},
+            "resources": [],
+            "stats": {},
+            "status": "running",
+            "title": None,
+            "usage": {},
+            "vault_ids": [],
+        }
+    )
+
+
+async def test_hub_ask_creates_session_under_callers_account_in_that_tenant(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="g1")
+    principal = await make_platform_principal(
+        db_session, platform="discord", external_id="u1", tenant=tenant
+    )
+    # A hub ask runs through the real admission gate (_admit), which denies a
+    # zero-balance tenant. Top up so the turn actually reaches create_session.
+    await make_ledger_entry(db_session, tenant=tenant, delta_usd=Decimal("10"))
+    await db_session.commit()
+
+    hub_tenant = HubTenant(
+        tenant_id=tenant.id,
+        account_id=principal.account_id,
+        workspace_id="g1",
+        workspace_name="PyMC",
+    )
+    claims = encode_hub_claims(platform="discord", platform_user_id="u1", tenants=[hub_tenant])
+    auth = StaticTokenVerifier(
+        tokens={_TOKEN: {"sub": "u1", "client_id": "c", "upstream_claims": claims}}
+    )
+
+    router = build_turn_router(str(tenant.id))
+    # build_turn_router wires the SSE-stream turn path the Discord/Slack driver
+    # consumes; the MCP ask tool instead polls GET /v1/sessions/{id} and reads
+    # GET /v1/sessions/{id}/events directly, as the round-trip test in
+    # test_agent_chat.py does, so those two routes are added on top.
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)$",
+        lambda _r, m: session_response(session_id=m.group(1), status="idle", agent_id=AGENT_ID),
+    )
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)/events$",
+        lambda _r, _m: httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "sevt_hub_msg",
+                        "type": "agent.message",
+                        "content": [{"type": "text", "text": "Hello from the agent!"}],
+                    }
+                ],
+                "next_page": None,
+            },
+        ),
+    )
+    runtime = _runtime(build_fake_anthropic(router.dispatch), db_session_factory)
+    mcp = build_hub_app(platform="discord", runtime=runtime, auth=auth, billing_config=None)
+
+    daimon_id = str(derive_agent_uuid(tenant_id=tenant.id, ma_agent_id=AGENT_ID))
+
+    create_session = AsyncMock(side_effect=lambda *a, **kw: _fake_session_for(kw))
+    with patch("daimon.adapters.mcp.tools.agent_chat.create_session", new=create_session):
+        result = await _call_tool(
+            mcp.http_app(path="/mcp", stateless_http=True, json_response=True),
+            "/mcp",
+            _TOKEN,
+            name="ask",
+            arguments={"daimon_id": daimon_id, "message": "status?"},
+        )
+
+    payload = result.get("result", result)
+    assert isinstance(payload, dict) and not payload.get("isError"), (
+        f"ask tool call over the hub app failed: {payload!r}"
+    )
+
+    create_session.assert_awaited_once()
+    kwargs = create_session.await_args.kwargs
+    assert kwargs["account_id"] == principal.account_id and kwargs["tenant_id"] == tenant.id, (
+        f"session must be created as the caller's account in the addressed tenant, got {kwargs!r}"
+    )
+    assert kwargs["agent_uuid"] == uuid.UUID(daimon_id), (
+        f"session must be tagged with the addressed daimon's derived uuid, got {kwargs!r}"
+    )
+
+    structured = payload.get("structuredContent") or {}
+    assert structured.get("message") == "Hello from the agent!", (
+        f"ask must surface the agent's reply text, got {payload!r}"
+    )

--- a/packages/adapters/mcp/tests/hub/test_turn_parity.py
+++ b/packages/adapters/mcp/tests/hub/test_turn_parity.py
@@ -1,9 +1,12 @@
-"""A hub ask bills the same usage event a chat turn does, against the addressed tenant."""
+"""A hub ask creates its MA session as the caller's account in the addressed tenant,
+the same attribution a chat driver's turn carries. MCP turns record no usage row today
+(that write happens only in the Discord/Slack SSE-driven ``run_turn`` path), so billing
+parity itself isn't something this test can verify -- only the attribution that would
+feed it."""
 
 from __future__ import annotations
 
 import uuid
-from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -67,6 +70,8 @@ from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from pydantic import PostgresDsn, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.applications import Starlette
+
+from .test_app import _lifespan
 
 pytestmark = pytest.mark.asyncio
 
@@ -216,12 +221,6 @@ def _runtime(client: AsyncAnthropic, session_factory: Any) -> McpRuntime:
         settings=settings,
         deployment_default=DeploymentDefault(environment_name="test-env"),
     )
-
-
-@asynccontextmanager
-async def _lifespan(app: Starlette):
-    async with app.router.lifespan_context(app):
-        yield
 
 
 async def _call_tool(

--- a/packages/adapters/mcp/tests/test_tool_schema_snapshot.py
+++ b/packages/adapters/mcp/tests/test_tool_schema_snapshot.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import pytest
 from cryptography.fernet import Fernet
+from daimon.adapters.mcp.hub.app import build_hub_app
+from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.server import create_mcp_app
 from daimon.core.config import (
     AnthropicSettings,
@@ -29,6 +31,7 @@ from daimon.core.config import (
     Settings,
     SlackSettings,
 )
+from daimon.core.defaults.loader import DeploymentDefault
 from daimon.testing.ma import build_stub_anthropic
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from pydantic import HttpUrl, PostgresDsn, SecretStr
@@ -121,6 +124,48 @@ async def test_rendered_tool_schema_matches_snapshot(
     assert not missing, f"expected tool group(s) missing from the rendered registry: {missing}"
 
     assert rendered == snapshot, "rendered tool schema drifted from the committed snapshot"
+
+
+async def test_rendered_hub_tool_schema_matches_snapshot(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """The hub mounts render a different surface from ``/mcp`` — a smaller tool
+    set, tool descriptions written for a coding-agent client, and server
+    instructions that tell it to call list_daimons first. The instructions are
+    part of the snapshot because they are prompt text the model reads, and
+    nothing else pins them."""
+    mcp = build_hub_app(
+        platform="discord",
+        runtime=McpRuntime(
+            session_factory=sessionmaker,
+            client=build_stub_anthropic(),
+            settings=_fully_configured_settings(),
+            deployment_default=DeploymentDefault(environment_name=None),
+        ),
+        auth=StaticTokenVerifier(tokens={}),
+        billing_config=None,
+    )
+    tools = await mcp.local_provider.list_tools()
+
+    rendered: dict[str, object] = {
+        "instructions": mcp.instructions,
+        "tools": dict(
+            sorted(
+                (
+                    tool.name,
+                    {
+                        "description": _strip_trailing_whitespace(tool.description),
+                        "parameters": tool.parameters,
+                    },
+                )
+                for tool in tools
+            )
+        ),
+    }
+
+    assert rendered["tools"], "the hub tool registry must not be empty"
+    assert rendered == snapshot, "rendered hub tool schema drifted from the committed snapshot"
 
 
 def _non_null_branch(container: dict[str, Any]) -> dict[str, Any]:

--- a/packages/adapters/mcp/tests/test_verifier.py
+++ b/packages/adapters/mcp/tests/test_verifier.py
@@ -202,3 +202,24 @@ async def test_verifier_rejects_malformed_jti_string(
     assert result is None, (
         "verify_token must return None (fail-closed) when jti is present but not a valid UUID"
     )
+
+
+async def test_verifier_rejects_a_hub_login_token_signed_with_the_same_secret(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A hub mount's token carries no account subject, only the login's tenant map, so
+    even one signed with this verifier's secret must not open the per-agent surface."""
+    token = pyjwt.encode(
+        {
+            "iss": "https://example.test/slack",
+            "aud": "https://example.test/slack/mcp",
+            "iat": 0,
+            "upstream_claims": {"platform": "slack", "platform_user_id": "U1", "tenants": []},
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+
+    verifier = DaimonJWTVerifier(secret=SECRET, sessionmaker=sessionmaker)
+    result = await verifier.verify_token(token)
+    assert result is None, "a token without an account sub must be rejected by the /mcp verifier"

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -622,6 +622,13 @@ async def test_start_turn_then_poll_get_session_and_read_transcript(
     )
 
 
+def _started(
+    handle: str, *, at: dt.datetime = dt.datetime(2026, 6, 23, 0, 0, tzinfo=dt.UTC)
+) -> dict[str, str]:
+    """The three-key shape start_turn/continue_turn return: handle plus turn boundary."""
+    return {"handle": handle, "turn_event_id": "sevt_boundary", "turn_started_at": at.isoformat()}
+
+
 async def test_ask_delivers_embedded_charts_without_artifact_settings() -> None:
     runtime = MagicMock()
     runtime.settings.artifacts = None
@@ -644,7 +651,7 @@ async def test_ask_delivers_embedded_charts_without_artifact_settings() -> None:
     with (
         patch(
             "daimon.adapters.mcp.tools.agent_chat._start_turn_impl",
-            new=AsyncMock(return_value={"handle": "ses_ask001"}),
+            new=AsyncMock(return_value=_started("ses_ask001", at=turn_started_at)),
         ),
         patch(
             "daimon.adapters.mcp.tools.agent_chat._get_session_impl",
@@ -704,7 +711,7 @@ async def test_ask_timeout_preserves_the_resumable_handle() -> None:
     with (
         patch(
             "daimon.adapters.mcp.tools.agent_chat._start_turn_impl",
-            new=AsyncMock(return_value={"handle": "ses_slow001"}),
+            new=AsyncMock(return_value=_started("ses_slow001")),
         ),
         patch(
             "daimon.adapters.mcp.tools.agent_chat._get_session_impl",
@@ -738,7 +745,7 @@ async def test_ask_surfaces_terminal_non_idle_status_without_waiting() -> None:
     with (
         patch(
             "daimon.adapters.mcp.tools.agent_chat._start_turn_impl",
-            new=AsyncMock(return_value={"handle": "ses_terminated001"}),
+            new=AsyncMock(return_value=_started("ses_terminated001")),
         ),
         patch(
             "daimon.adapters.mcp.tools.agent_chat._get_session_impl",
@@ -839,7 +846,7 @@ async def test_ask_keeps_polling_through_an_unmodeled_transient_status() -> None
     with (
         patch(
             "daimon.adapters.mcp.tools.agent_chat._start_turn_impl",
-            new=AsyncMock(return_value={"handle": "ses_queued001"}),
+            new=AsyncMock(return_value=_started("ses_queued001")),
         ),
         patch(
             "daimon.adapters.mcp.tools.agent_chat._get_session_impl",
@@ -2929,3 +2936,49 @@ async def test_ask_with_handle_continues_instead_of_starting(
         f"got {result!r} sent={sent!r}"
     )
     assert result.message == "done", f"got {result.message!r}"
+
+
+async def test_ask_with_handle_reads_only_this_turns_reply(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A resumed session is already idle and still holds the previous answer; ask must
+    read from this turn's boundary, not the newest agent.message in the transcript."""
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, m: httpx.Response(
+            200, json=_make_fake_session(session_id=m.group(1), status="idle")
+        ),
+    )
+    router.add(
+        "POST",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_continue_boundary",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="and then?")],
+                    type="user.message",
+                    processed_at=dt.datetime(2026, 6, 23, 0, 0, tzinfo=dt.UTC),
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+
+    def _events(r: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        bounded = "created_at[gte]" in r.url.params
+        text = "this turn" if bounded else "previous turn"
+        return httpx.Response(
+            200, json={"data": [_make_agent_message_event(text)], "next_page": None}
+        )
+
+    router.add("GET", r"/v1/sessions/([^/]+)/events", _events)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+
+    result = await _ask_impl(runtime, _auth(), "and then?", handle="sess_existing")
+
+    assert result.message == "this turn", (
+        f"ask returned the transcript's newest message instead of this turn's: {result!r}"
+    )

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -2835,3 +2835,97 @@ async def test_get_turn_cost_rejects_a_sibling_agents_session_and_lists_no_event
         )
 
     assert events_calls == [], "a rejected ownership check must issue no events.list call"
+
+
+# ---------------------------------------------------------------------------
+# Task 8: AgentDescription platform fields and ask resume via handle
+# ---------------------------------------------------------------------------
+
+
+async def test_describe_agent_reports_platform_and_workspace_id(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """describe_agent surfaces the auth claim's platform and external_id as workspace_id."""
+    client = build_fake_anthropic(_describe_agent_router().dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(),
+        tenant_id=_TENANT_ID,
+        role=Role.USER,
+        agent_id=_AGENT_UUID,
+        platform="discord",
+        external_id="guild-1",
+    )
+
+    description = await _describe_agent_impl(runtime, auth)
+
+    assert description.platform == "discord", f"got {description.platform!r}"
+    assert description.workspace_id == "guild-1", f"got {description.workspace_id!r}"
+    assert description.workspace is None, "the JWT surface has no workspace name to report"
+
+
+async def test_ask_with_handle_continues_instead_of_starting(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """With a handle, ask sends continue_turn on that session and never creates a new one."""
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _r, _m: list_response(
+            [
+                make_ma_agent(
+                    id=_MA_AGENT_ID,
+                    name="test-agent",
+                    metadata={
+                        "daimon_tenant": str(_TENANT_ID),
+                        "daimon_name": "test-agent",
+                    },
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, m: httpx.Response(
+            200, json=_make_fake_session(session_id=m.group(1), status="idle")
+        ),
+    )
+    sent: list[str] = []
+
+    def _send(r: httpx.Request, m: re.Match[str]) -> httpx.Response:
+        sent.append(m.group(1))
+        return send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_continue_boundary",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="follow up")],
+                    type="user.message",
+                    processed_at=dt.datetime(2026, 6, 23, 0, 0, tzinfo=dt.UTC),
+                ).model_dump(mode="json")
+            ]
+        )
+
+    router.add("POST", r"/v1/sessions/([^/]+)/events", _send)
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: httpx.Response(
+            200,
+            json={"data": [_make_agent_message_event("done")], "next_page": None},
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+
+    with patch(
+        "daimon.adapters.mcp.tools.agent_chat.create_session",
+        new=AsyncMock(side_effect=AssertionError("must not create")),
+    ):
+        result = await _ask_impl(runtime, _auth(), "follow up", handle="sess_existing")
+
+    assert result.handle == "sess_existing" and sent == ["sess_existing"], (
+        f"got {result!r} sent={sent!r}"
+    )
+    assert result.message == "done", f"got {result.message!r}"

--- a/packages/adapters/mcp/tests/tools/test_ctx_admit.py
+++ b/packages/adapters/mcp/tests/tools/test_ctx_admit.py
@@ -1,0 +1,35 @@
+"""_admit is the identity-taking core of the admission gate."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.tools._ctx import _admit  # pyright: ignore[reportPrivateUsage]
+from daimon.core.stores.domain import Role
+from fastmcp.exceptions import ToolError
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_admit_denies_when_over_balance() -> None:
+    auth = AuthIdentity(
+        account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.USER, platform_user_id="u1"
+    )
+    with (
+        patch("daimon.adapters.mcp.tools._ctx.is_over_balance", new=AsyncMock(return_value=True)),
+        pytest.raises(ToolError, match="credit is depleted"),
+    ):
+        await _admit(auth, sessionmaker=AsyncMock(), billing_config=None, tool_name="ask")
+
+
+async def test_admit_skips_billing_for_internal_identity() -> None:
+    auth = AuthIdentity(account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.USER)
+    with patch(
+        "daimon.adapters.mcp.tools._ctx.is_over_balance",
+        new=AsyncMock(side_effect=AssertionError("must not check")),
+    ):
+        result = await _admit(auth, sessionmaker=AsyncMock(), billing_config=None, tool_name="ask")
+    assert result is auth

--- a/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
+++ b/packages/adapters/scheduler/daimon/adapters/scheduler/main.py
@@ -42,6 +42,7 @@ from daimon.core.defaults.provisioning import reconcile_tenant_defaults
 from daimon.core.github_credentials import build_multifernet
 from daimon.core.headless_runner import run_turn
 from daimon.core.health import start_liveness_responder
+from daimon.core.hub_oauth_kv_sweep import sweep_expired_hub_oauth_kv
 from daimon.core.logging_setup import configure_log_level
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.ma_resolver import (
@@ -337,6 +338,16 @@ async def _sweep_slack_event_dedup(sm: async_sessionmaker[AsyncSession]) -> None
         log.exception("scheduler.slack_event_dedup_sweep.failed")
 
 
+async def _sweep_hub_oauth_kv(sm: async_sessionmaker[AsyncSession]) -> None:
+    """Prune expired hub login rows once. Boundary catch: a sweep failure
+    must not kill the scheduler loop; the next tick retries. No upstream call.
+    """
+    try:
+        await sweep_expired_hub_oauth_kv(sm, now=datetime.now(UTC))
+    except SQLAlchemyError:
+        log.exception("scheduler.hub_oauth_kv_sweep.failed")
+
+
 def _validate_mcp_settings(settings: Settings) -> None:
     """Single-tenant deployments require both ``settings.mcp.jwt_secret`` and
     ``settings.mcp.public_url`` so each routine fire can bind the daimon-mcp
@@ -456,6 +467,7 @@ async def run(
             await _sweep_headless_usage(client, sm, markup=settings.billing.markup)
             await _sweep_wizard_sessions(sm)
             await _sweep_slack_event_dedup(sm)
+            await _sweep_hub_oauth_kv(sm)
             return 0
 
         while not stop_event.is_set():
@@ -472,6 +484,7 @@ async def run(
             await _sweep_headless_usage(client, sm, markup=settings.billing.markup)
             await _sweep_wizard_sessions(sm)
             await _sweep_slack_event_dedup(sm)
+            await _sweep_hub_oauth_kv(sm)
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(
                     stop_event.wait(), timeout=scheduler_settings.tick_interval_s

--- a/packages/core/alembic/versions/0013_hub_oauth_kv.py
+++ b/packages/core/alembic/versions/0013_hub_oauth_kv.py
@@ -1,0 +1,44 @@
+"""Back the hub login proxies with a Postgres key-value table so logins
+survive restarts and replicas.
+
+Revision ID: 0013_hub_oauth_kv
+Revises: 0012_support_escalations
+Create Date: 2026-09-06
+
+downgrade: safe
+
+The column set mirrors what py-key-value-aio's PostgreSQLStore creates for
+itself, because that store reads and writes the table directly. It is created
+here rather than by the store's auto_create so the schema stays under Alembic
+like every other table.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0013_hub_oauth_kv"
+down_revision: str | None = "0012_support_escalations"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hub_oauth_kv",
+        sa.Column("collection", sa.Text(), nullable=False),
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("value", postgresql.JSONB(), nullable=False),
+        sa.Column("ttl", sa.Double(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("collection", "key"),
+    )
+    op.create_index("idx_hub_oauth_kv_expires_at", "hub_oauth_kv", ["expires_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_hub_oauth_kv_expires_at", table_name="hub_oauth_kv")
+    op.drop_table("hub_oauth_kv")

--- a/packages/core/alembic/versions/0013_hub_oauth_kv.py
+++ b/packages/core/alembic/versions/0013_hub_oauth_kv.py
@@ -36,9 +36,9 @@ def upgrade() -> None:
         sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
         sa.PrimaryKeyConstraint("collection", "key"),
     )
-    op.create_index("idx_hub_oauth_kv_expires_at", "hub_oauth_kv", ["expires_at"])
+    op.create_index("ix_hub_oauth_kv_expires_at", "hub_oauth_kv", ["expires_at"])
 
 
 def downgrade() -> None:
-    op.drop_index("idx_hub_oauth_kv_expires_at", table_name="hub_oauth_kv")
+    op.drop_index("ix_hub_oauth_kv_expires_at", table_name="hub_oauth_kv")
     op.drop_table("hub_oauth_kv")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -1215,7 +1215,7 @@ class HubOAuthKv(Base):
     Column shape is dictated by ``key_value.aio.stores.postgresql.PostgreSQLStore``,
     which reads and writes this table directly over asyncpg; daimon only ever
     deletes expired rows through ``stores.hub_oauth_kv``. Collections are
-    prefixed per platform (``slack.``, ``discord.``) by the adapter.
+    prefixed per platform (``slack__``, ``discord__``) by the adapter.
     """
 
     __tablename__ = "hub_oauth_kv"

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -1216,6 +1216,11 @@ class HubOAuthKv(Base):
     which reads and writes this table directly over asyncpg; daimon only ever
     deletes expired rows through ``stores.hub_oauth_kv``. Collections are
     prefixed per platform (``slack__``, ``discord__``) by the adapter.
+
+    Rows hold encrypted upstream access tokens but are keyed by the proxy's
+    own identifiers, not by account, so an account purge cannot address them.
+    Retention is bounded instead: every row carries a TTL no longer than the
+    upstream token's lifetime and the scheduled sweep deletes it once expired.
     """
 
     __tablename__ = "hub_oauth_kv"

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     DateTime,
+    Double,
     ForeignKey,
     ForeignKeyConstraint,
     Index,
@@ -1205,4 +1206,25 @@ class SupportEscalation(Base):
     delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class HubOAuthKv(Base):
+    """Backing table for the hub login proxies' key-value store.
+
+    Column shape is dictated by ``key_value.aio.stores.postgresql.PostgreSQLStore``,
+    which reads and writes this table directly over asyncpg; daimon only ever
+    deletes expired rows through ``stores.hub_oauth_kv``. Collections are
+    prefixed per platform (``slack.``, ``discord.``) by the adapter.
+    """
+
+    __tablename__ = "hub_oauth_kv"
+
+    collection: Mapped[str] = mapped_column(Text, primary_key=True)
+    key: Mapped[str] = mapped_column(Text, primary_key=True)
+    value: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    ttl: Mapped[float | None] = mapped_column(Double, nullable=True)
+    created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
     )

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -180,6 +180,19 @@ class HubSettings(BaseModel):
         default=None,
         description="Discord OAuth app client secret for the /discord/mcp login mount.",
     )
+    allowed_client_redirect_uris: list[str] = Field(
+        default=[
+            "http://localhost:*",
+            "http://127.0.0.1:*",
+            "https://claude.ai/*",
+            "https://claude.com/*",
+        ],
+        description=(
+            "Redirect URI patterns an MCP client may register with the hub login "
+            "mounts (wildcards allowed). Defaults cover coding agents on loopback "
+            "and claude.ai; widen only for a client you operate."
+        ),
+    )
     jwt_signing_key: SecretStr | None = Field(
         default=None,
         description=(

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -142,6 +142,9 @@ class McpSettings(BaseModel):
         return str(self.public_url).rstrip("/").removesuffix("/mcp").rstrip("/")
 
 
+_HUB_SIGNING_KEY_BYTES = 32
+
+
 class HubSettings(BaseModel):
     """OAuth-login MCP mounts for coding-agent clients.
 
@@ -173,9 +176,34 @@ class HubSettings(BaseModel):
         default=None,
         description=(
             "Base64url 32-byte key that signs hub login tokens. Required when "
-            "any hub mount is configured. Generate with Fernet.generate_key()."
+            "any hub mount is configured, and rejected at boot unless it "
+            "decodes to exactly 32 bytes. Generate with Fernet.generate_key()."
         ),
     )
+
+    @field_validator("jwt_signing_key")
+    @classmethod
+    def _check_signing_key(cls, value: SecretStr | None) -> SecretStr | None:
+        """Reject anything but a 32-byte base64url key.
+
+        FastMCP derives an HS256 secret and warns about short keys only for a
+        ``str`` secret; the proxy is handed ``bytes``, which it uses raw. A
+        passphrase would therefore be accepted silently as the signing secret.
+        """
+        if value is None:
+            return value
+        try:
+            decoded = base64.urlsafe_b64decode(value.get_secret_value())
+        except (binascii.Error, ValueError):
+            decoded = b""
+        if len(decoded) != _HUB_SIGNING_KEY_BYTES:
+            raise ValueError(
+                "DAIMON_HUB__JWT_SIGNING_KEY must be a base64url-encoded "
+                f"{_HUB_SIGNING_KEY_BYTES}-byte key; generate one with "
+                "python -c 'from cryptography.fernet import Fernet; "
+                "print(Fernet.generate_key().decode())'"
+            )
+        return value
 
     @property
     def slack_configured(self) -> bool:

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -142,6 +142,50 @@ class McpSettings(BaseModel):
         return str(self.public_url).rstrip("/").removesuffix("/mcp").rstrip("/")
 
 
+class HubSettings(BaseModel):
+    """OAuth-login MCP mounts for coding-agent clients.
+
+    A platform's mount appears only when both its client id and secret are
+    set; a deployment that sets neither runs exactly as before. The signing
+    key is shared by both mounts and must be a base64url 32-byte key, the same
+    shape as a Fernet key, so the proxy uses it directly rather than deriving
+    one from the client secret (rotating a client secret would otherwise
+    invalidate every issued login).
+    """
+
+    slack_client_id: str | None = Field(
+        default=None,
+        description="Slack OAuth app client ID for the /slack/mcp login mount.",
+    )
+    slack_client_secret: SecretStr | None = Field(
+        default=None,
+        description="Slack OAuth app client secret for the /slack/mcp login mount.",
+    )
+    discord_client_id: str | None = Field(
+        default=None,
+        description="Discord OAuth app client ID for the /discord/mcp login mount.",
+    )
+    discord_client_secret: SecretStr | None = Field(
+        default=None,
+        description="Discord OAuth app client secret for the /discord/mcp login mount.",
+    )
+    jwt_signing_key: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Base64url 32-byte key that signs hub login tokens. Required when "
+            "any hub mount is configured. Generate with Fernet.generate_key()."
+        ),
+    )
+
+    @property
+    def slack_configured(self) -> bool:
+        return self.slack_client_id is not None and self.slack_client_secret is not None
+
+    @property
+    def discord_configured(self) -> bool:
+        return self.discord_client_id is not None and self.discord_client_secret is not None
+
+
 class DiscordSettings(BaseModel):
     """Discord adapter config.
 
@@ -636,6 +680,7 @@ class Settings(BaseSettings):
     cli: CLISettings = Field(default_factory=CLISettings)
     log: LogSettings = Field(default_factory=LogSettings)
     mcp: McpSettings = Field(default_factory=McpSettings)
+    hub: HubSettings = Field(default_factory=HubSettings)
     discord: DiscordSettings | None = None
     slack: SlackSettings | None = None
     github: GithubSettings = Field(default_factory=GithubSettings)

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -158,7 +158,11 @@ class HubSettings(BaseModel):
 
     slack_client_id: str | None = Field(
         default=None,
-        description="Slack OAuth app client ID for the /slack/mcp login mount.",
+        description=(
+            "Slack OAuth app client ID for the /slack/mcp login mount. Register "
+            "<DAIMON_MCP__PUBLIC_URL origin>/slack/auth/callback as a redirect "
+            "URL on the Slack app."
+        ),
     )
     slack_client_secret: SecretStr | None = Field(
         default=None,
@@ -166,7 +170,11 @@ class HubSettings(BaseModel):
     )
     discord_client_id: str | None = Field(
         default=None,
-        description="Discord OAuth app client ID for the /discord/mcp login mount.",
+        description=(
+            "Discord OAuth app client ID for the /discord/mcp login mount. "
+            "Register <DAIMON_MCP__PUBLIC_URL origin>/discord/auth/callback as a "
+            "redirect URI on the Discord app."
+        ),
     )
     discord_client_secret: SecretStr | None = Field(
         default=None,

--- a/packages/core/daimon/core/defaults/ma_index.py
+++ b/packages/core/daimon/core/defaults/ma_index.py
@@ -11,6 +11,7 @@ others are left alone and a warning is logged.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Collection
 from typing import Literal
 
 import sentry_sdk
@@ -145,6 +146,27 @@ async def list_agents_by_tenant(
     async for ag in client.beta.agents.list(include_archived=False):
         if ag.metadata.get(MA_METADATA_KEY_TENANT) == str(tenant_id):
             results.append(ag)
+    return results
+
+
+async def list_agents_by_tenants(
+    client: AsyncAnthropic, *, tenant_ids: Collection[uuid.UUID]
+) -> dict[uuid.UUID, list[BetaManagedAgentsAgent]]:
+    """Return non-archived MA agents for several tenants from one org listing.
+
+    The org listing is paginated in full whichever way it is filtered, so a
+    caller holding many tenants (a hub login spanning several workspaces)
+    pays once here rather than once per tenant. Every requested tenant is a
+    key in the result, empty when it has no agents.
+    """
+    wanted = {str(t): t for t in tenant_ids}
+    results: dict[uuid.UUID, list[BetaManagedAgentsAgent]] = {t: [] for t in tenant_ids}
+    if not wanted:
+        return results
+    async for ag in client.beta.agents.list(include_archived=False):
+        tenant = wanted.get(ag.metadata.get(MA_METADATA_KEY_TENANT, ""))
+        if tenant is not None:
+            results[tenant].append(ag)
     return results
 
 

--- a/packages/core/daimon/core/hub_identity.py
+++ b/packages/core/daimon/core/hub_identity.py
@@ -1,0 +1,63 @@
+"""Map a platform login to the daimon tenants and accounts it can act as.
+
+A hub login proves one platform identity plus the set of workspaces (Slack
+team, Discord guilds) that identity belongs to. Only workspaces where daimon is
+installed and ready become tenants the caller can reach. For each, the caller's
+account is looked up or provisioned exactly as the chat adapters do on first
+contact, so a hub turn is billed and permission-checked as that person.
+
+Ordering is by workspace name so the list a client sees is stable across
+logins.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from daimon.core.stores.domain import Platform
+from daimon.core.stores.identity import get_or_create_platform_principal
+from daimon.core.stores.tenants import list_tenants_by_platform
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+@dataclass(frozen=True, kw_only=True)
+class HubTenant:
+    tenant_id: uuid.UUID
+    account_id: uuid.UUID
+    workspace_id: str
+    workspace_name: str
+
+
+async def resolve_hub_tenants(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    platform: Platform,
+    platform_user_id: str,
+    workspaces: Sequence[tuple[str, str]],
+) -> list[HubTenant]:
+    """Intersect ``workspaces`` (external id, display name) with ready tenants."""
+    names = dict(workspaces)
+    tenants = await list_tenants_by_platform(session_factory, platform=platform)
+    matched = [
+        t
+        for t in tenants
+        if t.external_id in names and t.archived_at is None and t.provision_status == "ready"
+    ]
+    resolved: list[HubTenant] = []
+    async with session_factory() as session, session.begin():
+        for tenant in matched:
+            principal = await get_or_create_platform_principal(
+                session, tenant_id=tenant.id, platform=platform, external_id=platform_user_id
+            )
+            resolved.append(
+                HubTenant(
+                    tenant_id=tenant.id,
+                    account_id=principal.account_id,
+                    workspace_id=tenant.external_id,
+                    workspace_name=names[tenant.external_id],
+                )
+            )
+    resolved.sort(key=lambda t: (t.workspace_name.lower(), t.workspace_id))
+    return resolved

--- a/packages/core/daimon/core/hub_oauth_kv_sweep.py
+++ b/packages/core/daimon/core/hub_oauth_kv_sweep.py
@@ -26,8 +26,15 @@ async def sweep_expired_hub_oauth_kv(
     now: datetime,
     limit: int = 500,
 ) -> int:
-    """Delete up to ``limit`` expired rows. Returns the number deleted."""
+    """Delete up to ``limit`` expired rows. Returns the number deleted.
+
+    A full batch means the sweep may not be keeping up, and one interval of
+    deletions is no longer evidence the table is bounded, so it is reported at
+    warning level as well.
+    """
     async with session_factory() as session, session.begin():
         count = await delete_expired_hub_oauth_kv(session, cutoff=now, limit=limit)
     _log.info("hub_oauth_kv_sweep.expired", count=count)
+    if count == limit:
+        _log.warning("hub_oauth_kv_sweep.backlog", count=count, limit=limit)
     return count

--- a/packages/core/daimon/core/hub_oauth_kv_sweep.py
+++ b/packages/core/daimon/core/hub_oauth_kv_sweep.py
@@ -1,0 +1,33 @@
+"""Prune expired rows from the hub login key-value table.
+
+Every row the proxies write carries its own TTL (authorization codes: five
+minutes, transactions: fifteen, upstream tokens: their upstream lifetime).
+The store honours TTL on read but never deletes, so without this sweep the
+table grows by one row per login attempt forever.
+
+Shell-only: one session, one delete, one log line. ``now`` is injected and
+the scheduler owns the boundary catch, as with the other sweepers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import structlog
+from daimon.core.stores.hub_oauth_kv import delete_expired_hub_oauth_kv
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+_log = structlog.get_logger(__name__)
+
+
+async def sweep_expired_hub_oauth_kv(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    now: datetime,
+    limit: int = 500,
+) -> int:
+    """Delete up to ``limit`` expired rows. Returns the number deleted."""
+    async with session_factory() as session, session.begin():
+        count = await delete_expired_hub_oauth_kv(session, cutoff=now, limit=limit)
+    _log.info("hub_oauth_kv_sweep.expired", count=count)
+    return count

--- a/packages/core/daimon/core/stores/hub_oauth_kv.py
+++ b/packages/core/daimon/core/stores/hub_oauth_kv.py
@@ -1,0 +1,31 @@
+"""Expiry deletion for the hub login key-value table.
+
+The proxies write this table through py-key-value-aio; daimon's only access
+is pruning rows whose ``expires_at`` has passed. Rows with a NULL
+``expires_at`` are permanent (dynamic client registrations) and are never
+touched here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, cast
+
+from daimon.core._models import HubOAuthKv
+from sqlalchemy import CursorResult, delete, select, tuple_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def delete_expired_hub_oauth_kv(
+    session: AsyncSession, *, cutoff: datetime, limit: int
+) -> int:
+    """Delete up to ``limit`` rows with ``expires_at < cutoff``; return the count."""
+    victims = (
+        select(HubOAuthKv.collection, HubOAuthKv.key)
+        .where(HubOAuthKv.expires_at.is_not(None), HubOAuthKv.expires_at < cutoff)
+        .limit(limit)
+    )
+    result = await session.execute(
+        delete(HubOAuthKv).where(tuple_(HubOAuthKv.collection, HubOAuthKv.key).in_(victims))
+    )
+    return cast(CursorResult[Any], result).rowcount

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -629,6 +629,26 @@ def test_hub_settings_rejects_a_signing_key_of_the_wrong_length() -> None:
         HubSettings(jwt_signing_key=SecretStr(short))
 
 
+def test_hub_settings_default_redirect_allowlist_is_loopback_and_claude() -> None:
+    hub = HubSettings()
+    assert hub.allowed_client_redirect_uris == [
+        "http://localhost:*",
+        "http://127.0.0.1:*",
+        "https://claude.ai/*",
+        "https://claude.com/*",
+    ], f"got {hub.allowed_client_redirect_uris!r}"
+
+
+def test_hub_settings_redirect_allowlist_read_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DAIMON_DATABASE__URL", "postgresql+asyncpg://u:p@h/d")
+    monkeypatch.setenv("DAIMON_ANTHROPIC__API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_HUB__ALLOWED_CLIENT_REDIRECT_URIS", '["https://ide.example/*"]')
+    settings = load_settings(_env_file=None)
+    assert settings.hub.allowed_client_redirect_uris == ["https://ide.example/*"], (
+        f"got {settings.hub.allowed_client_redirect_uris!r}"
+    )
+
+
 def test_hub_settings_read_from_nested_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DAIMON_DATABASE__URL", "postgresql+asyncpg://u:p@h/d")
     monkeypatch.setenv("DAIMON_ANTHROPIC__API_KEY", "sk-test")

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import base64
 from decimal import Decimal
 from pathlib import Path
 
 import pytest
+from cryptography.fernet import Fernet
 from daimon.core.config import (
     AnthropicSettings,
     ArtifactsSettings,
@@ -606,6 +608,25 @@ def test_hub_settings_platform_configured_requires_both_id_and_secret() -> None:
     assert hub.discord_configured is False, "client id alone must not count as configured"
     hub = HubSettings(discord_client_id="123", discord_client_secret=SecretStr("s"))
     assert hub.discord_configured is True, "id plus secret must count as configured"
+
+
+def test_hub_settings_accepts_a_fernet_shaped_signing_key() -> None:
+    key = Fernet.generate_key().decode()
+    hub = HubSettings(jwt_signing_key=SecretStr(key))
+    assert hub.jwt_signing_key is not None and hub.jwt_signing_key.get_secret_value() == key, (
+        f"a Fernet-generated key must be accepted unchanged, got {hub.jwt_signing_key!r}"
+    )
+
+
+def test_hub_settings_rejects_a_passphrase_signing_key() -> None:
+    with pytest.raises(ValidationError, match="DAIMON_HUB__JWT_SIGNING_KEY"):
+        HubSettings(jwt_signing_key=SecretStr("hunter2"))
+
+
+def test_hub_settings_rejects_a_signing_key_of_the_wrong_length() -> None:
+    short = base64.urlsafe_b64encode(b"\x00" * 16).decode()
+    with pytest.raises(ValidationError, match="DAIMON_HUB__JWT_SIGNING_KEY"):
+        HubSettings(jwt_signing_key=SecretStr(short))
 
 
 def test_hub_settings_read_from_nested_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -4,8 +4,16 @@ from decimal import Decimal
 from pathlib import Path
 
 import pytest
-from daimon.core.config import ArtifactsSettings, McpSettings, Settings, load_settings
-from pydantic import HttpUrl, ValidationError
+from daimon.core.config import (
+    AnthropicSettings,
+    ArtifactsSettings,
+    DatabaseSettings,
+    HubSettings,
+    McpSettings,
+    Settings,
+    load_settings,
+)
+from pydantic import HttpUrl, PostgresDsn, SecretStr, ValidationError
 
 
 def test_load_settings_parses_nested_delimiter_when_env_provided(
@@ -575,3 +583,36 @@ def test_slack_settings_max_concurrent_turns_per_tenant_defaults_to_3(
     assert settings.slack.max_concurrent_turns_per_tenant == 3, (
         "max_concurrent_turns_per_tenant must default to 3 (STURN-06 per-tenant cap)"
     )
+
+
+# --- HubSettings tests ---
+
+
+def test_hub_settings_default_to_unconfigured() -> None:
+    settings = Settings(
+        database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+        anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+    )
+    assert settings.hub.slack_configured is False, (
+        f"slack hub must be unconfigured by default, got {settings.hub!r}"
+    )
+    assert settings.hub.discord_configured is False, (
+        f"discord hub must be unconfigured by default, got {settings.hub!r}"
+    )
+
+
+def test_hub_settings_platform_configured_requires_both_id_and_secret() -> None:
+    hub = HubSettings(discord_client_id="123")
+    assert hub.discord_configured is False, "client id alone must not count as configured"
+    hub = HubSettings(discord_client_id="123", discord_client_secret=SecretStr("s"))
+    assert hub.discord_configured is True, "id plus secret must count as configured"
+
+
+def test_hub_settings_read_from_nested_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DAIMON_DATABASE__URL", "postgresql+asyncpg://u:p@h/d")
+    monkeypatch.setenv("DAIMON_ANTHROPIC__API_KEY", "sk-test")
+    monkeypatch.setenv("DAIMON_HUB__SLACK_CLIENT_ID", "slack-id")
+    monkeypatch.setenv("DAIMON_HUB__SLACK_CLIENT_SECRET", "slack-secret")
+    settings = load_settings(_env_file=None)
+    assert settings.hub.slack_client_id == "slack-id", f"got {settings.hub.slack_client_id!r}"
+    assert settings.hub.slack_configured is True, "env-provided id+secret must configure slack"

--- a/packages/core/tests/test_hub_identity.py
+++ b/packages/core/tests/test_hub_identity.py
@@ -77,13 +77,19 @@ async def test_skips_archived_and_non_ready_tenants(
     db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
 ) -> None:
     pending = await make_tenant(db_session, platform="discord", workspace_id="g-pending")
+    archived = await make_tenant(db_session, platform="discord", workspace_id="g-archived")
     await db_session.commit()
     await set_provision_status(db_session_factory, tenant_id=pending.id, status="pending")
+    await set_provision_status(
+        db_session_factory, tenant_id=archived.id, status="ready", archive=True
+    )
 
     tenants = await resolve_hub_tenants(
         db_session_factory,
         platform="discord",
         platform_user_id="u1",
-        workspaces=[("g-pending", "P")],
+        workspaces=[("g-pending", "P"), ("g-archived", "A")],
     )
-    assert tenants == [], f"a non-ready tenant must not be offered, got {tenants!r}"
+    assert tenants == [], (
+        f"neither a non-ready nor an archived tenant may be offered, got {tenants!r}"
+    )

--- a/packages/core/tests/test_hub_identity.py
+++ b/packages/core/tests/test_hub_identity.py
@@ -1,0 +1,89 @@
+"""resolve_hub_tenants intersects a user's workspaces with installed tenants."""
+
+from __future__ import annotations
+
+import pytest
+from daimon.core.hub_identity import resolve_hub_tenants
+from daimon.core.stores.identity import find_platform_principal
+from daimon.core.stores.tenants import set_provision_status
+from daimon.testing.factories import make_platform_principal, make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_returns_only_workspaces_with_a_ready_tenant(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    installed = await make_tenant(db_session, platform="discord", workspace_id="g-installed")
+    await make_tenant(db_session, platform="slack", workspace_id="g-other-platform")
+    await db_session.commit()
+
+    tenants = await resolve_hub_tenants(
+        db_session_factory,
+        platform="discord",
+        platform_user_id="u1",
+        workspaces=[
+            ("g-installed", "Installed"),
+            ("g-missing", "Missing"),
+            ("g-other-platform", "X"),
+        ],
+    )
+
+    assert [t.tenant_id for t in tenants] == [installed.id], f"got {tenants!r}"
+    assert tenants[0].workspace_name == "Installed", f"got {tenants[0].workspace_name!r}"
+
+
+async def test_provisions_an_account_on_first_contact_and_reuses_it_after(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await make_tenant(db_session, platform="discord", workspace_id="g1")
+    await db_session.commit()
+
+    first = await resolve_hub_tenants(
+        db_session_factory, platform="discord", platform_user_id="u1", workspaces=[("g1", "G")]
+    )
+    second = await resolve_hub_tenants(
+        db_session_factory, platform="discord", platform_user_id="u1", workspaces=[("g1", "G")]
+    )
+
+    assert first[0].account_id == second[0].account_id, "second login must reuse the account"
+    principal = await find_platform_principal(
+        db_session, tenant_id=tenant.id, platform="discord", external_id="u1"
+    )
+    assert principal is not None and principal.account_id == first[0].account_id, (
+        f"principal row must point at the resolved account, got {principal!r}"
+    )
+
+
+async def test_reuses_existing_principal_account(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    tenant = await make_tenant(db_session, platform="slack", workspace_id="T1")
+    principal = await make_platform_principal(
+        db_session, platform="slack", external_id="U1", tenant=tenant
+    )
+    await db_session.commit()
+
+    tenants = await resolve_hub_tenants(
+        db_session_factory, platform="slack", platform_user_id="U1", workspaces=[("T1", "Acme")]
+    )
+    assert tenants[0].account_id == principal.account_id, (
+        f"must resolve to the pre-existing account, got {tenants[0].account_id}"
+    )
+
+
+async def test_skips_archived_and_non_ready_tenants(
+    db_session: AsyncSession, db_session_factory: async_sessionmaker[AsyncSession]
+) -> None:
+    pending = await make_tenant(db_session, platform="discord", workspace_id="g-pending")
+    await db_session.commit()
+    await set_provision_status(db_session_factory, tenant_id=pending.id, status="pending")
+
+    tenants = await resolve_hub_tenants(
+        db_session_factory,
+        platform="discord",
+        platform_user_id="u1",
+        workspaces=[("g-pending", "P")],
+    )
+    assert tenants == [], f"a non-ready tenant must not be offered, got {tenants!r}"

--- a/packages/core/tests/test_hub_oauth_kv_sweep.py
+++ b/packages/core/tests/test_hub_oauth_kv_sweep.py
@@ -16,7 +16,7 @@ async def _insert(session: AsyncSession, *, key: str, expires_at: datetime | Non
     await session.execute(
         text(
             "INSERT INTO hub_oauth_kv (collection, key, value, ttl, created_at, expires_at) "
-            "VALUES ('discord.mcp-oauth-transactions', :key, '{}'::jsonb, NULL, now(), :exp)"
+            "VALUES ('discord__mcp-oauth-transactions', :key, '{}'::jsonb, NULL, now(), :exp)"
         ),
         {"key": key, "exp": expires_at},
     )

--- a/packages/core/tests/test_hub_oauth_kv_sweep.py
+++ b/packages/core/tests/test_hub_oauth_kv_sweep.py
@@ -1,0 +1,43 @@
+"""The hub_oauth_kv sweep deletes only rows whose expires_at has passed."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from daimon.core.hub_oauth_kv_sweep import sweep_expired_hub_oauth_kv
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _insert(session: AsyncSession, *, key: str, expires_at: datetime | None) -> None:
+    await session.execute(
+        text(
+            "INSERT INTO hub_oauth_kv (collection, key, value, ttl, created_at, expires_at) "
+            "VALUES ('discord.mcp-oauth-transactions', :key, '{}'::jsonb, NULL, now(), :exp)"
+        ),
+        {"key": key, "exp": expires_at},
+    )
+
+
+async def test_sweep_deletes_expired_rows_and_keeps_live_and_permanent_rows(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    now = datetime(2026, 9, 6, 12, 0, tzinfo=UTC)
+    await _insert(db_session, key="expired", expires_at=now - timedelta(seconds=1))
+    await _insert(db_session, key="live", expires_at=now + timedelta(hours=1))
+    await _insert(db_session, key="permanent", expires_at=None)
+    await db_session.commit()
+
+    deleted = await sweep_expired_hub_oauth_kv(db_session_factory, now=now)
+
+    assert deleted == 1, f"exactly the expired row should be deleted, got {deleted}"
+    remaining = (
+        (await db_session.execute(text("SELECT key FROM hub_oauth_kv ORDER BY key")))
+        .scalars()
+        .all()
+    )
+    assert list(remaining) == ["live", "permanent"], f"unexpected survivors: {remaining!r}"

--- a/packages/core/tests/test_hub_oauth_kv_sweep.py
+++ b/packages/core/tests/test_hub_oauth_kv_sweep.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 import pytest
+import structlog
 from daimon.core.hub_oauth_kv_sweep import sweep_expired_hub_oauth_kv
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -41,3 +42,22 @@ async def test_sweep_deletes_expired_rows_and_keeps_live_and_permanent_rows(
         .all()
     )
     assert list(remaining) == ["live", "permanent"], f"unexpected survivors: {remaining!r}"
+
+
+async def test_sweep_warns_when_it_fills_its_batch(
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    now = datetime(2026, 9, 6, 12, 0, tzinfo=UTC)
+    await _insert(db_session, key="expired-1", expires_at=now - timedelta(seconds=1))
+    await _insert(db_session, key="expired-2", expires_at=now - timedelta(seconds=1))
+    await db_session.commit()
+
+    with structlog.testing.capture_logs() as logs:
+        deleted = await sweep_expired_hub_oauth_kv(db_session_factory, now=now, limit=1)
+
+    assert deleted == 1, f"the batch limit must cap the delete, got {deleted}"
+    backlog = [e for e in logs if e["event"] == "hub_oauth_kv_sweep.backlog"]
+    assert backlog and backlog[0]["log_level"] == "warning", (
+        f"a full batch must be reported at warning level, got {logs!r}"
+    )

--- a/packages/core/tests/test_schema_tenant_invariant.py
+++ b/packages/core/tests/test_schema_tenant_invariant.py
@@ -54,6 +54,13 @@ _TENANT_ID_EXEMPT: dict[str, str] = {
     # Cross-tenant BY DESIGN: links a CLI principal to a platform principal for
     # operator impersonation. Both endpoints are globally unique principal UUIDs.
     "principal_links": "cross-principal link table (both PKs globally unique UUIDs)",
+    # FastMCP OAuthProxy state (client registrations, authorization codes,
+    # upstream and issued tokens), keyed by (collection, key) and
+    # Fernet-encrypted. A row belongs to one platform login, not a tenant; the
+    # caller's tenant scope lives inside the issued token's claims, so
+    # per-tenant isolation is enforced at request time by the hub middleware
+    # rather than by a column.
+    "hub_oauth_kv": "OAuthProxy login state keyed by (collection, key); tenant lives in the token claims, not the row",
 }
 
 

--- a/packages/testing/daimon/testing/ma.py
+++ b/packages/testing/daimon/testing/ma.py
@@ -164,6 +164,7 @@ def session_response(
     status: SessionStatus = "idle",
     agent_id: str | None = None,
     environment_id: str = "env_test",
+    metadata: dict[str, str] | None = None,
 ) -> httpx.Response:
     """Response for GET /v1/sessions/{id} (the SDK's `beta.sessions.retrieve`).
 
@@ -193,7 +194,7 @@ def session_response(
         environment_id=environment_id,
         created_at=now,
         updated_at=now,
-        metadata={},
+        metadata=metadata or {},
         outcome_evaluations=[],
         resources=[],
         stats=EMPTY_SESSION_STATS,

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "daimon",
+  "version": "0.1.0",
+  "description": "Ask the daimons in your Slack workspace and Discord servers from Claude Code.",
+  "author": { "name": "PyMC Labs" }
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "daimon-slack": {
+      "type": "http",
+      "url": "${DAIMON_MCP_URL:-https://daimon.decision.ai}/slack/mcp"
+    },
+    "daimon-discord": {
+      "type": "http",
+      "url": "${DAIMON_MCP_URL:-https://daimon.decision.ai}/discord/mcp"
+    }
+  }
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,49 @@
+# daimon plugin for Claude Code
+
+Talk to the daimons in your Slack workspace and Discord servers from inside Claude Code.
+The plugin connects to two hosted MCP servers — `daimon-slack` and `daimon-discord` — each
+behind its own OAuth login, so a daimon answers as you: it reads only the channels you can
+see and spends that workspace's credit.
+
+## Install
+
+Once published to a plugin marketplace:
+
+```
+claude plugin install daimon
+```
+
+To try it locally from a checkout of this repo, without publishing:
+
+```
+claude --plugin-dir ./plugin
+```
+
+## Log in
+
+The plugin declares `daimon-slack` and `daimon-discord` as HTTP MCP servers; neither
+carries credentials. Run `/mcp` inside Claude Code and authenticate each server you want
+to use — that starts the OAuth login for that platform and stores the resulting token
+locally. A server you never authenticate simply has no daimons to list.
+
+## What's included
+
+- **`daimon-context` skill**: activates when you ask about team context, project status,
+  decisions, or discussions that live in Slack or Discord, or name a daimon directly. It
+  lists the daimons you can reach, picks the ones likely to have the answer, asks them,
+  and merges the replies with their source workspace.
+- **`/daimon-status` command**: lists every connected `daimon-*` server and the daimons
+  reachable through it, without asking any of them a question. Use it to check what's
+  connected before asking something.
+
+## Self-hosted deployments
+
+By default the plugin points at `https://daimon.decision.ai`. If you run your own daimon
+deployment, set `DAIMON_MCP_URL` to your server's origin before starting Claude Code:
+
+```
+DAIMON_MCP_URL=https://your-daimon-host.example claude --plugin-dir ./plugin
+```
+
+`DAIMON_MCP_URL` must be an origin only — scheme and host, no path and no trailing
+`/mcp` — since the plugin appends `/slack/mcp` and `/discord/mcp` itself.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -36,6 +36,14 @@ locally. A server you never authenticate simply has no daimons to list.
   reachable through it, without asking any of them a question. Use it to check what's
   connected before asking something.
 
+## Billing
+
+A hub turn runs the same balance and cap admission check as the existing `/mcp`
+tools: a workspace with a depleted balance or an exhausted monthly cap refuses the
+turn before it starts. Like those tools today, a hub turn does not record a metered
+usage debit against the workspace once it completes — usage metering for
+MCP-initiated turns is tracked as a separate piece of work.
+
 ## Self-hosted deployments
 
 By default the plugin points at `https://daimon.decision.ai`. If you run your own daimon

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -10,8 +10,11 @@ see and spends that workspace's credit.
 Once published to a plugin marketplace:
 
 ```
-claude plugin install daimon
+claude plugin install daimon@<marketplace>
 ```
+
+The marketplace has to be named: a bare `daimon` only resolves against
+marketplace catalogs already cached locally.
 
 To try it locally from a checkout of this repo, without publishing:
 
@@ -32,7 +35,7 @@ locally. A server you never authenticate simply has no daimons to list.
   decisions, or discussions that live in Slack or Discord, or name a daimon directly. It
   lists the daimons you can reach, picks the ones likely to have the answer, asks them,
   and merges the replies with their source workspace.
-- **`/daimon-status` command**: lists every connected `daimon-*` server and the daimons
+- **`/daimon:daimon-status` command**: lists every connected `daimon-*` server and the daimons
   reachable through it, without asking any of them a question. Use it to check what's
   connected before asking something.
 

--- a/plugin/commands/daimon-status.md
+++ b/plugin/commands/daimon-status.md
@@ -1,0 +1,9 @@
+---
+description: Show which daimon servers are connected and which daimons are reachable.
+---
+
+For each connected MCP server whose name starts with `daimon-`, call `list_daimons`.
+Print one table with columns: Server, Workspace, Daimon, Role. If a server is not
+authenticated, print a row saying so and tell the user to run `/mcp`. If a server returns
+no daimons, print a row saying daimon is not installed in any workspace they belong to.
+Do not ask any daimon a question.

--- a/plugin/skills/daimon-context/SKILL.md
+++ b/plugin/skills/daimon-context/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: daimon-context
+description: Use when the user asks about team context, project status, decisions, or discussions that live in Slack or Discord, or names a daimon. Routes the question to the right daimon servers and merges their answers.
+---
+
+# daimon-context
+
+Each connected `daimon-*` MCP server is one chat platform. `daimon-slack` reaches the
+user's Slack workspace; `daimon-discord` reaches every Discord server they share with a
+daimon install. A daimon answers as the user: it reads only channels they can see and
+spends that workspace's credit.
+
+## Procedure
+
+1. When the question mentions Slack, Discord, the team, a channel, or a daimon by name,
+   call `list_daimons` on each connected server. Every entry has an `id`, a `name`, and a
+   `workspace`. Names repeat across workspaces; `id` does not.
+2. Pick the daimons whose `workspace` or `role_summary` plausibly holds the answer. Do not
+   ask all of them by default. Each workspace is billed separately.
+3. Call `ask(daimon_id, message)` on the chosen daimons in parallel. Phrase the message as
+   a question the daimon can answer from its own platform.
+4. Merge the replies. State which platform and workspace each fact came from.
+5. For a follow-up on the same topic, pass the previous result's `handle` to `ask` so the
+   daimon keeps its context and no new session is opened.
+
+## Failure modes
+
+- A server reports missing authentication: tell the user to run `/mcp` and authenticate
+  that server. Do not retry the call.
+- `ask` times out after about two minutes: the error carries a `handle`. Call
+  `get_session(daimon_id, handle)` until `idle`, then `list_events` to read the reply.
+  Do not resend the question.
+- One daimon fails while others answer: report the partial result and name the daimon
+  that did not answer.
+- `list_daimons` returns an empty list: daimon is not installed in any workspace the user
+  belongs to on that platform. Say so; there is nothing to retry.

--- a/uv.lock
+++ b/uv.lock
@@ -904,6 +904,7 @@ dependencies = [
     { name = "httpx" },
     { name = "imageio-ffmpeg" },
     { name = "pillow" },
+    { name = "py-key-value-aio", extra = ["postgresql"] },
     { name = "pydantic" },
     { name = "sentry-sdk" },
     { name = "slack-sdk" },
@@ -929,6 +930,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "imageio-ffmpeg", specifier = ">=0.6" },
     { name = "pillow", specifier = ">=11,<13" },
+    { name = "py-key-value-aio", extras = ["postgresql"], specifier = ">=0.4.4" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "sentry-sdk", specifier = ">=2.61" },
     { name = "slack-sdk", specifier = ">=3.42,<4" },
@@ -3028,6 +3030,9 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+postgresql = [
+    { name = "asyncpg" },
 ]
 
 [[package]]


### PR DESCRIPTION
Until now the only way for a coding agent to talk to a daimon was a per-agent MCP token minted for one agent in one workspace. Someone in three Slack workspaces and two Discord servers who wants to ask "what did the team decide about X" from Claude Code has to mint and juggle five tokens, and each one is scoped to a single agent rather than to the person. This branch adds two OAuth-login MCP mounts, `/slack/mcp` and `/discord/mcp`, and a Claude Code plugin that connects to them. A person logs in once per platform and reaches every daimon in every workspace they belong to where daimon is installed, acting as themselves in each.

## What changed

**Hub mounts.** Each platform gets its own `FastMCP` sub-app with its own FastMCP `OAuthProxy` in front of the platform's OAuth, so a Slack token is never evaluated by the Discord proxy. The login callback intersects the person's workspaces with ready, unarchived tenants and provisions their account in each the same way the chat adapters do on first contact. That tenant list is carried in the issued token's claims and read back by a middleware on every request. Starlette does not run a sub-app's lifespan and RFC 8414 discovery for a mounted path is fetched at the origin root, so mounting chains the sub-app lifespans into the parent's and re-roots each provider's well-known routes. A mount appears only when both the platform's client id and secret are set; a deployment that sets neither is unchanged.

**Tools address daimons by derived id, not name.** A hub caller spans tenants and agent names are unique only within one, so `list_daimons` hands out the per-agent derived UUID and every other tool (`describe_daimon`, `ask`, `start_turn`, `continue_turn`, `get_session`, `list_events`, `list_my_sessions`) takes it back as `daimon_id`. Resolution walks only the caller's own tenants, so an id from elsewhere is indistinguishable from a nonexistent one. Once resolved, the tool builds the ordinary `AuthIdentity` for the caller's account in that tenant and hands off to the existing agent-chat implementation functions, so a hub turn runs with the person's channel visibility and is attributed to the right tenant exactly as a per-agent token turn is. The hub never grants admin.

**Login state lives in Postgres.** A `hub_oauth_kv` table (migration 0013, downgrade safe) backs the proxies' client registrations, authorization codes, and upstream tokens, Fernet-encrypted with `DAIMON_CRYPTO__KEYS`, so logins survive restarts and replicas. The store honours TTL on read but never deletes, so the scheduler tick gains a bounded sweep for expired rows. The table is exempted from the tenant-column invariant test with the reason recorded there: a row belongs to one platform login, and tenant scope is enforced from the token claims at request time.

**Admission gate split.** `_check_admission` is now a thin wrapper over `_admit`, which takes an already-resolved identity. Existing tools are unchanged; the hub calls `_admit` directly because its identity is chosen per call from the daimon being addressed.

**Existing `/mcp` tools pick up two small additions.** `ask` accepts an optional `handle` to continue a conversation instead of starting a new one, and `describe_agent` reports `platform` and `workspace_id`. Both are additive; the tool schema snapshot is updated.

**Plugin.** `plugin/` holds a Claude Code plugin declaring `daimon-slack` and `daimon-discord` as HTTP MCP servers with no baked-in credentials (login happens through `/mcp` in Claude Code), a `daimon-context` skill that lists reachable daimons, picks the likely ones, asks them, and merges the answers with their source workspace, and a `/daimon-status` command. `DAIMON_MCP_URL` points it at a self-hosted deployment.

## Operator notes

New settings under `DAIMON_HUB__*`: Slack and Discord client id and secret, plus `JWT_SIGNING_KEY`, a base64url 32-byte key required when any mount is configured. The signing key is deliberately separate from the client secrets so rotating a client secret does not invalidate every issued login. `DAIMON_MCP__PUBLIC_URL` and `DAIMON_CRYPTO__KEYS` must also be set; boot fails with a `BootstrapError` naming the missing one. Requires `alembic upgrade head` for the new table.

Hub turns run the same balance and cap admission check as the existing `/mcp` turn tools, and like those tools they do not record a metered usage debit on completion. Metering for MCP-initiated turns is a separate piece of work; the plugin README says so.

## Review round

Three independent reviews (auth and isolation, wiring and data lifecycle, tests and plugin) ran on the rebased branch. Fixed here:

**Critical.** Session handles were agent-scoped, as on the per-agent surface where the token is the agent. Every workspace member shares a daimon, so any logged-in member could list, read, and continue other members' sessions, including channel threads. Hub tools now require the session's `daimon_account` to match the caller before `get_session`, `list_events`, `continue_turn`, and `ask` with a handle, and `list_my_sessions` filters on it. Also Critical: `ask` with a handle polled an already-idle session and returned the previous turn's answer; it now reads from this turn's boundary.

**Important.** The hub middleware rejects a token issued for the other platform's mount, on top of the proxy's issuer and audience check. The signing key must decode to 32 bytes or settings refuse to load. `DAIMON_HUB__ALLOWED_CLIENT_REDIRECT_URIS` restricts dynamic client registration to loopback and claude.ai by default. Tenant readiness is re-read from the database on every call. Both mounts share one Postgres pool, closed at shutdown. The org agent listing runs once per call instead of once per tenant. The migration's index name matches the model. Redirect URIs, scopes, and the plugin's namespaced command are documented. Tests added for cross-mount and cross-surface token rejection, the balance gate on the hub path, session ownership, each bootstrap requirement, the archived-tenant filter, structlog output in the no-token test, a sweep backlog warning, and a snapshot of the hub tool surface.

**Left as follow-ups.** Discord guild membership is re-read only on token refresh, so a removed member keeps a server's daimons for up to Discord's token lifetime; documented in the README and claims module. The `hub_oauth_kv` table is keyed by proxy identifiers and cannot be addressed by an account purge; retention is bounded by TTL and the sweep, documented on the model. Hub turns are still admission-gated but not metered.

## Verification

Rebased onto main after the report-host and support-escalation work landed; the `ask` tests were updated for the turn-boundary contract main introduced (a send must return an accepted event). Full CI set run locally on the rebased branch: ruff check and format, pyright 0 errors, import-linter 6/6, and all repo lint scripts clean. pytest: 5331 passed, 6 skipped, 3 failed. The three failures are unrelated to this branch: one is `test_mcp_settings_both_unset_by_default` picking up `DAIMON_MCP__*` from a sourced local `.env` (passes with a clean environment), the other two are notebook-host jail tests that `chown` under macOS and fail with `Operation not permitted`; that app is untouched here.

Hub-specific tests cover: mount and discovery route re-rooting, Slack and Discord login providers, claim encode/decode and middleware rejection of tokens without hub identity, tenant resolution and ordering, every tool wrapper driven over the wire, a turn-parity test showing a hub `ask` creates its MA session as the caller's account in the addressed tenant, and a check that neither the upstream token nor login claims reach a log line.

Not tested: a real OAuth round trip against Slack or Discord, and installing the plugin from a marketplace (only `--plugin-dir` was exercised).
