### PR TITLE
Report host seam: mounted-bundle isolated turns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,12 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_MCP__PUBLIC_URL=
 # On-disk directory for the media-tool FileStore. When unset, the server uses tempfile.gettempdir() / 'daimon-mcp-files' resolved at startup.
 # DAIMON_MCP__FILE_STORE_DIR=
+# Per-upload byte cap enforced by the bundle upload route. The mcp service runs on Cloud Run over HTTP/1, whose maximum request size is 32 MiB, so the default sits below it with headroom.
+# DAIMON_MCP__BUNDLE_MAX_BYTES=26214400
+# Per-token cap on bundle upload route calls per rolling hour. Prevents a compromised or buggy caller from exhausting the Files API upload path. Set to 0 to disable (not recommended in production).
+# DAIMON_MCP__BUNDLE_UPLOADS_PER_HOUR=20
+# How long an uploaded bundle object is retained on the Files API before deletion. Deletion is performed by the scheduler's pending-file sweeper, not by this process directly — a deployment running no scheduler will never reclaim these objects.
+# DAIMON_MCP__BUNDLE_TTL_DAYS=90
 
 # === Discord (optional) ===
 # Discord bot token. Required to run the Discord adapter. (required to run the Discord adapter; secret)

--- a/defaults/skills/report-reader/SKILL.md
+++ b/defaults/skills/report-reader/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: report-reader
+description: Answer questions about a published report from the analysis bundle mounted in this session. Covers unpacking the bundle, tracing a number back to its source table, model or raw data, refitting a model on request, and rebuilding and re-uploading the report. Use whenever you are a reader-facing agent for one published report.
+---
+
+# report-reader
+
+You are answering questions from a reader of one published report. Everything
+you say about that report should trace back to a file in the bundle mounted in
+this session — never to outside knowledge, and never to something you remember
+from another conversation.
+
+## First action in a session
+
+Before you do anything else, unpack the bundle:
+
+```bash
+mkdir -p /workspace/bundle && tar --no-same-owner --no-same-permissions -xzf /mnt/session/uploads/bundle.tar.gz -C /workspace/bundle
+```
+
+The archive is mounted read-only at `/mnt/session/uploads/bundle.tar.gz`.
+Extracting it first, before reading anything or answering anything, is what
+makes every later step in this session cheap — you are not re-reading the
+tarball on every question. Those two flags are there deliberately: the
+archive's stored ownership and permission bits belong to whoever built it,
+not to this sandbox, and applying them here would produce files you cannot
+necessarily read or write.
+
+## What is in the bundle
+
+Once extracted, expect this layout under `/workspace/bundle`:
+
+```
+README.md      how the publisher wants questions answered, and how to rebuild
+manifest.json  links each figure to its render script, table, model and data
+data/          the source data as it was loaded, before any joins
+prep/          scripts that join and clean data/ into the tables below
+models/        the fitted model(s): scripts, summaries, diagnostics, full trace
+tables/        the per-figure and headline numbers, already computed
+figures/       one render script (and rendered image) per figure
+typst/         the report's source — edit and rebuild from here
+```
+
+Read `README.md` first. It is written by whoever published this report, and
+where it says something different from this skill, follow the README — it
+knows things about this report that a general skill cannot. Read
+`manifest.json` next. It links each figure to the render script that drew it,
+the table row(s) behind that render, the model that produced them, and the raw
+data behind the model — that chain is what makes "why is this number X"
+answerable instead of guessable.
+
+## How to answer "why is this number what it is"
+
+Follow the chain `manifest.json` describes, in order:
+
+1. Find the figure or number in `manifest.json`.
+2. Open the table row it points to, in `tables/`.
+3. Open the model output behind that row, in `models/` (`summary.csv` or
+   `diagnostics.json` for fit quality, `idata.nc` for anything not already in
+   a summary table).
+4. If the question is about the raw inputs, follow the model's own listed
+   data files back into `data/`.
+
+Quote the file and the column for every number you state. When the source
+carries an interval or an uncertainty range, give it alongside the point
+estimate — don't state a mean as if it were exact. If the chain breaks
+partway — a file is missing, a script doesn't produce what the manifest
+claims — say plainly which link is missing. Never fill the gap with a
+plausible-sounding number.
+
+## When the bundle cannot answer
+
+If a question is genuinely outside what the bundle covers, say so in one
+sentence, then offer what the report *can* answer instead. Never estimate a
+number that is not in a file in front of you — an invented number that sounds
+right is worse than admitting the bundle doesn't cover it, because the reader
+has no way to tell the difference.
+
+## Refits and rebuilds
+
+Re-running a fit is allowed when the reader explicitly asks for a what-if the
+existing tables cannot answer — never as a way to double-check a number that
+`models/summary.csv` or `models/diagnostics.json` already gives you. A refit
+takes minutes, not seconds; tell the reader that before you start so they know
+to wait, rather than leaving them watching a silent pause. Every script under
+`run_order` in `manifest.json` is runnable in place from the bundle root.
+Report the diagnostics alongside the new number, not just the point estimate —
+a refit without its diagnostics is not more trustworthy than the original
+table, just newer. The sandbox's installed package versions may differ from
+the ones the bundle was originally built with; if they do, say so alongside
+the result rather than presenting it as an exact reproduction.
+
+## Handing back a revised report
+
+When the message you receive carries an upload URL, the reader has asked for a
+change to the report itself. Edit `typst/report.typ` (or whichever `.typ`
+file the bundle's `README.md` names as the entry point), rebuild the PDF, and
+upload it:
+
+```bash
+curl -sS -T report.pdf '<upload url>'
+```
+
+Then tell the reader the report has been swapped in. The upload URL is
+single-use and good for this turn only — if the message carries no upload URL,
+do not attempt an upload this turn; say what you would change and wait to be
+asked again. `typst` is installed in the default environment, so no setup step
+is needed before rebuilding.
+
+## What not to do
+
+- Do not commit or push anything, in this bundle or anywhere else.
+- Do not mention repositories, sandboxes, tools, or your own setup unless the
+  reader asks about them directly — you are answering questions about a
+  report, not narrating your environment.
+- Do not invent data. If it is not in a file in the bundle, you do not have
+  it.

--- a/packages/adapters/cli/daimon/adapters/cli/commands/mcp.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/mcp.py
@@ -2,6 +2,7 @@
 
 Subcommands:
   * mint-token         — signs a JWT for local debug / integration tests.
+  * mint-agent-token   — mints a long-lived, revocable agent-scoped token.
   * url                — prints DAIMON_MCP__PUBLIC_URL.
   * janitor            — find and optionally archive orphan daimon-mcp:* vaults.
   * sweep-credentials  — delete+recreate stale is_admin creds (defense-in-depth).
@@ -17,10 +18,12 @@ import datetime as dt
 import typer
 from daimon.adapters.cli.errors import run_cli
 from daimon.adapters.cli.runtime import CliRuntime, build_runtime
-from daimon.adapters.cli.tenant import discover_tenant
+from daimon.adapters.cli.tenant import TenantSelector, discover_tenant, resolve_tenant_override
 from daimon.core.config import Settings, load_settings
+from daimon.core.defaults.ma_index import find_agent_by_daimon_tag
 from daimon.core.errors import ConfigError
-from daimon.core.mcp_auth import mint_jwt
+from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.mcp_auth import mint_agent_mcp_token, mint_jwt
 from daimon.core.mcp_credential_sweep import sweep_stale_admin_credentials
 from daimon.core.mcp_vault_janitor import archive_orphan_mcp_vaults
 from daimon.core.stores.identity import get_or_create_cli_principal
@@ -84,6 +87,93 @@ async def mint_token(*, rt: CliRuntime, os_user: str | None) -> None:
         secret=rt.settings.mcp.jwt_secret.get_secret_value().encode(),
         now=dt.datetime.now(dt.UTC),
     )
+    typer.echo(token)
+
+
+@mcp_app.command(
+    "mint-agent-token",
+    help=(
+        "Mint a long-lived, revocable agent-scoped MCP token. This is an "
+        "operator and testing door, NOT the production path — reports mint "
+        "their own tokens when published, and a token minted here is "
+        "revoked with the same revocation the publishing side uses."
+    ),
+)
+def mcp_mint_agent_token_command(
+    tenant: str = typer.Option(..., "--tenant", help="Tenant uuid the agent belongs to."),
+    agent: str = typer.Option(..., "--agent", help="The agent's daimon name."),
+    label: str | None = typer.Option(
+        None, "--label", help="Human-readable label stored with the token row."
+    ),
+    ttl_days: int = typer.Option(
+        90, "--ttl-days", help="Days until the token expires. Defaults to 90."
+    ),
+) -> None:
+    settings = load_settings()
+    console = Console(highlight=False)
+
+    async def _with_runtime() -> None:
+        async with build_runtime(settings) as rt:
+            await mint_agent_token(
+                rt=rt, tenant=tenant, agent=agent, label=label, ttl_days=ttl_days
+            )
+
+    run_cli(_with_runtime(), console=console)
+
+
+async def mint_agent_token(
+    *,
+    rt: CliRuntime,
+    tenant: str,
+    agent: str,
+    label: str | None,
+    ttl_days: int,
+) -> None:
+    """Async body for `daimon mcp mint-agent-token`.
+
+    This is an operator and testing door, NOT the production path: reports
+    mint their own agent-scoped token when they are published
+    (`ensure_reader_variant` + `mint_agent_mcp_token`), and a token minted
+    here is revoked with the same `revoke_mcp_token` the publishing side
+    uses. This command exists so an operator debugging a report, or a test
+    needing a real agent token, has somewhere to get one without going
+    through a publish.
+    """
+    if rt.settings.mcp.jwt_secret is None:
+        raise ConfigError(
+            "DAIMON_MCP__JWT_SECRET is unset. Generate one with "
+            "`python -c 'import secrets; print(secrets.token_hex(32))'`."
+        )
+
+    async with rt.sessionmaker() as session, session.begin():
+        override = await resolve_tenant_override(session, TenantSelector(tenant_id=tenant))
+        tenant_id = await discover_tenant(session, override=override)
+        principal = await get_or_create_cli_principal(
+            session, tenant_id=tenant_id, os_user=rt.settings.cli.local_user
+        )
+        account_id = principal.account_id
+    # Session closed. MA call below.
+
+    ma_agent = await find_agent_by_daimon_tag(rt.anthropic, tenant_id=tenant_id, name=agent)
+    if ma_agent is None:
+        raise ConfigError(f"no agent named {agent!r} in tenant {tenant_id}.")
+
+    # mint_agent_mcp_token requires the DERIVED per-agent uuid, not MA's raw
+    # `agent_...` id — the verifier re-derives via derive_agent_uuid too, so
+    # passing the raw MA id here would mint a token no verifier accepts.
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(ma_agent.id))
+
+    async with rt.sessionmaker() as session, session.begin():
+        token = await mint_agent_mcp_token(
+            session,
+            account_id=account_id,
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            label=label,
+            secret=rt.settings.mcp.jwt_secret.get_secret_value().encode(),
+            now=dt.datetime.now(dt.UTC),
+            ttl_days=ttl_days,
+        )
     typer.echo(token)
 
 

--- a/packages/adapters/cli/tests/commands/test_mcp.py
+++ b/packages/adapters/cli/tests/commands/test_mcp.py
@@ -12,9 +12,15 @@ import httpx
 import jwt as pyjwt
 import pytest
 from anthropic import AsyncAnthropic
-from anthropic.types.beta import BetaManagedAgentsVault
+from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsVault
+from anthropic.types.beta.beta_managed_agents_model_config import BetaManagedAgentsModelConfig
 from daimon.adapters.cli import main as main_mod
-from daimon.adapters.cli.commands.mcp import mcp_sweep_credentials, mcp_url, mint_token
+from daimon.adapters.cli.commands.mcp import (
+    mcp_sweep_credentials,
+    mcp_url,
+    mint_agent_token,
+    mint_token,
+)
 from daimon.adapters.cli.runtime import CliRuntime
 from daimon.core.config import (
     AnthropicSettings,
@@ -23,6 +29,8 @@ from daimon.core.config import (
     McpSettings,
     Settings,
 )
+from daimon.core.defaults.metadata import MA_METADATA_KEY_NAME, MA_METADATA_KEY_TENANT
+from daimon.core.errors import ConfigError
 from daimon.testing.factories import make_tenant
 from daimon.testing.ma import build_fake_anthropic
 from pydantic import HttpUrl, PostgresDsn, SecretStr
@@ -123,6 +131,244 @@ async def test_mcp_mint_token_requires_secret(
 
     with pytest.raises(ConfigError, match="JWT_SECRET"):
         await mint_token(rt=rt, os_user=None)
+
+
+# ---------------------------------------------------------------------------
+# mint-agent-token tests
+# ---------------------------------------------------------------------------
+
+
+def _agent_wire(*, agent_id: str, name: str, tenant_id: uuid.UUID) -> dict[str, Any]:
+    """Serialized BetaManagedAgentsAgent for a GET /v1/agents list response."""
+    now = dt.datetime(2026, 6, 1, tzinfo=dt.UTC)
+    return BetaManagedAgentsAgent(
+        id=agent_id,
+        type="agent",
+        name=name,
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed=None),
+        metadata={MA_METADATA_KEY_TENANT: str(tenant_id), MA_METADATA_KEY_NAME: name},
+        description=None,
+        archived_at=None,
+        created_at=now,
+        updated_at=now,
+        version=1,
+        mcp_servers=[],
+        skills=[],
+        tools=[],
+        system="you are helpful",
+    ).model_dump(mode="json")
+
+
+@pytest.mark.asyncio
+async def test_mint_agent_token_success_writes_one_row_and_prints_token(
+    schema_sessionmaker: async_sessionmaker[AsyncSession],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful mint prints a token on stdout and writes exactly one
+    mcp_tokens row whose label matches what was passed."""
+    from daimon.adapters.cli.commands import mcp as mcp_cmd
+    from daimon.core.mcp_auth import mint_agent_mcp_token as real_mint_agent_mcp_token
+    from daimon.core.stores.mcp_tokens import get_mcp_token
+
+    tenant_id = await _seed_tenant(schema_sessionmaker)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.method == "GET" and req.url.path == "/v1/agents"
+        return httpx.Response(
+            200,
+            json={
+                "data": [_agent_wire(agent_id="ag_reader", name="my-agent", tenant_id=tenant_id)],
+                "has_more": False,
+            },
+        )
+
+    secret = "a" * 32
+    settings = _build_settings(jwt_secret=secret)
+    anthropic = build_fake_anthropic(handler)
+    rt = object.__new__(CliRuntime)
+    object.__setattr__(rt, "settings", settings)
+    object.__setattr__(rt, "anthropic", anthropic)
+    object.__setattr__(rt, "sessionmaker", schema_sessionmaker)
+    rt = cast(CliRuntime, rt)
+
+    # Spy on the write call itself — schema-per-test fixtures use
+    # schema_translate_map, which raw text() SQL does not honour, so a
+    # row-count query would silently hit the wrong schema. Counting real
+    # invocations of the store-backed writer is the reliable signal.
+    calls: list[dict[str, Any]] = []
+
+    async def spy_mint_agent_mcp_token(session: AsyncSession, **kwargs: Any) -> str:
+        calls.append(kwargs)
+        return await real_mint_agent_mcp_token(session, **kwargs)
+
+    monkeypatch.setattr(mcp_cmd, "mint_agent_mcp_token", spy_mint_agent_mcp_token)
+
+    await mint_agent_token(
+        rt=rt, tenant=str(tenant_id), agent="my-agent", label="ops-debug", ttl_days=90
+    )
+
+    out = capsys.readouterr().out
+    token = out.strip().splitlines()[-1]
+    claims = pyjwt.decode(token, secret, algorithms=["HS256"])
+    assert claims["agent_id"], "token must carry an agent_id claim"
+
+    assert len(calls) == 1, "mint_agent_mcp_token (the sole writer) must be called exactly once"
+    async with schema_sessionmaker() as s:
+        row = await get_mcp_token(s, jti=uuid.UUID(claims["jti"]))
+    assert row is not None, "the minted jti must have a corresponding row"
+    assert row.label == "ops-debug"
+
+
+@pytest.mark.asyncio
+async def test_mint_agent_token_ttl_days_sets_exp(
+    schema_sessionmaker: async_sessionmaker[AsyncSession],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--ttl-days 1 produces a token whose exp claim is about one day out."""
+    tenant_id = await _seed_tenant(schema_sessionmaker)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [_agent_wire(agent_id="ag_ttl", name="ttl-agent", tenant_id=tenant_id)],
+                "has_more": False,
+            },
+        )
+
+    secret = "b" * 32
+    settings = _build_settings(jwt_secret=secret)
+    anthropic = build_fake_anthropic(handler)
+    rt = object.__new__(CliRuntime)
+    object.__setattr__(rt, "settings", settings)
+    object.__setattr__(rt, "anthropic", anthropic)
+    object.__setattr__(rt, "sessionmaker", schema_sessionmaker)
+    rt = cast(CliRuntime, rt)
+
+    before = dt.datetime.now(dt.UTC)
+    await mint_agent_token(rt=rt, tenant=str(tenant_id), agent="ttl-agent", label=None, ttl_days=1)
+    out = capsys.readouterr().out
+    token = out.strip().splitlines()[-1]
+    claims = pyjwt.decode(token, secret, algorithms=["HS256"])
+
+    expected = before + dt.timedelta(days=1)
+    actual = dt.datetime.fromtimestamp(claims["exp"], tz=dt.UTC)
+    assert abs((actual - expected).total_seconds()) < 60, (
+        "exp should land about one day (ttl_days=1) after mint time"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mint_agent_token_unknown_agent_exits_nonzero_and_writes_no_row(
+    schema_sessionmaker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown --agent raises ConfigError and writes no token row."""
+    from daimon.adapters.cli.commands import mcp as mcp_cmd
+
+    tenant_id = await _seed_tenant(schema_sessionmaker)
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [], "has_more": False})
+
+    settings = _build_settings(jwt_secret="c" * 32)
+    anthropic = build_fake_anthropic(handler)
+    rt = object.__new__(CliRuntime)
+    object.__setattr__(rt, "settings", settings)
+    object.__setattr__(rt, "anthropic", anthropic)
+    object.__setattr__(rt, "sessionmaker", schema_sessionmaker)
+    rt = cast(CliRuntime, rt)
+
+    calls: list[Any] = []
+
+    async def spy_mint_agent_mcp_token(session: AsyncSession, **kwargs: Any) -> str:
+        calls.append(kwargs)
+        raise AssertionError("must not be called when the agent is unknown")
+
+    monkeypatch.setattr(mcp_cmd, "mint_agent_mcp_token", spy_mint_agent_mcp_token)
+
+    with pytest.raises(ConfigError, match="no-such-agent"):
+        await mint_agent_token(
+            rt=rt, tenant=str(tenant_id), agent="no-such-agent", label=None, ttl_days=90
+        )
+
+    assert calls == [], "the writer must never be reached for an unknown agent"
+
+
+@pytest.mark.asyncio
+async def test_mint_agent_token_requires_secret_writes_no_row(
+    schema_sessionmaker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A settings object with no mcp.jwt_secret exits non-zero and writes no row."""
+    from daimon.adapters.cli.commands import mcp as mcp_cmd
+
+    tenant_id = await _seed_tenant(schema_sessionmaker)
+    settings = _build_settings(jwt_secret=None)
+    rt = _make_rt(settings=settings, sessionmaker=schema_sessionmaker)
+
+    calls: list[Any] = []
+
+    async def spy_mint_agent_mcp_token(session: AsyncSession, **kwargs: Any) -> str:
+        calls.append(kwargs)
+        raise AssertionError("must not be called when jwt_secret is unset")
+
+    monkeypatch.setattr(mcp_cmd, "mint_agent_mcp_token", spy_mint_agent_mcp_token)
+
+    with pytest.raises(ConfigError, match="JWT_SECRET"):
+        await mint_agent_token(
+            rt=rt, tenant=str(tenant_id), agent="whatever", label=None, ttl_days=90
+        )
+
+    assert calls == [], "the writer must never be reached when jwt_secret is unset"
+
+
+def test_mcp_mint_agent_token_via_runner_prints_token(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    schema_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Typer-level smoke: `daimon mcp mint-agent-token` reaches mint_agent_token
+    and prints a bare token on stdout."""
+    import asyncio
+    import contextlib
+
+    from daimon.adapters.cli.commands import mcp as mcp_cmd
+
+    tenant_id = asyncio.run(_seed_tenant(schema_sessionmaker))
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    _agent_wire(agent_id="ag_runner", name="runner-agent", tenant_id=tenant_id)
+                ],
+                "has_more": False,
+            },
+        )
+
+    settings = _build_settings(jwt_secret="d" * 32)
+    monkeypatch.setattr(mcp_cmd, "load_settings", lambda: settings)
+
+    @contextlib.asynccontextmanager
+    async def _fake_build_runtime(_settings: Settings) -> AsyncIterator[CliRuntime]:
+        rt = object.__new__(CliRuntime)
+        object.__setattr__(rt, "settings", settings)
+        object.__setattr__(rt, "anthropic", build_fake_anthropic(handler))
+        object.__setattr__(rt, "sessionmaker", schema_sessionmaker)
+        yield cast(CliRuntime, rt)
+
+    monkeypatch.setattr(mcp_cmd, "build_runtime", _fake_build_runtime)
+
+    result = runner.invoke(
+        main_mod.app,
+        ["mcp", "mint-agent-token", "--tenant", str(tenant_id), "--agent", "runner-agent"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    token = result.stdout.strip().splitlines()[-1]
+    pyjwt.decode(token, "d" * 32, algorithms=["HS256"])
 
 
 def test_mcp_url_via_runner_prints_url(

--- a/packages/adapters/mcp/daimon/adapters/mcp/bundles.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/bundles.py
@@ -1,0 +1,167 @@
+"""PUT /bundles — push a report-host archive onto the Files API, ownership-bound.
+
+Mounted on the FastMCP-derived ASGI app via `add_route`, the same way
+`checkout.py` and `uploads.py` are — this bypasses `IdentityMiddleware`, so
+the bearer is verified here, not upstream. The bearer is the report's own
+agent token (minted by `mint_agent_mcp_token`), so an uploaded bundle is
+bound at mint time to the tenant and agent that will later mount it via
+`start_turn(bundle=...)`.
+
+The report host holds no Anthropic key by design (it cannot call the Files
+API itself), so this route exists to do the upload on its behalf and hand
+back a signed handle instead of a durable database row.
+
+Catch narrowly and only here: this module IS the catch boundary. An upload
+failure from the SDK propagates and Starlette turns it into a 500 — the
+correct loud failure for an ASGI edge.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import FileMetadata
+from daimon.core import bundle_handle
+from daimon.core.config import McpSettings
+from daimon.core.notebooks._rate_limit import RateLimiter
+from daimon.core.stores.pending_file_deletes import enqueue_pending_file_delete
+from fastmcp.server.auth import AccessToken
+from fastmcp.server.auth.auth import TokenVerifier
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response
+
+log = structlog.get_logger(__name__)
+
+_GZIP_MAGIC = b"\x1f\x8b"
+
+
+def build_bundles_route(
+    *,
+    anthropic: AsyncAnthropic,
+    session_factory: async_sessionmaker[AsyncSession],
+    auth: TokenVerifier,
+    mcp_settings: McpSettings,
+    rate_limiter: RateLimiter,
+) -> Callable[[Request], Awaitable[Response]]:
+    """Build the `PUT /bundles` handler with dependencies bound."""
+
+    async def handler(request: Request) -> Response:
+        # --- bearer-token auth gate, same shape as checkout.py ---
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.lower().startswith("bearer "):
+            return Response(status_code=401)
+        token = auth_header[len("bearer ") :]
+        access: AccessToken | None = await auth.verify_token(token)
+        if access is None:
+            return Response(status_code=401)
+
+        token_tenant_raw = access.claims.get("tenant_id")
+        if not isinstance(token_tenant_raw, str):
+            return Response(status_code=403)
+        try:
+            tenant_id = uuid.UUID(token_tenant_raw)
+        except ValueError:
+            return Response(status_code=403)
+
+        # agent_id is read from the raw JWT claim mint_agent_mcp_token signs —
+        # a plain account token has no agent scope and must not upload here.
+        token_agent_raw = access.claims.get("agent_id")
+        if not isinstance(token_agent_raw, str):
+            return Response(status_code=403)
+        try:
+            agent_id = uuid.UUID(token_agent_raw)
+        except ValueError:
+            return Response(status_code=403)
+
+        if mcp_settings.jwt_secret is None:
+            return PlainTextResponse(
+                "DAIMON_MCP__JWT_SECRET is required to mint a bundle handle",
+                status_code=500,
+            )
+
+        rate_limit_key = str(access.claims.get("jti") or agent_id)
+        if not rate_limiter.check_and_record(rate_limit_key):
+            return PlainTextResponse(
+                "bundle upload rate limit exceeded, try again later", status_code=429
+            )
+
+        declared = request.headers.get("content-length")
+        if (
+            declared is not None
+            and declared.isdigit()
+            and int(declared) > mcp_settings.bundle_max_bytes
+        ):
+            return PlainTextResponse(
+                f"bundle exceeds the {mcp_settings.bundle_max_bytes} byte limit",
+                status_code=413,
+            )
+
+        # Stream rather than buffering the whole body at once: a chunked body
+        # with no Content-Length would sail past the header check above, so
+        # the cap must also be enforced against a running total while reading.
+        digest = hashlib.sha256()
+        total_bytes = 0
+        with tempfile.SpooledTemporaryFile(max_size=mcp_settings.bundle_max_bytes) as spooled:
+            async for chunk in request.stream():
+                total_bytes += len(chunk)
+                if total_bytes > mcp_settings.bundle_max_bytes:
+                    return PlainTextResponse(
+                        f"bundle exceeds the {mcp_settings.bundle_max_bytes} byte limit",
+                        status_code=413,
+                    )
+                digest.update(chunk)
+                spooled.write(chunk)
+
+            spooled.seek(0)
+            magic = spooled.read(2)
+            spooled.seek(0)
+            if magic != _GZIP_MAGIC:
+                return PlainTextResponse("bundle must be a gzip archive", status_code=415)
+
+            uploaded: FileMetadata = await anthropic.beta.files.upload(
+                file=("bundle.tar.gz", spooled, "application/gzip"),
+            )
+
+        now = datetime.now(UTC)
+        delete_after = now + timedelta(days=mcp_settings.bundle_ttl_days)
+        async with session_factory() as session, session.begin():
+            await enqueue_pending_file_delete(
+                session, file_id=uploaded.id, delete_after=delete_after
+            )
+
+        # The handle's expiry and the uploaded object's deletion time share the
+        # same horizon on purpose — a handle that outlived its object would
+        # verify successfully against bytes that no longer exist.
+        handle = bundle_handle.mint(
+            mcp_settings.jwt_secret.get_secret_value(),
+            file_id=uploaded.id,
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            sha256=digest.hexdigest(),
+            now=now,
+            ttl_days=mcp_settings.bundle_ttl_days,
+        )
+
+        log.info(
+            "bundles.uploaded",
+            file_id=uploaded.id,
+            size_bytes=total_bytes,
+            tenant_id=str(tenant_id),
+        )
+        return JSONResponse(
+            {
+                "bundle": handle,
+                "sha256": digest.hexdigest(),
+                "size_bytes": total_bytes,
+                "expires_at": delete_after.isoformat(),
+            }
+        )
+
+    return handler

--- a/packages/adapters/mcp/daimon/adapters/mcp/runtime.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/runtime.py
@@ -27,5 +27,6 @@ class McpRuntime:
     deployment_default: DeploymentDefault
     gemini_client: genai.Client | None = None
     notebook_rate_limiter: RateLimiter | None = None
+    bundle_rate_limiter: RateLimiter | None = None
     fernet: MultiFernet | None = field(default=None)
     artifact_store: ArtifactStore | None = field(default=None)

--- a/packages/adapters/mcp/daimon/adapters/mcp/server.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/server.py
@@ -18,6 +18,7 @@ import structlog
 from anthropic import AsyncAnthropic
 from daimon.adapters.mcp.artifacts import build_artifact_store
 from daimon.adapters.mcp.auth.verifier import DaimonJWTVerifier
+from daimon.adapters.mcp.bundles import build_bundles_route
 from daimon.adapters.mcp.checkout import billing_cancel, billing_success, build_checkout_route
 from daimon.adapters.mcp.middleware.ma_errors import MaErrorMiddleware
 from daimon.adapters.mcp.middleware.mcp_identity import (
@@ -241,6 +242,9 @@ def create_mcp_app(
     notebook_rate_limiter = RateLimiter(
         max_requests=effective_settings.notebook.publish_rate_per_hour,
     )
+    bundle_rate_limiter = RateLimiter(
+        max_requests=effective_settings.mcp.bundle_uploads_per_hour,
+    )
 
     fernet = (
         build_multifernet(tuple(k.get_secret_value() for k in effective_settings.crypto.keys))
@@ -262,6 +266,7 @@ def create_mcp_app(
         deployment_default=deployment_default,
         gemini_client=gemini_client,
         notebook_rate_limiter=notebook_rate_limiter,
+        bundle_rate_limiter=bundle_rate_limiter,
         fernet=fernet,
         artifact_store=artifact_store,
     )
@@ -305,6 +310,19 @@ def create_mcp_app(
     app.add_route(
         "/uploads/{token}",
         build_upload_route(effective_sessionmaker),
+        methods=["PUT"],
+    )
+    # No token path segment (unlike /uploads/{token}): the bearer IS the
+    # credential here, so there is nothing else to put in the path.
+    app.add_route(
+        "/bundles",
+        build_bundles_route(
+            anthropic=effective_anthropic,
+            session_factory=effective_sessionmaker,
+            auth=effective_auth,
+            mcp_settings=effective_settings.mcp,
+            rate_limiter=bundle_rate_limiter,
+        ),
         methods=["PUT"],
     )
     app.add_route("/healthz", _healthz, methods=["GET"])

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -55,12 +55,14 @@ from decimal import Decimal
 from time import monotonic
 from typing import Any, Literal
 
+import anthropic
 import structlog
 from anthropic.types.beta import (
     BetaEnvironment,
     BetaManagedAgentsAgent,
     BetaManagedAgentsSession,
 )
+from anthropic.types.beta.session_create_params import Resource
 from anthropic.types.beta.sessions import BetaManagedAgentsSendSessionEvents
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.hosted_artifacts import ChartUrl, deliver_hosted_charts
@@ -71,12 +73,14 @@ from daimon.adapters.mcp.tools._ctx import (
 )
 from daimon.adapters.mcp.tools._pagination import Page
 from daimon.adapters.mcp.tools.sessions import SessionEventOut, SessionInfo
+from daimon.core import bundle_handle
 from daimon.core.billing import BillingConfig
 from daimon.core.defaults.ma_index import find_environment_by_daimon_tag, list_agents_by_tenant
+from daimon.core.defaults.metadata import MA_METADATA_KEY_ISOLATED
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.pricing import MODEL_PRICING, cost_of
 from daimon.core.scope import ScopeContext
-from daimon.core.sessions import create_session
+from daimon.core.sessions import create_isolated_session, create_session
 from daimon.core.stores.agent_repo_binding import get_binding
 from daimon.core.stores.scoped_config_read import resolve
 from fastmcp import Context, FastMCP
@@ -284,6 +288,7 @@ async def _start_turn_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
     message: str,
+    bundle: str | None = None,
 ) -> dict[str, str]:
     """Create a new MA session for the caller's agent and send the first message.
 
@@ -299,6 +304,11 @@ async def _start_turn_impl(
       cascade (``resolve()``, MPP-01 — same as Discord).
     - Look it up on MA via ``find_environment_by_daimon_tag``.
     - Raise ``ToolError("environment not found")`` if either step fails.
+
+    When ``bundle`` is given, the session is created on the isolated path
+    (``create_isolated_session``) with the bundle mounted as its only
+    resource, instead of the normal vault/repo/env-mounted ``create_session``
+    path. See ``bundle_handle`` and SPEC §1.1 for the verification steps.
     """
     ma_agent = await _resolve_ma_agent(runtime, auth)
 
@@ -312,32 +322,68 @@ async def _start_turn_impl(
     if environment is None:
         raise ToolError("environment not found")
 
-    github_fallback_pat: str | None = (
-        runtime.settings.github.fallback_pat.get_secret_value()
-        if runtime.settings.github.fallback_pat is not None
-        else None
-    )
-    github_app_id: str | None = runtime.settings.github.app_id
-    github_app_private_key: str | None = (
-        runtime.settings.github.app_private_key.get_secret_value()
-        if runtime.settings.github.app_private_key is not None
-        else None
-    )
+    is_isolated = ma_agent.metadata.get(MA_METADATA_KEY_ISOLATED) == "true"
 
-    session = await create_session(
-        runtime.client,
-        agent=ma_agent,
-        environment=environment,
-        mcp_settings=runtime.settings.mcp,
-        account_id=auth.account_id,
-        tenant_id=auth.tenant_id,
-        agent_uuid=auth.agent_id,
-        session_factory=runtime.session_factory,
-        fernet=runtime.fernet,
-        github_fallback_pat=github_fallback_pat,
-        github_app_id=github_app_id,
-        github_app_private_key=github_app_private_key,
-    )
+    if bundle is not None:
+        if not is_isolated:
+            raise ToolError("bundle requires an isolated agent")
+        if runtime.settings.mcp.jwt_secret is None:
+            raise ToolError("bundle upload is not configured on this deployment")
+        claims = (
+            bundle_handle.verify(
+                runtime.settings.mcp.jwt_secret.get_secret_value(),
+                bundle,
+                tenant_id=auth.tenant_id,
+                agent_id=auth.agent_id,
+                now=dt.datetime.now(dt.UTC),
+            )
+            if auth.agent_id is not None
+            else None
+        )
+        if claims is None:
+            raise ToolError("bundle not found")
+        try:
+            await runtime.client.beta.files.retrieve_metadata(claims.file_id)
+        except anthropic.NotFoundError as err:
+            raise ToolError("bundle expired; re-upload") from err
+        resources: list[Resource] = [
+            {"type": "file", "file_id": claims.file_id, "mount_path": "/bundle.tar.gz"}
+        ]
+        session = await create_isolated_session(
+            runtime.client,
+            agent=ma_agent,
+            environment=environment,
+            account_id=auth.account_id,
+            tenant_id=auth.tenant_id,
+            resources=resources,
+        )
+    else:
+        github_fallback_pat: str | None = (
+            runtime.settings.github.fallback_pat.get_secret_value()
+            if runtime.settings.github.fallback_pat is not None
+            else None
+        )
+        github_app_id: str | None = runtime.settings.github.app_id
+        github_app_private_key: str | None = (
+            runtime.settings.github.app_private_key.get_secret_value()
+            if runtime.settings.github.app_private_key is not None
+            else None
+        )
+
+        session = await create_session(
+            runtime.client,
+            agent=ma_agent,
+            environment=environment,
+            mcp_settings=runtime.settings.mcp,
+            account_id=auth.account_id,
+            tenant_id=auth.tenant_id,
+            agent_uuid=auth.agent_id,
+            session_factory=runtime.session_factory,
+            fernet=runtime.fernet,
+            github_fallback_pat=github_fallback_pat,
+            github_app_id=github_app_id,
+            github_app_private_key=github_app_private_key,
+        )
 
     sent = await runtime.client.beta.sessions.events.send(
         session.id,
@@ -799,7 +845,9 @@ def register_agent_chat_tools(
         return await _list_sessions_impl(runtime, await _auth(ctx))
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
-    async def start_turn(ctx: Context, message: str) -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+    async def start_turn(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context, message: str, bundle: str | None = None
+    ) -> dict[str, str]:
         """Start a new conversation turn with the agent and return a handle.
 
         Creates a persistent MA session with vault/repo/env parity and sends
@@ -810,6 +858,17 @@ def register_agent_chat_tools(
         this turn's first event: poll ``list_events`` with
         ``created_at_gte=turn_started_at`` and discard everything up to and
         including ``turn_event_id`` to read only this turn's transcript.
+
+        ``bundle`` is an opaque handle returned by the bundle upload route.
+        Passing it mounts that archive read-only in the session's uploads
+        directory instead of the normal vault/repo/env mounts, and requires
+        an isolated agent — a non-isolated agent is refused outright with
+        the message 'bundle requires an isolated agent'. A handle that fails
+        verification for any reason (tampered, expired, wrong tenant, wrong
+        agent) is refused with the message 'bundle not found', one wording
+        for every cause. A handle whose underlying file is gone is refused
+        with the message 'bundle expired; re-upload' — that one specifically
+        means push the archive again.
         """
         auth = await _check_admission(
             ctx,
@@ -817,7 +876,7 @@ def register_agent_chat_tools(
             billing_config=billing_config,
             tool_name="start_turn",
         )
-        return await _start_turn_impl(runtime, auth, message)
+        return await _start_turn_impl(runtime, auth, message, bundle)
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
     async def ask(ctx: Context, message: str) -> AskResult:  # pyright: ignore[reportUnusedFunction]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -98,26 +98,23 @@ log = structlog.get_logger(__name__)
 _MAX_EVENT_PAGES = 20
 
 
-def _turn_boundary(sent: BetaManagedAgentsSendSessionEvents, *, handle: str) -> tuple[str, str]:
-    """Read the turn boundary (event id, ISO timestamp) off a send response.
+def _turn_boundary(sent: BetaManagedAgentsSendSessionEvents) -> str:
+    """Read the turn boundary event id off a send response.
 
-    The accepted event IS the boundary (SPEC D-07): a caller reads events at
-    or after ``turn_started_at`` and discards everything up to and including
-    ``turn_event_id``, instead of guessing the boundary from its own clock.
-    Raises when the send accepted nothing — a send with no accepted event is
-    not a started turn and must not return a half-answer.
+    The accepted event's id IS the boundary a caller drops through: read
+    events at or after the seam's own pre-send clock reading and discard
+    everything up to and including this id. The timestamp is NOT read off
+    the echo — a live probe against the API showed the send response always
+    echoes the event with ``processed_at=None``; the timestamp only appears
+    roughly half a second later, once the agent starts on the event — so the
+    boundary's clock is the caller's own, captured immediately before the
+    send (see the callers' ``now`` parameter). Raises when the send accepted
+    nothing — a send with no accepted event is not a started turn and must
+    not return a half-answer.
     """
     if not sent.data:
         raise ToolError("send returned no accepted event")
-    event = sent.data[0]
-    if event.processed_at is None:
-        log.warning(
-            "agent_chat.turn_boundary.processed_at_missing", handle=handle, event_id=event.id
-        )
-        timestamp = dt.datetime.now(dt.UTC)
-    else:
-        timestamp = event.processed_at
-    return event.id, timestamp.isoformat()
+    return sent.data[0].id
 
 
 class AgentDescription(BaseModel):
@@ -289,15 +286,19 @@ async def _start_turn_impl(
     auth: AuthIdentity,
     message: str,
     bundle: str | None = None,
+    *,
+    now: Callable[[], dt.datetime] = lambda: dt.datetime.now(dt.UTC),
 ) -> dict[str, str]:
     """Create a new MA session for the caller's agent and send the first message.
 
     Returns ``{"handle": session_id, "turn_event_id": ..., "turn_started_at": ...}``.
-    ``turn_event_id`` and ``turn_started_at`` identify this turn's first event
-    (the accepted ``user.message``), taken from the ``events.send`` response.
-    A caller reading the transcript should ask ``list_events`` for events at
-    or after ``turn_started_at`` and discard everything up to and including
-    ``turn_event_id`` — this is the turn boundary, not the caller's own clock.
+    ``turn_event_id`` is the accepted ``user.message`` event's id, taken from
+    the ``events.send`` response. ``turn_started_at`` is ``now()`` captured
+    immediately BEFORE that call, not a timestamp read off the response — the
+    echo carries no usable timestamp of its own (see ``_turn_boundary``). A
+    caller reading the transcript should ask ``list_events`` for events with
+    ``created_at_gte=turn_started_at`` and discard everything up to and
+    including ``turn_event_id`` — this is the turn boundary.
 
     Environment resolution (fail-closed):
     - Resolve ``environment_name`` via the shared channel/tenant/deployment
@@ -385,6 +386,7 @@ async def _start_turn_impl(
             github_app_private_key=github_app_private_key,
         )
 
+    turn_started_at = now()
     sent = await runtime.client.beta.sessions.events.send(
         session.id,
         events=[
@@ -394,12 +396,12 @@ async def _start_turn_impl(
             }
         ],
     )
-    turn_event_id, turn_started_at = _turn_boundary(sent, handle=session.id)
+    turn_event_id = _turn_boundary(sent)
 
     return {
         "handle": session.id,
         "turn_event_id": turn_event_id,
-        "turn_started_at": turn_started_at,
+        "turn_started_at": turn_started_at.isoformat(),
     }
 
 
@@ -408,16 +410,21 @@ async def _continue_turn_impl(
     auth: AuthIdentity,
     handle: str,
     message: str,
+    *,
+    now: Callable[[], dt.datetime] = lambda: dt.datetime.now(dt.UTC),
 ) -> dict[str, str]:
     """Send a follow-up message on an existing session.
 
     Returns ``{"handle": handle, "turn_event_id": ..., "turn_started_at": ...}``,
-    the same three-key shape as ``start_turn`` — the boundary is taken from
-    THIS call's ``events.send`` response, not the session's earlier events.
-    ``_verify_agent_owns_session`` guards against cross-tenant AND
+    the same three-key shape as ``start_turn``. ``turn_event_id`` is taken
+    from THIS call's ``events.send`` response, not the session's earlier
+    events; ``turn_started_at`` is ``now()`` captured immediately BEFORE that
+    send (see ``_start_turn_impl`` for why the echo's own timestamp isn't
+    used). ``_verify_agent_owns_session`` guards against cross-tenant AND
     same-tenant cross-agent handles (Tampering threat mitigation, WR-03).
     """
     await _verify_agent_owns_session(runtime, auth, handle)
+    turn_started_at = now()
     sent = await runtime.client.beta.sessions.events.send(
         handle,
         events=[
@@ -427,11 +434,11 @@ async def _continue_turn_impl(
             }
         ],
     )
-    turn_event_id, turn_started_at = _turn_boundary(sent, handle=handle)
+    turn_event_id = _turn_boundary(sent)
     return {
         "handle": handle,
         "turn_event_id": turn_event_id,
-        "turn_started_at": turn_started_at,
+        "turn_started_at": turn_started_at.isoformat(),
     }
 
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -33,6 +33,9 @@ Headless loop (primitives plus the bounded ``ask`` convenience tool):
 - ``deliver_turn_charts`` finds the newest completed reply and delivers charts
   from that turn. It performs a bounded artifact-store write when optional
   link delivery is configured; it is not admission-gated.
+- ``archive_my_session`` archives a finished session so it stops being a live
+  session forever (a reader thread that never archives would otherwise be
+  re-read by every usage-sweep tick). Read-only ownership check, not gated.
 """
 
 from __future__ import annotations
@@ -44,11 +47,13 @@ from collections.abc import Awaitable, Callable
 from time import monotonic
 from typing import Any, Literal
 
+import structlog
 from anthropic.types.beta import (
     BetaEnvironment,
     BetaManagedAgentsAgent,
     BetaManagedAgentsSession,
 )
+from anthropic.types.beta.sessions import BetaManagedAgentsSendSessionEvents
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.hosted_artifacts import ChartUrl, deliver_hosted_charts
 from daimon.adapters.mcp.runtime import McpRuntime
@@ -73,9 +78,33 @@ from pydantic.json_schema import SkipJsonSchema
 
 from mcp.types import ImageContent, TextContent
 
+log = structlog.get_logger(__name__)
+
 # Each transcript page costs two upstream calls (ownership retrieve + events
 # list), so an uncapped walk on a long session can outlast any client timeout.
 _MAX_EVENT_PAGES = 20
+
+
+def _turn_boundary(sent: BetaManagedAgentsSendSessionEvents, *, handle: str) -> tuple[str, str]:
+    """Read the turn boundary (event id, ISO timestamp) off a send response.
+
+    The accepted event IS the boundary (SPEC D-07): a caller reads events at
+    or after ``turn_started_at`` and discards everything up to and including
+    ``turn_event_id``, instead of guessing the boundary from its own clock.
+    Raises when the send accepted nothing — a send with no accepted event is
+    not a started turn and must not return a half-answer.
+    """
+    if not sent.data:
+        raise ToolError("send returned no accepted event")
+    event = sent.data[0]
+    if event.processed_at is None:
+        log.warning(
+            "agent_chat.turn_boundary.processed_at_missing", handle=handle, event_id=event.id
+        )
+        timestamp = dt.datetime.now(dt.UTC)
+    else:
+        timestamp = event.processed_at
+    return event.id, timestamp.isoformat()
 
 
 class AgentDescription(BaseModel):
@@ -249,8 +278,12 @@ async def _start_turn_impl(
 ) -> dict[str, str]:
     """Create a new MA session for the caller's agent and send the first message.
 
-    Returns ``{"handle": session_id}`` — the caller passes ``handle`` to
-    subsequent ``continue_turn``, ``get_session``, and ``list_events`` calls.
+    Returns ``{"handle": session_id, "turn_event_id": ..., "turn_started_at": ...}``.
+    ``turn_event_id`` and ``turn_started_at`` identify this turn's first event
+    (the accepted ``user.message``), taken from the ``events.send`` response.
+    A caller reading the transcript should ask ``list_events`` for events at
+    or after ``turn_started_at`` and discard everything up to and including
+    ``turn_event_id`` — this is the turn boundary, not the caller's own clock.
 
     Environment resolution (fail-closed):
     - Resolve ``environment_name`` via the shared channel/tenant/deployment
@@ -297,7 +330,7 @@ async def _start_turn_impl(
         github_app_private_key=github_app_private_key,
     )
 
-    await runtime.client.beta.sessions.events.send(
+    sent = await runtime.client.beta.sessions.events.send(
         session.id,
         events=[
             {
@@ -306,8 +339,13 @@ async def _start_turn_impl(
             }
         ],
     )
+    turn_event_id, turn_started_at = _turn_boundary(sent, handle=session.id)
 
-    return {"handle": session.id}
+    return {
+        "handle": session.id,
+        "turn_event_id": turn_event_id,
+        "turn_started_at": turn_started_at,
+    }
 
 
 async def _continue_turn_impl(
@@ -318,11 +356,14 @@ async def _continue_turn_impl(
 ) -> dict[str, str]:
     """Send a follow-up message on an existing session.
 
+    Returns ``{"handle": handle, "turn_event_id": ..., "turn_started_at": ...}``,
+    the same three-key shape as ``start_turn`` — the boundary is taken from
+    THIS call's ``events.send`` response, not the session's earlier events.
     ``_verify_agent_owns_session`` guards against cross-tenant AND
     same-tenant cross-agent handles (Tampering threat mitigation, WR-03).
     """
     await _verify_agent_owns_session(runtime, auth, handle)
-    await runtime.client.beta.sessions.events.send(
+    sent = await runtime.client.beta.sessions.events.send(
         handle,
         events=[
             {
@@ -331,7 +372,12 @@ async def _continue_turn_impl(
             }
         ],
     )
-    return {"handle": handle}
+    turn_event_id, turn_started_at = _turn_boundary(sent, handle=handle)
+    return {
+        "handle": handle,
+        "turn_event_id": turn_event_id,
+        "turn_started_at": turn_started_at,
+    }
 
 
 async def _list_sessions_impl(
@@ -365,6 +411,24 @@ async def _get_session_impl(
     return SessionInfo.from_ma(s)
 
 
+async def _archive_my_session_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    handle: str,
+) -> dict[str, str]:
+    """Archive a finished session so it stops being a live session forever.
+
+    Without this, every reader thread accumulates as a live MA session and
+    the usage sweep re-reads all of them on every tick. Not a cancel — a
+    running turn is stopped with the cancel tool, not this one.
+    ``_verify_agent_owns_session`` guards cross-tenant AND same-tenant
+    cross-agent handles (WR-03).
+    """
+    await _verify_agent_owns_session(runtime, auth, handle)
+    await runtime.client.beta.sessions.archive(handle)
+    return {"handle": handle, "archived": "true"}
+
+
 async def _list_events_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
@@ -372,12 +436,20 @@ async def _list_events_impl(
     page: str | None,
     limit: int | None,
     order: Literal["asc", "desc"] | None,
+    created_at_gte: str | None = None,
+    types: list[str] | None = None,
 ) -> Page[SessionEventOut]:
     """List a session's events (the transcript) for the caller to read.
 
     This is how a primitives-only caller reads the agent's reply: fold the
     ``agent.message`` events client-side. ``_verify_agent_owns_session``
     guards cross-tenant AND same-tenant cross-agent handles (WR-03).
+
+    ``created_at_gte`` and ``types`` let a poller read one turn instead of
+    the whole transcript: pass the ``turn_started_at`` from ``start_turn``/
+    ``continue_turn`` as ``created_at_gte`` and
+    ``types=["agent.message", "session.status_idle"]`` to see only this
+    turn's reply and completion signal.
     """
     await _verify_agent_owns_session(runtime, auth, handle)
     list_kwargs: dict[str, Any] = {}
@@ -387,6 +459,10 @@ async def _list_events_impl(
         list_kwargs["limit"] = limit
     if order is not None:
         list_kwargs["order"] = order
+    if created_at_gte is not None:
+        list_kwargs["created_at_gte"] = created_at_gte
+    if types is not None:
+        list_kwargs["types"] = types
     cursor = await runtime.client.beta.sessions.events.list(handle, **list_kwargs)
     return Page[SessionEventOut](
         items=[
@@ -612,8 +688,13 @@ def register_agent_chat_tools(
         """Start a new conversation turn with the agent and return a handle.
 
         Creates a persistent MA session with vault/repo/env parity and sends
-        the first user message. Returns ``{"handle": "<session_id>"}`` which
-        you pass to ``get_session``, ``list_events``, and ``continue_turn``.
+        the first user message. Returns ``{"handle": "<session_id>",
+        "turn_event_id": "<event_id>", "turn_started_at": "<iso8601>"}``.
+        ``handle`` is passed to ``get_session``, ``list_events``, and
+        ``continue_turn``. ``turn_event_id`` and ``turn_started_at`` identify
+        this turn's first event: poll ``list_events`` with
+        ``created_at_gte=turn_started_at`` and discard everything up to and
+        including ``turn_event_id`` to read only this turn's transcript.
         """
         auth = await _check_admission(
             ctx,
@@ -646,7 +727,12 @@ def register_agent_chat_tools(
         """Send a follow-up message on an existing session.
 
         Use this to continue a multi-turn conversation. Returns
-        ``{"handle": "<session_id>"}`` unchanged for chaining.
+        ``{"handle": "<session_id>", "turn_event_id": "<event_id>",
+        "turn_started_at": "<iso8601>"}`` — the same three-key shape as
+        ``start_turn``, with the boundary taken from THIS message's send, not
+        the session's earlier turns. Poll ``list_events`` with
+        ``created_at_gte=turn_started_at`` and discard events up to and
+        including ``turn_event_id`` to read only this turn's transcript.
         """
         auth = await _check_admission(
             ctx,
@@ -667,19 +753,44 @@ def register_agent_chat_tools(
         return await _get_session_impl(runtime, await _auth(ctx), handle)
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
+    async def archive_my_session(ctx: Context, handle: str) -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+        """Archive a session when its conversation is finished.
+
+        An archived session is no longer live and stops being re-read by
+        usage collection. This is NOT a cancel — to stop a running turn, use
+        the cancel tool instead. Returns ``{"handle": "<session_id>",
+        "archived": "true"}``.
+        """
+        return await _archive_my_session_impl(runtime, await _auth(ctx), handle)
+
+    @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
     async def list_events(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         handle: str,
         page: str | None = None,
         limit: int | None = None,
         order: Literal["asc", "desc"] | None = None,
+        created_at_gte: str | None = None,
+        types: list[str] | None = None,
     ) -> Page[SessionEventOut]:
         """List a session's events — the transcript.
 
         The agent's reply is in the ``agent.message`` events. Call this once
         ``get_session`` reports the session is idle to read what the agent said.
+
+        A poller reading one turn should pass
+        ``types=["agent.message", "session.status_idle"]``,
+        ``created_at_gte=<the turn_started_at from start_turn/continue_turn>``,
+        and ``order="asc"``, then discard events up to and including the
+        ``turn_event_id`` it was given, locally. A turn is finished only when
+        a ``session.status_idle`` event appears AFTER the boundary, or
+        ``get_my_session`` reports the session ``terminated`` — a bare
+        ``idle`` status read right after a send may be the PREVIOUS turn's
+        state and must not be trusted. ``rescheduling`` counts as running.
         """
-        return await _list_events_impl(runtime, await _auth(ctx), handle, page, limit, order)
+        return await _list_events_impl(
+            runtime, await _auth(ctx), handle, page, limit, order, created_at_gte, types
+        )
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
     async def deliver_turn_charts(  # pyright: ignore[reportUnusedFunction]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_chat.py
@@ -36,6 +36,13 @@ Headless loop (primitives plus the bounded ``ask`` convenience tool):
 - ``archive_my_session`` archives a finished session so it stops being a live
   session forever (a reader thread that never archives would otherwise be
   re-read by every usage-sweep tick). Read-only ownership check, not gated.
+- ``cancel_turn`` sends one unconditional ``user.interrupt`` and reports the
+  status observed right after — no read-then-send race. Read-only ownership
+  check, not gated (a caller over balance must still be able to stop a turn).
+- ``get_turn_cost`` folds one finished turn's ``span.model_request_end``
+  events into a pre-markup USD cost. A separate tool, not a field on
+  ``get_session`` — the host polls status every two seconds and reads cost
+  once per terminal. Read-only ownership check, not gated.
 """
 
 from __future__ import annotations
@@ -44,6 +51,7 @@ import asyncio
 import datetime as dt
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
+from decimal import Decimal
 from time import monotonic
 from typing import Any, Literal
 
@@ -66,6 +74,7 @@ from daimon.adapters.mcp.tools.sessions import SessionEventOut, SessionInfo
 from daimon.core.billing import BillingConfig
 from daimon.core.defaults.ma_index import find_environment_by_daimon_tag, list_agents_by_tenant
 from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.pricing import MODEL_PRICING, cost_of
 from daimon.core.scope import ScopeContext
 from daimon.core.sessions import create_session
 from daimon.core.stores.agent_repo_binding import get_binding
@@ -429,6 +438,111 @@ async def _archive_my_session_impl(
     return {"handle": handle, "archived": "true"}
 
 
+async def _cancel_turn_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    handle: str,
+) -> dict[str, str]:
+    """Stop a running turn with one unconditional interrupt, then report status.
+
+    Sends ``user.interrupt`` unconditionally — no read-then-send: a status
+    read before the send would race the session's own state (it can change
+    between the read and the send), and the interrupt is safe to send at any
+    status anyway, including an already-idle or already-terminated session
+    (harmless no-op). This call returns immediately; it does not wait for the
+    interrupt to take effect — poll ``get_my_session`` to see the session
+    reach ``idle`` or ``terminated`` (contrast ``daimon.core.ma.
+    send_interrupt_and_wait``, which sends the same event and then blocks on
+    the SSE stream for a terminal ``session.status_idle``; this tool is
+    fire-and-return, not fire-and-wait).
+
+    An interrupted turn is still billed for what it already consumed before
+    the interrupt landed — the model work already done is real work and is
+    not refunded. The report host surfaces that to the reader.
+
+    ``_verify_agent_owns_session`` guards cross-tenant AND same-tenant
+    cross-agent handles (WR-03) before any send.
+    """
+    await _verify_agent_owns_session(runtime, auth, handle)
+    await runtime.client.beta.sessions.events.send(handle, events=[{"type": "user.interrupt"}])
+    session = await runtime.client.beta.sessions.retrieve(handle)
+    return {"handle": handle, "status": session.status}
+
+
+async def _get_turn_cost_impl(
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    handle: str,
+    turn_started_at: str,
+    turn_event_id: str,
+) -> dict[str, object]:
+    """Fold one finished turn's model-request cost — the RAW PROVIDER COST
+    BEFORE MARKUP.
+
+    This is NOT expected to equal the tenant ledger's debit for the same
+    turn: the ledger applies ``settings.billing.markup`` on top of this
+    figure (``daimon.core.tenant_balance.debit_amount``). An integrator who
+    assumes the two match will build a reconciliation that never balances.
+
+    Pass the ``turn_started_at``/``turn_event_id`` returned by ``start_turn``
+    or ``continue_turn``. Pages ``span.model_request_end`` events at or after
+    ``turn_started_at`` and folds each into
+    ``Decimal(str(cost_of(event.model_usage, pricing))).quantize(Decimal("0.000001"))``,
+    summed. The boundary event itself (``turn_event_id``) is never folded in,
+    even if it were ever echoed back by this filtered listing.
+
+    Returns ``{"cost_usd": <str(Decimal) or None>, "event_count": <int>}``.
+    ``cost_usd`` is serialised as a string, never a float — a float
+    round-trip is exactly the drift ``debit_amount``'s ``Decimal(str(...))``
+    conversion exists to avoid. ``cost_usd`` is ``None`` (NOT zero) when the
+    session's model has no pricing row: a zero would falsely claim the turn
+    was free. A turn with pricing but no model-request events yet returns a
+    real zero cost, distinguishable from the unpriced ``None`` case.
+
+    ``_verify_agent_owns_session`` guards cross-tenant AND same-tenant
+    cross-agent handles (WR-03); the session it returns is reused for the
+    pricing lookup rather than retrieved twice.
+    """
+    session = await _verify_agent_owns_session(runtime, auth, handle)
+    model_id = session.agent.model.id
+    pricing = MODEL_PRICING.get(model_id)
+    if pricing is None:
+        log.warning("agent_chat.get_turn_cost.unpriced_model", handle=handle, model_id=model_id)
+
+    total = Decimal("0")
+    event_count = 0
+    page: str | None = None
+    for _ in range(_MAX_EVENT_PAGES):
+        list_kwargs: dict[str, Any] = {
+            "created_at_gte": turn_started_at,
+            "types": ["span.model_request_end"],
+            "order": "asc",
+        }
+        if page is not None:
+            list_kwargs["page"] = page
+        cursor = await runtime.client.beta.sessions.events.list(handle, **list_kwargs)
+        for event in cursor.data:
+            if event.id == turn_event_id:
+                continue
+            if event.type != "span.model_request_end":
+                continue
+            event_count += 1
+            if pricing is None:
+                continue
+            cost = cost_of(event.model_usage, pricing)
+            if cost is None:
+                continue
+            total += Decimal(str(cost)).quantize(Decimal("0.000001"))
+        if cursor.next_page is None:
+            break
+        page = cursor.next_page
+
+    return {
+        "cost_usd": str(total) if pricing is not None else None,
+        "event_count": event_count,
+    }
+
+
 async def _list_events_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
@@ -658,9 +772,10 @@ def register_agent_chat_tools(
 
     ``start_turn``, ``continue_turn``, and ``ask`` run the shared
     ``_check_admission`` gate (the same balance/cap checks the media tools run)
-    before creating a session or sending an event. The four read-only tools and
-    ``deliver_turn_charts`` stay on bare ``_auth``; the latter performs a
-    bounded artifact-store write when optional link delivery is configured.
+    before creating a session or sending an event. Every other tool —
+    including ``cancel_turn`` and ``get_turn_cost`` — stays on bare ``_auth``;
+    ``deliver_turn_charts`` is the one exception that performs a bounded
+    artifact-store write when optional link delivery is configured.
     """
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
@@ -762,6 +877,44 @@ def register_agent_chat_tools(
         "archived": "true"}``.
         """
         return await _archive_my_session_impl(runtime, await _auth(ctx), handle)
+
+    @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
+    async def cancel_turn(ctx: Context, handle: str) -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+        """Stop a running turn immediately.
+
+        Sends an interrupt regardless of the session's current status —
+        sending one to an already-idle session is harmless. Returns
+        ``{"handle": "<session_id>", "status": "<observed_status>"}``
+        immediately; it does not wait for the interrupt to take effect, so
+        poll ``get_my_session`` to see the session reach ``idle`` or
+        ``terminated``. An interrupted turn is still billed for what it
+        already consumed before the interrupt landed: the model work already
+        done is real work and is not refunded.
+        """
+        return await _cancel_turn_impl(runtime, await _auth(ctx), handle)
+
+    @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
+    async def get_turn_cost(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        handle: str,
+        turn_started_at: str,
+        turn_event_id: str,
+    ) -> dict[str, object]:
+        """Return one finished turn's raw provider cost, before markup.
+
+        Pass the ``turn_started_at``/``turn_event_id`` returned by
+        ``start_turn`` or ``continue_turn``. Call this once per terminal —
+        the host polls status every two seconds and should read cost once,
+        not on every poll. Returns ``{"cost_usd": "<decimal string>" | None,
+        "event_count": <int>}``. ``cost_usd`` is ``None`` when the session's
+        model has no pricing row (never zero — zero would falsely claim the
+        turn was free). This figure is NOT expected to equal the tenant
+        ledger's debit for the same turn: the ledger applies
+        ``settings.billing.markup`` on top of it.
+        """
+        return await _get_turn_cost_impl(
+            runtime, await _auth(ctx), handle, turn_started_at, turn_event_id
+        )
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]
     async def list_events(  # pyright: ignore[reportUnusedFunction]

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2948,10 +2948,32 @@
         this turn's first event: poll ``list_events`` with
         ``created_at_gte=turn_started_at`` and discard everything up to and
         including ``turn_event_id`` to read only this turn's transcript.
+        
+        ``bundle`` is an opaque handle returned by the bundle upload route.
+        Passing it mounts that archive read-only in the session's uploads
+        directory instead of the normal vault/repo/env mounts, and requires
+        an isolated agent — a non-isolated agent is refused outright with
+        the message 'bundle requires an isolated agent'. A handle that fails
+        verification for any reason (tampered, expired, wrong tenant, wrong
+        agent) is refused with the message 'bundle not found', one wording
+        for every cause. A handle whose underlying file is gone is refused
+        with the message 'bundle expired; re-upload' — that one specifically
+        means push the archive again.
       ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
+          'bundle': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
           'message': dict({
             'type': 'string',
           }),

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -121,6 +121,32 @@
         'type': 'object',
       }),
     }),
+    'cancel_turn': dict({
+      'description': '''
+        Stop a running turn immediately.
+        
+        Sends an interrupt regardless of the session's current status —
+        sending one to an already-idle session is harmless. Returns
+        ``{"handle": "<session_id>", "status": "<observed_status>"}``
+        immediately; it does not wait for the interrupt to take effect, so
+        poll ``get_my_session`` to see the session reach ``idle`` or
+        ``terminated``. An interrupted turn is still billed for what it
+        already consumed before the interrupt landed: the model work already
+        done is real work and is not refunded.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'handle': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'handle',
+        ]),
+        'type': 'object',
+      }),
+    }),
     'clear_agent_default': dict({
       'description': '''
         Remove the agent default from a channel or the whole workspace.
@@ -1584,6 +1610,41 @@
         }),
         'required': list([
           'name',
+        ]),
+        'type': 'object',
+      }),
+    }),
+    'get_turn_cost': dict({
+      'description': '''
+        Return one finished turn's raw provider cost, before markup.
+        
+        Pass the ``turn_started_at``/``turn_event_id`` returned by
+        ``start_turn`` or ``continue_turn``. Call this once per terminal —
+        the host polls status every two seconds and should read cost once,
+        not on every poll. Returns ``{"cost_usd": "<decimal string>" | None,
+        "event_count": <int>}``. ``cost_usd`` is ``None`` when the session's
+        model has no pricing row (never zero — zero would falsely claim the
+        turn was free). This figure is NOT expected to equal the tenant
+        ledger's debit for the same turn: the ledger applies
+        ``settings.billing.markup`` on top of it.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'handle': dict({
+            'type': 'string',
+          }),
+          'turn_event_id': dict({
+            'type': 'string',
+          }),
+          'turn_started_at': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'handle',
+          'turn_started_at',
+          'turn_event_id',
         ]),
         'type': 'object',
       }),

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -36,6 +36,28 @@
         'type': 'object',
       }),
     }),
+    'archive_my_session': dict({
+      'description': '''
+        Archive a session when its conversation is finished.
+        
+        An archived session is no longer live and stops being re-read by
+        usage collection. This is NOT a cancel — to stop a running turn, use
+        the cancel tool instead. Returns ``{"handle": "<session_id>",
+        "archived": "true"}``.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'handle': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'handle',
+        ]),
+        'type': 'object',
+      }),
+    }),
     'ask': dict({
       'description': '''
         Ask one question and wait for the final answer and any chart images. Starts a
@@ -149,7 +171,12 @@
         Send a follow-up message on an existing session.
         
         Use this to continue a multi-turn conversation. Returns
-        ``{"handle": "<session_id>"}`` unchanged for chaining.
+        ``{"handle": "<session_id>", "turn_event_id": "<event_id>",
+        "turn_started_at": "<iso8601>"}`` — the same three-key shape as
+        ``start_turn``, with the boundary taken from THIS message's send, not
+        the session's earlier turns. Poll ``list_events`` with
+        ``created_at_gte=turn_started_at`` and discard events up to and
+        including ``turn_event_id`` to read only this turn's transcript.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -1649,10 +1676,31 @@
         
         The agent's reply is in the ``agent.message`` events. Call this once
         ``get_session`` reports the session is idle to read what the agent said.
+        
+        A poller reading one turn should pass
+        ``types=["agent.message", "session.status_idle"]``,
+        ``created_at_gte=<the turn_started_at from start_turn/continue_turn>``,
+        and ``order="asc"``, then discard events up to and including the
+        ``turn_event_id`` it was given, locally. A turn is finished only when
+        a ``session.status_idle`` event appears AFTER the boundary, or
+        ``get_my_session`` reports the session ``terminated`` — a bare
+        ``idle`` status read right after a send may be the PREVIOUS turn's
+        state and must not be trusted. ``rescheduling`` counts as running.
       ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
+          'created_at_gte': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
           'handle': dict({
             'type': 'string',
           }),
@@ -1686,6 +1734,20 @@
             'anyOf': list([
               dict({
                 'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+          'types': dict({
+            'anyOf': list([
+              dict({
+                'items': dict({
+                  'type': 'string',
+                }),
+                'type': 'array',
               }),
               dict({
                 'type': 'null',
@@ -2818,8 +2880,13 @@
         Start a new conversation turn with the agent and return a handle.
         
         Creates a persistent MA session with vault/repo/env parity and sends
-        the first user message. Returns ``{"handle": "<session_id>"}`` which
-        you pass to ``get_session``, ``list_events``, and ``continue_turn``.
+        the first user message. Returns ``{"handle": "<session_id>",
+        "turn_event_id": "<event_id>", "turn_started_at": "<iso8601>"}``.
+        ``handle`` is passed to ``get_session``, ``list_events``, and
+        ``continue_turn``. ``turn_event_id`` and ``turn_started_at`` identify
+        this turn's first event: poll ``list_events`` with
+        ``created_at_gte=turn_started_at`` and discard everything up to and
+        including ``turn_event_id`` to read only this turn's transcript.
       ''',
       'parameters': dict({
         'additionalProperties': False,

--- a/packages/adapters/mcp/tests/test_bundles_route.py
+++ b/packages/adapters/mcp/tests/test_bundles_route.py
@@ -1,0 +1,322 @@
+"""Tests for PUT /bundles — auth, streamed cap, gzip check, rate limit, happy path."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import FileMetadata
+from daimon.adapters.mcp.server import create_mcp_app
+from daimon.core import bundle_handle
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    McpSettings,
+    Settings,
+)
+from daimon.core.stores.pending_file_deletes import list_due_pending_file_deletes
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.applications import Starlette
+
+pytestmark = pytest.mark.asyncio
+
+_TENANT_ID: uuid.UUID = uuid.uuid4()
+_AGENT_ID: uuid.UUID = uuid.uuid4()
+_VALID_TOKEN = "bearer-test-token"
+_SECRET = "a" * 32
+
+
+class _FilesUploadCapture:
+    """Records POST /v1/files calls and serves a real FileMetadata.
+
+    Transport-level fake per guideline:testing T3 — no method-level mock on
+    the SDK's upload call. Counts calls so cap/gzip tests can assert zero
+    uploads happened.
+    """
+
+    def __init__(self, *, file_id: str = "file_bundle_test") -> None:
+        self.file_id = file_id
+        self.upload_count = 0
+        self.uploaded_bodies: list[bytes] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/files" and request.method == "POST":
+            self.upload_count += 1
+            self.uploaded_bodies.append(request.content)
+            metadata = FileMetadata(
+                id=self.file_id,
+                created_at=datetime.now(UTC),
+                filename="bundle.tar.gz",
+                mime_type="application/gzip",
+                size_bytes=len(request.content),
+                type="file",
+            )
+            return httpx.Response(200, json=metadata.model_dump(mode="json"))
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+
+def _client_for(capture: _FilesUploadCapture) -> AsyncAnthropic:
+    transport = httpx.MockTransport(capture.handler)
+    http_client = httpx.AsyncClient(transport=transport, base_url="https://api.anthropic.com")
+    return AsyncAnthropic(api_key="test", http_client=http_client)
+
+
+def _build_app(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    anthropic: AsyncAnthropic,
+    tokens: dict[str, dict[str, object]] | None = None,
+    bundle_max_bytes: int = 25 * 1024 * 1024,
+    bundle_uploads_per_hour: int = 20,
+) -> Starlette:
+    effective_tokens: dict[str, dict[str, object]] = tokens or {
+        _VALID_TOKEN: {
+            "client_id": "test",
+            "tenant_id": str(_TENANT_ID),
+            "agent_id": str(_AGENT_ID),
+            "jti": "jti-fixed",
+        }
+    }
+    return create_mcp_app(
+        settings=Settings(
+            database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+            anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+            mcp=McpSettings(
+                jwt_secret=SecretStr(_SECRET),
+                public_url=HttpUrl("https://x/mcp"),
+                bundle_max_bytes=bundle_max_bytes,
+                bundle_uploads_per_hour=bundle_uploads_per_hour,
+            ),
+        ),
+        sessionmaker=sessionmaker,
+        auth=StaticTokenVerifier(tokens=effective_tokens),
+        anthropic=anthropic,
+    )
+
+
+async def _chunked_body(total_bytes: int, chunk_size: int = 1024) -> AsyncIterator[bytes]:
+    """An async generator content= source — httpx omits Content-Length for it."""
+    sent = 0
+    chunk = b"\x1f\x8bx" * (chunk_size // 3 + 1)
+    while sent < total_bytes:
+        piece = chunk[: min(chunk_size, total_bytes - sent)]
+        sent += len(piece)
+        yield piece
+
+
+# ---------------------------------------------------------------------------
+# auth
+# ---------------------------------------------------------------------------
+
+
+async def test_bundles_no_authorization_header_returns_401(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    capture = _FilesUploadCapture()
+    app = _build_app(sessionmaker, anthropic=_client_for(capture))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.put("/bundles", content=gzip.compress(b"data"))
+    assert r.status_code == 401, "missing Authorization header must be rejected with 401"
+    assert capture.upload_count == 0, "no upload should be attempted without auth"
+
+
+async def test_bundles_rejected_bearer_returns_401(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    capture = _FilesUploadCapture()
+    app = _build_app(sessionmaker, anthropic=_client_for(capture))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.put(
+            "/bundles",
+            content=gzip.compress(b"data"),
+            headers={"Authorization": "Bearer forged-invalid-token"},
+        )
+    assert r.status_code == 401, "a token the verifier rejects must return 401"
+    assert capture.upload_count == 0, "no upload should be attempted with a rejected token"
+
+
+async def test_bundles_missing_tenant_id_claim_returns_403(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    token = "token-no-tenant"
+    capture = _FilesUploadCapture()
+    app = _build_app(
+        sessionmaker,
+        anthropic=_client_for(capture),
+        tokens={token: {"client_id": "test", "agent_id": str(_AGENT_ID)}},
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.put(
+            "/bundles",
+            content=gzip.compress(b"data"),
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 403, "a verified token with no tenant_id claim must be rejected"
+    assert capture.upload_count == 0
+
+
+async def test_bundles_missing_agent_id_claim_returns_403(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A plain account token (tenant scope, no agent scope) cannot upload — T-21-04-B."""
+    token = "token-no-agent"
+    capture = _FilesUploadCapture()
+    app = _build_app(
+        sessionmaker,
+        anthropic=_client_for(capture),
+        tokens={token: {"client_id": "test", "tenant_id": str(_TENANT_ID)}},
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.put(
+            "/bundles",
+            content=gzip.compress(b"data"),
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 403, (
+        "a verified token with a tenant_id but no agent_id claim must be rejected"
+    )
+    assert capture.upload_count == 0, "no upload should be attempted without agent scope"
+
+
+# ---------------------------------------------------------------------------
+# size cap
+# ---------------------------------------------------------------------------
+
+
+async def test_bundles_content_length_over_cap_returns_413(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    capture = _FilesUploadCapture()
+    app = _build_app(sessionmaker, anthropic=_client_for(capture), bundle_max_bytes=100)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.put(
+            "/bundles",
+            content=b"\x1f\x8b" + b"x" * 200,
+            headers={"Authorization": f"Bearer {_VALID_TOKEN}"},
+        )
+    assert r.status_code == 413, "a declared length over the cap must be refused"
+    assert capture.upload_count == 0, "an oversize declared length must never reach the SDK"
+
+
+async def test_bundles_chunked_body_exceeds_cap_mid_stream_returns_413(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """No Content-Length header (chunked) — only the mid-stream running-total
+    check can catch this; the header-only precedent would let it through."""
+    capture = _FilesUploadCapture()
+    app = _build_app(sessionmaker, anthropic=_client_for(capture), bundle_max_bytes=100)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.put(
+            "/bundles",
+            content=_chunked_body(total_bytes=500),
+            headers={"Authorization": f"Bearer {_VALID_TOKEN}"},
+        )
+    assert r.status_code == 413, "a chunked body exceeding the cap mid-stream must be refused"
+    assert capture.upload_count == 0, "an oversize streamed body must never reach the SDK"
+
+
+# ---------------------------------------------------------------------------
+# gzip check
+# ---------------------------------------------------------------------------
+
+
+async def test_bundles_non_gzip_body_returns_415(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    capture = _FilesUploadCapture()
+    app = _build_app(sessionmaker, anthropic=_client_for(capture))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.put(
+            "/bundles",
+            content=b"not gzip at all",
+            headers={"Authorization": f"Bearer {_VALID_TOKEN}"},
+        )
+    assert r.status_code == 415, "a non-gzip body must be refused with 415"
+    assert capture.upload_count == 0, "a non-gzip body must never reach the SDK"
+
+
+# ---------------------------------------------------------------------------
+# rate limit
+# ---------------------------------------------------------------------------
+
+
+async def test_bundles_second_upload_within_hour_returns_429(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    capture = _FilesUploadCapture()
+    app = _build_app(sessionmaker, anthropic=_client_for(capture), bundle_uploads_per_hour=1)
+    transport = httpx.ASGITransport(app=app)
+    body = gzip.compress(b"first upload payload")
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        first = await ac.put(
+            "/bundles", content=body, headers={"Authorization": f"Bearer {_VALID_TOKEN}"}
+        )
+        second = await ac.put(
+            "/bundles", content=body, headers={"Authorization": f"Bearer {_VALID_TOKEN}"}
+        )
+    assert first.status_code == 200, f"first upload under the limit should succeed: {first.text}"
+    assert second.status_code == 429, "second upload beyond the per-hour cap must be refused"
+    assert capture.upload_count == 1, "the rate-limited call must never reach the SDK"
+
+
+# ---------------------------------------------------------------------------
+# happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_bundles_happy_path_returns_signed_handle_and_enqueues_delete(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    db_session: AsyncSession,
+) -> None:
+    capture = _FilesUploadCapture(file_id="file_happy_path")
+    app = _build_app(sessionmaker, anthropic=_client_for(capture))
+    transport = httpx.ASGITransport(app=app)
+    body = gzip.compress(b"a small real gzip bundle body")
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.put(
+            "/bundles", content=body, headers={"Authorization": f"Bearer {_VALID_TOKEN}"}
+        )
+
+    assert r.status_code == 200, f"expected 200, got {r.status_code}: {r.text}"
+    payload = r.json()
+    assert set(payload) == {"bundle", "sha256", "size_bytes", "expires_at"}, (
+        "response must carry exactly bundle, sha256, size_bytes, expires_at"
+    )
+    assert payload["sha256"] == hashlib.sha256(body).hexdigest(), (
+        "sha256 must be over the exact uploaded bytes"
+    )
+    assert payload["size_bytes"] == len(body), "size_bytes must equal the uploaded body length"
+
+    claims = bundle_handle.verify(
+        _SECRET,
+        payload["bundle"],
+        tenant_id=_TENANT_ID,
+        agent_id=_AGENT_ID,
+        now=datetime.now(UTC),
+    )
+    assert claims is not None, "the returned handle must verify against the caller's own claims"
+    assert claims.file_id == "file_happy_path", (
+        "the handle's file_id must be the id the fake Files API returned"
+    )
+
+    due = await list_due_pending_file_deletes(
+        db_session, now=datetime.now(UTC) + timedelta(days=365)
+    )
+    matching = [row for row in due if row.file_id == "file_happy_path"]
+    assert len(matching) == 1, "exactly one pending-delete row must exist for the uploaded file_id"

--- a/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
+++ b/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
@@ -338,7 +338,7 @@ async def test_agent_id_claim_session_discovers_agent_chat_and_self_edit_tools_o
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
     """A session narrowed to agent-chat-tagged tools (an agent_id claim)
-    discovers the eight agent-chat tools plus the eight self-edit/vault tools
+    discovers the nine agent-chat tools plus the eight self-edit/vault tools
     tagged in this plan, and none of the tenant-wide roster tools."""
     async with sessionmaker() as s, s.begin():
         tenant = await make_tenant(s, platform="discord", workspace_id="agent-chat-reachability")
@@ -359,6 +359,7 @@ async def test_agent_id_claim_session_discovers_agent_chat_and_self_edit_tools_o
         "continue_turn",
         "get_my_session",
         "list_events",
+        "archive_my_session",
         "self_write_file",
         "self_read_file",
         "self_list_files",

--- a/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
+++ b/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
@@ -338,7 +338,7 @@ async def test_agent_id_claim_session_discovers_agent_chat_and_self_edit_tools_o
     sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
     """A session narrowed to agent-chat-tagged tools (an agent_id claim)
-    discovers the nine agent-chat tools plus the eight self-edit/vault tools
+    discovers the eleven agent-chat tools plus the eight self-edit/vault tools
     tagged in this plan, and none of the tenant-wide roster tools."""
     async with sessionmaker() as s, s.begin():
         tenant = await make_tenant(s, platform="discord", workspace_id="agent-chat-reachability")
@@ -360,6 +360,8 @@ async def test_agent_id_claim_session_discovers_agent_chat_and_self_edit_tools_o
         "get_my_session",
         "list_events",
         "archive_my_session",
+        "cancel_turn",
+        "get_turn_cost",
         "self_write_file",
         "self_read_file",
         "self_list_files",

--- a/packages/adapters/mcp/tests/test_runtime.py
+++ b/packages/adapters/mcp/tests/test_runtime.py
@@ -20,6 +20,7 @@ def test_mcp_runtime_is_frozen_dataclass_with_required_fields() -> None:
         "deployment_default",
         "gemini_client",
         "notebook_rate_limiter",
+        "bundle_rate_limiter",
         "fernet",
         "artifact_store",
     }, (

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -28,6 +28,10 @@ import httpx
 import pytest
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import BetaManagedAgentsSession
+from anthropic.types.beta.sessions import (
+    BetaManagedAgentsTextBlock,
+    BetaManagedAgentsUserMessageEvent,
+)
 from daimon.adapters.mcp.auth.resolver import AuthIdentity, Role
 from daimon.adapters.mcp.hosted_artifacts import ChartUrl, HostedChartDelivery
 from daimon.adapters.mcp.middleware.mcp_identity import (
@@ -43,6 +47,7 @@ from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.search_transform import AgentChatAwareBM25SearchTransform
 from daimon.adapters.mcp.tools.agent_chat import (
     AskResult,
+    _archive_my_session_impl,
     _ask_impl,
     _ask_tool_result,
     _continue_turn_impl,
@@ -347,6 +352,7 @@ async def test_narrowing_agent_id_claim_returns_only_agent_chat_tools() -> None:
         "deliver_turn_charts",
         "get_my_session",
         "list_events",
+        "archive_my_session",
     }
     assert set(tool_names) == expected, (
         f"agent_id-claim token should see ONLY the agent-chat tools; got: {sorted(tool_names)}"
@@ -434,6 +440,7 @@ async def test_narrowing_lists_agent_chat_tools_through_bm25_search_transform() 
         "deliver_turn_charts",
         "get_my_session",
         "list_events",
+        "archive_my_session",
     }
     assert set(tool_names) == expected, (
         "narrowed agent token must list exactly the agent-chat tools through the "
@@ -536,7 +543,16 @@ async def test_start_turn_then_poll_get_session_and_read_transcript(
     router.add(
         "POST",
         r"/v1/sessions/([^/]+)/events",
-        lambda _r, _m: send_events_response(data=None),
+        lambda _r, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_start_boundary",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="Say hello")],
+                    type="user.message",
+                    processed_at=dt.datetime(2026, 6, 23, 0, 0, tzinfo=dt.UTC),
+                ).model_dump(mode="json")
+            ]
+        ),
     )
     router.add(
         "GET",
@@ -1158,7 +1174,16 @@ async def test_start_turn_resolves_env_from_deployment_default_when_no_tenant_ro
     router.add(
         "POST",
         r"/v1/sessions/([^/]+)/events",
-        lambda _r, _m: send_events_response(data=None),
+        lambda _r, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_start_boundary",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="Say hello")],
+                    type="user.message",
+                    processed_at=dt.datetime(2026, 6, 23, 0, 0, tzinfo=dt.UTC),
+                ).model_dump(mode="json")
+            ]
+        ),
     )
     client = build_fake_anthropic(router.dispatch)
     # No tenant-scope config row is ever written to db_session_factory's schema
@@ -1362,6 +1387,7 @@ async def test_agent_chat_tools_have_no_agent_id_parameter() -> None:
         "deliver_turn_charts",
         "get_my_session",
         "list_events",
+        "archive_my_session",
     }
 
     for tool_name in agent_chat_names:
@@ -1695,3 +1721,312 @@ async def test_turn_tools_refuse_over_balance_tenant_before_creating_session(
     assert "TERMINAL ERROR" in content, f"refusal should be a TERMINAL ERROR; got {content!r}"
     assert "/billing" in content, f"refusal should name /billing; got {content!r}"
     mock_create_session.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Task 3: turn boundary (start_turn/continue_turn), list_events passthrough,
+# archive_my_session
+# ---------------------------------------------------------------------------
+
+
+def _agent_and_env_router() -> MARouter:
+    """Router with one agent + one environment, for start_turn's happy path."""
+    env_payload = {
+        "id": _ENV_ID,
+        "type": "environment",
+        "name": _ENV_NAME,
+        "config": EMPTY_CLOUD_CONFIG.model_dump(mode="json"),
+        "description": "",
+        "metadata": {
+            "daimon_tenant": str(_TENANT_ID),
+            "daimon_name": _ENV_NAME,
+        },
+        "created_at": "2026-06-23T00:00:00Z",
+        "updated_at": "2026-06-23T00:00:00Z",
+    }
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _r, _m: list_response(
+            [
+                make_ma_agent(
+                    id=_MA_AGENT_ID,
+                    name="test-agent",
+                    metadata={
+                        "daimon_tenant": str(_TENANT_ID),
+                        "daimon_name": "test-agent",
+                    },
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add("GET", r"/v1/environments", lambda _r, _m: list_response([env_payload]))
+    return router
+
+
+async def test_start_turn_returns_the_accepted_events_boundary(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """turn_event_id/turn_started_at come from events.send's data[0], not a guess."""
+    accepted_at = dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC)
+    router = _agent_and_env_router()
+    router.add(
+        "POST",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_boundary_001",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="hi")],
+                    type="user.message",
+                    processed_at=accepted_at,
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    auth = _auth()
+    fake_session = BetaManagedAgentsSession.model_validate(_make_fake_session(status="running"))
+
+    with patch(
+        "daimon.adapters.mcp.tools.agent_chat.create_session",
+        new=AsyncMock(return_value=fake_session),
+    ):
+        result = await _start_turn_impl(runtime, auth, "hi")
+
+    assert result["turn_event_id"] == "sevt_boundary_001", (
+        f"turn_event_id should be the send response's accepted event id; got {result!r}"
+    )
+    assert result["turn_started_at"] == accepted_at.isoformat(), (
+        f"turn_started_at should be the accepted event's processed_at, isoformat()'d; got {result!r}"
+    )
+
+
+async def test_continue_turn_returns_boundary_from_its_own_send() -> None:
+    """continue_turn's boundary is THIS send's accepted event, not session history."""
+    own_send_at = dt.datetime(2026, 9, 1, 11, 0, tzinfo=dt.UTC)
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
+    )
+    router.add(
+        "POST",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_continue_boundary",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="again")],
+                    type="user.message",
+                    processed_at=own_send_at,
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    result = await _continue_turn_impl(runtime, auth, "ses_test001", "again")
+
+    assert result == {
+        "handle": "ses_test001",
+        "turn_event_id": "sevt_continue_boundary",
+        "turn_started_at": own_send_at.isoformat(),
+    }
+
+
+async def test_start_turn_raises_when_send_accepts_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A send response with data=None means nothing was accepted — not a started turn."""
+    router = _agent_and_env_router()
+    router.add(
+        "POST",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: send_events_response(data=None),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    auth = _auth()
+    fake_session = BetaManagedAgentsSession.model_validate(_make_fake_session(status="running"))
+
+    with (
+        patch(
+            "daimon.adapters.mcp.tools.agent_chat.create_session",
+            new=AsyncMock(return_value=fake_session),
+        ),
+        pytest.raises(ToolError, match="send returned no accepted event"),
+    ):
+        await _start_turn_impl(runtime, auth, "hi")
+
+
+async def test_start_turn_falls_back_to_now_when_processed_at_is_missing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A missing processed_at still returns a parseable ISO timestamp, not a raise."""
+    router = _agent_and_env_router()
+    router.add(
+        "POST",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_no_timestamp",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="hi")],
+                    type="user.message",
+                    processed_at=None,
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    auth = _auth()
+    fake_session = BetaManagedAgentsSession.model_validate(_make_fake_session(status="running"))
+
+    with patch(
+        "daimon.adapters.mcp.tools.agent_chat.create_session",
+        new=AsyncMock(return_value=fake_session),
+    ):
+        result = await _start_turn_impl(runtime, auth, "hi")
+
+    assert result["turn_event_id"] == "sevt_no_timestamp"
+    # Must be a parseable ISO timestamp (the log.warning'd clock fallback), not a raise.
+    dt.datetime.fromisoformat(result["turn_started_at"])
+
+
+async def test_list_events_forwards_created_at_gte_and_types() -> None:
+    """created_at_gte and types both reach the SDK request when given."""
+    captured: list[httpx.Request] = []
+
+    def on_events(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        captured.append(req)
+        return httpx.Response(200, json={"data": [], "next_page": None})
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
+    )
+    router.add("GET", r"/v1/sessions/([^/]+)/events", on_events)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    await _list_events_impl(
+        runtime,
+        auth,
+        "ses_test001",
+        None,
+        None,
+        "asc",
+        "2026-09-01T10:00:00Z",
+        ["agent.message", "session.status_idle"],
+    )
+
+    assert len(captured) == 1, f"expected exactly one events.list call; got {len(captured)}"
+    query = captured[0].url.params
+    assert query.get("created_at[gte]") == "2026-09-01T10:00:00Z", (
+        f"created_at_gte should reach the wire as created_at[gte]; got {dict(query)!r}"
+    )
+    assert query.get_list("types[]") == ["agent.message", "session.status_idle"], (
+        f"types should reach the wire as repeated types[] params; got {dict(query)!r}"
+    )
+
+
+async def test_list_events_forwards_neither_when_not_given() -> None:
+    """Without created_at_gte/types, neither key reaches the SDK request (conditional, like page/limit/order)."""
+    captured: list[httpx.Request] = []
+
+    def on_events(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        captured.append(req)
+        return httpx.Response(200, json={"data": [], "next_page": None})
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
+    )
+    router.add("GET", r"/v1/sessions/([^/]+)/events", on_events)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    await _list_events_impl(runtime, auth, "ses_test001", None, None, None)
+
+    assert len(captured) == 1
+    query = captured[0].url.params
+    assert "created_at[gte]" not in query, (
+        f"unset created_at_gte must not be forwarded; got {dict(query)!r}"
+    )
+    assert "types[]" not in query, f"unset types must not be forwarded; got {dict(query)!r}"
+
+
+async def test_archive_my_session_rejects_a_sibling_agents_session_and_issues_no_archive_call() -> (
+    None
+):
+    """Ownership is checked before archiving — a sibling's session is refused with
+    zero archive calls (T-21-05-A)."""
+    archive_calls: list[str] = []
+
+    def on_archive(_req: httpx.Request, m: re.Match[str]) -> httpx.Response:
+        archive_calls.append(m.group(1))
+        return httpx.Response(
+            200,
+            json=_make_fake_session(
+                session_id="ses_sibling", agent_id="ag_sibling", status="terminated"
+            ),
+        )
+
+    router = _sibling_tenant_agents_router()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            200,
+            json=_make_fake_session(session_id="ses_sibling", agent_id="ag_sibling", status="idle"),
+        ),
+    )
+    router.add("POST", r"/v1/sessions/([^/]+)/archive", on_archive)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    with pytest.raises(ToolError, match="session not found"):
+        await _archive_my_session_impl(runtime, auth, "ses_sibling")
+
+    assert archive_calls == [], "a rejected ownership check must issue no archive call"
+
+
+async def test_archive_my_session_archives_an_owned_session_exactly_once() -> None:
+    """An owned session is archived with exactly one call to the archive endpoint."""
+    archive_calls: list[str] = []
+
+    def on_archive(_req: httpx.Request, m: re.Match[str]) -> httpx.Response:
+        archive_calls.append(m.group(1))
+        return httpx.Response(200, json=_make_fake_session(status="terminated"))
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
+    )
+    router.add("POST", r"/v1/sessions/([^/]+)/archive", on_archive)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    result = await _archive_my_session_impl(runtime, auth, "ses_test001")
+
+    assert result == {"handle": "ses_test001", "archived": "true"}
+    assert archive_calls == ["ses_test001"], (
+        f"expected exactly one archive call; got {archive_calls!r}"
+    )

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -1840,13 +1840,16 @@ def _mint_bundle(
     tenant_id: uuid.UUID = _TENANT_ID,
     agent_id: uuid.UUID = _AGENT_UUID,
 ) -> str:
+    # `now` is real wall-clock time, not a fixed calendar date: a fixed past
+    # date plus a fixed ttl eventually crosses its own expiry as the test
+    # suite ages (observed 2026-09-08, one week after this helper landed).
     return bundle_handle.mint(
         secret,
         file_id=file_id,
         tenant_id=tenant_id,
         agent_id=agent_id,
         sha256="a" * 64,
-        now=dt.datetime(2026, 9, 1, tzinfo=dt.UTC),
+        now=dt.datetime.now(dt.UTC),
         ttl_days=7,
     )
 
@@ -1908,7 +1911,19 @@ async def test_start_turn_with_bundle_mounts_the_single_resource_on_an_isolated_
 async def test_start_turn_with_bundle_preserves_the_boundary_return_shape(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """The bundle branch must not regress the plan 21-05 boundary return shape."""
+    """The bundle branch must not regress the plan 21-05 boundary return shape.
+
+    ``turn_started_at`` is the injected pre-send clock, not the echo's own
+    (absent, on the real API) timestamp — the echo's ``processed_at`` here is
+    set only to prove it is ignored, not read.
+    """
+    call_order: list[str] = []
+    fixed_at = dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC)
+
+    def now() -> dt.datetime:
+        call_order.append("now")
+        return fixed_at
+
     router = _isolated_agent_and_env_router()
     router.add(
         "POST", r"/v1/sessions", lambda _r, _m: httpx.Response(200, json=_make_fake_session())
@@ -1918,33 +1933,39 @@ async def test_start_turn_with_bundle_preserves_the_boundary_return_shape(
         r"/v1/files/([^/]+)",
         lambda _r, m: httpx.Response(200, json=_file_metadata_payload(m.group(1))),
     )
-    router.add(
-        "POST",
-        r"/v1/sessions/([^/]+)/events",
-        lambda _r, _m: send_events_response(
+
+    def on_send(_r: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        call_order.append("send")
+        return send_events_response(
             data=[
                 BetaManagedAgentsUserMessageEvent(
                     id="sevt_bundle_boundary_2",
                     content=[BetaManagedAgentsTextBlock(type="text", text="hi")],
                     type="user.message",
-                    processed_at=dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC),
+                    processed_at=None,
                 ).model_dump(mode="json")
             ]
-        ),
-    )
+        )
+
+    router.add("POST", r"/v1/sessions/([^/]+)/events", on_send)
     client = build_fake_anthropic(router.dispatch)
     runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
     runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
     auth = _auth()
     handle = _mint_bundle()
 
-    result = await _start_turn_impl(runtime, auth, "hi", handle)
+    result = await _start_turn_impl(runtime, auth, "hi", handle, now=now)
 
     assert set(result) == {"handle", "turn_event_id", "turn_started_at"}, (
         f"bundle branch must return the same three-key boundary shape; got {result!r}"
     )
     assert result["turn_event_id"] == "sevt_bundle_boundary_2"
-    assert result["turn_started_at"] == dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC).isoformat()
+    assert result["turn_started_at"] == fixed_at.isoformat(), (
+        "turn_started_at must be the injected clock, not the echo's processed_at"
+    )
+    assert call_order == ["now", "send"], (
+        f"the clock must be read BEFORE events.send, not after; got {call_order!r}"
+    )
 
 
 def _zero_upstream_router() -> tuple[MARouter, list[str], list[str]]:
@@ -2129,28 +2150,36 @@ async def test_start_turn_with_bundle_when_jwt_secret_unset_is_refused(
 async def test_start_turn_returns_the_accepted_events_boundary(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """turn_event_id/turn_started_at come from events.send's data[0], not a guess.
+    """turn_event_id comes from events.send's data[0]; turn_started_at from the
+    caller's own clock, captured before the send, not from the echo.
 
     Also proves branch B (no ``bundle``) is untouched by the 21-07 bundle
     branch: ``create_session`` still receives the full vault/repo/env
     argument set, not the isolated path's stripped-down call.
     """
-    accepted_at = dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC)
+    call_order: list[str] = []
+    fixed_at = dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC)
+
+    def now() -> dt.datetime:
+        call_order.append("now")
+        return fixed_at
+
     router = _agent_and_env_router()
-    router.add(
-        "POST",
-        r"/v1/sessions/([^/]+)/events",
-        lambda _r, _m: send_events_response(
+
+    def on_send(_r: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        call_order.append("send")
+        return send_events_response(
             data=[
                 BetaManagedAgentsUserMessageEvent(
                     id="sevt_boundary_001",
                     content=[BetaManagedAgentsTextBlock(type="text", text="hi")],
                     type="user.message",
-                    processed_at=accepted_at,
+                    processed_at=None,
                 ).model_dump(mode="json")
             ]
-        ),
-    )
+        )
+
+    router.add("POST", r"/v1/sessions/([^/]+)/events", on_send)
     client = build_fake_anthropic(router.dispatch)
     runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
     auth = _auth()
@@ -2160,13 +2189,16 @@ async def test_start_turn_returns_the_accepted_events_boundary(
         "daimon.adapters.mcp.tools.agent_chat.create_session",
         new=AsyncMock(return_value=fake_session),
     ) as mock_create_session:
-        result = await _start_turn_impl(runtime, auth, "hi")
+        result = await _start_turn_impl(runtime, auth, "hi", now=now)
 
     assert result["turn_event_id"] == "sevt_boundary_001", (
         f"turn_event_id should be the send response's accepted event id; got {result!r}"
     )
-    assert result["turn_started_at"] == accepted_at.isoformat(), (
-        f"turn_started_at should be the accepted event's processed_at, isoformat()'d; got {result!r}"
+    assert result["turn_started_at"] == fixed_at.isoformat(), (
+        f"turn_started_at should be the injected pre-send clock, isoformat()'d; got {result!r}"
+    )
+    assert call_order == ["now", "send"], (
+        f"the clock must be read BEFORE events.send, not after; got {call_order!r}"
     )
     assert mock_create_session.await_args is not None, "create_session should be awaited once"
     call_kwargs = mock_create_session.await_args.kwargs
@@ -2186,39 +2218,52 @@ async def test_start_turn_returns_the_accepted_events_boundary(
 
 
 async def test_continue_turn_returns_boundary_from_its_own_send() -> None:
-    """continue_turn's boundary is THIS send's accepted event, not session history."""
-    own_send_at = dt.datetime(2026, 9, 1, 11, 0, tzinfo=dt.UTC)
+    """continue_turn's turn_event_id is THIS send's accepted event, not session
+    history; turn_started_at is the caller's own clock, captured before THIS
+    send, not the echo's timestamp (the live API never populates one on the
+    echo)."""
+    call_order: list[str] = []
+    own_clock_at = dt.datetime(2026, 9, 1, 11, 0, tzinfo=dt.UTC)
+
+    def now() -> dt.datetime:
+        call_order.append("now")
+        return own_clock_at
+
     router = MARouter()
     router.add(
         "GET",
         r"/v1/sessions/([^/]+)",
         lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
     )
-    router.add(
-        "POST",
-        r"/v1/sessions/([^/]+)/events",
-        lambda _r, _m: send_events_response(
+
+    def on_send(_r: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        call_order.append("send")
+        return send_events_response(
             data=[
                 BetaManagedAgentsUserMessageEvent(
                     id="sevt_continue_boundary",
                     content=[BetaManagedAgentsTextBlock(type="text", text="again")],
                     type="user.message",
-                    processed_at=own_send_at,
+                    processed_at=None,
                 ).model_dump(mode="json")
             ]
-        ),
-    )
+        )
+
+    router.add("POST", r"/v1/sessions/([^/]+)/events", on_send)
     client = build_fake_anthropic(router.dispatch)
     runtime = _runtime(client)
     auth = _auth()
 
-    result = await _continue_turn_impl(runtime, auth, "ses_test001", "again")
+    result = await _continue_turn_impl(runtime, auth, "ses_test001", "again", now=now)
 
     assert result == {
         "handle": "ses_test001",
         "turn_event_id": "sevt_continue_boundary",
-        "turn_started_at": own_send_at.isoformat(),
+        "turn_started_at": own_clock_at.isoformat(),
     }
+    assert call_order == ["now", "send"], (
+        f"the clock must be read BEFORE events.send, not after; got {call_order!r}"
+    )
 
 
 async def test_start_turn_raises_when_send_accepts_nothing(
@@ -2246,10 +2291,19 @@ async def test_start_turn_raises_when_send_accepts_nothing(
         await _start_turn_impl(runtime, auth, "hi")
 
 
-async def test_start_turn_falls_back_to_now_when_processed_at_is_missing(
+async def test_start_turn_ignores_the_echos_processed_at_even_when_present(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """A missing processed_at still returns a parseable ISO timestamp, not a raise."""
+    """turn_started_at never reads the echo's processed_at, present or absent.
+
+    The live API always echoes ``processed_at=None`` on the send response (a
+    timestamp appears only ~0.5s later, once the agent starts on the event),
+    so the boundary's clock can only ever be the caller's own, captured
+    before the send. This test pins a non-None processed_at on the fake echo
+    specifically to prove it is never read.
+    """
+    injected_at = dt.datetime(2026, 9, 1, 12, 0, tzinfo=dt.UTC)
+    echoed_processed_at = dt.datetime(1999, 1, 1, tzinfo=dt.UTC)
     router = _agent_and_env_router()
     router.add(
         "POST",
@@ -2260,7 +2314,7 @@ async def test_start_turn_falls_back_to_now_when_processed_at_is_missing(
                     id="sevt_no_timestamp",
                     content=[BetaManagedAgentsTextBlock(type="text", text="hi")],
                     type="user.message",
-                    processed_at=None,
+                    processed_at=echoed_processed_at,
                 ).model_dump(mode="json")
             ]
         ),
@@ -2274,11 +2328,12 @@ async def test_start_turn_falls_back_to_now_when_processed_at_is_missing(
         "daimon.adapters.mcp.tools.agent_chat.create_session",
         new=AsyncMock(return_value=fake_session),
     ):
-        result = await _start_turn_impl(runtime, auth, "hi")
+        result = await _start_turn_impl(runtime, auth, "hi", now=lambda: injected_at)
 
     assert result["turn_event_id"] == "sevt_no_timestamp"
-    # Must be a parseable ISO timestamp (the log.warning'd clock fallback), not a raise.
-    dt.datetime.fromisoformat(result["turn_started_at"])
+    assert result["turn_started_at"] == injected_at.isoformat(), (
+        "turn_started_at must be the injected clock, never the echo's processed_at"
+    )
 
 
 async def test_list_events_forwards_created_at_gte_and_types() -> None:

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from anthropic import AsyncAnthropic
-from anthropic.types.beta import BetaManagedAgentsSession
+from anthropic.types.beta import BetaManagedAgentsSession, FileMetadata
 from anthropic.types.beta.sessions import (
     BetaManagedAgentsSpanModelRequestEndEvent,
     BetaManagedAgentsSpanModelUsage,
@@ -65,6 +65,7 @@ from daimon.adapters.mcp.tools.agent_chat import (
     register_agent_chat_tools,
 )
 from daimon.adapters.mcp.tools.sessions import SessionEventOut
+from daimon.core import bundle_handle
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.pricing import MODEL_PRICING, cost_of
 from daimon.core.scope import DeploymentDefault
@@ -87,11 +88,13 @@ from fastmcp.server.transforms import Visibility
 from fastmcp.server.transforms.search.base import serialize_tools_for_output_markdown
 from fastmcp.tools import ToolResult
 from mcp.types import ImageContent
+from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.types import ASGIApp, Message
 
 pytestmark = pytest.mark.asyncio
 
+_BUNDLE_SECRET = "test-bundle-handle-secret"
 _TENANT_ID = uuid.uuid4()
 _MA_AGENT_ID = "ag_test001"
 _AGENT_UUID = derive_agent_uuid(tenant_id=_TENANT_ID, ma_agent_id=_MA_AGENT_ID)
@@ -1779,10 +1782,359 @@ def _agent_and_env_router() -> MARouter:
     return router
 
 
+def _isolated_agent_and_env_router(*, ma_agent_id: str = _MA_AGENT_ID) -> MARouter:
+    """Router with one ISOLATED agent (``daimon_isolated="true"``) + one environment."""
+    env_payload = {
+        "id": _ENV_ID,
+        "type": "environment",
+        "name": _ENV_NAME,
+        "config": EMPTY_CLOUD_CONFIG.model_dump(mode="json"),
+        "description": "",
+        "metadata": {
+            "daimon_tenant": str(_TENANT_ID),
+            "daimon_name": _ENV_NAME,
+        },
+        "created_at": "2026-06-23T00:00:00Z",
+        "updated_at": "2026-06-23T00:00:00Z",
+    }
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _r, _m: list_response(
+            [
+                make_ma_agent(
+                    id=ma_agent_id,
+                    name="reader-agent",
+                    metadata={
+                        "daimon_tenant": str(_TENANT_ID),
+                        "daimon_name": "reader-agent",
+                        "daimon_isolated": "true",
+                    },
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add("GET", r"/v1/environments", lambda _r, _m: list_response([env_payload]))
+    return router
+
+
+def _file_metadata_payload(file_id: str) -> dict[str, Any]:
+    """A minimal valid ``FileMetadata`` payload for a ``retrieve_metadata`` fake."""
+    return FileMetadata.model_validate(
+        {
+            "id": file_id,
+            "created_at": "2026-09-01T00:00:00Z",
+            "filename": "bundle.tar.gz",
+            "mime_type": "application/gzip",
+            "size_bytes": 1024,
+            "type": "file",
+        }
+    ).model_dump(mode="json")
+
+
+def _mint_bundle(
+    *,
+    secret: str = _BUNDLE_SECRET,
+    file_id: str = "file_bundle_001",
+    tenant_id: uuid.UUID = _TENANT_ID,
+    agent_id: uuid.UUID = _AGENT_UUID,
+) -> str:
+    return bundle_handle.mint(
+        secret,
+        file_id=file_id,
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        sha256="a" * 64,
+        now=dt.datetime(2026, 9, 1, tzinfo=dt.UTC),
+        ttl_days=7,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 21-07: start_turn(bundle=) — verified mount, three refusals
+# ---------------------------------------------------------------------------
+
+
+async def test_start_turn_with_bundle_mounts_the_single_resource_on_an_isolated_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A verified bundle mounts as the ONLY resource, no vault_ids key at all."""
+    create_bodies: list[dict[str, Any]] = []
+
+    def on_create(request: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        create_bodies.append(json_body(request))
+        return httpx.Response(200, json=_make_fake_session(status="running"))
+
+    router = _isolated_agent_and_env_router()
+    router.add("POST", r"/v1/sessions", on_create)
+    router.add(
+        "GET",
+        r"/v1/files/([^/]+)",
+        lambda _r, m: httpx.Response(200, json=_file_metadata_payload(m.group(1))),
+    )
+    router.add(
+        "POST",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_bundle_boundary",
+                    content=[
+                        BetaManagedAgentsTextBlock(type="text", text="what does this report say?")
+                    ],
+                    type="user.message",
+                    processed_at=dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC),
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
+    auth = _auth()
+    handle = _mint_bundle(file_id="file_bundle_001")
+
+    await _start_turn_impl(runtime, auth, "what does this report say?", handle)
+
+    assert len(create_bodies) == 1, "exactly one session-create call should reach MA"
+    body = create_bodies[0]
+    assert body["resources"] == [
+        {"type": "file", "file_id": "file_bundle_001", "mount_path": "/bundle.tar.gz"}
+    ], f"the mounted resource must be exactly the bundle file, absolute path; got {body!r}"
+    assert "vault_ids" not in body, "an isolated bundle session must never carry a vault_ids key"
+
+
+async def test_start_turn_with_bundle_preserves_the_boundary_return_shape(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The bundle branch must not regress the plan 21-05 boundary return shape."""
+    router = _isolated_agent_and_env_router()
+    router.add(
+        "POST", r"/v1/sessions", lambda _r, _m: httpx.Response(200, json=_make_fake_session())
+    )
+    router.add(
+        "GET",
+        r"/v1/files/([^/]+)",
+        lambda _r, m: httpx.Response(200, json=_file_metadata_payload(m.group(1))),
+    )
+    router.add(
+        "POST",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: send_events_response(
+            data=[
+                BetaManagedAgentsUserMessageEvent(
+                    id="sevt_bundle_boundary_2",
+                    content=[BetaManagedAgentsTextBlock(type="text", text="hi")],
+                    type="user.message",
+                    processed_at=dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC),
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
+    auth = _auth()
+    handle = _mint_bundle()
+
+    result = await _start_turn_impl(runtime, auth, "hi", handle)
+
+    assert set(result) == {"handle", "turn_event_id", "turn_started_at"}, (
+        f"bundle branch must return the same three-key boundary shape; got {result!r}"
+    )
+    assert result["turn_event_id"] == "sevt_bundle_boundary_2"
+    assert result["turn_started_at"] == dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC).isoformat()
+
+
+def _zero_upstream_router() -> tuple[MARouter, list[str], list[str]]:
+    """An isolated-agent router with counting (never-should-fire) session-create and
+    files.retrieve_metadata routes, for the four handle-refusal tests."""
+    create_calls: list[str] = []
+    metadata_calls: list[str] = []
+    router = _isolated_agent_and_env_router()
+    router.add(
+        "POST",
+        r"/v1/sessions",
+        lambda r, _m: (create_calls.append(json_body(r).get("agent", "")), httpx.Response(200))[1],
+    )
+    router.add(
+        "GET",
+        r"/v1/files/([^/]+)",
+        lambda _r, m: (metadata_calls.append(m.group(1)), httpx.Response(200))[1],
+    )
+    return router, create_calls, metadata_calls
+
+
+async def test_start_turn_with_bundle_from_different_tenant_is_refused_as_not_found(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    router, create_calls, metadata_calls = _zero_upstream_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
+    auth = _auth()
+    handle = _mint_bundle(tenant_id=uuid.uuid4())
+
+    with pytest.raises(ToolError, match="bundle not found"):
+        await _start_turn_impl(runtime, auth, "hi", handle)
+
+    assert create_calls == [], "a wrong-tenant handle must never reach session creation"
+    assert metadata_calls == [], "a wrong-tenant handle must never reach the Files API"
+
+
+async def test_start_turn_with_bundle_from_different_agent_is_refused_as_not_found(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    router, create_calls, metadata_calls = _zero_upstream_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
+    auth = _auth()
+    handle = _mint_bundle(agent_id=uuid.uuid4())
+
+    with pytest.raises(ToolError, match="bundle not found"):
+        await _start_turn_impl(runtime, auth, "hi", handle)
+
+    assert create_calls == [], "a wrong-agent handle must never reach session creation"
+    assert metadata_calls == [], "a wrong-agent handle must never reach the Files API"
+
+
+async def test_start_turn_with_tampered_bundle_signature_is_refused_as_not_found(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    router, create_calls, metadata_calls = _zero_upstream_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
+    auth = _auth()
+    valid = _mint_bundle()
+    payload_b64, sig_b64 = valid.split(".")
+    flipped_char = "a" if sig_b64[0] != "a" else "b"
+    tampered = f"{payload_b64}.{flipped_char}{sig_b64[1:]}"
+
+    with pytest.raises(ToolError, match="bundle not found"):
+        await _start_turn_impl(runtime, auth, "hi", tampered)
+
+    assert create_calls == [], "a tampered signature must never reach session creation"
+    assert metadata_calls == [], "a tampered signature must never reach the Files API"
+
+
+async def test_start_turn_with_expired_bundle_is_refused_as_not_found(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    router, create_calls, metadata_calls = _zero_upstream_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
+    auth = _auth()
+    handle = bundle_handle.mint(
+        _BUNDLE_SECRET,
+        file_id="file_bundle_001",
+        tenant_id=_TENANT_ID,
+        agent_id=_AGENT_UUID,
+        sha256="a" * 64,
+        now=dt.datetime(2020, 1, 1, tzinfo=dt.UTC),
+        ttl_days=1,
+    )
+
+    with pytest.raises(ToolError, match="bundle not found"):
+        await _start_turn_impl(runtime, auth, "hi", handle)
+
+    assert create_calls == [], "an expired handle must never reach session creation"
+    assert metadata_calls == [], "an expired handle must never reach the Files API"
+
+
+async def test_start_turn_with_bundle_whose_file_is_gone_is_refused_as_expired(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The Files API says the object is gone: a distinct, actionable message."""
+    create_calls: list[str] = []
+    router = _isolated_agent_and_env_router()
+    router.add(
+        "POST",
+        r"/v1/sessions",
+        lambda r, _m: (create_calls.append(json_body(r).get("agent", "")), httpx.Response(200))[1],
+    )
+    router.add(
+        "GET",
+        r"/v1/files/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            404,
+            json={
+                "type": "error",
+                "error": {"type": "not_found_error", "message": "file already gone"},
+            },
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
+    auth = _auth()
+    handle = _mint_bundle(file_id="file_gone")
+
+    with pytest.raises(ToolError, match="bundle expired; re-upload"):
+        await _start_turn_impl(runtime, auth, "hi", handle)
+
+    assert create_calls == [], "a gone bundle object must never reach session creation"
+
+
+async def test_start_turn_with_bundle_on_non_isolated_agent_is_refused_before_verifying_handle(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The isolation check fires BEFORE handle verification — proven with a bad
+    handle: if the isolation check ran second, this handle would fail
+    ``bundle_handle.verify`` first and raise "bundle not found" instead. Only
+    checking isolation FIRST produces "bundle requires an isolated agent" here.
+    Also proven by a mutation: moving the isolation check after
+    ``bundle_handle.verify`` makes the metadata_calls assertion below fail too,
+    since a wrong-tenant handle would then be rejected before ever reaching
+    this assertion's message check."""
+    metadata_calls: list[str] = []
+    router = _agent_and_env_router()  # NOT isolated — no daimon_isolated metadata
+    router.add(
+        "GET",
+        r"/v1/files/([^/]+)",
+        lambda _r, m: (metadata_calls.append(m.group(1)), httpx.Response(200))[1],
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    runtime.settings.mcp.jwt_secret = SecretStr(_BUNDLE_SECRET)
+    auth = _auth()
+    handle = _mint_bundle(tenant_id=uuid.uuid4())  # a BAD handle — proves the order
+
+    with pytest.raises(ToolError, match="bundle requires an isolated agent"):
+        await _start_turn_impl(runtime, auth, "hi", handle)
+
+    assert metadata_calls == [], (
+        "the isolation check must fire before the handle is ever verified against the Files API"
+    )
+
+
+async def test_start_turn_with_bundle_when_jwt_secret_unset_is_refused(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """An unverifiable handle (no configured secret) must never be accepted."""
+    router = _isolated_agent_and_env_router()
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client, session_factory=db_session_factory, environment_name=_ENV_NAME)
+    assert runtime.settings.mcp.jwt_secret is None
+    auth = _auth()
+    handle = _mint_bundle()
+
+    with pytest.raises(ToolError, match="not configured"):
+        await _start_turn_impl(runtime, auth, "hi", handle)
+
+
 async def test_start_turn_returns_the_accepted_events_boundary(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """turn_event_id/turn_started_at come from events.send's data[0], not a guess."""
+    """turn_event_id/turn_started_at come from events.send's data[0], not a guess.
+
+    Also proves branch B (no ``bundle``) is untouched by the 21-07 bundle
+    branch: ``create_session`` still receives the full vault/repo/env
+    argument set, not the isolated path's stripped-down call.
+    """
     accepted_at = dt.datetime(2026, 9, 1, 10, 0, tzinfo=dt.UTC)
     router = _agent_and_env_router()
     router.add(
@@ -1807,7 +2159,7 @@ async def test_start_turn_returns_the_accepted_events_boundary(
     with patch(
         "daimon.adapters.mcp.tools.agent_chat.create_session",
         new=AsyncMock(return_value=fake_session),
-    ):
+    ) as mock_create_session:
         result = await _start_turn_impl(runtime, auth, "hi")
 
     assert result["turn_event_id"] == "sevt_boundary_001", (
@@ -1816,6 +2168,21 @@ async def test_start_turn_returns_the_accepted_events_boundary(
     assert result["turn_started_at"] == accepted_at.isoformat(), (
         f"turn_started_at should be the accepted event's processed_at, isoformat()'d; got {result!r}"
     )
+    assert mock_create_session.await_args is not None, "create_session should be awaited once"
+    call_kwargs = mock_create_session.await_args.kwargs
+    assert set(call_kwargs) == {
+        "agent",
+        "environment",
+        "mcp_settings",
+        "account_id",
+        "tenant_id",
+        "agent_uuid",
+        "session_factory",
+        "fernet",
+        "github_fallback_pat",
+        "github_app_id",
+        "github_app_private_key",
+    }, f"the non-bundle path must keep passing its full argument set; got {sorted(call_kwargs)!r}"
 
 
 async def test_continue_turn_returns_boundary_from_its_own_send() -> None:

--- a/packages/adapters/mcp/tests/tools/test_agent_chat.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_chat.py
@@ -21,6 +21,7 @@ import json
 import re
 import uuid
 from collections.abc import AsyncIterator
+from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -29,6 +30,8 @@ import pytest
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import BetaManagedAgentsSession
 from anthropic.types.beta.sessions import (
+    BetaManagedAgentsSpanModelRequestEndEvent,
+    BetaManagedAgentsSpanModelUsage,
     BetaManagedAgentsTextBlock,
     BetaManagedAgentsUserMessageEvent,
 )
@@ -50,10 +53,12 @@ from daimon.adapters.mcp.tools.agent_chat import (
     _archive_my_session_impl,
     _ask_impl,
     _ask_tool_result,
+    _cancel_turn_impl,
     _continue_turn_impl,
     _deliver_turn_charts_impl,
     _describe_agent_impl,
     _get_session_impl,
+    _get_turn_cost_impl,
     _list_events_impl,
     _list_sessions_impl,
     _start_turn_impl,
@@ -61,13 +66,16 @@ from daimon.adapters.mcp.tools.agent_chat import (
 )
 from daimon.adapters.mcp.tools.sessions import SessionEventOut
 from daimon.core.ma_identity import derive_agent_uuid
+from daimon.core.pricing import MODEL_PRICING, cost_of
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.agent_repo_binding import set_binding
+from daimon.core.tenant_balance import debit_amount
 from daimon.testing.factories import make_account, make_tenant
 from daimon.testing.ma import (
     EMPTY_CLOUD_CONFIG,
     MARouter,
     build_fake_anthropic,
+    json_body,
     list_response,
     send_events_response,
 )
@@ -353,6 +361,8 @@ async def test_narrowing_agent_id_claim_returns_only_agent_chat_tools() -> None:
         "get_my_session",
         "list_events",
         "archive_my_session",
+        "cancel_turn",
+        "get_turn_cost",
     }
     assert set(tool_names) == expected, (
         f"agent_id-claim token should see ONLY the agent-chat tools; got: {sorted(tool_names)}"
@@ -441,6 +451,8 @@ async def test_narrowing_lists_agent_chat_tools_through_bm25_search_transform() 
         "get_my_session",
         "list_events",
         "archive_my_session",
+        "cancel_turn",
+        "get_turn_cost",
     }
     assert set(tool_names) == expected, (
         "narrowed agent token must list exactly the agent-chat tools through the "
@@ -1388,6 +1400,8 @@ async def test_agent_chat_tools_have_no_agent_id_parameter() -> None:
         "get_my_session",
         "list_events",
         "archive_my_session",
+        "cancel_turn",
+        "get_turn_cost",
     }
 
     for tool_name in agent_chat_names:
@@ -2030,3 +2044,372 @@ async def test_archive_my_session_archives_an_owned_session_exactly_once() -> No
     assert archive_calls == ["ses_test001"], (
         f"expected exactly one archive call; got {archive_calls!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# cancel_turn — one unconditional interrupt, then report status
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_turn_sends_exactly_one_user_interrupt_event() -> None:
+    """The send the fake receives has exactly one event, and its type is
+    ``user.interrupt`` — asserted on the captured request body."""
+    captured: list[dict[str, Any]] = []
+
+    def on_send(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        captured.append(json_body(req))
+        return send_events_response(data=[])
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="running")),
+    )
+    router.add("POST", r"/v1/sessions/([^/]+)/events", on_send)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    await _cancel_turn_impl(runtime, auth, "ses_test001")
+
+    assert len(captured) == 1, f"expected exactly one send call; got {len(captured)}"
+    assert captured[0]["events"] == [{"type": "user.interrupt"}], (
+        f"cancel_turn must send exactly one user.interrupt event; got {captured[0]!r}"
+    )
+
+
+async def test_cancel_turn_issues_no_status_precheck_between_ownership_and_send() -> None:
+    """No read-then-send race (T-21-06-B): the recorded call order is
+    ownership-retrieve, send, status-retrieve — never an extra status read
+    wedged in front of the send."""
+    calls: list[str] = []
+
+    def on_retrieve(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        calls.append("retrieve")
+        return httpx.Response(200, json=_make_fake_session(status="running"))
+
+    def on_send(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        calls.append("send")
+        return send_events_response(data=[])
+
+    router = MARouter()
+    router.add("GET", r"/v1/sessions/([^/]+)", on_retrieve)
+    router.add("POST", r"/v1/sessions/([^/]+)/events", on_send)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    result = await _cancel_turn_impl(runtime, auth, "ses_test001")
+
+    assert calls == ["retrieve", "send", "retrieve"], (
+        "expected ownership-retrieve, send, status-retrieve in that order with no "
+        f"extra status read between the ownership check and the send; got {calls!r}"
+    )
+    assert result == {"handle": "ses_test001", "status": "running"}
+
+
+async def test_cancel_turn_rejects_a_sibling_agents_session_and_issues_zero_sends() -> None:
+    """Ownership is checked before any send — a sibling's session is refused
+    with zero interrupt sends (T-21-06-A)."""
+    send_calls: list[str] = []
+
+    def on_send(_req: httpx.Request, m: re.Match[str]) -> httpx.Response:
+        send_calls.append(m.group(1))
+        return send_events_response(data=[])
+
+    router = _sibling_tenant_agents_router()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            200,
+            json=_make_fake_session(
+                session_id="ses_sibling", agent_id="ag_sibling", status="running"
+            ),
+        ),
+    )
+    router.add("POST", r"/v1/sessions/([^/]+)/events", on_send)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    with pytest.raises(ToolError, match="session not found"):
+        await _cancel_turn_impl(runtime, auth, "ses_sibling")
+
+    assert send_calls == [], "a rejected ownership check must issue no interrupt send"
+
+
+async def test_cancel_turn_on_already_idle_session_returns_idle_without_raising() -> None:
+    """Sending an interrupt to an already-idle session is harmless — no raise."""
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
+    )
+    router.add(
+        "POST",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: send_events_response(data=[]),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    result = await _cancel_turn_impl(runtime, auth, "ses_test001")
+
+    assert result == {"handle": "ses_test001", "status": "idle"}
+
+
+# ---------------------------------------------------------------------------
+# get_turn_cost — fold one turn's model-request events, pre-markup
+# ---------------------------------------------------------------------------
+
+
+def _cost_event(
+    *,
+    event_id: str,
+    usage: BetaManagedAgentsSpanModelUsage,
+    processed_at: dt.datetime,
+) -> dict[str, Any]:
+    """Build a real ``span.model_request_end`` event payload inline."""
+    return BetaManagedAgentsSpanModelRequestEndEvent(
+        id=event_id,
+        model_request_start_id=f"{event_id}_start",
+        model_usage=usage,
+        processed_at=processed_at,
+        type="span.model_request_end",
+    ).model_dump(mode="json")
+
+
+async def test_get_turn_cost_folds_events_to_the_same_figure_as_debit_amount_at_markup_one() -> (
+    None
+):
+    """The fold equals sum(debit_amount(cost_of(usage, rates), markup=1)) over
+    the same events — the pre-markup cross-check SPEC 1.4 asks for."""
+    rates = MODEL_PRICING["claude-sonnet-4-6"]
+    usage_a = BetaManagedAgentsSpanModelUsage(
+        input_tokens=1000,
+        output_tokens=500,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
+    usage_b = BetaManagedAgentsSpanModelUsage(
+        input_tokens=2000,
+        output_tokens=100,
+        cache_creation_input_tokens=50,
+        cache_read_input_tokens=10,
+    )
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
+    )
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: list_response(
+            [
+                _cost_event(
+                    event_id="sevt_cost_a",
+                    usage=usage_a,
+                    processed_at=dt.datetime(2026, 9, 1, 10, 0, 1, tzinfo=dt.UTC),
+                ),
+                _cost_event(
+                    event_id="sevt_cost_b",
+                    usage=usage_b,
+                    processed_at=dt.datetime(2026, 9, 1, 10, 0, 2, tzinfo=dt.UTC),
+                ),
+            ]
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    result = await _get_turn_cost_impl(
+        runtime, auth, "ses_test001", "2026-09-01T10:00:00Z", "sevt_boundary"
+    )
+
+    expected = sum(
+        (debit_amount(cost_of(usage, rates), markup=Decimal(1)) for usage in (usage_a, usage_b)),
+        start=Decimal("0"),
+    )
+    assert result["cost_usd"] == str(expected), (
+        f"fold should equal sum(debit_amount(cost_of(usage, rates), markup=1)); got {result!r}"
+    )
+    assert result["event_count"] == 2
+
+
+async def test_get_turn_cost_excludes_the_boundary_event_itself() -> None:
+    """Events at or before ``turn_event_id`` are excluded: of three seeded
+    events, one IS the boundary, so ``event_count`` is 2, not 3."""
+    usage = BetaManagedAgentsSpanModelUsage(
+        input_tokens=100,
+        output_tokens=50,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
+    )
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: list_response(
+            [
+                _cost_event(
+                    event_id="sevt_boundary",
+                    usage=usage,
+                    processed_at=dt.datetime(2026, 9, 1, 10, 0, 0, tzinfo=dt.UTC),
+                ),
+                _cost_event(
+                    event_id="sevt_a",
+                    usage=usage,
+                    processed_at=dt.datetime(2026, 9, 1, 10, 0, 1, tzinfo=dt.UTC),
+                ),
+                _cost_event(
+                    event_id="sevt_b",
+                    usage=usage,
+                    processed_at=dt.datetime(2026, 9, 1, 10, 0, 2, tzinfo=dt.UTC),
+                ),
+            ]
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    result = await _get_turn_cost_impl(
+        runtime, auth, "ses_test001", "2026-09-01T10:00:00Z", "sevt_boundary"
+    )
+
+    assert result["event_count"] == 2, (
+        f"the boundary event itself must be excluded from the fold; got {result!r}"
+    )
+
+
+async def test_get_turn_cost_returns_none_but_still_counts_events_for_unpriced_model() -> None:
+    """No pricing row -> cost_usd is None (never zero — zero would falsely
+    claim the turn was free); event_count still counts the events (T-21-06-D)."""
+    session_json = BetaManagedAgentsSession.model_validate(
+        {
+            "id": "ses_test001",
+            "type": "session",
+            "agent": {
+                "id": _MA_AGENT_ID,
+                "name": "test-agent",
+                "version": 1,
+                "type": "agent",
+                "model": {"id": "claude-unpriced-model-x"},
+                "mcp_servers": [],
+                "skills": [],
+                "tools": [],
+            },
+            "archived_at": None,
+            "created_at": "2026-06-23T00:00:00Z",
+            "updated_at": "2026-06-23T00:00:00Z",
+            "outcome_evaluations": [],
+            "environment_id": _ENV_ID,
+            "metadata": {},
+            "resources": [],
+            "stats": {},
+            "status": "idle",
+            "title": None,
+            "usage": {},
+            "vault_ids": [],
+        }
+    ).model_dump(mode="json")
+    usage = BetaManagedAgentsSpanModelUsage(
+        input_tokens=100,
+        output_tokens=50,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
+    router = MARouter()
+    router.add(
+        "GET", r"/v1/sessions/([^/]+)", lambda _r, _m: httpx.Response(200, json=session_json)
+    )
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)/events",
+        lambda _r, _m: list_response(
+            [
+                _cost_event(
+                    event_id="sevt_unpriced",
+                    usage=usage,
+                    processed_at=dt.datetime(2026, 9, 1, 10, 0, 1, tzinfo=dt.UTC),
+                )
+            ]
+        ),
+    )
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    result = await _get_turn_cost_impl(
+        runtime, auth, "ses_test001", "2026-09-01T10:00:00Z", "sevt_boundary"
+    )
+
+    assert result == {"cost_usd": None, "event_count": 1}, (
+        f"an unpriced model must yield None cost while still counting events; got {result!r}"
+    )
+
+
+async def test_get_turn_cost_returns_a_real_zero_when_priced_model_has_no_events_yet() -> None:
+    """A priced model with no span.model_request_end events yet returns a
+    real zero — distinct from the unpriced None case."""
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(200, json=_make_fake_session(status="idle")),
+    )
+    router.add("GET", r"/v1/sessions/([^/]+)/events", lambda _r, _m: list_response([]))
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    result = await _get_turn_cost_impl(
+        runtime, auth, "ses_test001", "2026-09-01T10:00:00Z", "sevt_boundary"
+    )
+
+    assert result == {"cost_usd": "0", "event_count": 0}, (
+        f"a priced model with no events yet must return a real zero, not None; got {result!r}"
+    )
+
+
+async def test_get_turn_cost_rejects_a_sibling_agents_session_and_lists_no_events() -> None:
+    """Ownership is checked before any events read — a sibling's session is
+    refused with zero events.list calls."""
+    events_calls: list[str] = []
+
+    def on_events(_req: httpx.Request, m: re.Match[str]) -> httpx.Response:
+        events_calls.append(m.group(1))
+        return list_response([])
+
+    router = _sibling_tenant_agents_router()
+    router.add(
+        "GET",
+        r"/v1/sessions/([^/]+)",
+        lambda _r, _m: httpx.Response(
+            200,
+            json=_make_fake_session(session_id="ses_sibling", agent_id="ag_sibling", status="idle"),
+        ),
+    )
+    router.add("GET", r"/v1/sessions/([^/]+)/events", on_events)
+    client = build_fake_anthropic(router.dispatch)
+    runtime = _runtime(client)
+    auth = _auth()
+
+    with pytest.raises(ToolError, match="session not found"):
+        await _get_turn_cost_impl(
+            runtime, auth, "ses_sibling", "2026-09-01T10:00:00Z", "sevt_boundary"
+        )
+
+    assert events_calls == [], "a rejected ownership check must issue no events.list call"

--- a/packages/core/daimon/core/bundle_handle.py
+++ b/packages/core/daimon/core/bundle_handle.py
@@ -1,0 +1,128 @@
+"""Mint and verify signed bundle handles.
+
+A bundle handle carries the ownership facts a database row would otherwise
+hold — which Files-API object, which tenant, which agent, its content hash,
+and its expiry — as an HMAC-signed string. Verifying the signature and the
+embedded claims is the whole ownership check; no table and no lookup are
+needed.
+
+Pure: no I/O, no clock, no RNG. The caller injects ``now``.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import uuid
+from datetime import datetime, timedelta
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+__all__ = ["BundleHandleClaims", "mint", "verify"]
+
+
+class BundleHandleClaims(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    file_id: str
+    tenant_id: uuid.UUID
+    agent_id: uuid.UUID
+    sha256: str
+    exp: int
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _unb64(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def mint(
+    secret: str,
+    *,
+    file_id: str,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    sha256: str,
+    now: datetime,
+    ttl_days: int,
+) -> str:
+    """Return a ``<payload_b64>.<sig_b64>`` bundle handle."""
+    if now.tzinfo is None:
+        raise ValueError("now must be a timezone-aware datetime (UTC)")
+    fields = [file_id, str(tenant_id), str(agent_id), sha256]
+    for field in fields:
+        if "|" in field:
+            raise ValueError("bundle handle fields must not contain '|'")
+    exp = int((now + timedelta(days=ttl_days)).timestamp())
+    payload = "|".join([*fields, str(exp)])
+    payload_b64 = _b64(payload.encode())
+    sig = hmac.new(secret.encode(), payload_b64.encode(), hashlib.sha256).digest()
+    return f"{payload_b64}.{_b64(sig)}"
+
+
+def verify(
+    secret: str,
+    handle: str,
+    *,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+    now: datetime,
+) -> BundleHandleClaims | None:
+    """Verify a bundle handle. Returns ``None`` on every failure, indistinguishably.
+
+    Malformed shape, bad base64, wrong field count, bad signature, expiry, and
+    tenant/agent mismatch all collapse to ``None`` — the caller maps every case
+    to one message, never leaking which check failed. A tz-naive ``now`` is a
+    programming error and still raises ``ValueError``.
+    """
+    if now.tzinfo is None:
+        raise ValueError("now must be a timezone-aware datetime (UTC)")
+
+    parts = handle.split(".")
+    if len(parts) != 2:
+        return None
+    payload_b64, sig_b64 = parts
+
+    try:
+        provided_sig = _unb64(sig_b64)
+    except (ValueError, binascii.Error):
+        return None
+
+    expected_sig = hmac.new(secret.encode(), payload_b64.encode(), hashlib.sha256).digest()
+    if not hmac.compare_digest(provided_sig, expected_sig):
+        return None
+
+    try:
+        payload = _unb64(payload_b64).decode()
+    except (ValueError, binascii.Error, UnicodeDecodeError):
+        return None
+
+    fields = payload.split("|")
+    if len(fields) != 5:
+        return None
+    file_id, claim_tenant_id, claim_agent_id, sha256, exp_str = fields
+
+    try:
+        claims = BundleHandleClaims(
+            file_id=file_id,
+            tenant_id=uuid.UUID(claim_tenant_id),
+            agent_id=uuid.UUID(claim_agent_id),
+            sha256=sha256,
+            exp=int(exp_str),
+        )
+    except (ValueError, ValidationError):
+        return None
+
+    if claims.exp <= int(now.timestamp()):
+        return None
+    if claims.tenant_id != tenant_id:
+        return None
+    if claims.agent_id != agent_id:
+        return None
+
+    return claims

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -99,6 +99,33 @@ class McpSettings(BaseModel):
             "at startup."
         ),
     )
+    bundle_max_bytes: int = Field(
+        default=25 * 1024 * 1024,
+        description=(
+            "Per-upload byte cap enforced by the bundle upload route. The mcp "
+            "service runs on Cloud Run over HTTP/1, whose maximum request size "
+            "is 32 MiB, so the default sits below it with headroom."
+        ),
+    )
+    bundle_uploads_per_hour: int = Field(
+        default=20,
+        description=(
+            "Per-token cap on bundle upload route calls per rolling hour. "
+            "Prevents a compromised or buggy caller from exhausting the "
+            "Files API upload path. Set to 0 to disable (not recommended in "
+            "production)."
+        ),
+    )
+    bundle_ttl_days: int = Field(
+        default=90,
+        description=(
+            "How long an uploaded bundle object is retained on the Files API "
+            "before deletion. Deletion is performed by the scheduler's "
+            "pending-file sweeper, not by this process directly — a "
+            "deployment running no scheduler will never reclaim these "
+            "objects."
+        ),
+    )
 
     @property
     def app_root_url(self) -> str | None:

--- a/packages/core/daimon/core/defaults/metadata.py
+++ b/packages/core/daimon/core/defaults/metadata.py
@@ -13,6 +13,11 @@ MA_METADATA_KEY_ACCOUNT = "daimon_account"
 MA_METADATA_KEY_MANAGED = "daimon_managed"
 MA_METADATA_KEY_SPEC_HASH = "daimon_spec_hash"
 MA_METADATA_KEY_ISOLATED = "daimon_isolated"
+# Stamped on a reader variant (see `daimon.core.reader_agent`) with the
+# source agent's spec-hash-or-fallback fingerprint, so a subsequent publish
+# can tell "unchanged source, reuse the variant" from "source moved, update
+# it" without re-deriving the whole spec first.
+MA_METADATA_KEY_READER_OF = "daimon_reader_of"
 
 # Marks a whole MA workspace as a throwaway one that the test-only workspace
 # nuke is allowed to empty. Stamped on a single sentinel agent, never on a

--- a/packages/core/daimon/core/defaults/metadata.py
+++ b/packages/core/daimon/core/defaults/metadata.py
@@ -12,6 +12,7 @@ MA_METADATA_KEY_NAME = "daimon_name"
 MA_METADATA_KEY_ACCOUNT = "daimon_account"
 MA_METADATA_KEY_MANAGED = "daimon_managed"
 MA_METADATA_KEY_SPEC_HASH = "daimon_spec_hash"
+MA_METADATA_KEY_ISOLATED = "daimon_isolated"
 
 # Marks a whole MA workspace as a throwaway one that the test-only workspace
 # nuke is allowed to empty. Stamped on a single sentinel agent, never on a
@@ -45,6 +46,7 @@ def build_metadata(
     account_id: uuid.UUID | None = None,
     managed: bool = False,
     spec_hash: str | None = None,
+    isolated: bool = False,
 ) -> dict[str, str]:
     """Return the MA metadata tag for `(tenant_id, local_name)`.
 
@@ -66,6 +68,12 @@ def build_metadata(
     When `spec_hash` is provided, stamp `daimon_spec_hash=<hash>` so a
     subsequent reconcile can short-circuit to SKIPPED when MA's current
     metadata already carries the same hash (the L13 idempotency contract).
+
+    When `isolated=True`, stamp `daimon_isolated="true"`. This is the stamp a
+    tool reads back off the live MA agent (never the local spec object) to
+    decide that a session for it must be created with no vault, no env-file
+    mount and no memory store. It is the string `"true"` rather than a bool
+    because MA metadata values are strings. Omitted entirely when `False`.
     """
     metadata: dict[str, str] = {
         MA_METADATA_KEY_TENANT: str(tenant_id),
@@ -77,6 +85,8 @@ def build_metadata(
         metadata[MA_METADATA_KEY_MANAGED] = "true"
     if spec_hash is not None:
         metadata[MA_METADATA_KEY_SPEC_HASH] = spec_hash
+    if isolated:
+        metadata[MA_METADATA_KEY_ISOLATED] = "true"
     return metadata
 
 

--- a/packages/core/daimon/core/defaults/reconcile_agents.py
+++ b/packages/core/daimon/core/defaults/reconcile_agents.py
@@ -60,17 +60,32 @@ async def reconcile_agent(
     `call_reconcile_for_panel` updating a user fork). Without this guard,
     every panel edit re-stamps the user fork as managed → next `defaults
     apply` sweeps it because it isn't in the seeded spec list.
+
+    `spec.isolated` is a third mode alongside `managed=True/False`: an
+    isolated spec never gains the default daimon-mcp server, the matching
+    `mcp_toolset` tool, or the credential-guidance block. Its sessions are
+    created via `create_isolated_session`, which carries no MCP vault, so
+    there is nothing for either the MCP wiring or the guidance text to point
+    the model at — attaching them would describe machinery the session does
+    not have.
     """
     # Prepend the credential-guidance block so every agent knows where its
     # secrets live (mounted env file) vs MCP vault-bound auth, instead of
     # hallucinating "no key" / hunting for non-existent MCP keys. Applied
     # before the spec-hash computation so the block participates in the hash:
     # existing agents update exactly once to gain it, then stabilise (the
-    # block is idempotent under re-application).
-    spec = spec.model_copy(update={"system": apply_credential_guidance(spec.system or "")})
+    # block is idempotent under re-application). Skipped for isolated specs:
+    # they have no MCP vault and no mounted env file, so the block's guidance
+    # would be actively wrong.
+    if not spec.isolated:
+        spec = spec.model_copy(update={"system": apply_credential_guidance(spec.system or "")})
 
-    merged_mcp = merge_default_mcp_server(spec.mcp_servers, public_url)
-    merged_tools = merge_default_mcp_toolset(spec.tools, public_url)
+    # Gate both merges on `spec.isolated` by passing None instead of
+    # public_url — reuses the existing `public_url is None` early return
+    # already built into both mcp_merge functions rather than adding a new
+    # branch inside mcp_merge.py itself.
+    merged_mcp = merge_default_mcp_server(spec.mcp_servers, None if spec.isolated else public_url)
+    merged_tools = merge_default_mcp_toolset(spec.tools, None if spec.isolated else public_url)
     update: dict[str, object] = {}
     if merged_mcp is not spec.mcp_servers:
         update["mcp_servers"] = merged_mcp
@@ -127,6 +142,7 @@ async def reconcile_agent(
         account_id=account_id,
         managed=managed,
         spec_hash=spec_hash,
+        isolated=spec.isolated,
     )
 
     if ma_match is not None:

--- a/packages/core/daimon/core/reader_agent.py
+++ b/packages/core/daimon/core/reader_agent.py
@@ -1,0 +1,88 @@
+"""Derive a read-only reader variant of a publisher's agent.
+
+SPEC D-04/§1.7: a published report is answered by a *variant* of whatever
+agent the publisher names, not a fixed generic `report-reader` agent. The
+variant keeps the source's prompt, model and skills (so it answers in the
+voice the client already knows) and loses every MCP server and every
+`mcp_toolset` tool (so a report reader can never reach the source's
+integrations — see threat T-21-03-A).
+
+Split in two, functional-core/imperative-shell:
+
+- `derive_reader_spec` is the pure `AgentSpec -> AgentSpec` transform. No I/O,
+  fully unit-testable, and the only place the isolation guarantees are
+  decided.
+- `ensure_reader_variant` is the thin shell: resolve the source agent on MA,
+  derive its spec, then find-or-create-or-update the variant, keyed so that
+  publishing twice from an unchanged source reuses one variant instead of
+  creating a second (threat T-21-03-D).
+"""
+
+from __future__ import annotations
+
+from daimon.core.specs import AgentSpec, SkillRef
+
+# Skill seeded from the defaults tree (its SKILL.md lands in a later plan)
+# that teaches the model how to unpack and read the mounted report bundle.
+READER_SKILL_NAME = "report-reader"
+
+# Appended to the source agent's system prompt. Prose the model reads, not a
+# spec citation — carries the five clauses SPEC §1.7 names for a reader
+# variant's behaviour.
+READER_BLOCK = """
+
+## Answering questions about this report
+
+You are now a reader for one published report, not the general-purpose \
+agent you were before. Answer only from the bundle mounted in this session \
+— never fall back on outside knowledge or on what you remember from other \
+conversations. For every number you state, cite the file and the column it \
+came from. If the bundle genuinely cannot answer a question, say so plainly \
+instead of guessing or extrapolating a plausible-sounding figure — never \
+invent data to fill a gap. Only rebuild or refit a model when the reader \
+explicitly asks for it, and when you do, say up front that a refit takes a \
+few minutes so they know to wait.
+"""
+
+
+def derive_reader_spec(source: AgentSpec) -> AgentSpec:
+    """Pure transform: the source agent's spec, stripped to a report reader.
+
+    - `name` gains a `-reader` suffix.
+    - `isolated=True` and `mcp_servers=None` — a reader variant is created
+      via `create_isolated_session` (no vault, no env mount), so it has
+      nothing to authenticate an MCP server with.
+    - `tools` drops every `mcp_toolset` entry, collapsing to `None` when
+      nothing is left (an empty list and `None` are not equivalent to
+      `dump_agent_spec`'s downstream merge).
+    - `mcp_servers` and every `mcp_toolset` tool are dropped *together*:
+      `AgentSpec._require_mcp_toolset_when_mcp_servers_set` rejects a spec
+      that declares one without the other, so dropping only one half would
+      raise at validation instead of producing a clean variant.
+    - `skills` gains exactly one `report-reader` ref, added only when no
+      existing ref already carries that `skill_id` — deriving from an
+      already-derived spec must not duplicate it.
+    - `system` gains `READER_BLOCK`, appended only when not already present,
+      for the same idempotence reason.
+    - `model`, `description`, `multiagent` and `skill_repos` carry through
+      unchanged.
+
+    `source` is never mutated — `model_copy` returns a new instance.
+    """
+    non_mcp_tools = [tool for tool in (source.tools or []) if tool.get("type") != "mcp_toolset"]
+    skills = list(source.skills)
+    if not any(ref.skill_id == READER_SKILL_NAME for ref in skills):
+        skills.append(SkillRef(type="custom", skill_id=READER_SKILL_NAME))
+    system = source.system or ""
+    if READER_BLOCK not in system:
+        system += READER_BLOCK
+    return source.model_copy(
+        update={
+            "name": f"{source.name}-reader",
+            "isolated": True,
+            "mcp_servers": None,
+            "tools": non_mcp_tools or None,
+            "skills": skills,
+            "system": system,
+        }
+    )

--- a/packages/core/daimon/core/reader_agent.py
+++ b/packages/core/daimon/core/reader_agent.py
@@ -20,7 +20,26 @@ Split in two, functional-core/imperative-shell:
 
 from __future__ import annotations
 
-from daimon.core.specs import AgentSpec, SkillRef
+import uuid
+from typing import cast
+
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsSkillParams
+from anthropic.types.beta.agent_create_params import Tool
+from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
+    BetaManagedAgentsURLMCPServerParams,
+)
+from daimon.core.defaults.ma_index import find_agent_by_daimon_tag, find_agents_by_daimon_tag
+from daimon.core.defaults.metadata import (
+    MA_METADATA_KEY_READER_OF,
+    MA_METADATA_KEY_SPEC_HASH,
+    build_metadata,
+    compute_spec_fingerprint,
+)
+from daimon.core.defaults.skills import resolve_refs
+from daimon.core.errors import DaimonError
+from daimon.core.ma import update_agent_with_version_retry
+from daimon.core.specs import AgentSpec, SkillRef, dump_agent_spec
 
 # Skill seeded from the defaults tree (its SKILL.md lands in a later plan)
 # that teaches the model how to unpack and read the mounted report bundle.
@@ -86,3 +105,127 @@ def derive_reader_spec(source: AgentSpec) -> AgentSpec:
             "system": system,
         }
     )
+
+
+async def ensure_reader_variant(
+    anthropic: AsyncAnthropic,
+    *,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID,
+    source_name: str,
+) -> BetaManagedAgentsAgent:
+    """Find, create or update the reader variant of `source_name`, on MA only.
+
+    Deliberate deviation from SPEC §1.7's literal signature: the spec writes
+    `ensure_reader_variant(anthropic, session_factory, *, ...)`, but nothing
+    in this function's work touches the database — resolving the source,
+    deriving the spec, resolving skill refs and creating or updating the
+    agent are all Managed Agents calls. `guideline:architecture` forbids
+    taking a collaborator you do not use, so `session_factory` is omitted.
+
+    Reuse is keyed on `daimon_reader_of`, a fingerprint of the *source's*
+    shape: `daimon_spec_hash` off the source's own metadata when it carries
+    one (every defaults-reconciled agent does), else a fingerprint of the
+    source's `(id, version)` pair. Both change exactly when the source
+    changes — a reconciled agent's spec hash moves on edit, and MA bumps
+    `version` on every update regardless of how the agent got created — so
+    either branch is a stable "has the source changed" signal.
+
+    Raises `DaimonError` when `source_name` does not resolve to an agent on
+    MA — fails loudly rather than silently falling back to a different
+    agent.
+    """
+    source_ma = await find_agent_by_daimon_tag(anthropic, tenant_id=tenant_id, name=source_name)
+    if source_ma is None:
+        raise DaimonError(f"agent {source_name!r} not found")
+
+    reader_of = source_ma.metadata.get(MA_METADATA_KEY_SPEC_HASH) or compute_spec_fingerprint(
+        {"agent_id": source_ma.id, "version": source_ma.version}
+    )
+
+    # The source's skills are already resolved MA skill params (real skill
+    # ids, not authoring names) — reconstructed as SkillRef only so
+    # `derive_reader_spec` can run its dedup check against them. They are
+    # never re-resolved through `resolve_refs` (see below): a custom skill's
+    # already-resolved id would not match any tenant display_title.
+    source_skills = [
+        SkillRef(type=skill.type, skill_id=skill.skill_id) for skill in source_ma.skills
+    ]
+    source_spec = AgentSpec(
+        name=source_ma.name,
+        model=source_ma.model.id,
+        description=source_ma.description,
+        system=source_ma.system,
+        tools=cast(
+            "list[Tool] | None",
+            [tool.model_dump(mode="json") for tool in source_ma.tools] or None,
+        ),
+        mcp_servers=cast(
+            "list[BetaManagedAgentsURLMCPServerParams] | None",
+            [server.model_dump(mode="json") for server in source_ma.mcp_servers] or None,
+        ),
+        skills=source_skills,
+    )
+    reader_spec = derive_reader_spec(source_spec)
+
+    # Only the newly-derived `report-reader` ref is an authoring name that
+    # needs resolving; every other entry in `reader_spec.skills` came
+    # straight off `source_ma.skills` above and is already a resolved MA
+    # skill param — pass it through unchanged instead of routing it through
+    # `resolve_refs`'s display_title lookup (see `source_skills` comment).
+    resolved_skills: list[BetaManagedAgentsSkillParams] = []
+    new_refs: list[SkillRef] = []
+    for ref in reader_spec.skills:
+        if ref.skill_id == READER_SKILL_NAME:
+            new_refs.append(ref)
+        else:
+            resolved_skills.append(
+                cast("BetaManagedAgentsSkillParams", {"type": ref.type, "skill_id": ref.skill_id})
+            )
+    resolved_skills.extend(await resolve_refs(anthropic, refs=new_refs, tenant_id=tenant_id))
+
+    reader_spec_dump = dump_agent_spec(reader_spec, mode="json")
+    reader_spec_hash = compute_spec_fingerprint(
+        {"spec": reader_spec_dump, "skills": resolved_skills}
+    )
+    # managed=False is load-bearing: a variant stamped managed would be
+    # archived by the next `defaults apply` sweep because it is not in the
+    # seeded spec list (threat T-21-03-C).
+    metadata = build_metadata(
+        tenant_id=tenant_id,
+        name=reader_spec.name,
+        account_id=account_id,
+        managed=False,
+        spec_hash=reader_spec_hash,
+        isolated=True,
+    )
+    metadata[MA_METADATA_KEY_READER_OF] = reader_of
+
+    matches = await find_agents_by_daimon_tag(anthropic, tenant_id=tenant_id, name=reader_spec.name)
+    match = matches[0] if matches else None
+
+    if match is None:
+        return await anthropic.beta.agents.create(
+            **dump_agent_spec(reader_spec),
+            skills=resolved_skills,
+            metadata=metadata,
+        )
+
+    if (
+        match.metadata.get(MA_METADATA_KEY_READER_OF) == reader_of
+        and match.metadata.get(MA_METADATA_KEY_SPEC_HASH) == reader_spec_hash
+    ):
+        # Reuse across publishes: neither the source nor the derived shape
+        # changed since the variant was last written. No MA write.
+        return match
+
+    async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
+        return await anthropic.beta.agents.update(
+            fresh.id,
+            version=fresh.version,
+            **dump_agent_spec(reader_spec),
+            skills=resolved_skills,
+            metadata=cast("dict[str, str | None]", metadata),
+        )
+
+    return await update_agent_with_version_retry(anthropic, match.id, _apply)

--- a/packages/core/daimon/core/sessions.py
+++ b/packages/core/daimon/core/sessions.py
@@ -37,7 +37,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 _log = structlog.get_logger(__name__)
 
-__all__ = ["create_session"]
+__all__ = ["create_session", "create_isolated_session"]
 
 
 async def create_session(
@@ -269,4 +269,51 @@ async def create_session(
         metadata=metadata if metadata else omit,
         vault_ids=[vault_id] if vault_id is not None else omit,
         resources=resources if resources else omit,
+    )
+
+
+async def create_isolated_session(
+    anthropic: AsyncAnthropic,
+    *,
+    agent: BetaManagedAgentsAgent,
+    environment: BetaEnvironment,
+    account_id: uuid.UUID | None,
+    tenant_id: uuid.UUID | None,
+    resources: list[Resource],
+) -> BetaManagedAgentsSession:
+    """Create an MA session for an isolated agent — `create_session` with every
+    optional mount removed.
+
+    This is the DEGENERATE sibling of `create_session`, not a smaller version
+    of it: it has no `mcp_settings`, no `agent_uuid`, no `session_factory`, no
+    `fernet`, and no `github_*` parameter, and it must never grow one "for
+    symmetry" — the absent parameters are the security property. It attaches
+    no credential vault (so no session-create kwarg for one is passed at
+    all — not even the SDK's omit sentinel), mounts no tenant secrets file,
+    and provisions no per-agent long-lived store. There is simply no branch
+    in this function that could reach for any of those.
+
+    Contrast with `create_session`'s two optional-mount branches: its memory
+    mount is degrade-not-block (a provisioning failure is logged and
+    swallowed) and its MCP credential mirror hard-fails the turn on error.
+    This function has neither branch, and therefore no degrade path at all —
+    there is nothing optional left to degrade. A caller gets exactly the
+    `resources` it passed and nothing else: no vault, no env file, no memory
+    store, no repo. `resources` is passed unconditionally (never omitted);
+    an isolated session with an empty resource list is a caller bug, not a
+    degraded mode.
+
+    On MA failure: `anthropic.APIError` propagates uncaught.
+    """
+    metadata: dict[str, str] = {}
+    if account_id is not None:
+        metadata[MA_METADATA_KEY_ACCOUNT] = str(account_id)
+    if tenant_id is not None:
+        metadata[MA_METADATA_KEY_TENANT] = str(tenant_id)
+
+    return await anthropic.beta.sessions.create(
+        agent=agent.id,
+        environment_id=environment.id,
+        metadata=metadata if metadata else omit,
+        resources=resources,
     )

--- a/packages/core/daimon/core/specs.py
+++ b/packages/core/daimon/core/specs.py
@@ -82,7 +82,7 @@ class AgentSpec(BaseModel):
     verbatim — any SDK rename or discriminator change is inherited without
     re-declaration.
 
-    Two fields diverge from the SDK:
+    Three fields diverge from the SDK:
 
     - `metadata` is omitted entirely. The upload call synthesizes
       `{daimon_account, daimon_name}` at the SDK boundary; operators cannot
@@ -93,6 +93,17 @@ class AgentSpec(BaseModel):
       IDs don't exist until skills have uploaded. `Field(exclude=True)` keeps
       it out of `model_dump()`; the resolved list is passed as a separate
       kwarg at the call site.
+    - `isolated: bool` is an authoring-side property of how daimon builds and
+      mounts the agent, not a Managed Agents create parameter — it never
+      appears in an `agents.create`/`agents.update` payload. `dump_agent_spec`
+      splats its output straight into the SDK call, so an unexcluded field
+      would be sent upstream as an unknown parameter and rejected.
+      `Field(exclude=True)` keeps it out of `model_dump()`, exactly like
+      `skills` and `skill_repos` above. Because it is excluded, `isolated`
+      does not participate in `compute_spec_fingerprint` (which hashes
+      `dump_agent_spec(spec, mode="json")`) — that is correct rather than a
+      gap, since the flag's only observable effects (no `mcp_servers`, no
+      `mcp_toolset` tool) both participate in the hash directly.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -106,6 +117,7 @@ class AgentSpec(BaseModel):
     multiagent: BetaManagedAgentsMultiagentParams | None = None
     skills: list[SkillRef] = Field(default_factory=list[SkillRef], exclude=True)
     skill_repos: list[SkillRepo] = Field(default_factory=list[SkillRepo], exclude=True)
+    isolated: bool = Field(default=False, exclude=True)
 
     @model_validator(mode="after")
     def _require_mcp_toolset_when_mcp_servers_set(self) -> AgentSpec:

--- a/packages/core/tests/contracts/test_bundle_mount.py
+++ b/packages/core/tests/contracts/test_bundle_mount.py
@@ -1,0 +1,204 @@
+"""Contract tests pinning the live MA facts the bundle mount is built on:
+
+(a) a session file resource whose `mount_path` starts with `/` still joins
+    under `/mnt/session/uploads/`, the same as a bare relative name — the
+    join rule the reader skill's extraction command depends on;
+(b) what `sessions.create` does when handed a deleted file id, recorded
+    explicitly (an error at create, or a session that fails later) so the
+    pre-check ahead of it in the route has a documented reason either way.
+
+Runtime discipline: haiku only, one session per test. Env-gated by
+DAIMON_TEST_ANTHROPIC_API_KEY; the default `uv run pytest` deselects the
+contract marker so this never gates CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import tarfile
+import uuid
+
+import anthropic
+import pytest
+import pytest_asyncio
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import (
+    BetaCloudConfigParams,
+    BetaEnvironment,
+    BetaManagedAgentsAgent,
+    BetaManagedAgentsDeltaEvent,
+    BetaManagedAgentsStartEvent,
+)
+from anthropic.types.beta.beta_managed_agents_file_resource_params import (
+    BetaManagedAgentsFileResourceParams,
+)
+from anthropic.types.beta.sessions import BetaManagedAgentsAgentMessageEvent
+from anthropic.types.beta.sessions.beta_managed_agents_session_error_event import (
+    BetaManagedAgentsSessionErrorEvent,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_session_status_idle_event import (
+    BetaManagedAgentsSessionStatusIdleEvent,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_user_message_event_params import (
+    BetaManagedAgentsUserMessageEventParams,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_user_tool_confirmation_event_params import (
+    BetaManagedAgentsUserToolConfirmationEventParams,
+)
+
+pytestmark = pytest.mark.contract
+
+_MA_BETA = "managed-agents-2026-04-01"
+_TURN_TIMEOUT_S = 300.0
+
+_ENV_CONFIG: BetaCloudConfigParams = {
+    "type": "cloud",
+    "networking": {"type": "unrestricted"},
+    "packages": {"apt": [], "cargo": [], "gem": [], "go": [], "npm": [], "pip": []},
+}
+
+
+def _build_tiny_gzip_tar(name: str, content: bytes) -> bytes:
+    """Build a small real gzip-compressed tar archive with one member."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=name)
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def live_environment(anthropic_client: AsyncAnthropic) -> BetaEnvironment:
+    """Module-scoped real environment. Cleaned up by conftest's workspace wipe."""
+    name = f"contract-test-bundle-env-{uuid.uuid4().hex[:8]}"
+    return await anthropic_client.beta.environments.create(name=name, config=_ENV_CONFIG)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def live_agent(anthropic_client: AsyncAnthropic) -> BetaManagedAgentsAgent:
+    """Module-scoped real agent with a bash tool, to prove where a mount lands."""
+    name = f"contract-test-bundle-agent-{uuid.uuid4().hex[:8]}"
+    return await anthropic_client.beta.agents.create(
+        name=name,
+        model={"id": "claude-haiku-4-5"},
+        system=(
+            "You are a test agent. Run the exact bash commands you are given, "
+            "then reply exactly as instructed."
+        ),
+        tools=[{"type": "agent_toolset_20260401", "configs": [{"name": "bash"}]}],
+    )
+
+
+async def _send_command_and_capture_reply(
+    client: AsyncAnthropic, session_id: str, command: str
+) -> str:
+    """Send one exact-command turn, drain to idle auto-allowing tool
+    confirmations, and return the concatenated text of every agent.message
+    event seen — the agent's own evidence of what the command observed."""
+    message: BetaManagedAgentsUserMessageEventParams = {
+        "type": "user.message",
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    f"Run exactly: {command}\n"
+                    "Then reply with exactly the full output of that command, nothing else."
+                ),
+            }
+        ],
+    }
+    await client.beta.sessions.events.send(session_id, events=[message])
+    confirmed: set[str] = set()
+    reply_parts: list[str] = []
+
+    async def _drain() -> None:
+        async for event in await client.beta.sessions.events.stream(session_id=session_id):
+            if isinstance(event, BetaManagedAgentsStartEvent | BetaManagedAgentsDeltaEvent):
+                continue
+            if isinstance(event, BetaManagedAgentsAgentMessageEvent):
+                reply_parts.extend(block.text for block in event.content)
+                continue
+            if isinstance(event, BetaManagedAgentsSessionErrorEvent):
+                detail = getattr(event.error, "message", None) or repr(event.error)
+                raise RuntimeError(f"session.error: {detail}")
+            if isinstance(event, BetaManagedAgentsSessionStatusIdleEvent):
+                if event.stop_reason.type == "requires_action":
+                    fresh = [t for t in event.stop_reason.event_ids if t not in confirmed]
+                    if fresh:
+                        confirmed.update(fresh)
+                        decisions: list[BetaManagedAgentsUserToolConfirmationEventParams] = [
+                            {"type": "user.tool_confirmation", "result": "allow", "tool_use_id": t}
+                            for t in fresh
+                        ]
+                        await client.beta.sessions.events.send(session_id, events=decisions)
+                    continue
+                return
+
+    await asyncio.wait_for(_drain(), timeout=_TURN_TIMEOUT_S)
+    return "".join(reply_parts)
+
+
+async def test_absolute_mount_path_joins_under_uploads(
+    anthropic_client: AsyncAnthropic,
+    live_agent: BetaManagedAgentsAgent,
+    live_environment: BetaEnvironment,
+) -> None:
+    archive = _build_tiny_gzip_tar("hello.txt", b"contract bundle mount fixture\n")
+    uploaded = await anthropic_client.beta.files.upload(
+        file=("bundle.tar.gz", io.BytesIO(archive), "application/gzip"),
+    )
+    resource: BetaManagedAgentsFileResourceParams = {
+        "type": "file",
+        "file_id": uploaded.id,
+        "mount_path": "/bundle.tar.gz",
+    }
+    session = await anthropic_client.beta.sessions.create(
+        agent=live_agent.id, environment_id=live_environment.id, resources=[resource]
+    )
+
+    reply = await _send_command_and_capture_reply(
+        anthropic_client,
+        session.id,
+        "test -f /mnt/session/uploads/bundle.tar.gz && echo MOUNT_FOUND || echo MOUNT_MISSING",
+    )
+    assert "MOUNT_FOUND" in reply, (
+        "an absolute mount_path of '/bundle.tar.gz' must join under "
+        f"/mnt/session/uploads/, same as a relative one; observed agent reply: {reply!r}"
+    )
+
+
+async def test_sessions_create_with_a_deleted_file_id(
+    anthropic_client: AsyncAnthropic,
+    live_agent: BetaManagedAgentsAgent,
+    live_environment: BetaEnvironment,
+) -> None:
+    archive = _build_tiny_gzip_tar("gone.txt", b"deleted before session create\n")
+    uploaded = await anthropic_client.beta.files.upload(
+        file=("to-delete.tar.gz", io.BytesIO(archive), "application/gzip"),
+    )
+    await anthropic_client.beta.files.delete(uploaded.id, betas=[_MA_BETA])
+
+    resource: BetaManagedAgentsFileResourceParams = {
+        "type": "file",
+        "file_id": uploaded.id,
+        "mount_path": "/deleted.tar.gz",
+    }
+    try:
+        session = await anthropic_client.beta.sessions.create(
+            agent=live_agent.id, environment_id=live_environment.id, resources=[resource]
+        )
+    except anthropic.APIStatusError as err:
+        assert err.status_code >= 400, (
+            f"observed: sessions.create rejects a deleted file id up front with "
+            f"{type(err).__name__} (status {err.status_code}) — the route's pre-check "
+            "can rely on an error at create time"
+        )
+        return
+
+    assert session.status in ("idle", "active", "running", "rescheduling", "terminated"), (
+        "observed: sessions.create accepted a deleted file id without raising; the "
+        f"session was created with status {session.status!r} — a create-time pre-check "
+        "is therefore load-bearing, not redundant, for this failure mode"
+    )

--- a/packages/core/tests/contracts/test_turn_boundary.py
+++ b/packages/core/tests/contracts/test_turn_boundary.py
@@ -2,12 +2,19 @@
 
 (a) a bare `idle` status can be observed immediately after a send — status
     alone is never a valid completion signal;
-(b) `sessions.events.list(created_at_gte=...)` is inclusive of the exact
-    timestamp it is anchored on, which is what lets the boundary event itself
-    be dropped client-side instead of silently missed;
+(b) the send response's echoed event carries no `processed_at` at all, and
+    a `created_at_gte` filter anchored on the caller's OWN pre-send clock
+    reading (not the echo) includes the boundary event and excludes every
+    event from an earlier turn on the same session;
 (c)-(e) `user.interrupt` converges to a terminal state from `running`, from
     `rescheduling` (skipped with a reason if that state cannot be reached
     deterministically), and is a no-op when sent to an already-idle session.
+
+(b) supersedes an earlier version of this suite that expected the echo to
+carry a usable `processed_at`. A live run showed the echo's `processed_at`
+is always None; the timestamp only appears roughly half a second later,
+once the agent starts on the event. The boundary's clock has to be the
+caller's own, captured immediately before the send.
 
 Runtime discipline: haiku only, one session per test. Env-gated by
 DAIMON_TEST_ANTHROPIC_API_KEY; the default `uv run pytest` deselects the
@@ -17,6 +24,7 @@ contract marker so this never gates CI.
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import uuid
 from collections.abc import Callable
 
@@ -147,11 +155,16 @@ async def test_status_immediately_after_send_is_not_a_completion_signal(
     )
 
 
-async def test_created_at_gte_boundary_is_inclusive_of_the_boundary_event(
+async def test_send_echo_carries_no_processed_at(
     anthropic_client: AsyncAnthropic,
     live_agent: BetaManagedAgentsAgent,
     live_environment: BetaEnvironment,
 ) -> None:
+    """The fact D-07 r4 rests on: the send response's echoed event has no
+    processed_at at all, immediately after the send returns. A timestamp
+    only appears roughly half a second later, once the agent starts on the
+    event — too late to serve as the boundary's clock, which is why the
+    seam captures its own reading before the send instead."""
     session = await anthropic_client.beta.sessions.create(
         agent=live_agent.id, environment_id=live_environment.id
     )
@@ -160,28 +173,92 @@ async def test_created_at_gte_boundary_is_inclusive_of_the_boundary_event(
         "content": [{"type": "text", "text": "Reply with exactly: DONE"}],
     }
     sent = await anthropic_client.beta.sessions.events.send(session.id, events=[message])
-    assert sent.data, (
-        "send must echo back the sent event so its processed_at can anchor the boundary"
-    )
+    assert sent.data, "send must echo back the sent event"
     boundary_event = sent.data[0]
-    assert boundary_event.processed_at is not None, (
-        "the boundary event must carry a processed_at timestamp to anchor created_at_gte on"
+    assert boundary_event.processed_at is None, (
+        f"the send echo is expected to carry no processed_at immediately after the "
+        f"send returns; observed {boundary_event.processed_at!r}. If this ever starts "
+        "returning a timestamp, the boundary's clock source should be reconsidered."
     )
+
+
+async def test_created_at_gte_with_a_pre_send_clock_bound_isolates_the_second_turn(
+    anthropic_client: AsyncAnthropic,
+    live_agent: BetaManagedAgentsAgent,
+    live_environment: BetaEnvironment,
+) -> None:
+    """A created_at_gte filter anchored on the CALLER's own pre-send clock
+    reading (never the echo, which carries none) includes the second turn's
+    boundary event and excludes every event from the first turn on the same
+    session. Also proves that filtering by type still surfaces the boundary
+    event first."""
+    session = await anthropic_client.beta.sessions.create(
+        agent=live_agent.id, environment_id=live_environment.id
+    )
+    first_message: BetaManagedAgentsUserMessageEventParams = {
+        "type": "user.message",
+        "content": [{"type": "text", "text": "Reply with exactly: FIRST"}],
+    }
+    await anthropic_client.beta.sessions.events.send(session.id, events=[first_message])
+    first_idle = await _poll_until(
+        anthropic_client, session.id, lambda s: s == "idle", _IDLE_WAIT_S
+    )
+    assert first_idle is not None, (
+        f"the first turn never reached idle within {_IDLE_WAIT_S}s — the second turn's "
+        "boundary cannot be exercised without a finished first turn to isolate from"
+    )
+    first_turn_ids = {
+        event.id
+        async for event in anthropic_client.beta.sessions.events.list(
+            session_id=session.id, order="asc"
+        )
+    }
+
+    turn_started_at = dt.datetime.now(dt.UTC)
+    second_message: BetaManagedAgentsUserMessageEventParams = {
+        "type": "user.message",
+        "content": [{"type": "text", "text": "Reply with exactly: SECOND"}],
+    }
+    sent = await anthropic_client.beta.sessions.events.send(session.id, events=[second_message])
+    assert sent.data, "send must echo back the sent event"
+    boundary_event_id = sent.data[0].id
+
+    second_idle = await _poll_until(
+        anthropic_client, session.id, lambda s: s == "idle", _IDLE_WAIT_S
+    )
+    assert second_idle is not None, f"the second turn never reached idle within {_IDLE_WAIT_S}s"
 
     results = [
         event
         async for event in anthropic_client.beta.sessions.events.list(
-            session_id=session.id, created_at_gte=boundary_event.processed_at, order="asc"
+            session_id=session.id, created_at_gte=turn_started_at, order="asc"
         )
     ]
-    assert results, (
-        "an inclusive created_at_gte filter anchored on the boundary event's own timestamp "
-        "must return at least the boundary event itself"
+    result_ids = [event.id for event in results]
+    assert boundary_event_id in result_ids, (
+        f"a created_at_gte filter anchored on the caller's own pre-send clock reading "
+        f"must include the boundary event {boundary_event_id!r}; got {result_ids!r}"
     )
-    assert results[0].id == boundary_event.id, (
-        f"the boundary event ({boundary_event.id}) must be the first result under an "
-        f"inclusive created_at_gte filter in asc order; got {results[0].id!r} first instead "
-        "— either the filter is exclusive of the boundary or an earlier event leaked through"
+    leaked_first_turn_ids = first_turn_ids.intersection(result_ids)
+    assert not leaked_first_turn_ids, (
+        f"a pre-send clock bound must exclude every event from the prior turn; "
+        f"first-turn events leaked through: {leaked_first_turn_ids!r}"
+    )
+
+    typed_results = [
+        event
+        async for event in anthropic_client.beta.sessions.events.list(
+            session_id=session.id,
+            created_at_gte=turn_started_at,
+            types=["user.message", "agent.message", "session.status_idle"],
+            order="asc",
+        )
+    ]
+    assert typed_results, "the typed, bounded listing must return at least the boundary event"
+    assert typed_results[0].id == boundary_event_id, (
+        f"with created_at_gte and a type filter together, the boundary event "
+        f"({boundary_event_id}) must be the first result in asc order; got "
+        f"{typed_results[0].id!r} first instead"
     )
 
 

--- a/packages/core/tests/contracts/test_turn_boundary.py
+++ b/packages/core/tests/contracts/test_turn_boundary.py
@@ -101,6 +101,36 @@ async def _poll_until(
         await asyncio.sleep(_POLL_INTERVAL_S)
 
 
+async def _wait_for_idle_event_since(
+    anthropic_client: AsyncAnthropic,
+    session_id: str,
+    since: dt.datetime,
+    deadline_s: float,
+) -> str | None:
+    """Poll `events.list` for a `session.status_idle` event at or after `since`.
+
+    A session's status can still read `idle` for a brief window right after a
+    send — the flip to `running` lags by roughly half a second — so polling
+    `sessions.retrieve` immediately after a send can observe a turn that has
+    not actually started yet. An idle EVENT that lands after the boundary,
+    not a status snapshot, is the only completion signal this suite trusts.
+    Returns the first matching event's id, or None if none appears within
+    the deadline.
+    """
+    deadline = asyncio.get_running_loop().time() + deadline_s
+    while True:
+        async for event in anthropic_client.beta.sessions.events.list(
+            session_id=session_id,
+            created_at_gte=since,
+            types=["session.status_idle"],
+            order="asc",
+        ):
+            return event.id
+        if asyncio.get_running_loop().time() >= deadline:
+            return None
+        await asyncio.sleep(_POLL_INTERVAL_S)
+
+
 async def _interrupt_and_wait_for_terminal(
     anthropic_client: AsyncAnthropic, session_id: str, deadline_s: float
 ) -> str:
@@ -195,24 +225,32 @@ async def test_created_at_gte_with_a_pre_send_clock_bound_isolates_the_second_tu
     session = await anthropic_client.beta.sessions.create(
         agent=live_agent.id, environment_id=live_environment.id
     )
+    first_turn_started_at = dt.datetime.now(dt.UTC)
     first_message: BetaManagedAgentsUserMessageEventParams = {
         "type": "user.message",
         "content": [{"type": "text", "text": "Reply with exactly: FIRST"}],
     }
     await anthropic_client.beta.sessions.events.send(session.id, events=[first_message])
-    first_idle = await _poll_until(
-        anthropic_client, session.id, lambda s: s == "idle", _IDLE_WAIT_S
+    first_idle_event_id = await _wait_for_idle_event_since(
+        anthropic_client, session.id, first_turn_started_at, _IDLE_WAIT_S
     )
-    assert first_idle is not None, (
-        f"the first turn never reached idle within {_IDLE_WAIT_S}s — the second turn's "
-        "boundary cannot be exercised without a finished first turn to isolate from"
+    assert first_idle_event_id is not None, (
+        f"the first turn's session.status_idle event never appeared within {_IDLE_WAIT_S}s "
+        "— the second turn's boundary cannot be exercised without a finished first turn to "
+        "isolate from"
     )
-    first_turn_ids = {
-        event.id
+    first_turn_events = [
+        event
         async for event in anthropic_client.beta.sessions.events.list(
             session_id=session.id, order="asc"
         )
-    }
+    ]
+    first_turn_ids = {event.id for event in first_turn_events}
+    assert first_turn_ids, "the first turn must have produced events before it can be isolated from"
+    assert any(event.type == "agent.message" for event in first_turn_events), (
+        "the first turn must have produced an agent.message event before its ids are "
+        f"snapshotted for isolation; observed types: {[e.type for e in first_turn_events]!r}"
+    )
 
     turn_started_at = dt.datetime.now(dt.UTC)
     second_message: BetaManagedAgentsUserMessageEventParams = {
@@ -223,10 +261,12 @@ async def test_created_at_gte_with_a_pre_send_clock_bound_isolates_the_second_tu
     assert sent.data, "send must echo back the sent event"
     boundary_event_id = sent.data[0].id
 
-    second_idle = await _poll_until(
-        anthropic_client, session.id, lambda s: s == "idle", _IDLE_WAIT_S
+    second_idle_event_id = await _wait_for_idle_event_since(
+        anthropic_client, session.id, turn_started_at, _IDLE_WAIT_S
     )
-    assert second_idle is not None, f"the second turn never reached idle within {_IDLE_WAIT_S}s"
+    assert second_idle_event_id is not None, (
+        f"the second turn's session.status_idle event never appeared within {_IDLE_WAIT_S}s"
+    )
 
     results = [
         event

--- a/packages/core/tests/contracts/test_turn_boundary.py
+++ b/packages/core/tests/contracts/test_turn_boundary.py
@@ -1,0 +1,279 @@
+"""Contract tests pinning the live MA facts the turn boundary is built on:
+
+(a) a bare `idle` status can be observed immediately after a send — status
+    alone is never a valid completion signal;
+(b) `sessions.events.list(created_at_gte=...)` is inclusive of the exact
+    timestamp it is anchored on, which is what lets the boundary event itself
+    be dropped client-side instead of silently missed;
+(c)-(e) `user.interrupt` converges to a terminal state from `running`, from
+    `rescheduling` (skipped with a reason if that state cannot be reached
+    deterministically), and is a no-op when sent to an already-idle session.
+
+Runtime discipline: haiku only, one session per test. Env-gated by
+DAIMON_TEST_ANTHROPIC_API_KEY; the default `uv run pytest` deselects the
+contract marker so this never gates CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Callable
+
+import pytest
+import pytest_asyncio
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import BetaCloudConfigParams, BetaEnvironment, BetaManagedAgentsAgent
+from anthropic.types.beta.sessions.beta_managed_agents_user_interrupt_event_params import (
+    BetaManagedAgentsUserInterruptEventParams,
+)
+from anthropic.types.beta.sessions.beta_managed_agents_user_message_event_params import (
+    BetaManagedAgentsUserMessageEventParams,
+)
+
+pytestmark = pytest.mark.contract
+
+_POLL_INTERVAL_S = 0.5
+_RUNNING_WAIT_S = 15.0
+_RESCHEDULING_WAIT_S = 10.0
+_TERMINAL_WAIT_S = 30.0
+_IDLE_WAIT_S = 15.0
+
+_ENV_CONFIG: BetaCloudConfigParams = {
+    "type": "cloud",
+    "networking": {"type": "unrestricted"},
+    "packages": {"apt": [], "cargo": [], "gem": [], "go": [], "npm": [], "pip": []},
+}
+
+
+@pytest_asyncio.fixture(scope="module")
+async def live_environment(anthropic_client: AsyncAnthropic) -> BetaEnvironment:
+    """Module-scoped real environment. Cleaned up by conftest's workspace wipe."""
+    name = f"contract-test-boundary-env-{uuid.uuid4().hex[:8]}"
+    return await anthropic_client.beta.environments.create(name=name, config=_ENV_CONFIG)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def live_agent(anthropic_client: AsyncAnthropic) -> BetaManagedAgentsAgent:
+    """Module-scoped real agent with no tools — status/boundary tests need only a reply."""
+    name = f"contract-test-boundary-agent-{uuid.uuid4().hex[:8]}"
+    return await anthropic_client.beta.agents.create(
+        name=name, model={"id": "claude-haiku-4-5"}, system="contract turn-boundary test"
+    )
+
+
+@pytest_asyncio.fixture(scope="module")
+async def live_bash_agent(anthropic_client: AsyncAnthropic) -> BetaManagedAgentsAgent:
+    """Module-scoped real agent with a bash tool — interrupt tests need a
+    command that stays running long enough to observe."""
+    name = f"contract-test-boundary-bash-agent-{uuid.uuid4().hex[:8]}"
+    return await anthropic_client.beta.agents.create(
+        name=name,
+        model={"id": "claude-haiku-4-5"},
+        system="You are a test agent. Run exactly the bash commands you are given.",
+        tools=[{"type": "agent_toolset_20260401", "configs": [{"name": "bash"}]}],
+    )
+
+
+async def _poll_until(
+    anthropic_client: AsyncAnthropic,
+    session_id: str,
+    predicate: Callable[[str], bool],
+    deadline_s: float,
+) -> str | None:
+    """Poll `sessions.retrieve` every `_POLL_INTERVAL_S` until `predicate` is
+    true or `deadline_s` elapses. Returns the matching status, or None."""
+    deadline = asyncio.get_running_loop().time() + deadline_s
+    while True:
+        session = await anthropic_client.beta.sessions.retrieve(session_id)
+        if predicate(session.status):
+            return session.status
+        if asyncio.get_running_loop().time() >= deadline:
+            return None
+        await asyncio.sleep(_POLL_INTERVAL_S)
+
+
+async def _interrupt_and_wait_for_terminal(
+    anthropic_client: AsyncAnthropic, session_id: str, deadline_s: float
+) -> str:
+    """Send `user.interrupt`, then poll until a `session.status_idle` event
+    is observable (session status is `idle` AND the event is listed) or the
+    session reaches `terminated`. Returns which terminal signal was seen.
+
+    Raises AssertionError with the last observed status on timeout — this is
+    itself the assertion the interrupt-convergence tests make.
+    """
+    interrupt: BetaManagedAgentsUserInterruptEventParams = {"type": "user.interrupt"}
+    await anthropic_client.beta.sessions.events.send(session_id, events=[interrupt])
+
+    deadline = asyncio.get_running_loop().time() + deadline_s
+    last_status = "unknown"
+    while asyncio.get_running_loop().time() < deadline:
+        session = await anthropic_client.beta.sessions.retrieve(session_id)
+        last_status = session.status
+        if last_status == "terminated":
+            return "terminated"
+        if last_status == "idle":
+            async for event in anthropic_client.beta.sessions.events.list(
+                session_id=session_id, types=["session.status_idle"], order="desc", limit=1
+            ):
+                assert event.type == "session.status_idle"
+                return "session.status_idle"
+        await asyncio.sleep(_POLL_INTERVAL_S)
+    raise AssertionError(
+        f"interrupt did not converge to a terminal state within {deadline_s}s "
+        f"(last observed status: {last_status!r})"
+    )
+
+
+async def test_status_immediately_after_send_is_not_a_completion_signal(
+    anthropic_client: AsyncAnthropic,
+    live_agent: BetaManagedAgentsAgent,
+    live_environment: BetaEnvironment,
+) -> None:
+    session = await anthropic_client.beta.sessions.create(
+        agent=live_agent.id, environment_id=live_environment.id
+    )
+    message: BetaManagedAgentsUserMessageEventParams = {
+        "type": "user.message",
+        "content": [{"type": "text", "text": "Reply with exactly: DONE"}],
+    }
+    await anthropic_client.beta.sessions.events.send(session.id, events=[message])
+    retrieved = await anthropic_client.beta.sessions.retrieve(session.id)
+    assert retrieved.status in ("idle", "running", "rescheduling"), (
+        f"status immediately after a send must be idle, running or rescheduling; "
+        f"observed {retrieved.status!r}. A bare idle here being possible is exactly "
+        "why status alone is never trusted as a completion signal."
+    )
+
+
+async def test_created_at_gte_boundary_is_inclusive_of_the_boundary_event(
+    anthropic_client: AsyncAnthropic,
+    live_agent: BetaManagedAgentsAgent,
+    live_environment: BetaEnvironment,
+) -> None:
+    session = await anthropic_client.beta.sessions.create(
+        agent=live_agent.id, environment_id=live_environment.id
+    )
+    message: BetaManagedAgentsUserMessageEventParams = {
+        "type": "user.message",
+        "content": [{"type": "text", "text": "Reply with exactly: DONE"}],
+    }
+    sent = await anthropic_client.beta.sessions.events.send(session.id, events=[message])
+    assert sent.data, (
+        "send must echo back the sent event so its processed_at can anchor the boundary"
+    )
+    boundary_event = sent.data[0]
+    assert boundary_event.processed_at is not None, (
+        "the boundary event must carry a processed_at timestamp to anchor created_at_gte on"
+    )
+
+    results = [
+        event
+        async for event in anthropic_client.beta.sessions.events.list(
+            session_id=session.id, created_at_gte=boundary_event.processed_at, order="asc"
+        )
+    ]
+    assert results, (
+        "an inclusive created_at_gte filter anchored on the boundary event's own timestamp "
+        "must return at least the boundary event itself"
+    )
+    assert results[0].id == boundary_event.id, (
+        f"the boundary event ({boundary_event.id}) must be the first result under an "
+        f"inclusive created_at_gte filter in asc order; got {results[0].id!r} first instead "
+        "— either the filter is exclusive of the boundary or an earlier event leaked through"
+    )
+
+
+async def test_interrupt_from_running_converges_to_terminal(
+    anthropic_client: AsyncAnthropic,
+    live_bash_agent: BetaManagedAgentsAgent,
+    live_environment: BetaEnvironment,
+) -> None:
+    session = await anthropic_client.beta.sessions.create(
+        agent=live_bash_agent.id, environment_id=live_environment.id
+    )
+    message: BetaManagedAgentsUserMessageEventParams = {
+        "type": "user.message",
+        "content": [
+            {"type": "text", "text": "Run exactly: sleep 8\nThen reply with exactly: DONE"}
+        ],
+    }
+    await anthropic_client.beta.sessions.events.send(session.id, events=[message])
+
+    running_status = await _poll_until(
+        anthropic_client, session.id, lambda s: s in ("running", "rescheduling"), _RUNNING_WAIT_S
+    )
+    assert running_status is not None, (
+        f"session never reached running/rescheduling within {_RUNNING_WAIT_S}s — cannot "
+        "exercise interrupt-from-running without first observing it running"
+    )
+
+    terminal = await _interrupt_and_wait_for_terminal(
+        anthropic_client, session.id, _TERMINAL_WAIT_S
+    )
+    assert terminal in ("session.status_idle", "terminated"), (
+        f"interrupt from running must converge to a session.status_idle event or terminated; "
+        f"observed {terminal!r}"
+    )
+
+
+async def test_interrupt_from_rescheduling_converges_to_terminal_or_skips(
+    anthropic_client: AsyncAnthropic,
+    live_bash_agent: BetaManagedAgentsAgent,
+    live_environment: BetaEnvironment,
+) -> None:
+    session = await anthropic_client.beta.sessions.create(
+        agent=live_bash_agent.id, environment_id=live_environment.id
+    )
+    message: BetaManagedAgentsUserMessageEventParams = {
+        "type": "user.message",
+        "content": [
+            {"type": "text", "text": "Run exactly: sleep 8\nThen reply with exactly: DONE"}
+        ],
+    }
+    await anthropic_client.beta.sessions.events.send(session.id, events=[message])
+
+    rescheduling_status = await _poll_until(
+        anthropic_client, session.id, lambda s: s == "rescheduling", _RESCHEDULING_WAIT_S
+    )
+    if rescheduling_status is None:
+        pytest.skip(
+            f"session did not enter rescheduling within {_RESCHEDULING_WAIT_S}s for a plain "
+            "long-running bash command — rescheduling was not reached deterministically by "
+            "this test, so interrupt-from-rescheduling is unverified rather than proven"
+        )
+
+    terminal = await _interrupt_and_wait_for_terminal(
+        anthropic_client, session.id, _TERMINAL_WAIT_S
+    )
+    assert terminal in ("session.status_idle", "terminated"), (
+        f"interrupt from rescheduling must converge to a session.status_idle event or "
+        f"terminated; observed {terminal!r}"
+    )
+
+
+async def test_interrupt_on_idle_session_is_a_noop(
+    anthropic_client: AsyncAnthropic,
+    live_agent: BetaManagedAgentsAgent,
+    live_environment: BetaEnvironment,
+) -> None:
+    session = await anthropic_client.beta.sessions.create(
+        agent=live_agent.id, environment_id=live_environment.id
+    )
+    idle_status = await _poll_until(
+        anthropic_client, session.id, lambda s: s == "idle", _IDLE_WAIT_S
+    )
+    assert idle_status is not None, (
+        f"a freshly created session with no message sent must reach idle within "
+        f"{_IDLE_WAIT_S}s before this test can send an interrupt to it"
+    )
+
+    interrupt: BetaManagedAgentsUserInterruptEventParams = {"type": "user.interrupt"}
+    await anthropic_client.beta.sessions.events.send(session.id, events=[interrupt])
+
+    retrieved = await anthropic_client.beta.sessions.retrieve(session.id)
+    assert retrieved.status == "idle", (
+        f"an interrupt sent to an already-idle session must not raise and must leave the "
+        f"session idle; observed {retrieved.status!r} afterward"
+    )

--- a/packages/core/tests/defaults/test_metadata.py
+++ b/packages/core/tests/defaults/test_metadata.py
@@ -5,6 +5,7 @@ import uuid
 
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_ACCOUNT,
+    MA_METADATA_KEY_ISOLATED,
     MA_METADATA_KEY_NAME,
     MA_METADATA_KEY_TENANT,
     build_metadata,
@@ -43,6 +44,22 @@ def test_build_metadata_stamps_account_when_provided() -> None:
     assert md[MA_METADATA_KEY_TENANT] == str(tenant_id)
     assert md[MA_METADATA_KEY_NAME] == "user-agent"
     assert len(md) == 3
+
+
+def test_build_metadata_omits_isolated_when_false() -> None:
+    tenant_id = uuid.UUID("70121a77-33ce-566b-a2ee-47d93bc422ae")
+    md = build_metadata(tenant_id=tenant_id, name="daimon")
+    assert MA_METADATA_KEY_ISOLATED not in md, (
+        "isolated defaults to False and must not stamp daimon_isolated at all"
+    )
+
+
+def test_build_metadata_stamps_isolated_when_true() -> None:
+    tenant_id = uuid.UUID("70121a77-33ce-566b-a2ee-47d93bc422ae")
+    md = build_metadata(tenant_id=tenant_id, name="reader", isolated=True)
+    assert md[MA_METADATA_KEY_ISOLATED] == "true", (
+        "isolated=True must stamp daimon_isolated='true' (string, MA metadata values are strings)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/core/tests/defaults/test_reconcile_agents.py
+++ b/packages/core/tests/defaults/test_reconcile_agents.py
@@ -1214,3 +1214,102 @@ async def test_reconcile_agent_retries_once_on_version_conflict() -> None:
         "retried merge must be recomputed against the SECOND retrieve — a concurrent writer's "
         f"MCP server must not be dropped; got mcp_servers={sent_mcp!r}"
     )
+
+
+async def test_reconcile_agent_isolated_spec_gets_no_mcp_wiring_or_guidance() -> None:
+    """T-21-02-D: an isolated spec must never gain the default daimon-mcp
+    server or its matching mcp_toolset tool, even with public_url set —
+    reconcile_agent must gate both merge calls on spec.isolated rather than
+    relying on mcp_merge.py's own public_url-is-None early return."""
+    spec = AgentSpec(
+        name="reader",
+        model="claude-sonnet-4-6",
+        system="You are a reader agent.",
+        tools=[{"type": "agent_toolset_20260401", "configs": [{"name": "bash"}]}],
+        isolated=True,
+    )
+    router = _router_with_agents([])
+    created_payload: dict[str, Any] = {}
+
+    def on_create(req: httpx.Request, _m: object) -> httpx.Response:
+        created_payload.update(json.loads(req.content))
+        return httpx.Response(
+            200,
+            json=_tagged_agent(id_="ag_reader", name=spec.name, tenant_id=TENANT_ID),
+        )
+
+    router.add("POST", r"/v1/agents", on_create)
+    client = build_fake_anthropic_http(router.dispatch)
+
+    outcome = await reconcile_agent(
+        client, spec, tenant_id=TENANT_ID, dry_run=False, public_url=_DEFAULT_MCP_URL
+    )
+    assert outcome.action is Action.CREATED
+
+    mcp_servers = created_payload.get("mcp_servers")
+    assert not mcp_servers, (
+        "isolated spec's POST body must carry no mcp_servers entry, even with public_url set"
+    )
+    tool_types = [t.get("type") for t in created_payload.get("tools", [])]
+    assert "mcp_toolset" not in tool_types, (
+        "isolated spec's POST body must carry no mcp_toolset tool"
+    )
+    guidance_sentinel = CREDENTIAL_GUIDANCE_BLOCK.splitlines()[0]
+    assert guidance_sentinel not in (created_payload.get("system") or ""), (
+        "isolated spec's system must not gain the credential-guidance block — "
+        "there is no MCP vault or mounted env file for it to describe"
+    )
+
+
+async def test_reconcile_agent_isolated_spec_stamps_daimon_isolated_metadata() -> None:
+    """T-21-02-E: daimon_isolated must be stamped in MA metadata (the tool
+    layer reads it back at session-create time, not the local spec object)."""
+    spec = AgentSpec(name="reader", model="claude-sonnet-4-6", isolated=True)
+    router = _router_with_agents([])
+    created_payload: dict[str, Any] = {}
+
+    def on_create(req: httpx.Request, _m: object) -> httpx.Response:
+        created_payload.update(json.loads(req.content))
+        return httpx.Response(
+            200,
+            json=_tagged_agent(id_="ag_reader2", name=spec.name, tenant_id=TENANT_ID),
+        )
+
+    router.add("POST", r"/v1/agents", on_create)
+    client = build_fake_anthropic_http(router.dispatch)
+
+    await reconcile_agent(client, spec, tenant_id=TENANT_ID, dry_run=False)
+
+    assert created_payload["metadata"]["daimon_isolated"] == "true", (
+        "reconcile must pass spec.isolated through to build_metadata"
+    )
+
+
+async def test_reconcile_agent_non_isolated_spec_still_gets_full_mcp_wiring() -> None:
+    """Regression pin: gating on spec.isolated must not become over-broad —
+    a non-isolated spec with the same public_url still gets both the
+    daimon-mcp server and the mcp_toolset tool."""
+    spec = _agent_spec()
+    router = _router_with_agents([])
+    created_payload: dict[str, Any] = {}
+
+    def on_create(req: httpx.Request, _m: object) -> httpx.Response:
+        created_payload.update(json.loads(req.content))
+        return httpx.Response(
+            200,
+            json=_tagged_agent(id_="ag_full", name=spec.name, tenant_id=TENANT_ID),
+        )
+
+    router.add("POST", r"/v1/agents", on_create)
+    client = build_fake_anthropic_http(router.dispatch)
+
+    await reconcile_agent(
+        client, spec, tenant_id=TENANT_ID, dry_run=False, public_url=_DEFAULT_MCP_URL
+    )
+
+    mcp_servers = created_payload.get("mcp_servers")
+    assert mcp_servers and mcp_servers[0]["name"] == "daimon-mcp", (
+        "non-isolated spec must still gain the default daimon-mcp server"
+    )
+    tool_types = [t.get("type") for t in created_payload.get("tools", [])]
+    assert "mcp_toolset" in tool_types, "non-isolated spec must still gain the mcp_toolset tool"

--- a/packages/core/tests/defaults/test_spec_mirrors_sdk.py
+++ b/packages/core/tests/defaults/test_spec_mirrors_sdk.py
@@ -29,10 +29,12 @@ def test_agent_spec_mirrors_sdk() -> None:
     # metadata synthesized at upload; betas not author-facing; skills is the
     # identity-reference exception (authoring names, not SDK skill params).
     exempt = {"metadata", "betas"}
-    # The spec's `skills` and `skill_repos` are sibling authoring fields not
-    # sent to the SDK (skills resolved at upload; skill_repos consumed by
-    # the sync subsystem). Excluded from the mirror comparison.
-    sibling = {"skills", "skill_repos"}
+    # The spec's `skills`, `skill_repos`, and `isolated` are sibling authoring
+    # fields not sent to the SDK (skills resolved at upload; skill_repos
+    # consumed by the sync subsystem; isolated is a daimon-side authoring
+    # property excluded via Field(exclude=True) — see AgentSpec's docstring).
+    # Excluded from the mirror comparison.
+    sibling = {"skills", "skill_repos", "isolated"}
     assert spec_fields - sibling == sdk_fields - exempt - sibling, (
         "AgentSpec drifted from the SDK. "
         f"spec-minus-sibling={spec_fields - sibling}, "

--- a/packages/core/tests/test_bundle_handle.py
+++ b/packages/core/tests/test_bundle_handle.py
@@ -1,0 +1,213 @@
+"""Tests for the pure bundle-handle mint/verify pair."""
+
+from __future__ import annotations
+
+import base64
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from daimon.core.bundle_handle import mint, verify
+
+
+def test_round_trip_returns_claims_equal_to_what_was_minted() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    tenant_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    handle = mint(
+        "secret",
+        file_id="file_abc123",
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        sha256="a" * 64,
+        now=now,
+        ttl_days=90,
+    )
+    claims = verify("secret", handle, tenant_id=tenant_id, agent_id=agent_id, now=now)
+    assert claims is not None, "a freshly minted handle should verify"
+    assert claims.file_id == "file_abc123", "file_id should round-trip"
+    assert claims.tenant_id == tenant_id, "tenant_id should round-trip"
+    assert claims.agent_id == agent_id, "agent_id should round-trip"
+    assert claims.sha256 == "a" * 64, "sha256 should round-trip"
+    assert claims.exp == int((now + timedelta(days=90)).timestamp()), "exp should be now + ttl_days"
+
+
+def test_verify_returns_none_when_signed_with_a_different_secret() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    tenant_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    handle = mint(
+        "secret-one",
+        file_id="file_abc",
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        sha256="b" * 64,
+        now=now,
+        ttl_days=90,
+    )
+    claims = verify("secret-two", handle, tenant_id=tenant_id, agent_id=agent_id, now=now)
+    assert claims is None, "a handle signed with a different secret must not verify"
+
+
+def test_verify_returns_none_when_payload_half_is_tampered() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    tenant_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    handle = mint(
+        "secret",
+        file_id="file_abc",
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        sha256="c" * 64,
+        now=now,
+        ttl_days=90,
+    )
+    payload_b64, sig_b64 = handle.split(".", 1)
+    flipped_char = "A" if payload_b64[0] != "A" else "B"
+    tampered = flipped_char + payload_b64[1:] + "." + sig_b64
+    claims = verify("secret", tampered, tenant_id=tenant_id, agent_id=agent_id, now=now)
+    assert claims is None, "flipping a character of the payload half must not verify"
+
+
+def test_verify_returns_none_when_signature_half_is_tampered() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    tenant_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    handle = mint(
+        "secret",
+        file_id="file_abc",
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        sha256="d" * 64,
+        now=now,
+        ttl_days=90,
+    )
+    payload_b64, sig_b64 = handle.split(".", 1)
+    flipped_char = "A" if sig_b64[0] != "A" else "B"
+    tampered = payload_b64 + "." + flipped_char + sig_b64[1:]
+    claims = verify("secret", tampered, tenant_id=tenant_id, agent_id=agent_id, now=now)
+    assert claims is None, "flipping a character of the signature half must not verify"
+
+
+def test_verify_returns_none_when_exp_has_passed() -> None:
+    mint_time = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    tenant_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    handle = mint(
+        "secret",
+        file_id="file_abc",
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        sha256="e" * 64,
+        now=mint_time,
+        ttl_days=1,
+    )
+    later = mint_time + timedelta(days=2)
+    claims = verify("secret", handle, tenant_id=tenant_id, agent_id=agent_id, now=later)
+    assert claims is None, "a handle whose exp has passed must not verify"
+
+
+def test_verify_returns_none_when_checked_against_the_wrong_tenant() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    handle = mint(
+        "secret",
+        file_id="file_abc",
+        tenant_id=tenant_a,
+        agent_id=agent_id,
+        sha256="f" * 64,
+        now=now,
+        ttl_days=90,
+    )
+    claims = verify("secret", handle, tenant_id=tenant_b, agent_id=agent_id, now=now)
+    assert claims is None, "a handle minted for tenant A must not verify against tenant B"
+
+
+def test_verify_returns_none_when_checked_against_the_wrong_agent() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    tenant_id = uuid.uuid4()
+    agent_a = uuid.uuid4()
+    agent_b = uuid.uuid4()
+    handle = mint(
+        "secret",
+        file_id="file_abc",
+        tenant_id=tenant_id,
+        agent_id=agent_a,
+        sha256="0" * 64,
+        now=now,
+        ttl_days=90,
+    )
+    claims = verify("secret", handle, tenant_id=tenant_id, agent_id=agent_b, now=now)
+    assert claims is None, "a handle minted for agent A must not verify against agent B"
+
+
+def test_verify_returns_none_when_handle_has_no_dot() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    claims = verify("secret", "no-dot-here", tenant_id=uuid.uuid4(), agent_id=uuid.uuid4(), now=now)
+    assert claims is None, "a handle with no '.' separator must not verify"
+
+
+def test_verify_returns_none_when_handle_has_two_dots() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    claims = verify("secret", "a.b.c", tenant_id=uuid.uuid4(), agent_id=uuid.uuid4(), now=now)
+    assert claims is None, "a handle with two '.' separators must not verify"
+
+
+def test_verify_returns_none_when_payload_has_four_fields() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    tenant_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    # Build a handle whose payload is missing the sha256 field (4 parts, not 5).
+    handle = mint(
+        "secret",
+        file_id="file_abc",
+        tenant_id=tenant_id,
+        agent_id=agent_id,
+        sha256="1" * 64,
+        now=now,
+        ttl_days=90,
+    )
+    payload_b64, _ = handle.split(".", 1)
+    raw = base64.urlsafe_b64decode(payload_b64 + "=" * (-len(payload_b64) % 4)).decode()
+    fields = raw.split("|")
+    four_field_payload = "|".join(fields[:4])
+    four_field_b64 = base64.urlsafe_b64encode(four_field_payload.encode()).decode().rstrip("=")
+    # Re-sign so this exercises the field-count check, not the signature check.
+    import hashlib
+    import hmac
+
+    sig = hmac.new(b"secret", four_field_b64.encode(), hashlib.sha256).digest()
+    tampered_sig_b64 = base64.urlsafe_b64encode(sig).decode().rstrip("=")
+    tampered = f"{four_field_b64}.{tampered_sig_b64}"
+    claims = verify("secret", tampered, tenant_id=tenant_id, agent_id=agent_id, now=now)
+    assert claims is None, "a payload with four fields (missing one) must not verify"
+
+
+def test_mint_rejects_naive_now() -> None:
+    naive = datetime(2026, 6, 9, 12, 0, 0)  # no tzinfo
+    with pytest.raises(ValueError, match="timezone-aware"):
+        mint(
+            "secret",
+            file_id="file_abc",
+            tenant_id=uuid.uuid4(),
+            agent_id=uuid.uuid4(),
+            sha256="2" * 64,
+            now=naive,
+            ttl_days=90,
+        )
+
+
+def test_mint_rejects_file_id_containing_pipe() -> None:
+    now = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+    with pytest.raises(ValueError, match=r"must not contain '\|'"):
+        mint(
+            "secret",
+            file_id="file|abc",
+            tenant_id=uuid.uuid4(),
+            agent_id=uuid.uuid4(),
+            sha256="3" * 64,
+            now=now,
+            ttl_days=90,
+        )

--- a/packages/core/tests/test_reader_agent.py
+++ b/packages/core/tests/test_reader_agent.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any
+
+from daimon.core.reader_agent import READER_BLOCK, READER_SKILL_NAME, derive_reader_spec
+from daimon.core.specs import AgentSpec, SkillRef
+
+
+def _agent_spec(**overrides: object) -> AgentSpec:
+    defaults: dict[str, object] = {
+        "name": "alpha",
+        "model": "claude-sonnet-5",
+        "system": "You are alpha, a data analyst.",
+    }
+    defaults.update(overrides)
+    return AgentSpec.model_validate(defaults)
+
+
+def test_derive_reader_spec_appends_reader_suffix_to_name() -> None:
+    source = _agent_spec(name="alpha")
+
+    derived = derive_reader_spec(source)
+
+    assert derived.name == "alpha-reader"
+
+
+def test_derive_reader_spec_marks_isolated_with_no_mcp_servers() -> None:
+    source = _agent_spec(
+        mcp_servers=[{"type": "url", "name": "daimon-mcp", "url": "https://x/mcp"}],
+        tools=[{"type": "mcp_toolset", "mcp_server_name": "daimon-mcp"}],
+    )
+
+    derived = derive_reader_spec(source)
+
+    assert derived.isolated is True, "reader variant must be created via create_isolated_session"
+    assert derived.mcp_servers is None, "reader variant must have no MCP surface"
+
+
+def test_derive_reader_spec_drops_only_mcp_toolset_tool() -> None:
+    tools: list[dict[str, Any]] = [
+        {"type": "mcp_toolset", "mcp_server_name": "daimon-mcp"},
+        {
+            "type": "custom",
+            "name": "lookup",
+            "description": "Look something up.",
+            "input_schema": {"type": "object", "properties": {}},
+        },
+    ]
+    source = _agent_spec(
+        mcp_servers=[{"type": "url", "name": "daimon-mcp", "url": "https://x/mcp"}],
+        tools=tools,
+    )
+
+    derived = derive_reader_spec(source)
+
+    assert derived.tools is not None
+    tool_types = [tool.get("type") for tool in derived.tools]
+    assert tool_types == ["custom"], "only the mcp_toolset entry should be dropped"
+
+
+def test_derive_reader_spec_collapses_tools_to_none_when_only_mcp_toolset_present() -> None:
+    source = _agent_spec(
+        mcp_servers=[{"type": "url", "name": "daimon-mcp", "url": "https://x/mcp"}],
+        tools=[{"type": "mcp_toolset", "mcp_server_name": "daimon-mcp"}],
+    )
+
+    derived = derive_reader_spec(source)
+
+    assert derived.tools is None, (
+        "an empty list and None are not equivalent downstream — must collapse to None"
+    )
+
+
+def test_derive_reader_spec_adds_report_reader_skill_alongside_existing_skills() -> None:
+    source = _agent_spec(skills=[SkillRef(type="custom", skill_id="pymc-artifact-style")])
+
+    derived = derive_reader_spec(source)
+
+    skill_ids = [ref.skill_id for ref in derived.skills]
+    assert skill_ids == ["pymc-artifact-style", READER_SKILL_NAME]
+
+
+def test_derive_reader_spec_is_idempotent_on_skills_and_system() -> None:
+    source = _agent_spec(skills=[SkillRef(type="custom", skill_id="pymc-artifact-style")])
+
+    once = derive_reader_spec(source)
+    twice = derive_reader_spec(once)
+
+    reader_skill_count = sum(1 for ref in twice.skills if ref.skill_id == READER_SKILL_NAME)
+    assert reader_skill_count == 1, "deriving twice must not duplicate the report-reader skill ref"
+    assert twice.system is not None
+    assert twice.system.count(READER_BLOCK) == 1, (
+        "deriving twice must not duplicate the appended reader block"
+    )
+
+
+def test_derive_reader_spec_appends_reader_block_to_source_system() -> None:
+    source = _agent_spec(system="You are alpha, a data analyst.")
+
+    derived = derive_reader_spec(source)
+
+    assert derived.system is not None
+    assert derived.system.startswith(source.system or "")
+    assert "cite the file and the column" in derived.system, (
+        "reader block must carry the citation clause"
+    )
+
+
+def test_derive_reader_spec_does_not_mutate_source() -> None:
+    source = _agent_spec(
+        mcp_servers=[{"type": "url", "name": "daimon-mcp", "url": "https://x/mcp"}],
+        tools=[{"type": "mcp_toolset", "mcp_server_name": "daimon-mcp"}],
+    )
+
+    derive_reader_spec(source)
+
+    assert source.mcp_servers is not None, "source spec must be untouched by derivation"
+    assert source.isolated is False

--- a/packages/core/tests/test_reader_agent.py
+++ b/packages/core/tests/test_reader_agent.py
@@ -1,9 +1,34 @@
 from __future__ import annotations
 
+import re
+import uuid
 from typing import Any
 
-from daimon.core.reader_agent import READER_BLOCK, READER_SKILL_NAME, derive_reader_spec
+import httpx
+import pytest
+from anthropic.types.beta import BetaManagedAgentsAgent, SkillListResponse
+from daimon.core.defaults.metadata import (
+    MA_METADATA_KEY_ISOLATED,
+    MA_METADATA_KEY_MANAGED,
+    MA_METADATA_KEY_NAME,
+    MA_METADATA_KEY_READER_OF,
+    MA_METADATA_KEY_SPEC_HASH,
+    MA_METADATA_KEY_TENANT,
+    compute_spec_fingerprint,
+    tenant_scoped_display_title,
+)
+from daimon.core.errors import DaimonError
+from daimon.core.reader_agent import (
+    READER_BLOCK,
+    READER_SKILL_NAME,
+    derive_reader_spec,
+    ensure_reader_variant,
+)
 from daimon.core.specs import AgentSpec, SkillRef
+from daimon.testing.ma import MARouter, build_fake_anthropic, json_body, list_response
+
+TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000a1")
+ACCOUNT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000a2")
 
 
 def _agent_spec(**overrides: object) -> AgentSpec:
@@ -116,3 +141,286 @@ def test_derive_reader_spec_does_not_mutate_source() -> None:
 
     assert source.mcp_servers is not None, "source spec must be untouched by derivation"
     assert source.isolated is False
+
+
+# ---------------------------------------------------------------------------
+# ensure_reader_variant — find, create or update, keyed by the source's shape
+# ---------------------------------------------------------------------------
+
+
+def _source_agent_dict(
+    *,
+    id_: str,
+    name: str = "alpha",
+    tenant_id: uuid.UUID = TENANT_ID,
+    spec_hash: str | None = "src-hash-1",
+    version: int = 1,
+    system: str = "You are alpha, a data analyst.",
+) -> dict[str, Any]:
+    metadata: dict[str, str] = {
+        MA_METADATA_KEY_TENANT: str(tenant_id),
+        MA_METADATA_KEY_NAME: name,
+    }
+    if spec_hash is not None:
+        metadata[MA_METADATA_KEY_SPEC_HASH] = spec_hash
+    return BetaManagedAgentsAgent.model_validate(
+        {
+            "id": id_,
+            "type": "agent",
+            "name": name,
+            "model": {"id": "claude-sonnet-4-6"},
+            "metadata": metadata,
+            "description": None,
+            "archived_at": None,
+            "created_at": "2026-09-01T00:00:00Z",
+            "updated_at": "2026-09-01T00:00:00Z",
+            "version": version,
+            "mcp_servers": [],
+            "skills": [],
+            "tools": [],
+            "system": system,
+        }
+    ).model_dump(mode="json")
+
+
+def _reader_agent_dict(
+    *,
+    id_: str,
+    name: str,
+    tenant_id: uuid.UUID,
+    metadata_extra: dict[str, str],
+    version: int = 1,
+) -> dict[str, Any]:
+    metadata: dict[str, str] = {
+        MA_METADATA_KEY_TENANT: str(tenant_id),
+        MA_METADATA_KEY_NAME: name,
+        **metadata_extra,
+    }
+    return BetaManagedAgentsAgent.model_validate(
+        {
+            "id": id_,
+            "type": "agent",
+            "name": name,
+            "model": {"id": "claude-sonnet-4-6"},
+            "metadata": metadata,
+            "description": None,
+            "archived_at": None,
+            "created_at": "2026-09-01T00:00:00Z",
+            "updated_at": "2026-09-01T00:00:00Z",
+            "version": version,
+            "mcp_servers": [],
+            "skills": [{"type": "custom", "skill_id": "sk_reader_resolved", "version": "1"}],
+            "tools": [],
+            "system": "",
+        }
+    ).model_dump(mode="json")
+
+
+def _router(agents: list[dict[str, Any]]) -> MARouter:
+    """List + per-id retrieve + a skills list that resolves the report-reader ref."""
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response(agents))
+
+    def _retrieve(req: httpx.Request, match: re.Match[str]) -> httpx.Response:
+        agent_id = match.group(1)
+        for agent in agents:
+            if agent["id"] == agent_id:
+                return httpx.Response(200, json=agent)
+        return httpx.Response(
+            404,
+            json={"type": "error", "error": {"type": "not_found_error", "message": "not found"}},
+        )
+
+    router.add("GET", r"/v1/agents/([^/]+)", _retrieve)
+    canonical_title = tenant_scoped_display_title(tenant_id=TENANT_ID, name=READER_SKILL_NAME)
+    router.add(
+        "GET",
+        r"/v1/skills",
+        lambda req, _m: list_response(
+            [
+                SkillListResponse(
+                    id="sk_reader_resolved",
+                    type="custom",
+                    display_title=canonical_title,
+                    latest_version="1",
+                    created_at="2026-09-01T00:00:00Z",
+                    updated_at="2026-09-01T00:00:00Z",
+                    source="custom",
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    return router
+
+
+def _add_create_route(router: MARouter, captured: dict[str, Any]) -> None:
+    def on_create(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        captured.update(json_body(req))
+        return httpx.Response(
+            200,
+            json=_reader_agent_dict(
+                id_="ag_reader",
+                name="alpha-reader",
+                tenant_id=TENANT_ID,
+                metadata_extra=captured["metadata"],
+            ),
+        )
+
+    router.add("POST", r"/v1/agents", on_create)
+
+
+async def test_ensure_reader_variant_creates_when_no_existing_variant() -> None:
+    """No existing variant -> exactly one agents.create, stamped isolated/unmanaged."""
+    source = _source_agent_dict(id_="ag_src", spec_hash="src-hash-1")
+    router = _router([source])
+    created: dict[str, Any] = {}
+    _add_create_route(router, created)
+    client = build_fake_anthropic(router.dispatch)
+
+    result = await ensure_reader_variant(
+        client, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="alpha"
+    )
+
+    assert result.id == "ag_reader"
+    md = created["metadata"]
+    assert md[MA_METADATA_KEY_ISOLATED] == "true"
+    assert MA_METADATA_KEY_MANAGED not in md, "a reader variant must never be stamped managed"
+    assert md[MA_METADATA_KEY_READER_OF] == "src-hash-1"
+
+
+async def test_ensure_reader_variant_reuses_on_unchanged_source() -> None:
+    """Second call against an unchanged source issues zero create/update calls."""
+    source = _source_agent_dict(id_="ag_src", spec_hash="src-hash-1")
+    router = _router([source])
+    created: dict[str, Any] = {}
+    _add_create_route(router, created)
+    client = build_fake_anthropic(router.dispatch)
+    first = await ensure_reader_variant(
+        client, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="alpha"
+    )
+
+    # No POST route registered at all on this router — any create or update
+    # attempt raises AssertionError from MARouter, failing the test.
+    reader_variant = _reader_agent_dict(
+        id_="ag_reader", name="alpha-reader", tenant_id=TENANT_ID, metadata_extra=first.metadata
+    )
+    router2 = _router([source, reader_variant])
+    client2 = build_fake_anthropic(router2.dispatch)
+
+    second = await ensure_reader_variant(
+        client2, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="alpha"
+    )
+
+    assert second.id == "ag_reader"
+
+
+async def test_ensure_reader_variant_updates_when_source_spec_hash_changes() -> None:
+    """A changed source spec hash issues exactly one agents.update, zero agents.create."""
+    source = _source_agent_dict(id_="ag_src", spec_hash="src-hash-1")
+    router = _router([source])
+    created: dict[str, Any] = {}
+    _add_create_route(router, created)
+    client = build_fake_anthropic(router.dispatch)
+    first = await ensure_reader_variant(
+        client, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="alpha"
+    )
+
+    changed_source = _source_agent_dict(id_="ag_src", spec_hash="src-hash-2")
+    reader_variant = _reader_agent_dict(
+        id_="ag_reader",
+        name="alpha-reader",
+        tenant_id=TENANT_ID,
+        metadata_extra=first.metadata,
+        version=first.version,
+    )
+    router2 = _router([changed_source, reader_variant])
+    updated: dict[str, Any] = {}
+
+    def on_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        updated.update(json_body(req))
+        return httpx.Response(
+            200,
+            json=_reader_agent_dict(
+                id_="ag_reader",
+                name="alpha-reader",
+                tenant_id=TENANT_ID,
+                metadata_extra=updated["metadata"],
+                version=first.version + 1,
+            ),
+        )
+
+    # No POST /v1/agents (create) route on this router — a stray create call
+    # raises AssertionError from MARouter, failing the test.
+    router2.add("POST", r"/v1/agents/ag_reader", on_update)
+    client2 = build_fake_anthropic(router2.dispatch)
+
+    second = await ensure_reader_variant(
+        client2, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="alpha"
+    )
+
+    assert updated["version"] == first.version, "update must use MA's version, not a stale one"
+    assert updated["metadata"][MA_METADATA_KEY_READER_OF] == "src-hash-2"
+    assert second.version == first.version + 1
+
+
+async def test_ensure_reader_variant_reader_of_fallback_changes_with_source_version() -> None:
+    """No daimon_spec_hash on the source -> reader_of falls back to (id, version); bumping
+    version changes it, forcing an update even though nothing else about the source moved."""
+    source_v1 = _source_agent_dict(id_="ag_src", spec_hash=None, version=1)
+    router = _router([source_v1])
+    created: dict[str, Any] = {}
+    _add_create_route(router, created)
+    client = build_fake_anthropic(router.dispatch)
+    first = await ensure_reader_variant(
+        client, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="alpha"
+    )
+
+    expected_reader_of_v1 = compute_spec_fingerprint({"agent_id": "ag_src", "version": 1})
+    assert first.metadata[MA_METADATA_KEY_READER_OF] == expected_reader_of_v1
+
+    source_v2 = _source_agent_dict(id_="ag_src", spec_hash=None, version=2)
+    reader_variant = _reader_agent_dict(
+        id_="ag_reader",
+        name="alpha-reader",
+        tenant_id=TENANT_ID,
+        metadata_extra=first.metadata,
+        version=first.version,
+    )
+    router2 = _router([source_v2, reader_variant])
+    updated: dict[str, Any] = {}
+
+    def on_update(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        updated.update(json_body(req))
+        return httpx.Response(
+            200,
+            json=_reader_agent_dict(
+                id_="ag_reader",
+                name="alpha-reader",
+                tenant_id=TENANT_ID,
+                metadata_extra=updated["metadata"],
+                version=first.version + 1,
+            ),
+        )
+
+    router2.add("POST", r"/v1/agents/ag_reader", on_update)
+    client2 = build_fake_anthropic(router2.dispatch)
+
+    await ensure_reader_variant(
+        client2, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="alpha"
+    )
+
+    expected_reader_of_v2 = compute_spec_fingerprint({"agent_id": "ag_src", "version": 2})
+    assert expected_reader_of_v2 != expected_reader_of_v1
+    assert updated["metadata"][MA_METADATA_KEY_READER_OF] == expected_reader_of_v2
+
+
+async def test_ensure_reader_variant_raises_for_unknown_source() -> None:
+    """Unknown source_name raises DaimonError and issues no create/update calls."""
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response([]))
+    client = build_fake_anthropic(router.dispatch)
+
+    with pytest.raises(DaimonError, match="ghost"):
+        await ensure_reader_variant(
+            client, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="ghost"
+        )

--- a/packages/core/tests/test_sessions_isolated.py
+++ b/packages/core/tests/test_sessions_isolated.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+import httpx
+from anthropic.types.beta import BetaEnvironment, BetaManagedAgentsAgent, BetaManagedAgentsSession
+from anthropic.types.beta.session_create_params import Resource
+from daimon.core.sessions import create_isolated_session
+from daimon.testing.ma import EMPTY_CLOUD_CONFIG
+from daimon.testing.ma import build_fake_anthropic as build_fake_anthropic_http
+
+
+def _make_agent(*, anthropic_id: str = "ag_reader", name: str = "reader") -> BetaManagedAgentsAgent:
+    """Inline BetaManagedAgentsAgent construction — no DB needed."""
+    return BetaManagedAgentsAgent.model_validate(
+        {
+            "id": anthropic_id,
+            "type": "agent",
+            "name": name,
+            "model": {"id": "claude-opus-4-7"},
+            "metadata": {},
+            "description": None,
+            "archived_at": None,
+            "created_at": "2026-04-21T00:00:00Z",
+            "updated_at": "2026-04-21T00:00:00Z",
+            "version": 1,
+            "mcp_servers": [],
+            "skills": [],
+            "tools": [],
+            "system": None,
+        }
+    )
+
+
+def _make_env(*, anthropic_id: str = "env_reader", name: str = "e") -> BetaEnvironment:
+    """Inline BetaEnvironment construction — no DB needed."""
+    return BetaEnvironment(
+        id=anthropic_id,
+        type="environment",
+        name=name,
+        config=EMPTY_CLOUD_CONFIG,
+        metadata={},
+        description="",
+        created_at="2026-04-21T00:00:00Z",
+        updated_at="2026-04-21T00:00:00Z",
+    )
+
+
+def _bundle_resource(file_id: str = "file_bundle") -> Resource:
+    return {"type": "file", "file_id": file_id, "mount_path": "/bundle.tar.gz"}
+
+
+def _session_body(
+    *,
+    session_id: str,
+    agent_id: str,
+    environment_id: str,
+    metadata: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build a BetaManagedAgentsSession JSON body via validated SDK models."""
+    return BetaManagedAgentsSession.model_validate(
+        {
+            "id": session_id,
+            "agent": {
+                "id": agent_id,
+                "mcp_servers": [],
+                "model": {"id": "claude-opus-4-7"},
+                "name": "reader",
+                "skills": [],
+                "tools": [],
+                "type": "agent",
+                "version": 1,
+            },
+            "created_at": "2026-04-21T00:00:00Z",
+            "outcome_evaluations": [],
+            "environment_id": environment_id,
+            "metadata": metadata or {},
+            "resources": [],
+            "stats": {},
+            "status": "idle",
+            "type": "session",
+            "updated_at": "2026-04-21T00:00:00Z",
+            "usage": {},
+            "vault_ids": [],
+        }
+    ).model_dump(mode="json")
+
+
+async def test_create_isolated_session_sends_exactly_the_passed_resources() -> None:
+    agent = _make_agent()
+    env = _make_env()
+    resources = [_bundle_resource("file_abc")]
+    requests: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json=_session_body(
+                session_id="sess_iso", agent_id=body["agent"], environment_id=body["environment_id"]
+            ),
+        )
+
+    client = build_fake_anthropic_http(_handler)
+
+    result = await create_isolated_session(
+        client,
+        agent=agent,
+        environment=env,
+        account_id=None,
+        tenant_id=None,
+        resources=resources,
+    )
+
+    assert isinstance(result, BetaManagedAgentsSession), (
+        "create_isolated_session must return BetaManagedAgentsSession"
+    )
+    assert len(requests) == 1, "must issue exactly one POST /v1/sessions call"
+    body = json.loads(requests[0].content)
+    assert body["resources"] == [dict(resources[0])], (
+        "session-create body must carry exactly the resources the caller passed, nothing else"
+    )
+
+
+async def test_create_isolated_session_never_sends_vault_ids_key() -> None:
+    """T-21-02-A: the absence of the vault_ids kwarg is the security property —
+    assert on the raw captured JSON body, not on a kwarg the fake reconstructs."""
+    agent = _make_agent()
+    env = _make_env()
+    requests: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json=_session_body(
+                session_id="sess_novault",
+                agent_id=body["agent"],
+                environment_id=body["environment_id"],
+            ),
+        )
+
+    client = build_fake_anthropic_http(_handler)
+
+    await create_isolated_session(
+        client,
+        agent=agent,
+        environment=env,
+        account_id=None,
+        tenant_id=None,
+        resources=[_bundle_resource()],
+    )
+
+    body = json.loads(requests[0].content)
+    assert "vault_ids" not in body, (
+        "create_isolated_session must never pass vault_ids, not even as omit"
+    )
+
+
+async def test_create_isolated_session_stamps_account_and_tenant_when_given() -> None:
+    agent = _make_agent()
+    env = _make_env()
+    account_id = uuid.UUID("00000000-0000-0000-0000-000000000099")
+    tenant_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    requests: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json=_session_body(
+                session_id="sess_md",
+                agent_id=body["agent"],
+                environment_id=body["environment_id"],
+                metadata=body.get("metadata"),
+            ),
+        )
+
+    client = build_fake_anthropic_http(_handler)
+
+    await create_isolated_session(
+        client,
+        agent=agent,
+        environment=env,
+        account_id=account_id,
+        tenant_id=tenant_id,
+        resources=[_bundle_resource()],
+    )
+
+    body = json.loads(requests[0].content)
+    assert body["metadata"]["daimon_account"] == str(account_id)
+    assert body["metadata"]["daimon_tenant"] == str(tenant_id)
+
+
+async def test_create_isolated_session_omits_metadata_keys_when_ids_are_none() -> None:
+    agent = _make_agent()
+    env = _make_env()
+    requests: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json=_session_body(
+                session_id="sess_nomd",
+                agent_id=body["agent"],
+                environment_id=body["environment_id"],
+            ),
+        )
+
+    client = build_fake_anthropic_http(_handler)
+
+    await create_isolated_session(
+        client,
+        agent=agent,
+        environment=env,
+        account_id=None,
+        tenant_id=None,
+        resources=[_bundle_resource()],
+    )
+
+    body = json.loads(requests[0].content)
+    assert "daimon_account" not in body.get("metadata", {})
+    assert "daimon_tenant" not in body.get("metadata", {})
+
+
+async def test_create_isolated_session_makes_zero_vault_or_file_upload_calls() -> None:
+    """Strongest available proof of no hidden mounts: the fake records zero
+    calls to any vaults endpoint and zero calls to files.upload."""
+    agent = _make_agent()
+    env = _make_env()
+    requests: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json=_session_body(
+                session_id="sess_novoups",
+                agent_id=body["agent"],
+                environment_id=body["environment_id"],
+            ),
+        )
+
+    client = build_fake_anthropic_http(_handler)
+
+    await create_isolated_session(
+        client,
+        agent=agent,
+        environment=env,
+        account_id=None,
+        tenant_id=None,
+        resources=[_bundle_resource()],
+    )
+
+    paths = [r.url.path for r in requests]
+    assert all("vault" not in p for p in paths), f"no vault endpoint should be called; got {paths}"
+    assert all("files" not in p for p in paths), f"no files.upload call should be made; got {paths}"
+    assert paths == ["/v1/sessions"], "exactly one call, to session create, and nothing else"

--- a/packages/core/tests/test_specs.py
+++ b/packages/core/tests/test_specs.py
@@ -575,3 +575,27 @@ def test_build_authoring_params_drops_response_fields_the_sdk_does_not_declare()
     assert spec.tools is not None and spec.tools[0]["type"] == "agent_toolset_20260401", (
         "pruned params validate against the extra=forbid authoring spec"
     )
+
+
+def test_agent_spec_isolated_defaults_false_and_round_trips_when_true() -> None:
+    """`isolated` is a daimon-local field (like `skills`): extra="forbid" does
+    not reject it, and it round-trips through model_validate."""
+    default_spec = AgentSpec.model_validate({"name": "daimon", "model": "claude-sonnet-4-6"})
+    assert default_spec.isolated is False, "isolated defaults to False"
+
+    isolated_spec = AgentSpec.model_validate(
+        {"name": "reader", "model": "claude-sonnet-4-6", "isolated": True}
+    )
+    assert isolated_spec.isolated is True, "isolated=true in the mapping must round-trip"
+
+
+def test_dump_agent_spec_excludes_isolated_from_ma_payload() -> None:
+    """`isolated` must never reach the MA create/update payload — it is
+    declared `Field(exclude=True)` exactly like `skills`/`skill_repos`.
+    Deleting `exclude=True` from the field declaration makes this fail."""
+    spec = AgentSpec(name="reader", model="claude-sonnet-4-6", isolated=True)
+    dumped = dump_agent_spec(spec)
+    assert "isolated" not in dumped, (
+        "isolated must be excluded from dump_agent_spec output — an unexcluded "
+        "field would be sent to MA as an unknown create/update parameter"
+    )

--- a/scripts/lint_anti_patterns.sh
+++ b/scripts/lint_anti_patterns.sh
@@ -111,6 +111,8 @@ ALLOWLIST_T5=(
   "slack/agent_setup/write.py"
   # preflight probe agents are archived immediately — never host sessions/skills.
   "core/defaults/preflight.py"
+  # reader variant create/update both go through dump_agent_spec(reader_spec).
+  "core/reader_agent.py"
 )
 # get_earliest_tenant is fully retired — the oldest-tenant
 # path no longer exists anywhere. Zero allowlist: any occurrence fails.


### PR DESCRIPTION
## Summary

This is the first of three changes that add a report-host seam: a set of
agent-chat tools and an upload route that let an isolated Managed Agents
session answer questions about a single mounted archive, without any of the
capabilities an ordinary daimon agent carries.

An **isolated agent** is a new agent shape that carries nothing but the
archive it was given: no MCP servers, no vault, no environment file, no
memory store, no repository. It exists so a report reader can be handed to
an external recipient without exposing any of the tenant's other
credentials or tools.

### What the seam can do

- Start a turn against a mounted archive on an isolated agent, and continue
  an existing turn.
- Stop a running turn with a single, unconditional interrupt — no
  read-then-send race.
- Read what a finished turn cost, pre-markup, before the ledger applies its
  own markup.
- Filter a session's event transcript down to exactly one turn, using an
  inclusive timestamp boundary anchored on the caller's own clock (the send
  response's echoed event carries no usable timestamp of its own).
- Archive a finished session, so an idle sweep doesn't have to keep re-reading
  every reader session forever.

### New upload route

`PUT /bundles` accepts a gzip-compressed tar over a bearer-authenticated,
streamed upload; the same auth shape as the existing checkout route. It is
capped at 25 MiB by default — chosen because the service that receives it
runs on a platform with a 32 MiB HTTP/1 request limit, and the cap needs
headroom under that ceiling. It also enforces a per-token hourly rate limit,
and every upload is scheduled for deletion after a configurable retention
window; the scheduler's existing sweep is what actually performs that
deletion, not the route itself.

### Contract suite

Before this PR was opened, a live contract suite ran against a disposable
staging workspace to pin the three upstream behaviours the design depends on
that a transport-level fake cannot answer:

- an interrupt sent while a turn is running converges to a terminal state
  (`session.status_idle` or `terminated`);
- a `created_at_gte` filter anchored on the caller's own pre-send clock
  reading is inclusive of the boundary event and excludes every event from
  the prior turn on the same session;
- a file resource with an absolute `mount_path` joins under the same
  `/mnt/session/uploads/` prefix as a relative one.

All three passed. Two unrelated, pre-existing failures elsewhere in the
contract suite were observed and left as-is (documented separately) — they
predate this branch and touch code this change does not.

This change is usable on its own: it does not yet wire a user-facing entry
point to any of these tools, which is what the next two changes in this
series add.

## Test plan

- [x] Full project gate green on the branch (tests, strict type-check, lint,
      format, import-linter boundary contracts, env-example freshness,
      anti-pattern lints, migration lint)
- [x] Live contract suite run against a disposable staging workspace; the
      three design-critical assertions above passed
- [x] `uv run pyright` clean project-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJPPkRT2D8mdGA95jKXoNW