### PR TITLE
Add report-host: a standalone per-recipient report reader with chat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,18 @@ jobs:
       - name: pytest (notebook-host)
         run: uv run pytest apps/notebook-host -n auto
 
+  pytest-report-host:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras --all-packages
+      - name: pytest (report-host)
+        run: uv run pytest apps/report-host -n auto
+
   docker-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -252,7 +264,7 @@ jobs:
 
   deploy-gcp:
     name: Deploy to GCP (staging)
-    needs: [lint, pytest-core, pytest-mcp, pytest-discord, pytest-slack, pytest-parity, pytest-notebook-host, docker-build]
+    needs: [lint, pytest-core, pytest-mcp, pytest-discord, pytest-slack, pytest-parity, pytest-notebook-host, pytest-report-host, docker-build]
     # vars.GCP_WIF_PROVIDER doubles as the deploy switch: repository variables
     # don't propagate to forks/clones, so a repo with no GCP config skips this
     # job cleanly (green CI) instead of failing at the auth step. Operators

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
       REPO: ${{ vars.GCP_AR_REPO }}
       ZONE: ${{ vars.GCP_ZONE }}
       NOTEBOOK_DOMAIN: ${{ vars.NOTEBOOK_DOMAIN }}
+      REPORT_DOMAIN: ${{ vars.REPORT_DOMAIN }}
     steps:
       # Guard both entry points: ci.yml/promote.yml pass a full github.sha,
       # but workflow_dispatch is free text — reject branch names, short SHAs,
@@ -86,6 +87,7 @@ jobs:
           BASE=${{ env.AR_HOST }}/${{ vars.GCP_PROJECT_ID }}/${{ env.REPO }}
           echo "daimon=$BASE/daimon:$SHA" >> "$GITHUB_OUTPUT"
           echo "notebook=$BASE/notebook-host:$SHA" >> "$GITHUB_OUTPUT"
+          echo "report=$BASE/report-host:$SHA" >> "$GITHUB_OUTPUT"
 
       - name: Build + push daimon image
         run: |
@@ -96,6 +98,11 @@ jobs:
         run: |
           docker build -t "${{ steps.tags.outputs.notebook }}" -f apps/notebook-host/Dockerfile .
           docker push "${{ steps.tags.outputs.notebook }}"
+
+      - name: Build + push report-host image
+        run: |
+          docker build -t "${{ steps.tags.outputs.report }}" -f apps/report-host/Dockerfile .
+          docker push "${{ steps.tags.outputs.report }}"
 
       - name: Run migrations (blocking gate)
         run: |
@@ -175,6 +182,18 @@ jobs:
               sudo docker image prune -af || true
             '
 
+      - name: Resolve seam URL for report-host
+        id: seam
+        run: |
+          # report-host's DAIMON_REPORT__MCP_URL points at the same mcp
+          # Cloud Run service the workers call, mounted at /mcp. The service
+          # URL is stable for the life of the service but has no predictable
+          # form, so it is discovered the same way the health gate step
+          # below discovers it, not hardcoded or stored as a variable.
+          URL=$(gcloud run services describe ${{ vars.GCP_AR_REPO }}-mcp --region "$REGION" \
+            --format='value(status.url)')
+          echo "url=$URL/mcp" >> "$GITHUB_OUTPUT"
+
       - name: Refresh notebook-host VM container (recreate in place)
         run: |
           gcloud compute ssh ${{ vars.GCP_AR_REPO }}-notebook --zone "$ZONE" \
@@ -189,6 +208,13 @@ jobs:
               # (the compose file and Caddyfile live in the operator private infra repo).
               export NOTEBOOK_DOMAIN="${{ env.NOTEBOOK_DOMAIN }}"
               export NOTEBOOK_PUBLIC_URL_BASE="https://${{ env.NOTEBOOK_DOMAIN }}"
+              # report-host is the second service on this same VM, behind the
+              # same Caddy on its own hostname (the compose file and Caddyfile
+              # live in the companion infra repo).
+              export REPORT_IMAGE="${{ steps.tags.outputs.report }}"
+              export REPORT_DOMAIN="${{ env.REPORT_DOMAIN }}"
+              export REPORT_PUBLIC_URL_BASE="https://${{ env.REPORT_DOMAIN }}"
+              export REPORT_MCP_URL="${{ steps.seam.outputs.url }}"
               # Same DOCKER_CONFIG redirect as the workers refresh: use root
               # docker config (has the Artifact Registry credential helper).
               export DOCKER_CONFIG=/root/.docker
@@ -210,6 +236,24 @@ jobs:
               cd /etc/daimon
               sudo -E docker compose -f compose.notebook.yml pull
               sudo -E docker compose -f compose.notebook.yml up -d --remove-orphans
+              # Gate: report-host must come up and stay up. `up -d` alone does
+              # not fail on a crash-looping container, and a green step that
+              # proves nothing is worse than a red one -- same reasoning as
+              # the slack worker gate above, modelled on it here.
+              for i in $(seq 1 20); do
+                sleep 6
+                running=$(sudo docker inspect --format "{{.State.Running}}" daimon-report-host-1)
+                restarts=$(sudo docker inspect --format "{{.RestartCount}}" daimon-report-host-1)
+                if [ "$running" = "true" ] && [ "$restarts" = "0" ] \
+                  && sudo docker exec daimon-report-host-1 python -c "import urllib.request; urllib.request.urlopen(\"http://localhost:8002/health\", timeout=3)" 2>/dev/null; then
+                  echo "report host healthy (attempt $i)"
+                  break
+                fi
+                if [ "$i" = "20" ]; then
+                  echo "report host not healthy after 120s (running=$running restarts=$restarts)" >&2
+                  exit 1
+                fi
+              done
               # Same prune as the workers refresh (see comment there).
               sudo docker image prune -af || true
             '

--- a/apps/report-host/Dockerfile
+++ b/apps/report-host/Dockerfile
@@ -1,0 +1,28 @@
+# Stripped-env report host. NO Anthropic key, NO database credential, NO
+# platform bot token bake into this image. The secrets it holds at runtime
+# are the admin bearer and, in its own SQLite file, one seam token per
+# published report — both supplied at runtime, never baked in.
+
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:0.9.11 /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+COPY apps/report-host/pyproject.toml ./pyproject.toml
+COPY apps/report-host/src ./src
+
+RUN uv sync --no-dev
+
+RUN mkdir -p /data/reports
+ENV DAIMON_REPORT__DATA_DIR=/data/reports
+
+EXPOSE 8002
+
+# Runs the report_host package's __main__ entrypoint.
+CMD ["uv", "run", "python", "-m", "report_host"]

--- a/apps/report-host/README.md
+++ b/apps/report-host/README.md
@@ -1,0 +1,42 @@
+# report-host
+
+A standalone FastAPI process that serves a published report — a rendered
+document plus a chat sidebar backed by daimon — as its own web page. Designed
+to sit beside the notebook host as a second stripped-env app: it talks to
+daimon only over HTTP/MCP, and never imports the `daimon` package.
+
+## Trust model
+
+**Stripped-env invariant.** This process carries no Anthropic key, no
+database credential, and no platform bot token. The only secrets present at
+runtime are its own admin bearer and, in its own SQLite file, one seam token
+per published report — both supplied at runtime, never baked into the image.
+
+**Import boundary.** `report_host` cannot import `daimon` — enforced by an
+`import-linter` forbidden contract, not just convention.
+
+## Structure
+
+- `src/report_host/` — the package. `__main__.py` is the uvicorn entrypoint;
+  the app factory (`create_app`) and its routes land in a later plan.
+- `tests/` — package tests, collected by the root pytest run and gated by a
+  dedicated CI shard.
+- `Dockerfile` — stripped-env container image, no daimon dependency.
+
+## Routes
+
+- `GET /health` — liveness probe, returns `{"ok": "true"}`.
+
+Report and chat routes are added by later plans in this PR.
+
+## Running locally
+
+```bash
+uv run python -m report_host
+curl -sf http://localhost:8002/health
+```
+
+## Configuration
+
+This app's settings module has not landed yet; a later plan in this PR adds
+it along with the corresponding section in the root `.env.example` generator.

--- a/apps/report-host/README.md
+++ b/apps/report-host/README.md
@@ -1,42 +1,124 @@
 # report-host
 
-A standalone FastAPI process that serves a published report — a rendered
-document plus a chat sidebar backed by daimon — as its own web page. Designed
-to sit beside the notebook host as a second stripped-env app: it talks to
-daimon only over HTTP/MCP, and never imports the `daimon` package.
+A standalone FastAPI process that serves one published report: a PDF in a
+viewer, with a chat sidebar backed by daimon, behind a per-recipient link and
+a per-report spending budget. It talks to daimon only over HTTP, through the
+MCP seam exposed by the daimon MCP adapter — it holds no Anthropic key and no
+database credential. The only secrets present at runtime are its own admin
+bearer and, in its own SQLite file, one seam token per published report.
+
+Designed to sit beside the notebook host as a second stripped-env app: same
+shape, same trust model, no import of the `daimon` package (enforced by an
+`import-linter` forbidden contract, not just convention).
+
+## Running it locally
+
+```bash
+DAIMON_REPORT__ADMIN_SECRETS=dev-secret \
+DAIMON_REPORT__MCP_URL=http://localhost:8000/mcp \
+DAIMON_REPORT__PUBLIC_URL_BASE=http://localhost:8002/ \
+DAIMON_REPORT__DATA_DIR=/tmp/reports \
+  uv run python -m report_host
+```
+
+Then publish a report through the admin API (see Routes below) and open the
+`GET /r/{slug}` link it returns for the first recipient. `GET /health`
+answers `{"ok": true}` with no credential — it is the compose and
+reverse-proxy liveness probe.
+
+## Environment
+
+The repository-wide `.env.example` generator walks the core settings model
+only; it cannot see a standalone app's own settings. This table is the
+canonical, human-maintained record of every variable `report_host.config`
+reads — **update it whenever `config.py` changes**, since nothing else checks
+that they stay in sync except this README's own test.
+
+| Setting | Env var | Default | What it controls |
+|---|---|---|---|
+| `data_dir` | `DAIMON_REPORT__DATA_DIR` | `/data/reports` | Root of the persistent volume: the SQLite file, per-report bundle archives, and PDF revisions. |
+| `admin_secrets` | `DAIMON_REPORT__ADMIN_SECRETS` (CSV) | *(required — the host refuses to start without at least one)* | Bearer tokens accepted on admin routes. Provide more than one to rotate without downtime. |
+| `mcp_url` | `DAIMON_REPORT__MCP_URL` | *(required)* | The seam endpoint this host calls to run turns, poll cost, and push bundles. |
+| `public_url_base` | `DAIMON_REPORT__PUBLIC_URL_BASE` | *(required)* | External URL prefix used to build recipient links and the per-turn upload URL handed to the agent. |
+| `host_port` | `DAIMON_REPORT__HOST_PORT` | `8002` | Port the host's uvicorn server binds. |
+| `reserve_usd` | `DAIMON_REPORT__RESERVE_USD` | `0.60` | Amount held against a report's spend cap the moment a turn starts, replaced by the real cost once it settles. |
+| `poll_interval_seconds` | `DAIMON_REPORT__POLL_INTERVAL_SECONDS` | `2.0` | How often the host polls the seam for turn progress. |
+| `turn_timeout_seconds` | `DAIMON_REPORT__TURN_TIMEOUT_SECONDS` | `1200` | A turn still running past this many seconds is cancelled by the host. |
+| `max_pdf_bytes` | `DAIMON_REPORT__MAX_PDF_BYTES` | `52428800` (50 MiB) | Hard ceiling on an uploaded revised-PDF body size. |
+| `max_bundle_bytes` | `DAIMON_REPORT__MAX_BUNDLE_BYTES` | `26214400` (25 MiB) | Hard ceiling on a published report bundle; mirrors and independently enforces the seam's own bundle cap. |
+| `max_open_threads_per_recipient` | `DAIMON_REPORT__MAX_OPEN_THREADS_PER_RECIPIENT` | `3` | Cap on concurrently open threads a single recipient may hold. |
+| `max_running_turns_per_report` | `DAIMON_REPORT__MAX_RUNNING_TURNS_PER_REPORT` | `4` | Cap on concurrently running turns across one report's threads. |
+| `recipient_link_ttl_days` | `DAIMON_REPORT__RECIPIENT_LINK_TTL_DAYS` | `90` | How long a per-recipient link remains valid before expiring. |
+| `thread_idle_archive_hours` | `DAIMON_REPORT__THREAD_IDLE_ARCHIVE_HOURS` | `24` | A thread idle longer than this is archived, upstream then locally, by the host's background sweep. |
+
+## Routes
+
+Every route below requires exactly one credential format; none accepts more
+than one.
+
+- `GET /health` — liveness probe. No credential.
+- `GET /r/{slug}?k=<token>` — the viewer + chat sidebar. Per-recipient link
+  token, also accepted as a cookie set on first visit.
+- `GET /api/{slug}/state`, `GET /api/{slug}/threads/{id}` — read state and
+  thread history. Per-recipient link token.
+- `POST /api/{slug}/ask`, `POST /api/{slug}/threads/{id}/cancel`,
+  `POST /api/{slug}/threads/{id}/close` — drive a conversation. Per-recipient
+  link token.
+- `GET /files/{slug}/{name}` — fetch a PDF revision. Per-recipient link token.
+- `PUT /upload/{turn_token}` — the one-time revised-PDF upload URL handed to
+  the agent for a single turn. Per-turn, single-use token.
+- `PUT /publish/{capability_token}` — publish a report bundle (a gzip
+  archive). Single-use capability token minted by daimon.
+- `PUT /admin/reports/{slug}`, `DELETE /admin/reports/{slug}`,
+  `DELETE /admin/reports/{slug}/recipients/{token}` — create, update, delete
+  a report and revoke a recipient link. Admin bearer.
+
+## Operational notes
+
+- **Bundle archives are reclaimed by daimon's scheduler, not by this host.**
+  A bundle pushed at publish time is deleted upstream on a retention timer
+  run by daimon's own scheduler process. An operator who does not run that
+  scheduler will accumulate uploaded archives indefinitely — this host has no
+  cleanup path of its own for them.
+- **Every reader thread is a live upstream session until it is archived.**
+  The idle sweep (`thread_idle_archive_hours`) does this automatically, but a
+  host that is stopped for longer than that window before the sweep runs
+  will re-attach to, rather than lose, any turn still in flight on restart.
+- **A report whose seam token stops being accepted is marked unauthorized in
+  its own state**, and the sidebar tells the reader the report needs
+  re-publishing. The fix is a re-publish through the admin API, which mints a
+  fresh token.
+
+## Data
+
+The persistent volume (`data_dir`) holds:
+
+- `host.sqlite` — reports, recipients, revisions, threads and messages.
+- one directory per report slug, holding its published bundle archive and
+  every PDF revision served to readers.
+
+The SQLite file holds one **seam token per report**, at the same trust level
+as the admin bearer itself — either one lets a caller act as that report
+against daimon. **This volume must not be shared with another service.**
 
 ## Trust model
 
 **Stripped-env invariant.** This process carries no Anthropic key, no
-database credential, and no platform bot token. The only secrets present at
-runtime are its own admin bearer and, in its own SQLite file, one seam token
-per published report — both supplied at runtime, never baked into the image.
+database credential, and no platform bot token — the only secrets present at
+runtime are the admin bearer and the per-report seam tokens described above.
 
 **Import boundary.** `report_host` cannot import `daimon` — enforced by an
 `import-linter` forbidden contract, not just convention.
 
 ## Structure
 
-- `src/report_host/` — the package. `__main__.py` is the uvicorn entrypoint;
-  the app factory (`create_app`) and its routes land in a later plan.
+- `src/report_host/` — the package: `config.py` (settings), `mcp_client.py`
+  (the seam calls), `reports_store.py` / `threads_store.py` (SQLite),
+  `capability.py` (publish-token verification), `turns.py` (the per-thread
+  turn driver), `routes.py` / `admin.py` / `uploads.py` (the reader, admin
+  and upload routers), `sweeps.py` (restart-resume, deadline-cancel,
+  idle-archive, recipient-prune), `main.py` (the app factory and lifespan),
+  `viewer/` (the static PDF viewer and chat sidebar).
 - `tests/` — package tests, collected by the root pytest run and gated by a
   dedicated CI shard.
 - `Dockerfile` — stripped-env container image, no daimon dependency.
-
-## Routes
-
-- `GET /health` — liveness probe, returns `{"ok": "true"}`.
-
-Report and chat routes are added by later plans in this PR.
-
-## Running locally
-
-```bash
-uv run python -m report_host
-curl -sf http://localhost:8002/health
-```
-
-## Configuration
-
-This app's settings module has not landed yet; a later plan in this PR adds
-it along with the corresponding section in the root `.env.example` generator.

--- a/apps/report-host/pyproject.toml
+++ b/apps/report-host/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "report-host"
+version = "0.1.0"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "PyMC Labs" }]
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.30",
+    "httpx>=0.27",
+    "pydantic>=2.7",
+    "pydantic-settings>=2.4",
+    "mcp>=1.27",
+]
+
+[project.urls]
+Repository = "https://github.com/pymc-labs/daimon"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/report_host"]

--- a/apps/report-host/src/report_host/__init__.py
+++ b/apps/report-host/src/report_host/__init__.py
@@ -1,0 +1,11 @@
+"""report_host: a standalone host that serves a published report and its chat
+sidebar.
+
+This process talks to the daimon core only over HTTP, through the MCP seam
+exposed by the daimon MCP adapter. It holds no Anthropic key, no database
+credential, and no platform bot token — the only secrets it carries at
+runtime are its own admin bearer and, in its own SQLite file, one seam token
+per published report.
+"""
+
+from __future__ import annotations

--- a/apps/report-host/src/report_host/__main__.py
+++ b/apps/report-host/src/report_host/__main__.py
@@ -1,0 +1,27 @@
+"""uvicorn entrypoint: `uv run python -m report_host`.
+
+The app factory (`create_app`) and its settings module land in a later plan
+in this PR. Until then this entrypoint defines a minimal FastAPI app inline
+with only the health route the Caddy/compose probe needs, so the service is
+importable and runnable at every point in this PR's history.
+"""
+
+from __future__ import annotations
+
+import uvicorn
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"ok": "true"}
+
+
+def main() -> None:
+    uvicorn.run(app, host="0.0.0.0", port=8002, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/report-host/src/report_host/__main__.py
+++ b/apps/report-host/src/report_host/__main__.py
@@ -1,26 +1,17 @@
-"""uvicorn entrypoint: `uv run python -m report_host`.
-
-The app factory (`create_app`) and its settings module land in a later plan
-in this PR. Until then this entrypoint defines a minimal FastAPI app inline
-with only the health route the Caddy/compose probe needs, so the service is
-importable and runnable at every point in this PR's history.
-"""
+"""uvicorn entrypoint: `uv run python -m report_host`."""
 
 from __future__ import annotations
 
 import uvicorn
-from fastapi import FastAPI
 
-app = FastAPI()
-
-
-@app.get("/health")
-def health() -> dict[str, str]:
-    return {"ok": "true"}
+from report_host.config import load_settings
+from report_host.main import create_app
 
 
 def main() -> None:
-    uvicorn.run(app, host="0.0.0.0", port=8002, log_level="info")
+    settings = load_settings()
+    app = create_app(settings)
+    uvicorn.run(app, host="0.0.0.0", port=settings.host_port, log_level="info")
 
 
 if __name__ == "__main__":

--- a/apps/report-host/src/report_host/admin.py
+++ b/apps/report-host/src/report_host/admin.py
@@ -45,7 +45,7 @@ def _validate_slug(slug: str) -> str:
     below.
     """
     if not slug or len(slug) > _SLUG_MAX_LEN or not _SLUG_PATTERN.fullmatch(slug):
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"invalid slug: {slug!r}")
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=f"invalid slug: {slug!r}")
     return slug
 
 

--- a/apps/report-host/src/report_host/admin.py
+++ b/apps/report-host/src/report_host/admin.py
@@ -1,0 +1,215 @@
+"""Admin routes for report-host: publish (create-or-update), delete, revoke.
+
+Everything daimon does to a report from the publishing side goes through this
+router, gated by the admin bearer — mirroring
+``notebook_host.admin._bearer_dep`` in shape. The bearer alone only proves
+the caller is daimon, not which tenant's report is being touched: every
+report row carries its own ``tenant_id``, and the publish and delete routes
+both refuse a caller-supplied tenant that does not match the existing row
+(T-21-16-B, slug squatting). The publish-upload route
+(``PUT /publish/{capability_token}``) is authorised by a capability token
+instead and lives in a separate module — the two authorisation mechanisms
+never mix in one place.
+"""
+
+import asyncio
+import hmac
+import re
+import secrets
+import shutil
+import sqlite3
+from collections.abc import Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel
+
+from report_host import reports_store
+from report_host.config import Settings
+
+# Lowercase alphanumerics and hyphens only, no leading/trailing hyphen, bounded
+# length. The slug becomes both a directory name and a URL segment, so a
+# separator or a ".." is a filesystem bug waiting to happen (T-21-16-D).
+_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SLUG_MAX_LEN = 64
+
+# Deliberately silent about which tenant already owns the slug (T-21-16-C).
+_TENANT_MISMATCH_MESSAGE = "this slug belongs to a different tenant"
+
+
+def _validate_slug(slug: str) -> str:
+    """Reject anything that is not a safe directory name and URL segment.
+
+    Called before any store lookup or path construction in every handler
+    below.
+    """
+    if not slug or len(slug) > _SLUG_MAX_LEN or not _SLUG_PATTERN.fullmatch(slug):
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"invalid slug: {slug!r}")
+    return slug
+
+
+def _bearer_dep(settings: Settings) -> Callable[[str | None], None]:
+    def require(authorization: str | None = Header(default=None)) -> None:
+        provided = authorization or ""
+        # No short-circuit: comparing every entry avoids a timing leak of
+        # which secret, if any, matched (T-21-16-A).
+        matched = False
+        for secret in settings.admin_secrets:
+            expected = f"Bearer {secret.get_secret_value()}"
+            if hmac.compare_digest(provided, expected):
+                matched = True
+        if not matched:
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+
+    return require
+
+
+class RecipientIn(BaseModel):
+    name: str
+    label: str
+
+
+class PublishRequest(BaseModel):
+    title: str
+    tenant_id: str
+    agent_name: str
+    cap_usd: Decimal
+    seam_token: str
+    recipients: list[RecipientIn]
+
+
+class RecipientLink(BaseModel):
+    name: str
+    link: str
+
+
+class PublishResponse(BaseModel):
+    # No seam_token here — it must never be echoed back into a response or a
+    # log (T-21-16-F).
+    slug: str
+    links: list[RecipientLink]
+
+
+class DeleteResponse(BaseModel):
+    deleted: bool
+
+
+def build_admin_router(
+    *,
+    settings: Settings,
+    conn_factory: Callable[[], sqlite3.Connection],
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> APIRouter:
+    """Build the admin router: publish (create-or-update), delete, revoke.
+
+    ``conn_factory`` is called exactly once, here, mirroring the reader
+    router's single-shared-connection design (production passes a factory
+    calling ``reports_store.connect(settings.data_dir)``; tests pass a
+    lambda over an already-open ``tmp_path`` connection). ``now`` is
+    injected so tests control every timestamp without a real clock.
+
+    The bearer dependency is attached at the router level rather than
+    per-route, so a route added here later can never forget it.
+    """
+    conn = conn_factory()
+    require_admin = _bearer_dep(settings)
+    slug_locks: dict[str, asyncio.Lock] = {}
+
+    def lock_for(slug: str) -> asyncio.Lock:
+        lock = slug_locks.get(slug)
+        if lock is None:
+            lock = asyncio.Lock()
+            slug_locks[slug] = lock
+        return lock
+
+    router = APIRouter(dependencies=[Depends(require_admin)])
+
+    @router.put("/admin/reports/{slug}")
+    async def put_report(slug: str, body: PublishRequest) -> PublishResponse:  # pyright: ignore[reportUnusedFunction]
+        """Create a report, or replace its metadata and recipient set.
+
+        Refuses 403 when an existing row belongs to a different tenant —
+        one tenant must not take over another tenant's slug by publishing
+        over it. Otherwise ``save_report`` preserves spend, the served PDF
+        and the bundle reference (T-21-16-E); every previously issued
+        recipient link is revoked and a fresh one minted per submitted
+        recipient, since a re-publish replaces the recipient set outright
+        rather than diffing old against new.
+        """
+        validated_slug = _validate_slug(slug)
+        async with lock_for(validated_slug):
+            existing = reports_store.load_report(conn, slug=validated_slug)
+            if existing is not None and existing.tenant_id != body.tenant_id:
+                raise HTTPException(status.HTTP_403_FORBIDDEN, detail=_TENANT_MISMATCH_MESSAGE)
+
+            reports_store.save_report(
+                conn,
+                slug=validated_slug,
+                title=body.title,
+                tenant_id=body.tenant_id,
+                agent_name=body.agent_name,
+                cap_usd=body.cap_usd,
+                agent_token=body.seam_token,
+                now=now(),
+            )
+
+            for recipient in reports_store.list_recipients(conn, slug=validated_slug):
+                if recipient.revoked_at is None:
+                    reports_store.revoke_recipient(
+                        conn, slug=validated_slug, token=recipient.token, now=now()
+                    )
+
+            links: list[RecipientLink] = []
+            for recipient_in in body.recipients:
+                token = secrets.token_urlsafe(24)
+                reports_store.add_recipient(
+                    conn,
+                    slug=validated_slug,
+                    name=recipient_in.name,
+                    label=recipient_in.label,
+                    token=token,
+                    now=now(),
+                    ttl_days=settings.recipient_link_ttl_days,
+                )
+                links.append(
+                    RecipientLink(
+                        name=recipient_in.name,
+                        link=f"{settings.public_url_base}r/{validated_slug}?k={token}",
+                    )
+                )
+        return PublishResponse(slug=validated_slug, links=links)
+
+    @router.delete("/admin/reports/{slug}")
+    async def delete_report_route(slug: str, tenant_id: str) -> DeleteResponse:  # pyright: ignore[reportUnusedFunction]
+        """Delete a report (cascading recipients, revisions and threads).
+
+        Reports ``deleted`` rather than an unconditional success — a caller
+        that cannot tell "I removed it" from "there was nothing by that
+        name" reports a typo'd slug as a real deletion (T-21-16-G). Refuses
+        403 on a tenant mismatch, leaving the row and its directory
+        untouched.
+        """
+        validated_slug = _validate_slug(slug)
+        async with lock_for(validated_slug):
+            existing = reports_store.load_report(conn, slug=validated_slug)
+            if existing is not None and existing.tenant_id != tenant_id:
+                raise HTTPException(status.HTTP_403_FORBIDDEN, detail=_TENANT_MISMATCH_MESSAGE)
+            deleted = reports_store.delete_report(conn, slug=validated_slug)
+            report_dir = settings.data_dir / validated_slug
+            # A validated slug can never escape data_dir, but this is the
+            # one place that removes a directory tree, so it re-asserts the
+            # containment it depends on rather than trusting validation
+            # alone (T-21-16-D).
+            if report_dir.parent == settings.data_dir:
+                shutil.rmtree(report_dir, ignore_errors=True)
+        return DeleteResponse(deleted=deleted)
+
+    @router.delete("/admin/reports/{slug}/recipients/{token}")
+    async def delete_recipient_route(slug: str, token: str) -> DeleteResponse:  # pyright: ignore[reportUnusedFunction]
+        """Revoke one recipient's link. Revoking an already-revoked link is not an error."""
+        validated_slug = _validate_slug(slug)
+        revoked = reports_store.revoke_recipient(conn, slug=validated_slug, token=token, now=now())
+        return DeleteResponse(deleted=revoked)
+
+    return router

--- a/apps/report-host/src/report_host/capability.py
+++ b/apps/report-host/src/report_host/capability.py
@@ -1,0 +1,70 @@
+"""Capability-token verification for report-host publish uploads.
+
+Mirror of ``daimon.core.notebooks.capability`` (the mint side). Duplicated,
+not imported: report-host is a standalone app and does not depend on
+daimon-core. The two are kept in lockstep by a test on each side — this
+module's tests, and ``packages/core/tests/test_capability_lockstep.py`` on
+the core side. The signature is verified against every configured admin
+secret, constant-time and with no short-circuit, so verification time does
+not leak which secret matched.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, SecretStr, ValidationError
+
+Op = Literal["report"]
+
+
+class CapabilityClaims(BaseModel, frozen=True, extra="forbid"):
+    # extra="forbid": an unexpected key in the signed payload is a schema
+    # mismatch between mint and verify, not something to silently drop — it
+    # is exactly the drift the lockstep test on the core side exists to catch.
+    slug: str
+    op: Op
+    name: str | None
+    max_bytes: int
+    exp: int
+    jti: str
+
+
+def _unb64(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def verify_token(secrets: list[SecretStr], token: str, *, now: datetime) -> CapabilityClaims | None:
+    """Verify the HMAC signature (any configured secret), expiry, and op.
+
+    Returns ``None`` on any failure: a malformed token, a bad signature
+    against every secret, an ``exp`` in the past, or an ``op`` that is not
+    ``"report"``. Never raises on attacker-controlled input.
+    """
+    try:
+        payload_b64, sig_b64 = token.split(".", 1)
+        provided_sig = _unb64(sig_b64)
+    except (ValueError, binascii.Error):
+        return None
+    # Constant-time, no short-circuit — no timing leak of which secret matched.
+    matched = False
+    for secret in secrets:
+        expected = hmac.new(
+            secret.get_secret_value().encode(), payload_b64.encode(), hashlib.sha256
+        ).digest()
+        if hmac.compare_digest(provided_sig, expected):
+            matched = True
+    if not matched:
+        return None
+    try:
+        claims = CapabilityClaims.model_validate_json(_unb64(payload_b64))
+    except (ValueError, binascii.Error, ValidationError):
+        return None
+    if datetime.fromtimestamp(claims.exp, tz=UTC) < now:
+        return None
+    return claims

--- a/apps/report-host/src/report_host/config.py
+++ b/apps/report-host/src/report_host/config.py
@@ -1,0 +1,123 @@
+"""pydantic-settings for report-host.
+
+Constructed via `load_settings()`. Never import a module-level settings
+singleton — construct once at the edge (app startup, test fixture) and
+inject downstream.
+
+Env prefix: DAIMON_REPORT__  (flat — no nested delimiter needed here, all
+fields are top-level on the single Settings class).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import Field, HttpUrl, SecretStr, field_validator, model_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    data_dir: Path = Field(
+        default=Path("/data/reports"),
+        description="Root of the host's persistent volume: SQLite stores, bundles, PDFs.",
+    )
+    # Bearer tokens accepted on admin routes. Provide MORE than one to rotate
+    # without downtime: add the new one, deploy bot with new value, drop the
+    # old. `DAIMON_REPORT__ADMIN_SECRETS=primary,backup` is the canonical
+    # form. Unlike the notebook host, this service has no existing deployment
+    # to preserve compatibility with, so there is no singular `admin_secret`
+    # alias here — a required list with a clear error is better than a
+    # deprecated alias that never had users.
+    admin_secrets: Annotated[list[SecretStr], NoDecode] = Field(
+        default_factory=list[SecretStr],
+        description=(
+            "CSV of bearer tokens accepted on admin routes "
+            "(DAIMON_REPORT__ADMIN_SECRETS=primary,backup). At least one is required — "
+            "the host refuses to start without one."
+        ),
+    )
+
+    @field_validator("admin_secrets", mode="before")
+    @classmethod
+    def _split_admin_secrets(cls, v: object) -> object:
+        # pydantic-settings reads env as a string; comma-split into a list.
+        if isinstance(v, str):
+            return [s.strip() for s in v.split(",") if s.strip()]
+        return v
+
+    @model_validator(mode="after")
+    def _require_admin_secret(self) -> Settings:
+        if not self.admin_secrets:
+            raise ValueError(
+                "at least one admin bearer required: set DAIMON_REPORT__ADMIN_SECRETS (CSV)"
+            )
+        return self
+
+    mcp_url: HttpUrl = Field(
+        description="The seam endpoint this host calls to run turns, poll cost, and mint tokens."
+    )
+    public_url_base: HttpUrl = Field(
+        description=(
+            "External URL prefix used to build recipient links and the per-turn upload "
+            "URL handed to the agent."
+        )
+    )
+    host_port: int = Field(default=8002, description="Port the host's uvicorn server binds.")
+    reserve_usd: Decimal = Field(
+        default=Decimal("0.60"),
+        description=(
+            "Amount held against a report's spend cap the moment a turn starts, released "
+            "and replaced by the real cost once the turn settles. Measured reader turns ran "
+            "roughly sixteen to sixty-three cents; a revision-with-rebuild came in under "
+            "this reserve."
+        ),
+    )
+    poll_interval_seconds: float = Field(
+        default=2.0, description="How often the host polls the seam for turn progress."
+    )
+    turn_timeout_seconds: int = Field(
+        default=1200,
+        description="A turn still running past this many seconds is cancelled by the host.",
+    )
+    max_pdf_bytes: int = Field(
+        default=50 * 1024 * 1024,
+        description="Hard ceiling on an uploaded revised-PDF body size.",
+    )
+    max_bundle_bytes: int = Field(
+        default=25 * 1024 * 1024,
+        description=(
+            "Hard ceiling on a published report bundle. Mirrors the seam's own bundle cap "
+            "and is enforced independently here as a second layer of defense."
+        ),
+    )
+    max_open_threads_per_recipient: int = Field(
+        default=3, description="Cap on concurrently open threads a single recipient may hold."
+    )
+    max_running_turns_per_report: int = Field(
+        default=4, description="Cap on concurrently running turns across one report's threads."
+    )
+    recipient_link_ttl_days: int = Field(
+        default=90, description="How long a per-recipient link remains valid before expiring."
+    )
+    thread_idle_archive_hours: int = Field(
+        default=24,
+        description="A thread idle longer than this is archived by the host's sweep.",
+    )
+
+    model_config = SettingsConfigDict(
+        env_prefix="DAIMON_REPORT__",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+
+def load_settings(*, _env_file: str | None = ".env") -> Settings:
+    """Construct a Settings from the live process env + optional .env file.
+
+    `_env_file` exists to give tests a way to disable `.env` loading
+    (`_env_file=None`) so they only see `monkeypatch.setenv` values.
+    """
+    return Settings(_env_file=_env_file)  # pyright: ignore[reportCallIssue]

--- a/apps/report-host/src/report_host/consumed_store.py
+++ b/apps/report-host/src/report_host/consumed_store.py
@@ -1,0 +1,94 @@
+"""Durable registry of burned single-use capability-token jtis.
+
+`PUT /publish/{capability_token}` is authenticated by a capability token
+whose `jti` must be usable exactly once. Recording that in memory (a
+process-local set) means a token captured inside its TTL survives a host
+restart and can be replayed — the burned set vanished with the process that
+burned it. This file is the fix: burned jtis persist to disk, keyed to the
+token's own `exp` so the set can be pruned instead of growing for the life
+of a host designed to run indefinitely.
+
+Mirrors `notebook_host.consumed_store` byte-for-byte in shape (the two apps
+do not share code — report-host is a standalone app with no dependency on
+notebook-host or daimon-core). Pure functions only — the single I/O is the
+file read/write (no clock, no process control, no network); `burn_jti` and
+`prune_consumed` take `now` as an explicit parameter rather than reading the
+clock. A malformed file is treated as empty rather than fatal, and writes
+are atomic (tmp + rename).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+_REGISTRY_MODE = 0o600
+"""Explicit mode for consumed.json — host-owned process state, not meant to
+be readable by anything else on the volume."""
+
+
+def load_consumed(path: Path) -> dict[str, int]:
+    """Read the registry as {jti: exp}. Returns an empty dict if missing or malformed.
+
+    A malformed file means a previous instance died mid-write. We can't trust
+    partial state, so we forget it and let the next burn rebuild it.
+    """
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, int] = {}
+    for jti_obj, exp_obj in raw.items():  # pyright: ignore[reportUnknownVariableType]
+        if not isinstance(jti_obj, str) or not isinstance(exp_obj, int):
+            continue
+        out[jti_obj] = exp_obj
+    return out
+
+
+def save_consumed(path: Path, records: dict[str, int]) -> None:
+    """Atomically rewrite the registry (tmp + rename on the same filesystem).
+
+    The tmp file is locked to `_REGISTRY_MODE` (0600) before the rename, not
+    after — no window where a freshly written registry is world-readable.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(records, indent=2))
+    os.chmod(tmp, _REGISTRY_MODE)
+    os.replace(tmp, path)
+
+
+def prune_consumed(records: dict[str, int], *, now: int) -> dict[str, int]:
+    """Return a new dict without entries whose `exp` has passed.
+
+    Pure — takes `now` explicitly rather than reading the clock. Does not
+    mutate `records`.
+    """
+    return {jti: exp for jti, exp in records.items() if exp > now}
+
+
+def is_consumed(path: Path, jti: str) -> bool:
+    """Whether `jti` has already been burned."""
+    return jti in load_consumed(path)
+
+
+def burn_jti(path: Path, jti: str, *, exp: int, now: int) -> bool:
+    """Atomically check-and-burn `jti`. Returns True if this call burned it.
+
+    Loads, prunes expired entries (bounding the file's steady-state size),
+    then inserts `jti` with `exp` if it wasn't already present. One call does
+    the check and the write, so there is no window between them — the caller
+    must place this before reading the request body so two concurrent
+    replays of the same token cannot both observe it as unused.
+    """
+    records = prune_consumed(load_consumed(path), now=now)
+    already_burned = jti in records
+    if not already_burned:
+        records[jti] = exp
+    save_consumed(path, records)
+    return not already_burned

--- a/apps/report-host/src/report_host/main.py
+++ b/apps/report-host/src/report_host/main.py
@@ -1,0 +1,157 @@
+"""FastAPI app factory for report-host.
+
+``create_app(settings)`` wires:
+  - the single SQLite connection (``reports_store.connect``, applying both
+    ``reports_store``'s and ``threads_store``'s schema, once, at construction)
+  - a ``SeamClient`` over one ``httpx.AsyncClient`` owned by the app
+  - the reader router (which also mounts the viewer's static assets — see
+    ``routes.build_reader_router``), the admin router and the uploads router
+  - ``GET /health``, requiring no credential — the compose/reverse-proxy probe
+  - a ``lifespan`` that, on entry, resumes every thread the host left running
+    across a restart and starts one background task looping the deadline-cancel,
+    idle-archive and recipient-prune sweeps; on exit, flips the shutting-down
+    flag every ``run_turn`` call reads (so an in-flight turn leaves its thread
+    ``running`` rather than telling the reader the answer was lost), cancels
+    the sweep task, and closes the HTTP client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import sqlite3
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+import httpx
+from fastapi import FastAPI
+
+from report_host import reports_store, turns
+from report_host.admin import build_admin_router
+from report_host.config import Settings
+from report_host.mcp_client import SeamClient
+from report_host.routes import build_reader_router
+from report_host.sweeps import (
+    archive_idle_threads,
+    cancel_expired_turns,
+    prune_expired_recipients,
+    resume_running_threads,
+)
+from report_host.threads_store import ThreadRow
+from report_host.uploads import build_uploads_router
+
+_log = logging.getLogger(__name__)
+
+# Housekeeping cadence: idle threads and expired deadlines are hours-scale
+# concerns, so a five-minute tick is frequent enough without hammering the
+# seam or the local database on every request cycle.
+_SWEEP_INTERVAL_SECONDS = 300.0
+
+
+def create_app(settings: Settings) -> FastAPI:
+    conn = reports_store.connect(settings.data_dir)
+    http_client = httpx.AsyncClient()
+    seam = SeamClient(
+        mcp_url=str(settings.mcp_url),
+        http_client=http_client,
+        max_bundle_bytes=settings.max_bundle_bytes,
+    )
+
+    def now() -> datetime:
+        return datetime.now(UTC)
+
+    # A plain closure flag, not a module-level global (architecture rule 3):
+    # `create_app` is the one place that owns it, and every `run_turn` call
+    # this app schedules — from `ask`'s background task and from the resume
+    # sweep alike — reads the exact same flag through `_run_turn` below. This
+    # is what makes a turn interrupted by shutdown leave its thread `running`
+    # (so the next boot's resume re-attaches to it) rather than being told,
+    # incorrectly, that the answer was lost (T-21-18-A).
+    shutting_down = False
+
+    def is_shutting_down() -> bool:
+        return shutting_down
+
+    async def _run_turn(
+        *,
+        conn: sqlite3.Connection,
+        seam: SeamClient,
+        settings: Settings,
+        thread: ThreadRow,
+        message: str | None,
+        now: Callable[[], datetime],
+    ) -> None:
+        await turns.run_turn(
+            conn=conn,
+            seam=seam,
+            settings=settings,
+            thread=thread,
+            message=message,
+            now=now,
+            shutting_down=is_shutting_down,
+        )
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:  # pyright: ignore[reportUnusedFunction]
+        nonlocal shutting_down
+        resumed = await resume_running_threads(
+            conn=conn,
+            seam=seam,
+            settings=settings,
+            now=now,
+            schedule=asyncio.create_task,
+            run_turn=_run_turn,
+        )
+        if resumed:
+            _log.info("resumed %d thread(s) still running on the seam", resumed)
+        sweep_task = asyncio.create_task(
+            _sweep_loop(conn=conn, seam=seam, settings=settings, now=now)
+        )
+        try:
+            yield
+        finally:
+            shutting_down = True
+            sweep_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await sweep_task
+            await http_client.aclose()
+
+    app = FastAPI(lifespan=lifespan)
+    app.include_router(
+        build_reader_router(
+            settings=settings, conn_factory=lambda: conn, seam=seam, now=now, run_turn=_run_turn
+        )
+    )
+    app.include_router(build_admin_router(settings=settings, conn_factory=lambda: conn, now=now))
+    app.include_router(
+        build_uploads_router(settings=settings, conn_factory=lambda: conn, seam=seam)
+    )
+
+    @app.get("/health")
+    def health() -> dict[str, bool]:  # pyright: ignore[reportUnusedFunction]
+        return {"ok": True}
+
+    return app
+
+
+async def _sweep_loop(
+    *, conn: sqlite3.Connection, seam: SeamClient, settings: Settings, now: Callable[[], datetime]
+) -> None:
+    """Background task: every ``_SWEEP_INTERVAL_SECONDS``, cancel expired
+    turns, archive idle threads, and prune expired recipients.
+
+    One sweep failing must not stop the next tick (T-21-18-G) — the
+    individual sweep functions already guard per item; this loop's own
+    ``except Exception`` is the outer belt for a failure in the loop
+    plumbing itself (e.g. a database file gone missing).
+    """
+    while True:
+        await asyncio.sleep(_SWEEP_INTERVAL_SECONDS)
+        try:
+            await cancel_expired_turns(conn=conn, seam=seam, settings=settings, now=now)
+            await archive_idle_threads(conn=conn, seam=seam, settings=settings, now=now)
+            prune_expired_recipients(conn=conn, now=now)
+        except Exception:
+            _log.exception("sweep iteration failed; will retry next cycle")

--- a/apps/report-host/src/report_host/mcp_client.py
+++ b/apps/report-host/src/report_host/mcp_client.py
@@ -1,0 +1,341 @@
+"""SeamClient — the report host's only outbound surface.
+
+Every question a reader asks becomes a sequence of seam tool calls carrying
+the report's own token: the token minted for the reader variant under the
+publishing account, which is what makes the Q&A billed and admission-gated
+in the right tenant. The token is a parameter on every method, never
+instance state, so one client object can safely serve many reports at once
+with no chance of one report's calls being billed or attributed to another.
+
+Transport shape: a fresh streamable-HTTP MCP session is opened per call, one
+``httpx.AsyncClient`` per call carrying that call's own ``Authorization``
+header. An early throwaway prototype measured roughly one second of overhead
+per call and judged it acceptable at a two-second poll interval; nothing
+about this module's scope changes that trade-off, so the shape is kept
+rather than pooling one long-lived MCP session across reports (which would
+reintroduce exactly the shared-state risk this module exists to avoid).
+
+Boundary timestamps (``turn_started_at``) are carried as the opaque ISO-8601
+strings the seam returns and are never round-tripped through ``datetime`` —
+whatever string ``start_turn``/``continue_turn`` hand back is byte-identical
+to what a caller later sends as ``list_events``'s ``created_at_gte``.
+
+Errors, all deriving from one base:
+
+- ``SeamError`` — any seam failure not otherwise typed.
+- ``SeamUnauthorizedError`` — the transport answered 401, or the MCP layer
+  refused the bearer. Callers should mark the report unauthorized.
+- ``BundleExpiredError`` — the tool error text names the bundle's underlying
+  Files API object as gone. Callers should re-push the archive and retry.
+
+Nothing else gets its own type; a taxonomy nobody branches on is noise.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import IO, cast
+
+import httpx
+from mcp import ClientSession
+from mcp import types as mcp_types
+from mcp.client.streamable_http import streamable_http_client
+
+log = logging.getLogger(__name__)
+
+_BUNDLE_EXPIRED_TEXT = "bundle expired; re-upload"
+
+
+def _flatten_first[ExcT: BaseException](group: BaseExceptionGroup[ExcT]) -> ExcT:
+    """Unwrap nested ``except*`` ExceptionGroups down to one leaf exception.
+
+    mcp's streamable-HTTP transport runs its request loop inside an anyio
+    task group, so a transport failure always arrives wrapped in an
+    ExceptionGroup (PEP 654) even for a single request — a plain
+    ``except httpx.HTTPStatusError`` would never match it, and a nested
+    task group can wrap it more than once.
+    """
+    current: BaseException = group
+    while isinstance(current, BaseExceptionGroup):
+        current = cast("BaseException", current.exceptions[0])
+    return cast("ExcT", current)
+
+
+class SeamError(Exception):
+    """Raised on any seam failure not otherwise typed."""
+
+
+class SeamUnauthorizedError(SeamError):
+    """The seam rejected the bearer token (HTTP 401)."""
+
+
+class BundleExpiredError(SeamError):
+    """The bundle's underlying Files API object is gone; re-push the archive."""
+
+
+@dataclass(frozen=True)
+class StartedTurn:
+    """The three boundary fields returned by ``start_turn``/``continue_turn``."""
+
+    handle: str
+    turn_event_id: str
+    turn_started_at: str
+
+
+@dataclass(frozen=True)
+class SessionStatus:
+    """A session's plain status string, as returned by ``get_my_session``/``cancel_turn``."""
+
+    status: str
+
+
+@dataclass(frozen=True)
+class TurnEvents:
+    """A page of a session's transcript."""
+
+    items: list[dict[str, object]]
+    next_page: str | None
+
+
+@dataclass(frozen=True)
+class TurnCost:
+    """One finished turn's raw provider cost, before markup."""
+
+    cost_usd: Decimal | None
+    event_count: int
+
+
+@dataclass(frozen=True)
+class BundlePushed:
+    """The signed handle and metadata returned by ``PUT /bundles``."""
+
+    handle: str
+    sha256: str
+    size_bytes: int
+    expires_at: str
+
+
+def _require_str(data: dict[str, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str):
+        raise SeamError(f"seam response missing string field {key!r}: {data!r}")
+    return value
+
+
+def _require_int(data: dict[str, object], key: str) -> int:
+    value = data.get(key)
+    if not isinstance(value, int):
+        raise SeamError(f"seam response missing int field {key!r}: {data!r}")
+    return value
+
+
+def _optional_str(data: dict[str, object], key: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SeamError(f"seam response field {key!r} was not a string: {data!r}")
+    return value
+
+
+def _require_list_of_dicts(data: dict[str, object], key: str) -> list[dict[str, object]]:
+    value = data.get(key)
+    if not isinstance(value, list):
+        raise SeamError(f"seam response missing list field {key!r}: {data!r}")
+    items: list[dict[str, object]] = []
+    for entry in cast("list[object]", value):
+        if not isinstance(entry, dict):
+            raise SeamError(f"seam response list field {key!r} contained a non-object entry")
+        items.append(cast("dict[str, object]", entry))
+    return items
+
+
+def _started_turn_from(data: dict[str, object]) -> StartedTurn:
+    return StartedTurn(
+        handle=_require_str(data, "handle"),
+        turn_event_id=_require_str(data, "turn_event_id"),
+        turn_started_at=_require_str(data, "turn_started_at"),
+    )
+
+
+def _first_text(result: mcp_types.CallToolResult) -> str:
+    for block in result.content:
+        if isinstance(block, mcp_types.TextContent):
+            return block.text
+    return ""
+
+
+def _decode_tool_result(tool: str, result: mcp_types.CallToolResult) -> dict[str, object]:
+    if result.isError:
+        text = _first_text(result)
+        if _BUNDLE_EXPIRED_TEXT in text:
+            raise BundleExpiredError(text)
+        raise SeamError(f"{tool}: {text}")
+    structured = result.structuredContent
+    if isinstance(structured, dict):
+        return cast("dict[str, object]", structured)
+    text = _first_text(result)
+    parsed: object = json.loads(text) if text else {}
+    if not isinstance(parsed, dict):
+        raise SeamError(f"{tool} returned non-object JSON: {parsed!r}")
+    return cast("dict[str, object]", parsed)
+
+
+class SeamClient:
+    """Typed wrappers over the agent-chat seam, one client object serving many reports.
+
+    Collaborators are fixed at construction (the seam's MCP endpoint URL and
+    an ``httpx.AsyncClient`` used for the plain-HTTP bundle push); the
+    report's own token is a parameter on every method call, never instance
+    state — this is what makes cross-report token confusion structurally
+    impossible rather than a matter of caller discipline.
+
+    ``transport`` is an optional seam for tests to redirect the per-call MCP
+    sessions onto an in-process ASGI fake (``httpx.ASGITransport``) instead of
+    the real network; production leaves it ``None`` and gets a real
+    connection per call, same as the prototype.
+    """
+
+    def __init__(
+        self,
+        *,
+        mcp_url: str,
+        http_client: httpx.AsyncClient,
+        max_bundle_bytes: int = 25 * 1024 * 1024,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._mcp_url = mcp_url
+        self._bundles_url = str(httpx.URL(mcp_url).copy_with(path="/bundles"))
+        self._http = http_client
+        self._max_bundle_bytes = max_bundle_bytes
+        self._transport = transport
+
+    async def _call_tool(
+        self, *, token: str, tool: str, arguments: dict[str, object]
+    ) -> dict[str, object]:
+        headers = {"Authorization": f"Bearer {token}"}
+        log.debug("seam call tool=%s handle=%s", tool, arguments.get("handle"))
+        try:
+            async with (
+                httpx.AsyncClient(
+                    transport=self._transport, headers=headers, follow_redirects=True
+                ) as call_client,
+                streamable_http_client(self._mcp_url, http_client=call_client) as (
+                    read,
+                    write,
+                    _get_session_id,
+                ),
+                ClientSession(read, write) as session,
+            ):
+                await session.initialize()
+                result = await session.call_tool(tool, arguments)
+        except* httpx.HTTPStatusError as eg:
+            err = _flatten_first(eg)
+            if err.response.status_code == 401:
+                raise SeamUnauthorizedError(f"seam rejected the bearer for {tool}") from err
+            raise SeamError(f"{tool} transport error: {err}") from err
+        except* httpx.HTTPError as eg:
+            err = _flatten_first(eg)
+            raise SeamError(f"{tool} transport error: {err}") from err
+        return _decode_tool_result(tool, result)
+
+    async def start_turn(
+        self, *, token: str, message: str, bundle: str | None = None
+    ) -> StartedTurn:
+        arguments: dict[str, object] = {"message": message}
+        if bundle is not None:
+            arguments["bundle"] = bundle
+        data = await self._call_tool(token=token, tool="start_turn", arguments=arguments)
+        return _started_turn_from(data)
+
+    async def continue_turn(self, *, token: str, handle: str, message: str) -> StartedTurn:
+        data = await self._call_tool(
+            token=token,
+            tool="continue_turn",
+            arguments={"handle": handle, "message": message},
+        )
+        return _started_turn_from(data)
+
+    async def get_session(self, *, token: str, handle: str) -> SessionStatus:
+        data = await self._call_tool(
+            token=token, tool="get_my_session", arguments={"handle": handle}
+        )
+        return SessionStatus(status=_require_str(data, "status"))
+
+    async def list_events(
+        self,
+        *,
+        token: str,
+        handle: str,
+        created_at_gte: str,
+        types: list[str],
+        page: str | None = None,
+    ) -> TurnEvents:
+        arguments: dict[str, object] = {
+            "handle": handle,
+            "created_at_gte": created_at_gte,
+            "types": types,
+            "order": "asc",
+        }
+        if page is not None:
+            arguments["page"] = page
+        data = await self._call_tool(token=token, tool="list_events", arguments=arguments)
+        return TurnEvents(
+            items=_require_list_of_dicts(data, "items"),
+            next_page=_optional_str(data, "next_page"),
+        )
+
+    async def cancel_turn(self, *, token: str, handle: str) -> SessionStatus:
+        data = await self._call_tool(token=token, tool="cancel_turn", arguments={"handle": handle})
+        return SessionStatus(status=_require_str(data, "status"))
+
+    async def get_turn_cost(
+        self, *, token: str, handle: str, turn_started_at: str, turn_event_id: str
+    ) -> TurnCost:
+        data = await self._call_tool(
+            token=token,
+            tool="get_turn_cost",
+            arguments={
+                "handle": handle,
+                "turn_started_at": turn_started_at,
+                "turn_event_id": turn_event_id,
+            },
+        )
+        raw_cost = data.get("cost_usd")
+        cost_usd = Decimal(str(raw_cost)) if raw_cost is not None else None
+        return TurnCost(cost_usd=cost_usd, event_count=_require_int(data, "event_count"))
+
+    async def archive_session(self, *, token: str, handle: str) -> None:
+        await self._call_tool(token=token, tool="archive_my_session", arguments={"handle": handle})
+
+    async def push_bundle(
+        self, *, token: str, archive: bytes | IO[bytes], size_bytes: int
+    ) -> BundlePushed:
+        if size_bytes > self._max_bundle_bytes:
+            raise SeamError(
+                f"bundle of {size_bytes} bytes exceeds the {self._max_bundle_bytes} byte cap"
+            )
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/gzip"}
+        log.debug("seam call tool=push_bundle")
+        try:
+            response = await self._http.put(self._bundles_url, content=archive, headers=headers)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as err:
+            if err.response.status_code == 401:
+                raise SeamUnauthorizedError("seam rejected the bearer for push_bundle") from err
+            raise SeamError(f"push_bundle transport error: {err}") from err
+        except httpx.HTTPError as err:
+            raise SeamError(f"push_bundle transport error: {err}") from err
+        data: object = response.json()
+        if not isinstance(data, dict):
+            raise SeamError(f"push_bundle returned non-object JSON: {data!r}")
+        payload = cast("dict[str, object]", data)
+        return BundlePushed(
+            handle=_require_str(payload, "bundle"),
+            sha256=_require_str(payload, "sha256"),
+            size_bytes=_require_int(payload, "size_bytes"),
+            expires_at=_require_str(payload, "expires_at"),
+        )

--- a/apps/report-host/src/report_host/reports_store.py
+++ b/apps/report-host/src/report_host/reports_store.py
@@ -87,6 +87,17 @@ CREATE TABLE IF NOT EXISTS revisions (
     note TEXT,
     PRIMARY KEY (slug, name)
 );
+
+-- One per-turn upload token, minted by the ask route so a turn's first
+-- message can carry a one-time URL the agent PUTs a revised PDF to. No FK to
+-- threads(id): that table lives in threads_store's schema, applied after
+-- this one, so a forward reference here would break connect()'s ordering.
+CREATE TABLE IF NOT EXISTS upload_tokens (
+    token TEXT PRIMARY KEY,
+    slug TEXT NOT NULL REFERENCES reports(slug) ON DELETE CASCADE,
+    thread_id INTEGER NOT NULL,
+    created_at TEXT NOT NULL
+);
 """
 
 
@@ -462,3 +473,19 @@ def list_revisions(conn: sqlite3.Connection, *, slug: str) -> list[RevisionRow]:
 def set_current_pdf(conn: sqlite3.Connection, *, slug: str, name: str) -> None:
     with conn:
         conn.execute("UPDATE reports SET current_pdf = ? WHERE slug = ?", (name, slug))
+
+
+def create_upload_token(
+    conn: sqlite3.Connection, *, token: str, slug: str, thread_id: int, now: datetime
+) -> None:
+    """Record a per-turn upload token minted for a reader's question.
+
+    The route that consumes this token — validating single use and swapping
+    in the uploaded PDF as a new revision — lands in a later plan; this only
+    persists the row so that route has something to read and burn.
+    """
+    with conn:
+        conn.execute(
+            "INSERT INTO upload_tokens (token, slug, thread_id, created_at) VALUES (?, ?, ?, ?)",
+            (token, slug, thread_id, dt_to_text(now)),
+        )

--- a/apps/report-host/src/report_host/reports_store.py
+++ b/apps/report-host/src/report_host/reports_store.py
@@ -451,6 +451,18 @@ def list_recipients(conn: sqlite3.Connection, *, slug: str) -> list[RecipientRow
     return [_row_to_recipient(row) for row in rows]
 
 
+def prune_expired_recipients(conn: sqlite3.Connection, *, now: datetime) -> int:
+    """Delete every recipient row past its expiry, revoked or not.
+
+    Belt and braces against the reader route's own ``load_recipient`` expiry
+    check (T-21-18-E): a second, independent control, and it keeps the table
+    from growing forever. Returns how many rows were removed.
+    """
+    with conn:
+        cur = conn.execute("DELETE FROM recipients WHERE expires_at <= ?", (dt_to_text(now),))
+    return cur.rowcount
+
+
 def add_revision(
     conn: sqlite3.Connection,
     *,

--- a/apps/report-host/src/report_host/reports_store.py
+++ b/apps/report-host/src/report_host/reports_store.py
@@ -139,6 +139,14 @@ class RevisionRow:
     note: str | None
 
 
+@dataclass(frozen=True)
+class UploadTokenRow:
+    token: str
+    slug: str
+    thread_id: int
+    created_at: datetime
+
+
 def to_micros(amount: Decimal) -> int:
     """Quantize a Decimal USD amount to an exact integer micro-dollar count."""
     return int((amount * _MICROS_PER_USD).to_integral_value(rounding=ROUND_HALF_UP))
@@ -481,11 +489,36 @@ def create_upload_token(
     """Record a per-turn upload token minted for a reader's question.
 
     The route that consumes this token — validating single use and swapping
-    in the uploaded PDF as a new revision — lands in a later plan; this only
-    persists the row so that route has something to read and burn.
+    in the uploaded PDF as a new revision — is `uploads.turn_upload`, which
+    calls `consume_upload_token` below.
     """
     with conn:
         conn.execute(
             "INSERT INTO upload_tokens (token, slug, thread_id, created_at) VALUES (?, ?, ?, ?)",
             (token, slug, thread_id, dt_to_text(now)),
         )
+
+
+def consume_upload_token(conn: sqlite3.Connection, *, token: str) -> UploadTokenRow | None:
+    """Atomically look up and burn a per-turn upload token.
+
+    One `DELETE ... RETURNING`, no preceding read: the row's presence IS its
+    unused state, so deleting it and returning what was deleted is the
+    single-use check and the burn in one statement — two concurrent uses of
+    the same token cannot both see it as present (T-21-17-B).
+    """
+    with conn:
+        cur = conn.execute(
+            "DELETE FROM upload_tokens WHERE token = ? "
+            "RETURNING token, slug, thread_id, created_at",
+            (token,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return UploadTokenRow(
+        token=row["token"],
+        slug=row["slug"],
+        thread_id=row["thread_id"],
+        created_at=text_to_dt(row["created_at"]),
+    )

--- a/apps/report-host/src/report_host/reports_store.py
+++ b/apps/report-host/src/report_host/reports_store.py
@@ -1,0 +1,464 @@
+"""Durable store for reports, their recipients and revisions.
+
+One SQLite file at ``data_dir / "host.sqlite"``. ``connect()`` is the only
+function that opens a connection and the only place any schema is applied
+(idempotently, ``CREATE TABLE IF NOT EXISTS``) — it applies this module's own
+tables, then calls ``threads_store.apply_schema(conn)`` so both halves of the
+host's durable state live in one file. That import happens inside
+``connect()``, not at module load time, so ``threads_store`` (which reuses
+this module's connection but never imports it) and this module never form a
+cycle. Every other function in this module and in ``threads_store`` takes an
+already-open connection as its first parameter — there is no module-level
+connection and no import-time side effect, unlike the prototype this ports
+from (``spikes/report-host/host/app.py``), which opened a connection at
+import and kept it as a global.
+
+Money (``cap_usd``, ``spent_usd``) is stored as **INTEGER micro-dollars**
+(1 USD = 1_000_000) and surfaced as ``Decimal`` at every function boundary —
+never as SQLite's ``REAL``. Integers are exact; the prototype stored money as
+``REAL`` and compared floats against a cap, which is a rounding bug waiting
+to happen. Storing micro-dollars as an integer also makes ``reserve_budget``'s
+single conditional ``UPDATE`` an exact comparison, not a floating-point one.
+Every other point-in-time column (``created_at``, ``expires_at``,
+``bundle_expires_at``, ...) is stored as TEXT, an ISO-8601 string produced by
+``datetime.isoformat()`` — never ``REAL`` either — and read back with
+``datetime.fromisoformat``. Callers should pass timezone-aware datetimes
+(UTC) so that lexical TEXT ordering agrees with chronological ordering.
+
+``archive_path`` is the publish route's own record of where it persisted the
+report's most recently pushed archive under ``settings.data_dir / slug``. It
+is never derived from caller input by this module (T-21-12-H): the publish
+route composes it and hands it to ``save_bundle_reference`` as one unit with
+the bundle handle/sha256/expiry it describes, because a handle recorded
+without the archive that produced it is a re-push that cannot happen.
+
+Per-report seam tokens (``seam_token``) sit in this database at the same
+trust level as the admin bearer (T-21-12-F): the host's data volume is not
+shared with any other service, and revocation-on-delete is the real control,
+landing with the publishing routes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+from pathlib import Path
+from typing import Literal
+
+SeamStatus = Literal["ok", "unauthorized"]
+
+_MICROS_PER_USD = Decimal(1_000_000)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS reports (
+    slug TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    tenant_id TEXT NOT NULL,
+    agent_name TEXT NOT NULL,
+    cap_usd INTEGER NOT NULL,
+    spent_usd INTEGER NOT NULL DEFAULT 0,
+    current_pdf TEXT,
+    seam_token TEXT NOT NULL,
+    seam_status TEXT NOT NULL DEFAULT 'ok',
+    bundle_handle TEXT,
+    bundle_sha256 TEXT,
+    bundle_expires_at TEXT,
+    archive_path TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS recipients (
+    token TEXT PRIMARY KEY,
+    slug TEXT NOT NULL REFERENCES reports(slug) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    label TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    revoked_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS revisions (
+    slug TEXT NOT NULL REFERENCES reports(slug) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    by_thread TEXT,
+    note TEXT,
+    PRIMARY KEY (slug, name)
+);
+"""
+
+
+@dataclass(frozen=True)
+class ReportRow:
+    slug: str
+    title: str
+    tenant_id: str
+    agent_name: str
+    cap_usd: Decimal
+    spent_usd: Decimal
+    current_pdf: str | None
+    seam_token: str
+    seam_status: SeamStatus
+    bundle_handle: str | None
+    bundle_sha256: str | None
+    bundle_expires_at: datetime | None
+    archive_path: str | None
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class RecipientRow:
+    token: str
+    slug: str
+    name: str
+    label: str
+    created_at: datetime
+    expires_at: datetime
+    revoked_at: datetime | None
+
+
+@dataclass(frozen=True)
+class RevisionRow:
+    slug: str
+    name: str
+    created_at: datetime
+    by_thread: str | None
+    note: str | None
+
+
+def to_micros(amount: Decimal) -> int:
+    """Quantize a Decimal USD amount to an exact integer micro-dollar count."""
+    return int((amount * _MICROS_PER_USD).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def from_micros(micros: int) -> Decimal:
+    return Decimal(micros) / _MICROS_PER_USD
+
+
+def dt_to_text(value: datetime) -> str:
+    return value.isoformat()
+
+
+def text_to_dt(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _row_to_report(row: sqlite3.Row) -> ReportRow:
+    bundle_expires_at = row["bundle_expires_at"]
+    return ReportRow(
+        slug=row["slug"],
+        title=row["title"],
+        tenant_id=row["tenant_id"],
+        agent_name=row["agent_name"],
+        cap_usd=from_micros(row["cap_usd"]),
+        spent_usd=from_micros(row["spent_usd"]),
+        current_pdf=row["current_pdf"],
+        seam_token=row["seam_token"],
+        seam_status=row["seam_status"],
+        bundle_handle=row["bundle_handle"],
+        bundle_sha256=row["bundle_sha256"],
+        bundle_expires_at=text_to_dt(bundle_expires_at) if bundle_expires_at else None,
+        archive_path=row["archive_path"],
+        created_at=text_to_dt(row["created_at"]),
+    )
+
+
+def _row_to_recipient(row: sqlite3.Row) -> RecipientRow:
+    revoked_at = row["revoked_at"]
+    return RecipientRow(
+        token=row["token"],
+        slug=row["slug"],
+        name=row["name"],
+        label=row["label"],
+        created_at=text_to_dt(row["created_at"]),
+        expires_at=text_to_dt(row["expires_at"]),
+        revoked_at=text_to_dt(revoked_at) if revoked_at else None,
+    )
+
+
+def _row_to_revision(row: sqlite3.Row) -> RevisionRow:
+    return RevisionRow(
+        slug=row["slug"],
+        name=row["name"],
+        created_at=text_to_dt(row["created_at"]),
+        by_thread=row["by_thread"],
+        note=row["note"],
+    )
+
+
+def connect(data_dir: Path) -> sqlite3.Connection:
+    """Open (creating if needed) the host's single SQLite database.
+
+    Creates ``data_dir`` if missing, opens ``data_dir / "host.sqlite"``,
+    enables foreign keys and WAL, and idempotently applies this module's
+    schema followed by ``threads_store``'s. This is the only place a
+    connection is created in the report-host codebase.
+    """
+    from report_host import threads_store
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(data_dir / "host.sqlite")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.executescript(_SCHEMA)
+    threads_store.apply_schema(conn)
+    return conn
+
+
+def load_report(conn: sqlite3.Connection, *, slug: str) -> ReportRow | None:
+    row = conn.execute("SELECT * FROM reports WHERE slug = ?", (slug,)).fetchone()
+    return _row_to_report(row) if row is not None else None
+
+
+def save_report(
+    conn: sqlite3.Connection,
+    *,
+    slug: str,
+    title: str,
+    tenant_id: str,
+    agent_name: str,
+    cap_usd: Decimal,
+    agent_token: str,
+    now: datetime,
+) -> ReportRow:
+    """Create a report, or replace its metadata if ``slug`` already exists.
+
+    A re-publish (an existing ``slug``) updates ``title``, ``tenant_id``,
+    ``agent_name``, ``cap_usd`` and the seam token, and resets
+    ``seam_status`` to healthy (a fresh token implies re-authorization) —
+    but leaves ``spent_usd``, ``current_pdf`` and every bundle field
+    (``bundle_handle``, ``bundle_sha256``, ``bundle_expires_at``,
+    ``archive_path``) untouched. An admin metadata edit must not zero a
+    report's spend or orphan the archive the one re-push depends on.
+    """
+    with conn:
+        conn.execute(
+            """
+            INSERT INTO reports (
+                slug, title, tenant_id, agent_name, cap_usd, spent_usd,
+                seam_token, seam_status, created_at
+            )
+            VALUES (
+                :slug, :title, :tenant_id, :agent_name, :cap_usd, 0,
+                :agent_token, 'ok', :created_at
+            )
+            ON CONFLICT(slug) DO UPDATE SET
+                title = excluded.title,
+                tenant_id = excluded.tenant_id,
+                agent_name = excluded.agent_name,
+                cap_usd = excluded.cap_usd,
+                seam_token = excluded.seam_token,
+                seam_status = 'ok'
+            """,
+            {
+                "slug": slug,
+                "title": title,
+                "tenant_id": tenant_id,
+                "agent_name": agent_name,
+                "cap_usd": to_micros(cap_usd),
+                "agent_token": agent_token,
+                "created_at": dt_to_text(now),
+            },
+        )
+    report = load_report(conn, slug=slug)
+    if report is None:
+        raise RuntimeError(f"report {slug!r} vanished immediately after save_report")
+    return report
+
+
+def delete_report(conn: sqlite3.Connection, *, slug: str) -> bool:
+    """Delete a report (cascading to its recipients and revisions).
+
+    Returns whether a row was actually removed, so a caller can distinguish
+    a wrong slug from a real deletion.
+    """
+    with conn:
+        cur = conn.execute("DELETE FROM reports WHERE slug = ?", (slug,))
+    return cur.rowcount > 0
+
+
+def save_bundle_reference(
+    conn: sqlite3.Connection,
+    *,
+    slug: str,
+    handle: str,
+    sha256: str,
+    expires_at: datetime,
+    archive_path: str,
+) -> None:
+    """Record a freshly pushed bundle and the archive that produced it.
+
+    All four fields move together in one statement: a handle saved without
+    the archive path that produced it is a re-push that cannot happen, so
+    these are not separate setters.
+    """
+    with conn:
+        conn.execute(
+            """
+            UPDATE reports
+            SET bundle_handle = :handle,
+                bundle_sha256 = :sha256,
+                bundle_expires_at = :expires_at,
+                archive_path = :archive_path
+            WHERE slug = :slug
+            """,
+            {
+                "slug": slug,
+                "handle": handle,
+                "sha256": sha256,
+                "expires_at": dt_to_text(expires_at),
+                "archive_path": archive_path,
+            },
+        )
+
+
+def set_seam_status(conn: sqlite3.Connection, *, slug: str, status: SeamStatus) -> None:
+    with conn:
+        conn.execute("UPDATE reports SET seam_status = ? WHERE slug = ?", (status, slug))
+
+
+def reserve_budget(conn: sqlite3.Connection, *, slug: str, amount: Decimal) -> Decimal | None:
+    """Atomically add ``amount`` to a report's spend if it still fits under the cap.
+
+    One conditional ``UPDATE ... RETURNING``, with no preceding read of
+    ``spent_usd``. Two concurrent readers racing this function cannot both
+    pass: the ``WHERE`` clause is evaluated against the row as SQLite's
+    writer serialization sees it at ``UPDATE`` time, never against a value
+    either caller read earlier. Returns the new spend on success, ``None``
+    when the reservation would exceed the cap (the spend is left unchanged).
+    """
+    with conn:
+        cur = conn.execute(
+            """
+            UPDATE reports
+            SET spent_usd = spent_usd + :amount
+            WHERE slug = :slug AND spent_usd + :amount <= cap_usd
+            RETURNING spent_usd
+            """,
+            {"slug": slug, "amount": to_micros(amount)},
+        )
+        row = cur.fetchone()
+    return from_micros(row["spent_usd"]) if row is not None else None
+
+
+def settle_budget(
+    conn: sqlite3.Connection, *, slug: str, reserved: Decimal, actual: Decimal | None
+) -> None:
+    """Replace a prior reservation with the real cost once a turn ends.
+
+    When ``actual`` is ``None`` (an unpriced model), the reservation is left
+    in place rather than refunded — an unknown cost is not a zero cost.
+    """
+    if actual is None:
+        return
+    delta = to_micros(actual) - to_micros(reserved)
+    with conn:
+        conn.execute(
+            "UPDATE reports SET spent_usd = spent_usd + :delta WHERE slug = :slug",
+            {"slug": slug, "delta": delta},
+        )
+
+
+def add_recipient(
+    conn: sqlite3.Connection,
+    *,
+    slug: str,
+    name: str,
+    label: str,
+    token: str,
+    now: datetime,
+    ttl_days: int,
+) -> RecipientRow:
+    expires_at = now + timedelta(days=ttl_days)
+    with conn:
+        conn.execute(
+            """
+            INSERT INTO recipients (token, slug, name, label, created_at, expires_at)
+            VALUES (:token, :slug, :name, :label, :created_at, :expires_at)
+            """,
+            {
+                "token": token,
+                "slug": slug,
+                "name": name,
+                "label": label,
+                "created_at": dt_to_text(now),
+                "expires_at": dt_to_text(expires_at),
+            },
+        )
+    return RecipientRow(
+        token=token,
+        slug=slug,
+        name=name,
+        label=label,
+        created_at=now,
+        expires_at=expires_at,
+        revoked_at=None,
+    )
+
+
+def load_recipient(
+    conn: sqlite3.Connection, *, slug: str, token: str, now: datetime
+) -> RecipientRow | None:
+    """Look up a recipient. Returns ``None`` for an unknown, revoked, or expired token."""
+    row = conn.execute(
+        """
+        SELECT * FROM recipients
+        WHERE slug = ? AND token = ? AND revoked_at IS NULL AND expires_at > ?
+        """,
+        (slug, token, dt_to_text(now)),
+    ).fetchone()
+    return _row_to_recipient(row) if row is not None else None
+
+
+def revoke_recipient(conn: sqlite3.Connection, *, slug: str, token: str, now: datetime) -> bool:
+    with conn:
+        cur = conn.execute(
+            """
+            UPDATE recipients SET revoked_at = ?
+            WHERE slug = ? AND token = ? AND revoked_at IS NULL
+            """,
+            (dt_to_text(now), slug, token),
+        )
+    return cur.rowcount > 0
+
+
+def list_recipients(conn: sqlite3.Connection, *, slug: str) -> list[RecipientRow]:
+    rows = conn.execute(
+        "SELECT * FROM recipients WHERE slug = ? ORDER BY created_at", (slug,)
+    ).fetchall()
+    return [_row_to_recipient(row) for row in rows]
+
+
+def add_revision(
+    conn: sqlite3.Connection,
+    *,
+    slug: str,
+    name: str,
+    by_thread: str | None,
+    note: str | None,
+    now: datetime,
+) -> RevisionRow:
+    with conn:
+        conn.execute(
+            """
+            INSERT INTO revisions (slug, name, created_at, by_thread, note)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (slug, name, dt_to_text(now), by_thread, note),
+        )
+    return RevisionRow(slug=slug, name=name, created_at=now, by_thread=by_thread, note=note)
+
+
+def list_revisions(conn: sqlite3.Connection, *, slug: str) -> list[RevisionRow]:
+    rows = conn.execute(
+        "SELECT * FROM revisions WHERE slug = ? ORDER BY created_at", (slug,)
+    ).fetchall()
+    return [_row_to_revision(row) for row in rows]
+
+
+def set_current_pdf(conn: sqlite3.Connection, *, slug: str, name: str) -> None:
+    with conn:
+        conn.execute("UPDATE reports SET current_pdf = ? WHERE slug = ?", (name, slug))

--- a/apps/report-host/src/report_host/routes.py
+++ b/apps/report-host/src/report_host/routes.py
@@ -1,0 +1,206 @@
+"""Reader-facing routes: the viewer, state and thread reads, and the files route.
+
+The only part of the report host a browser ever reaches. Every route resolves
+a per-recipient link token first, through the ``resolve_recipient`` dependency
+built inside ``build_reader_router``, and every read below it is scoped to
+that recipient (and, for threads, to the report's own slug) — the
+store-level three-way scope ``threads_store.load_thread`` enforces. Unknown,
+revoked and expired tokens are indistinguishable to a caller: one 403, one
+message, so a guess learns nothing (T-21-15-A).
+
+Admin, upload-token-consuming and publish routes are NOT here — they land in
+later plans. This module owns only what a report's reader can reach.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from report_host import reports_store, threads_store
+from report_host.config import Settings
+from report_host.mcp_client import SeamClient
+from report_host.reports_store import RecipientRow, SeamStatus
+from report_host.threads_store import Role, ThreadStatus
+
+_VIEWER_DIR = Path(__file__).parent / "viewer"
+
+# A single literal for every reason a recipient dependency can fail: unknown
+# token, revoked token, expired token. A reader whose link expired and a
+# stranger guessing tokens get the same answer (T-21-15-A).
+_RECIPIENT_INVALID_MESSAGE = "this link is not valid for this report"
+
+
+class BudgetOut(BaseModel):
+    cap_usd: Decimal
+    spent_usd: Decimal
+    reserve_usd: Decimal
+
+
+class RevisionOut(BaseModel):
+    name: str
+    created_at: datetime
+    note: str | None
+
+
+class ThreadSummary(BaseModel):
+    id: int
+    title: str
+    status: ThreadStatus
+    created_at: datetime
+
+
+class StateResponse(BaseModel):
+    slug: str
+    title: str
+    current_pdf: str | None
+    revisions: list[RevisionOut]
+    budget: BudgetOut
+    seam_status: SeamStatus
+    recipient_name: str
+    threads: list[ThreadSummary]
+
+
+class MessageOut(BaseModel):
+    id: int
+    role: Role
+    text: str
+    created_at: datetime
+
+
+class ThreadDetailResponse(BaseModel):
+    id: int
+    status: ThreadStatus
+    elapsed_seconds: float | None
+    messages: list[MessageOut]
+
+
+def _validate_pdf_name(name: str) -> None:
+    """Reject a traversal-shaped or non-PDF name before any path is built."""
+    if "/" in name or "\\" in name or ".." in name or not name.endswith(".pdf"):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="invalid file name")
+
+
+def build_reader_router(
+    *,
+    settings: Settings,
+    conn_factory: Callable[[], sqlite3.Connection],
+    seam: SeamClient,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> APIRouter:
+    """Build the reader-facing router.
+
+    ``conn_factory`` is called exactly once, here, to obtain the single
+    SQLite connection every route in this router shares — mirroring the
+    one-connection design ``reports_store``/``threads_store`` are built
+    around; production passes a factory that calls
+    ``reports_store.connect(settings.data_dir)``, tests pass a lambda
+    returning an already-open connection over a ``tmp_path`` file. ``now``
+    is injected (never a global clock) so tests can control it. ``seam`` is
+    unused by the routes in this file and consumed by ``ask``/``cancel``/
+    ``close``, added in a later commit in this same plan.
+    """
+    conn = conn_factory()
+    router = APIRouter()
+    router.mount("/viewer", StaticFiles(directory=_VIEWER_DIR), name="viewer-assets")
+
+    def resolve_recipient(slug: str, request: Request) -> RecipientRow:
+        token = request.query_params.get("k") or request.cookies.get(f"rh_{slug}")
+        recipient = (
+            reports_store.load_recipient(conn, slug=slug, token=token, now=now()) if token else None
+        )
+        if recipient is None:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail=_RECIPIENT_INVALID_MESSAGE)
+        return recipient
+
+    @router.get("/r/{slug}")
+    def get_viewer(  # pyright: ignore[reportUnusedFunction]
+        slug: str, recipient: Annotated[RecipientRow, Depends(resolve_recipient)]
+    ) -> HTMLResponse:
+        html = (_VIEWER_DIR / "index.html").read_text()
+        response = HTMLResponse(html)
+        response.set_cookie(
+            f"rh_{slug}",
+            recipient.token,
+            httponly=True,
+            samesite="lax",
+            secure=True,
+            max_age=settings.recipient_link_ttl_days * 86400,
+        )
+        return response
+
+    @router.get("/api/{slug}/state")
+    def get_state(  # pyright: ignore[reportUnusedFunction]
+        slug: str, recipient: Annotated[RecipientRow, Depends(resolve_recipient)]
+    ) -> StateResponse:
+        report = reports_store.load_report(conn, slug=slug)
+        if report is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        revisions = reports_store.list_revisions(conn, slug=slug)
+        threads = threads_store.list_threads(conn, slug=slug, recipient_token=recipient.token)
+        return StateResponse(
+            slug=slug,
+            title=report.title,
+            current_pdf=report.current_pdf,
+            revisions=[
+                RevisionOut(name=r.name, created_at=r.created_at, note=r.note) for r in revisions
+            ],
+            budget=BudgetOut(
+                cap_usd=report.cap_usd,
+                spent_usd=report.spent_usd,
+                reserve_usd=settings.reserve_usd,
+            ),
+            seam_status=report.seam_status,
+            recipient_name=recipient.name,
+            threads=[
+                ThreadSummary(id=t.id, title=t.title, status=t.status, created_at=t.created_at)
+                for t in threads
+            ],
+        )
+
+    @router.get("/api/{slug}/threads/{thread_id}")
+    def get_thread(  # pyright: ignore[reportUnusedFunction]
+        slug: str,
+        thread_id: int,
+        recipient: Annotated[RecipientRow, Depends(resolve_recipient)],
+        after: int = 0,
+    ) -> ThreadDetailResponse:
+        thread = threads_store.load_thread(
+            conn, thread_id=thread_id, slug=slug, recipient_token=recipient.token
+        )
+        if thread is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        elapsed_seconds: float | None = None
+        if thread.status == "running" and thread.turn_started_at is not None:
+            elapsed_seconds = (now() - thread.turn_started_at).total_seconds()
+        messages = threads_store.list_messages(conn, thread_id=thread.id, after_id=after)
+        return ThreadDetailResponse(
+            id=thread.id,
+            status=thread.status,
+            elapsed_seconds=elapsed_seconds,
+            messages=[
+                MessageOut(id=m.id, role=m.role, text=m.text, created_at=m.created_at)
+                for m in messages
+            ],
+        )
+
+    @router.get("/files/{slug}/{name}")
+    def get_file(  # pyright: ignore[reportUnusedFunction]
+        slug: str, name: str, recipient: Annotated[RecipientRow, Depends(resolve_recipient)]
+    ) -> FileResponse:
+        _validate_pdf_name(name)
+        path = settings.data_dir / slug / name
+        if not path.is_file():
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        return FileResponse(path, media_type="application/pdf")
+
+    return router

--- a/apps/report-host/src/report_host/routes.py
+++ b/apps/report-host/src/report_host/routes.py
@@ -12,8 +12,6 @@ Admin, upload-token-consuming and publish routes are NOT here — they land in
 later plans. This module owns only what a report's reader can reach.
 """
 
-from __future__ import annotations
-
 import secrets
 import sqlite3
 from collections.abc import Awaitable, Callable
@@ -141,7 +139,7 @@ def build_reader_router(
     router = APIRouter()
     router.mount("/viewer", StaticFiles(directory=_VIEWER_DIR), name="viewer-assets")
 
-    def resolve_recipient(slug: str, request: Request) -> RecipientRow:
+    async def resolve_recipient(slug: str, request: Request) -> RecipientRow:
         token = request.query_params.get("k") or request.cookies.get(f"rh_{slug}")
         recipient = (
             reports_store.load_recipient(conn, slug=slug, token=token, now=now()) if token else None
@@ -151,7 +149,7 @@ def build_reader_router(
         return recipient
 
     @router.get("/r/{slug}")
-    def get_viewer(  # pyright: ignore[reportUnusedFunction]
+    async def get_viewer(  # pyright: ignore[reportUnusedFunction]
         slug: str, recipient: Annotated[RecipientRow, Depends(resolve_recipient)]
     ) -> HTMLResponse:
         html = (_VIEWER_DIR / "index.html").read_text()
@@ -167,7 +165,7 @@ def build_reader_router(
         return response
 
     @router.get("/api/{slug}/state")
-    def get_state(  # pyright: ignore[reportUnusedFunction]
+    async def get_state(  # pyright: ignore[reportUnusedFunction]
         slug: str, recipient: Annotated[RecipientRow, Depends(resolve_recipient)]
     ) -> StateResponse:
         report = reports_store.load_report(conn, slug=slug)
@@ -196,7 +194,7 @@ def build_reader_router(
         )
 
     @router.get("/api/{slug}/threads/{thread_id}")
-    def get_thread(  # pyright: ignore[reportUnusedFunction]
+    async def get_thread(  # pyright: ignore[reportUnusedFunction]
         slug: str,
         thread_id: int,
         recipient: Annotated[RecipientRow, Depends(resolve_recipient)],
@@ -222,7 +220,7 @@ def build_reader_router(
         )
 
     @router.get("/files/{slug}/{name}")
-    def get_file(  # pyright: ignore[reportUnusedFunction]
+    async def get_file(  # pyright: ignore[reportUnusedFunction]
         slug: str, name: str, recipient: Annotated[RecipientRow, Depends(resolve_recipient)]
     ) -> FileResponse:
         _validate_pdf_name(name)
@@ -237,8 +235,8 @@ def build_reader_router(
     async def ask(  # pyright: ignore[reportUnusedFunction]
         slug: str,
         body: AskRequest,
-        recipient: Annotated[RecipientRow, Depends(resolve_recipient)],
         background_tasks: BackgroundTasks,
+        recipient: Annotated[RecipientRow, Depends(resolve_recipient)],
     ) -> AskResponse:
         report = reports_store.load_report(conn, slug=slug)
         if report is None:

--- a/apps/report-host/src/report_host/routes.py
+++ b/apps/report-host/src/report_host/routes.py
@@ -1,9 +1,9 @@
-"""Reader-facing routes: the viewer, state and thread reads, and the files route.
+"""Reader-facing routes: the viewer, state and thread reads, ask, cancel, close, files.
 
 The only part of the report host a browser ever reaches. Every route resolves
 a per-recipient link token first, through the ``resolve_recipient`` dependency
-built inside ``build_reader_router``, and every read below it is scoped to
-that recipient (and, for threads, to the report's own slug) — the
+built inside ``build_reader_router``, and every read and write below it is
+scoped to that recipient (and, for threads, to the report's own slug) — the
 store-level three-way scope ``threads_store.load_thread`` enforces. Unknown,
 revoked and expired tokens are indistinguishable to a caller: one 403, one
 message, so a guess learns nothing (T-21-15-A).
@@ -14,19 +14,20 @@ later plans. This module owns only what a report's reader can reach.
 
 from __future__ import annotations
 
+import secrets
 import sqlite3
-from collections.abc import Callable
-from datetime import UTC, datetime
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from report_host import reports_store, threads_store
+from report_host import reports_store, threads_store, turns
 from report_host.config import Settings
 from report_host.mcp_client import SeamClient
 from report_host.reports_store import RecipientRow, SeamStatus
@@ -38,6 +39,14 @@ _VIEWER_DIR = Path(__file__).parent / "viewer"
 # token, revoked token, expired token. A reader whose link expired and a
 # stranger guessing tokens get the same answer (T-21-15-A).
 _RECIPIENT_INVALID_MESSAGE = "this link is not valid for this report"
+_REPORT_UNAUTHORIZED_MESSAGE = (
+    "this report's connection to daimon has expired; ask the publisher to re-publish it"
+)
+_CAP_RUNNING_MESSAGE = "daimon is busy answering other questions on this report; try again shortly"
+_CAP_OPEN_THREADS_MESSAGE = "close a conversation before starting another one"
+_THREAD_BUSY_MESSAGE = "daimon is still answering the previous question in this thread"
+_THREAD_NOT_RUNNING_MESSAGE = "this thread is not running"
+_CANCEL_MESSAGE = "This question was stopped. It is still billed for what it consumed."
 
 
 class BudgetOut(BaseModel):
@@ -84,6 +93,23 @@ class ThreadDetailResponse(BaseModel):
     messages: list[MessageOut]
 
 
+class AskRequest(BaseModel):
+    message: str
+    thread: int | None = None
+
+
+class AskResponse(BaseModel):
+    thread: int
+
+
+class CancelResponse(BaseModel):
+    status: str
+
+
+class CloseResponse(BaseModel):
+    status: str
+
+
 def _validate_pdf_name(name: str) -> None:
     """Reject a traversal-shaped or non-PDF name before any path is built."""
     if "/" in name or "\\" in name or ".." in name or not name.endswith(".pdf"):
@@ -96,6 +122,7 @@ def build_reader_router(
     conn_factory: Callable[[], sqlite3.Connection],
     seam: SeamClient,
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    run_turn: Callable[..., Awaitable[None]] = turns.run_turn,
 ) -> APIRouter:
     """Build the reader-facing router.
 
@@ -105,9 +132,10 @@ def build_reader_router(
     around; production passes a factory that calls
     ``reports_store.connect(settings.data_dir)``, tests pass a lambda
     returning an already-open connection over a ``tmp_path`` file. ``now``
-    is injected (never a global clock) so tests can control it. ``seam`` is
-    unused by the routes in this file and consumed by ``ask``/``cancel``/
-    ``close``, added in a later commit in this same plan.
+    and ``run_turn`` are injected (never a global clock, never a hardcoded
+    turn driver) so tests can control both without driving a real seam turn
+    end to end — ``ask`` schedules ``run_turn`` as a background task and
+    never awaits it itself.
     """
     conn = conn_factory()
     router = APIRouter()
@@ -202,5 +230,146 @@ def build_reader_router(
         if not path.is_file():
             raise HTTPException(status.HTTP_404_NOT_FOUND)
         return FileResponse(path, media_type="application/pdf")
+
+    # -- Task 2: ask, cancel, close ---------------------------------------
+
+    @router.post("/api/{slug}/ask")
+    async def ask(  # pyright: ignore[reportUnusedFunction]
+        slug: str,
+        body: AskRequest,
+        recipient: Annotated[RecipientRow, Depends(resolve_recipient)],
+        background_tasks: BackgroundTasks,
+    ) -> AskResponse:
+        report = reports_store.load_report(conn, slug=slug)
+        if report is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        if report.seam_status == "unauthorized":
+            raise HTTPException(status.HTTP_409_CONFLICT, detail=_REPORT_UNAUTHORIZED_MESSAGE)
+
+        # Both caps, before any spend, seam call, or run_turn schedule.
+        if (
+            threads_store.count_running_turns(conn, slug=slug)
+            >= settings.max_running_turns_per_report
+        ):
+            raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, detail=_CAP_RUNNING_MESSAGE)
+        is_new_thread = body.thread is None
+        if (
+            is_new_thread
+            and threads_store.count_open_threads(conn, slug=slug, recipient_token=recipient.token)
+            >= settings.max_open_threads_per_recipient
+        ):
+            raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, detail=_CAP_OPEN_THREADS_MESSAGE)
+
+        if body.thread is not None:
+            thread = threads_store.load_thread(
+                conn, thread_id=body.thread, slug=slug, recipient_token=recipient.token
+            )
+            if thread is None:
+                raise HTTPException(status.HTTP_404_NOT_FOUND)
+        else:
+            thread = threads_store.create_thread(
+                conn,
+                slug=slug,
+                recipient_token=recipient.token,
+                title=body.message[:60],
+                now=now(),
+            )
+
+        began = threads_store.begin_turn(
+            conn,
+            thread_id=thread.id,
+            reserved_usd=settings.reserve_usd,
+            deadline_at=now() + timedelta(seconds=settings.turn_timeout_seconds),
+            now=now(),
+        )
+        if not began:
+            raise HTTPException(status.HTTP_409_CONFLICT, detail=_THREAD_BUSY_MESSAGE)
+        thread = threads_store.load_thread(
+            conn, thread_id=thread.id, slug=slug, recipient_token=recipient.token
+        )
+        assert thread is not None  # this exact row just transitioned to running, above
+
+        upload_token = secrets.token_urlsafe(24)
+        reports_store.create_upload_token(
+            conn, token=upload_token, slug=slug, thread_id=thread.id, now=now()
+        )
+        upload_url = f"{settings.public_url_base}upload/{upload_token}"
+        # The reader persona lives in the reader agent's own prompt and skill;
+        # this preamble only orients the agent to the viewer and the upload
+        # command, so the two never drift out of sync.
+        if thread.handle is None:
+            preamble = (
+                f"You are answering {recipient.name}, who is looking at this report in a "
+                "viewer beside this chat. If you produce a revised PDF this turn, upload it "
+                f"with exactly: curl -sS -T <file.pdf> '{upload_url}'\n\n"
+            )
+        else:
+            preamble = (
+                "(If you produce a revised PDF this turn, upload it with: "
+                f"curl -sS -T <file.pdf> '{upload_url}')\n\n"
+            )
+
+        threads_store.add_message(
+            conn,
+            thread_id=thread.id,
+            role="user",
+            text=body.message,
+            now=now(),
+            bundle_sha256=None,
+            pdf_revision=None,
+        )
+        background_tasks.add_task(
+            run_turn,
+            conn=conn,
+            seam=seam,
+            settings=settings,
+            thread=thread,
+            message=preamble + body.message,
+            now=now,
+        )
+        return AskResponse(thread=thread.id)
+
+    @router.post("/api/{slug}/threads/{thread_id}/cancel")
+    async def cancel(  # pyright: ignore[reportUnusedFunction]
+        slug: str, thread_id: int, recipient: Annotated[RecipientRow, Depends(resolve_recipient)]
+    ) -> CancelResponse:
+        thread = threads_store.load_thread(
+            conn, thread_id=thread_id, slug=slug, recipient_token=recipient.token
+        )
+        if thread is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        if thread.status != "running" or thread.handle is None:
+            raise HTTPException(status.HTTP_409_CONFLICT, detail=_THREAD_NOT_RUNNING_MESSAGE)
+        report = reports_store.load_report(conn, slug=slug)
+        if report is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        result = await seam.cancel_turn(token=report.seam_token, handle=thread.handle)
+        threads_store.add_message(
+            conn,
+            thread_id=thread.id,
+            role="system",
+            text=_CANCEL_MESSAGE,
+            now=now(),
+            bundle_sha256=None,
+            pdf_revision=None,
+        )
+        return CancelResponse(status=result.status)
+
+    @router.post("/api/{slug}/threads/{thread_id}/close")
+    async def close(  # pyright: ignore[reportUnusedFunction]
+        slug: str, thread_id: int, recipient: Annotated[RecipientRow, Depends(resolve_recipient)]
+    ) -> CloseResponse:
+        thread = threads_store.load_thread(
+            conn, thread_id=thread_id, slug=slug, recipient_token=recipient.token
+        )
+        if thread is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        if thread.archived_at is not None:
+            return CloseResponse(status="archived")  # idempotent: already closed
+        report = reports_store.load_report(conn, slug=slug)
+        if report is not None and thread.handle is not None:
+            await seam.archive_session(token=report.seam_token, handle=thread.handle)
+        threads_store.archive_thread(conn, thread_id=thread.id, now=now())
+        return CloseResponse(status="archived")
 
     return router

--- a/apps/report-host/src/report_host/sweeps.py
+++ b/apps/report-host/src/report_host/sweeps.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta
 from decimal import Decimal
+from typing import Any
 
 from report_host import reports_store, threads_store, turns
 from report_host.config import Settings
@@ -44,8 +45,8 @@ async def resume_running_threads(
     seam: SeamClient,
     settings: Settings,
     now: Callable[[], datetime],
-    schedule: Callable[[Awaitable[None]], object],
-    run_turn: Callable[..., Awaitable[None]] = turns.run_turn,
+    schedule: Callable[[Coroutine[Any, Any, None]], object],
+    run_turn: Callable[..., Coroutine[Any, Any, None]] = turns.run_turn,
 ) -> int:
     """Re-attach to every thread the host left ``running`` across a restart.
 

--- a/apps/report-host/src/report_host/sweeps.py
+++ b/apps/report-host/src/report_host/sweeps.py
@@ -1,0 +1,177 @@
+"""Restart-resume, deadline-cancel, idle-archive and recipient-expiry sweeps.
+
+Every function takes its collaborators explicitly — a connection, the seam
+client, the settings, an injected clock, and (for the resume pass) the
+scheduler used to launch a re-attach and the turn driver itself. No
+module-level state, no clock reached for from inside.
+
+The prototype (``spikes/report-host/host/app.py``) hit this restart problem
+head-on: a deploy mid-turn surfaced a raw ``'NoneType' object is not
+subscriptable`` because its poll task died while the seam turn kept running.
+These four sweeps are the host's cleanup: re-attach to what survived a
+restart, cancel what timed out while the host was down, archive what has
+sat idle too long, and prune what has expired — one bad row must never abort
+a whole pass (T-21-18-G), so every loop below catches per item, logs, and
+continues.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from report_host import reports_store, threads_store, turns
+from report_host.config import Settings
+from report_host.mcp_client import SeamClient
+
+log = logging.getLogger(__name__)
+
+_RESTART_ASK_AGAIN_MESSAGE = (
+    "The report host restarted before daimon received this question. Please ask it again."
+)
+_DEADLINE_CANCELLED_MESSAGE = (
+    "This question was not answered within the time limit and has been stopped. "
+    "It is still billed for what it consumed."
+)
+
+
+async def resume_running_threads(
+    *,
+    conn: sqlite3.Connection,
+    seam: SeamClient,
+    settings: Settings,
+    now: Callable[[], datetime],
+    schedule: Callable[[Awaitable[None]], object],
+    run_turn: Callable[..., Awaitable[None]] = turns.run_turn,
+) -> int:
+    """Re-attach to every thread the host left ``running`` across a restart.
+
+    A thread with no bound ``handle`` never reached the seam — the question
+    was lost before it was ever sent. Tell the reader to ask again, release
+    the reservation (no seam turn ever ran, so there is nothing to bill),
+    and end the turn; never schedule anything for it. A thread with a
+    handle is a turn the seam is still running server-side: schedule
+    ``run_turn(..., message=None)`` so the poller resumes exactly where it
+    left off, distinguishing "lost" from "still running" (T-21-18-A,
+    T-21-18-C). Returns how many re-attaches were scheduled.
+    """
+    resumed = 0
+    for thread in threads_store.list_running_threads(conn):
+        try:
+            if thread.handle is None:
+                threads_store.add_message(
+                    conn,
+                    thread_id=thread.id,
+                    role="system",
+                    text=_RESTART_ASK_AGAIN_MESSAGE,
+                    now=now(),
+                    bundle_sha256=None,
+                    pdf_revision=None,
+                )
+                if thread.reserved_usd is not None:
+                    reports_store.settle_budget(
+                        conn, slug=thread.slug, reserved=thread.reserved_usd, actual=Decimal(0)
+                    )
+                threads_store.end_turn(conn, thread_id=thread.id, now=now())
+                continue
+            schedule(
+                run_turn(
+                    conn=conn,
+                    seam=seam,
+                    settings=settings,
+                    thread=thread,
+                    message=None,
+                    now=now,
+                )
+            )
+            resumed += 1
+        except Exception:
+            log.exception("resume failed for thread=%s; continuing", thread.id)
+            continue
+    return resumed
+
+
+async def cancel_expired_turns(
+    *, conn: sqlite3.Connection, seam: SeamClient, settings: Settings, now: Callable[[], datetime]
+) -> int:
+    """Cancel a running turn whose deadline passed while the host was down.
+
+    Left unwatched, such a turn would run to completion with no poller
+    watching it settle (T-21-18-A — this is the after-a-restart case; a live
+    host's own ``run_turn`` already cancels at its deadline itself). Calls
+    ``cancel_turn`` once and stores the billing-disclosure message, then
+    leaves the thread ``running`` — the poller (re-attached by
+    ``resume_running_threads``) reaches the seam's own terminal state and
+    settles the reservation itself; this sweep never ends a turn. Returns
+    how many were cancelled.
+    """
+    cancelled = 0
+    current = now()
+    for thread in threads_store.list_running_threads(conn):
+        try:
+            if thread.handle is None or thread.turn_deadline_at is None:
+                continue
+            if thread.turn_deadline_at > current:
+                continue
+            report = reports_store.load_report(conn, slug=thread.slug)
+            if report is None:
+                continue
+            await seam.cancel_turn(token=report.seam_token, handle=thread.handle)
+            threads_store.add_message(
+                conn,
+                thread_id=thread.id,
+                role="system",
+                text=_DEADLINE_CANCELLED_MESSAGE,
+                now=now(),
+                bundle_sha256=report.bundle_sha256,
+                pdf_revision=report.current_pdf,
+            )
+            cancelled += 1
+        except Exception:
+            log.exception("deadline cancel failed for thread=%s; continuing", thread.id)
+            continue
+    return cancelled
+
+
+async def archive_idle_threads(
+    *, conn: sqlite3.Connection, seam: SeamClient, settings: Settings, now: Callable[[], datetime]
+) -> int:
+    """Archive, upstream then locally, every thread idle past the configured window.
+
+    The seam call must succeed before the local archive happens (T-21-18-B):
+    a local-only archive would hide a session that is still live upstream
+    and never reclaimed by the seam's own usage sweep. A seam failure on one
+    thread must not stop the others. A thread that never bound a handle
+    (idle without ever running a turn) has nothing to archive upstream and
+    is archived locally outright. Returns how many were archived.
+    """
+    cutoff = now() - timedelta(hours=settings.thread_idle_archive_hours)
+    archived = 0
+    for thread in threads_store.list_threads_idle_since(conn, cutoff=cutoff):
+        try:
+            if thread.handle is not None:
+                report = reports_store.load_report(conn, slug=thread.slug)
+                if report is None:
+                    continue
+                await seam.archive_session(token=report.seam_token, handle=thread.handle)
+            threads_store.archive_thread(conn, thread_id=thread.id, now=now())
+            archived += 1
+        except Exception:
+            log.exception("idle archive failed for thread=%s; continuing", thread.id)
+            continue
+    return archived
+
+
+def prune_expired_recipients(*, conn: sqlite3.Connection, now: Callable[[], datetime]) -> int:
+    """Delete recipient rows past their expiry.
+
+    Belt and braces: expiry is already enforced at the reader route
+    (``reports_store.load_recipient``'s own ``expires_at`` check), but
+    pruning keeps the table from growing forever and keeps a link dead even
+    if that route-level check were ever relaxed (T-21-18-E). Returns how
+    many rows were removed.
+    """
+    return reports_store.prune_expired_recipients(conn, now=now())

--- a/apps/report-host/src/report_host/threads_store.py
+++ b/apps/report-host/src/report_host/threads_store.py
@@ -197,6 +197,19 @@ def load_thread(
     return _row_to_thread(row) if row is not None else None
 
 
+def load_thread_by_id(conn: sqlite3.Connection, *, thread_id: int) -> ThreadRow | None:
+    """Look up a thread by id alone, with no recipient or slug scope.
+
+    Reader-facing code always goes through `load_thread`'s three-way scope
+    (T-21-12-A). This unscoped lookup exists only for the upload route,
+    which authorises by a per-turn token that already names its own thread
+    id and has no recipient token to scope by — it still needs to read that
+    thread's current status to refuse a token whose turn has already ended.
+    """
+    row = conn.execute("SELECT * FROM threads WHERE id = ?", (thread_id,)).fetchone()
+    return _row_to_thread(row) if row is not None else None
+
+
 def list_threads(conn: sqlite3.Connection, *, slug: str, recipient_token: str) -> list[ThreadRow]:
     rows = conn.execute(
         "SELECT * FROM threads WHERE slug = ? AND recipient_token = ? ORDER BY created_at",

--- a/apps/report-host/src/report_host/threads_store.py
+++ b/apps/report-host/src/report_host/threads_store.py
@@ -38,7 +38,7 @@ from typing import Literal
 from report_host.reports_store import dt_to_text, from_micros, text_to_dt, to_micros
 
 ThreadStatus = Literal["idle", "running"]
-Role = Literal["user", "assistant"]
+Role = Literal["user", "assistant", "system"]
 
 # Alias for the connection's row type (row_factory is set once, in
 # reports_store.connect()), so the mapping helpers below share one spelling.

--- a/apps/report-host/src/report_host/threads_store.py
+++ b/apps/report-host/src/report_host/threads_store.py
@@ -1,0 +1,372 @@
+"""Durable store for threads, their per-turn boundary, and grounded messages.
+
+Shares one SQLite file and one connection with ``reports_store``: this
+module owns the DDL for ``threads`` and ``messages`` via ``apply_schema``,
+called once by ``reports_store.connect()`` after that module's own schema.
+This module holds no connection logic of its own and never imports
+``reports_store`` — every function here takes an already-open connection
+(the one ``reports_store.connect()`` returned) as its first parameter, which
+is what lets ``reports_store`` import this module without a cycle.
+
+A thread carries the seam session it belongs to (``handle``) and, per turn,
+the boundary the seam handed back: ``turn_event_id`` and ``turn_started_at``.
+Those two fields are what makes the poller read *this* turn's events rather
+than a previous turn's — the prototype's own failure mode — and both are
+cleared by ``end_turn``. ``begin_turn`` and ``end_turn`` are each a single
+conditional statement, not a read followed by a write: a second question
+racing an in-flight turn in the same thread must be refused by the store,
+not by a route-level check-then-write.
+
+Money (``reserved_usd``) and every timestamp column follow the same
+representation ``reports_store`` documents: INTEGER micro-dollars and
+ISO-8601 TEXT respectively, never ``REAL``.
+
+Every stored message records the bundle digest and PDF revision it was
+grounded in (``bundle_sha256``, ``pdf_revision``) — the audit trail SPEC §3
+requires: every answer must be traceable to the data and the report revision
+it was drawn from.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from report_host.reports_store import dt_to_text, from_micros, text_to_dt, to_micros
+
+ThreadStatus = Literal["idle", "running"]
+Role = Literal["user", "assistant"]
+
+# Alias for the connection's row type (row_factory is set once, in
+# reports_store.connect()), so the mapping helpers below share one spelling.
+Row = sqlite3.Row
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS threads (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT NOT NULL REFERENCES reports(slug) ON DELETE CASCADE,
+    recipient_token TEXT NOT NULL,
+    handle TEXT,
+    title TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'idle',
+    created_at TEXT NOT NULL,
+    idle_since TEXT NOT NULL,
+    turn_started_at TEXT,
+    turn_event_id TEXT,
+    turn_deadline_at TEXT,
+    reserved_usd INTEGER,
+    archived_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id INTEGER NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    text TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    bundle_sha256 TEXT,
+    pdf_revision TEXT
+);
+"""
+
+
+@dataclass(frozen=True)
+class ThreadRow:
+    id: int
+    slug: str
+    recipient_token: str
+    handle: str | None
+    title: str
+    status: ThreadStatus
+    created_at: datetime
+    idle_since: datetime
+    turn_started_at: datetime | None
+    turn_event_id: str | None
+    turn_deadline_at: datetime | None
+    reserved_usd: Decimal | None
+    archived_at: datetime | None
+
+
+@dataclass(frozen=True)
+class MessageRow:
+    id: int
+    thread_id: int
+    role: Role
+    text: str
+    created_at: datetime
+    bundle_sha256: str | None
+    pdf_revision: str | None
+
+
+def apply_schema(conn: sqlite3.Connection) -> None:
+    """Idempotently create the ``threads`` and ``messages`` tables.
+
+    Called once by ``reports_store.connect()``, after that module's own
+    schema (``threads.slug`` references ``reports.slug``). Not meant to be
+    called directly outside that flow, but safe to call more than once.
+    """
+    conn.executescript(_SCHEMA)
+
+
+def _row_to_thread(row: Row) -> ThreadRow:
+    turn_started_at = row["turn_started_at"]
+    turn_deadline_at = row["turn_deadline_at"]
+    reserved_usd = row["reserved_usd"]
+    archived_at = row["archived_at"]
+    return ThreadRow(
+        id=row["id"],
+        slug=row["slug"],
+        recipient_token=row["recipient_token"],
+        handle=row["handle"],
+        title=row["title"],
+        status=row["status"],
+        created_at=text_to_dt(row["created_at"]),
+        idle_since=text_to_dt(row["idle_since"]),
+        turn_started_at=text_to_dt(turn_started_at) if turn_started_at else None,
+        turn_event_id=row["turn_event_id"],
+        turn_deadline_at=text_to_dt(turn_deadline_at) if turn_deadline_at else None,
+        reserved_usd=from_micros(reserved_usd) if reserved_usd is not None else None,
+        archived_at=text_to_dt(archived_at) if archived_at else None,
+    )
+
+
+def _row_to_message(row: Row) -> MessageRow:
+    return MessageRow(
+        id=row["id"],
+        thread_id=row["thread_id"],
+        role=row["role"],
+        text=row["text"],
+        created_at=text_to_dt(row["created_at"]),
+        bundle_sha256=row["bundle_sha256"],
+        pdf_revision=row["pdf_revision"],
+    )
+
+
+def create_thread(
+    conn: sqlite3.Connection, *, slug: str, recipient_token: str, title: str, now: datetime
+) -> ThreadRow:
+    with conn:
+        cur = conn.execute(
+            """
+            INSERT INTO threads (slug, recipient_token, title, status, created_at, idle_since)
+            VALUES (:slug, :recipient_token, :title, 'idle', :created_at, :idle_since)
+            """,
+            {
+                "slug": slug,
+                "recipient_token": recipient_token,
+                "title": title,
+                "created_at": dt_to_text(now),
+                "idle_since": dt_to_text(now),
+            },
+        )
+        thread_id = cur.lastrowid
+    assert thread_id is not None  # AUTOINCREMENT always assigns one on INSERT
+    return ThreadRow(
+        id=thread_id,
+        slug=slug,
+        recipient_token=recipient_token,
+        handle=None,
+        title=title,
+        status="idle",
+        created_at=now,
+        idle_since=now,
+        turn_started_at=None,
+        turn_event_id=None,
+        turn_deadline_at=None,
+        reserved_usd=None,
+        archived_at=None,
+    )
+
+
+def load_thread(
+    conn: sqlite3.Connection, *, thread_id: int, slug: str, recipient_token: str
+) -> ThreadRow | None:
+    """Look up a thread, scoped by id, slug and recipient together.
+
+    A thread id from one recipient is not readable by another, and a thread
+    id from one report is not readable under a different slug — this is the
+    store-level half of the isolation the routes rely on (T-21-12-A).
+    """
+    row = conn.execute(
+        "SELECT * FROM threads WHERE id = ? AND slug = ? AND recipient_token = ?",
+        (thread_id, slug, recipient_token),
+    ).fetchone()
+    return _row_to_thread(row) if row is not None else None
+
+
+def list_threads(conn: sqlite3.Connection, *, slug: str, recipient_token: str) -> list[ThreadRow]:
+    rows = conn.execute(
+        "SELECT * FROM threads WHERE slug = ? AND recipient_token = ? ORDER BY created_at",
+        (slug, recipient_token),
+    ).fetchall()
+    return [_row_to_thread(row) for row in rows]
+
+
+def count_open_threads(conn: sqlite3.Connection, *, slug: str, recipient_token: str) -> int:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS n FROM threads
+        WHERE slug = ? AND recipient_token = ? AND archived_at IS NULL
+        """,
+        (slug, recipient_token),
+    ).fetchone()
+    return int(row["n"])
+
+
+def count_running_turns(conn: sqlite3.Connection, *, slug: str) -> int:
+    row = conn.execute(
+        "SELECT COUNT(*) AS n FROM threads WHERE slug = ? AND status = 'running'",
+        (slug,),
+    ).fetchone()
+    return int(row["n"])
+
+
+def begin_turn(
+    conn: sqlite3.Connection,
+    *,
+    thread_id: int,
+    reserved_usd: Decimal,
+    deadline_at: datetime,
+    now: datetime,
+) -> bool:
+    """Start a turn, unless one is already running in this thread.
+
+    One conditional ``UPDATE``, no preceding read of ``status``: a second
+    question submitted while a turn is running must be refused, and the
+    refusal is this function's return value, not a route-level
+    read-then-write race.
+    """
+    with conn:
+        cur = conn.execute(
+            """
+            UPDATE threads
+            SET status = 'running', turn_started_at = :now, turn_deadline_at = :deadline_at,
+                reserved_usd = :reserved_usd
+            WHERE id = :thread_id AND status != 'running'
+            """,
+            {
+                "thread_id": thread_id,
+                "now": dt_to_text(now),
+                "deadline_at": dt_to_text(deadline_at),
+                "reserved_usd": to_micros(reserved_usd),
+            },
+        )
+    return cur.rowcount == 1
+
+
+def bind_turn_boundary(
+    conn: sqlite3.Connection,
+    *,
+    thread_id: int,
+    handle: str,
+    turn_event_id: str,
+    turn_started_at: datetime,
+) -> None:
+    """Record the seam session id and the exact boundary the seam handed back."""
+    with conn:
+        conn.execute(
+            """
+            UPDATE threads
+            SET handle = :handle, turn_event_id = :turn_event_id, turn_started_at = :turn_started_at
+            WHERE id = :thread_id
+            """,
+            {
+                "thread_id": thread_id,
+                "handle": handle,
+                "turn_event_id": turn_event_id,
+                "turn_started_at": dt_to_text(turn_started_at),
+            },
+        )
+
+
+def end_turn(conn: sqlite3.Connection, *, thread_id: int, now: datetime) -> None:
+    """Clear the turn boundary, the reservation and the deadline; return to idle."""
+    with conn:
+        conn.execute(
+            """
+            UPDATE threads
+            SET status = 'idle', turn_started_at = NULL, turn_event_id = NULL,
+                turn_deadline_at = NULL, reserved_usd = NULL, idle_since = :now
+            WHERE id = :thread_id
+            """,
+            {"thread_id": thread_id, "now": dt_to_text(now)},
+        )
+
+
+def list_running_threads(conn: sqlite3.Connection) -> list[ThreadRow]:
+    """What the restart-resume sweep reads: every thread mid-turn."""
+    rows = conn.execute(
+        "SELECT * FROM threads WHERE status = 'running' ORDER BY turn_started_at"
+    ).fetchall()
+    return [_row_to_thread(row) for row in rows]
+
+
+def archive_thread(conn: sqlite3.Connection, *, thread_id: int, now: datetime) -> None:
+    with conn:
+        conn.execute(
+            "UPDATE threads SET archived_at = ? WHERE id = ?", (dt_to_text(now), thread_id)
+        )
+
+
+def list_threads_idle_since(conn: sqlite3.Connection, *, cutoff: datetime) -> list[ThreadRow]:
+    """What the idle-archive sweep reads: idle, unarchived threads older than ``cutoff``."""
+    rows = conn.execute(
+        """
+        SELECT * FROM threads
+        WHERE status = 'idle' AND archived_at IS NULL AND idle_since < ?
+        ORDER BY idle_since
+        """,
+        (dt_to_text(cutoff),),
+    ).fetchall()
+    return [_row_to_thread(row) for row in rows]
+
+
+def add_message(
+    conn: sqlite3.Connection,
+    *,
+    thread_id: int,
+    role: Role,
+    text: str,
+    now: datetime,
+    bundle_sha256: str | None,
+    pdf_revision: str | None,
+) -> MessageRow:
+    with conn:
+        cur = conn.execute(
+            """
+            INSERT INTO messages (thread_id, role, text, created_at, bundle_sha256, pdf_revision)
+            VALUES (:thread_id, :role, :text, :created_at, :bundle_sha256, :pdf_revision)
+            """,
+            {
+                "thread_id": thread_id,
+                "role": role,
+                "text": text,
+                "created_at": dt_to_text(now),
+                "bundle_sha256": bundle_sha256,
+                "pdf_revision": pdf_revision,
+            },
+        )
+        message_id = cur.lastrowid
+    assert message_id is not None  # AUTOINCREMENT always assigns one on INSERT
+    return MessageRow(
+        id=message_id,
+        thread_id=thread_id,
+        role=role,
+        text=text,
+        created_at=now,
+        bundle_sha256=bundle_sha256,
+        pdf_revision=pdf_revision,
+    )
+
+
+def list_messages(
+    conn: sqlite3.Connection, *, thread_id: int, after_id: int = 0
+) -> list[MessageRow]:
+    rows = conn.execute(
+        "SELECT * FROM messages WHERE thread_id = ? AND id > ? ORDER BY id",
+        (thread_id, after_id),
+    ).fetchall()
+    return [_row_to_message(row) for row in rows]

--- a/apps/report-host/src/report_host/turns.py
+++ b/apps/report-host/src/report_host/turns.py
@@ -2,9 +2,9 @@
 
 Split functional-core / imperative-shell. ``read_turn_progress`` is the pure
 decision: given a session's status and its events since a turn's boundary,
-what new text arrived and is the turn over. ``run_turn`` (the imperative
-shell around it — the only place that calls the seam, sleeps, or touches the
-clock or the database) lands alongside it in this module.
+what new text arrived and is the turn over. ``run_turn`` is the thin
+imperative shell around it — the only place that calls the seam, sleeps, or
+touches the clock or the database.
 
 **The done rule** (SPEC D-07, §1.3): a turn is finished only when a
 ``session.status_idle`` event survives the boundary filter, or
@@ -13,13 +13,53 @@ never trusted — right after a send the session has not started yet and
 reads idle — and ``rescheduling`` counts as running. This is the exact bug
 the prototype (``spikes/report-host/host/app.py``) hit: it trusted a bare
 idle status and ended a follow-up question in three seconds with nothing.
+
+The budget reserved at turn start is reconciled against the seam's real cost
+on ANY terminal path — idle, terminated, cancelled-at-deadline, or a bundle
+push failure — never only on the clean one (SPEC D-06). Every reconciling
+call funnels through the single ``_settle_reservation`` helper below.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import asyncio
+import sqlite3
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
 from typing import Literal, cast
+
+from report_host import reports_store, threads_store
+from report_host.config import Settings
+from report_host.mcp_client import (
+    BundleExpiredError,
+    SeamClient,
+    SeamError,
+    SeamUnauthorizedError,
+)
+from report_host.reports_store import ReportRow
+from report_host.threads_store import ThreadRow
+
+# One fixed, reader-facing message for a bundle the host cannot re-push —
+# either there is no archive on record, the file is no longer on the volume,
+# or it resolves outside `settings.data_dir`. A single constant (not an
+# f-string) so a reader is never shown a filesystem path, a slug, or an
+# exception string, and so tests can assert on it by identity.
+BUNDLE_MISSING_MESSAGE = "this report's files have expired; ask the publisher to re-publish"
+
+_CAP_REACHED_MESSAGE = (
+    "This report has reached its spending cap. No further questions can be answered."
+)
+_UNAUTHORIZED_MESSAGE = (
+    "This report's connection to daimon has expired; ask the publisher to re-publish it."
+)
+_REPORT_MISSING_MESSAGE = "This report could not be found; ask the publisher to re-publish it."
+_DEADLINE_MESSAGE = (
+    "This question was not answered within the time limit and has been stopped. "
+    "It is still billed for what it consumed."
+)
 
 
 @dataclass(frozen=True)
@@ -102,3 +142,260 @@ def read_turn_progress(
         terminal_reason=terminal_reason,
         new_event_ids=frozenset(new_ids),
     )
+
+
+def _settle_reservation(
+    conn: sqlite3.Connection, *, slug: str, reserved: Decimal, actual: Decimal | None
+) -> None:
+    """Replace a reservation with its real outcome — every terminal path funnels here.
+
+    ``actual=None`` keeps the reservation in place (an unpriced turn);
+    ``actual=Decimal("0")`` releases it entirely (no seam turn ever ran, or
+    the report was marked unauthorized before one could).
+    """
+    reports_store.settle_budget(conn, slug=slug, reserved=reserved, actual=actual)
+
+
+def _resolve_archive_path(*, settings: Settings, report: ReportRow) -> Path | None:
+    """Resolve ``report.archive_path`` and confirm it is inside ``data_dir``.
+
+    Returns ``None`` — never raises — when the path is null, is not on the
+    volume, or resolves outside ``settings.data_dir``: the corrupted-row case
+    (T-21-14-H) a hand-edited database row could otherwise turn into reading
+    an arbitrary file. The caller takes the missing-archive branch on
+    ``None`` rather than trusting the path.
+    """
+    if report.archive_path is None:
+        return None
+    data_dir = settings.data_dir.resolve()
+    candidate = Path(report.archive_path).resolve()
+    if not candidate.is_relative_to(data_dir):
+        return None
+    if not candidate.is_file():
+        return None
+    return candidate
+
+
+async def run_turn(
+    *,
+    conn: sqlite3.Connection,
+    seam: SeamClient,
+    settings: Settings,
+    thread: ThreadRow,
+    message: str | None,
+    now: Callable[[], datetime],
+    shutting_down: Callable[[], bool] = lambda: False,
+) -> None:
+    """Drive one turn to a terminal state, with its reserve settled.
+
+    ``message=None`` re-attaches to a turn the seam is already running after
+    a host restart: no send, straight to the poll, using the handle and
+    boundary the thread already carries. Collaborators — including the
+    clock and the shutdown flag — are injected, never read from a global,
+    so a restart's resume sweep and a real reader question call this
+    function identically.
+
+    Exception boundary: this runs as a background task, so it is a
+    legitimate catch site. Only ``SeamError`` is caught, and it is stored as
+    a message the reader can act on; anything else is a bug in the host and
+    propagates.
+    """
+    try:
+        report = reports_store.load_report(conn, slug=thread.slug)
+        if report is None:
+            threads_store.add_message(
+                conn,
+                thread_id=thread.id,
+                role="system",
+                text=_REPORT_MISSING_MESSAGE,
+                now=now(),
+                bundle_sha256=None,
+                pdf_revision=None,
+            )
+            return
+
+        if message is not None:
+            reserved = reports_store.reserve_budget(
+                conn, slug=report.slug, amount=settings.reserve_usd
+            )
+            if reserved is None:
+                threads_store.add_message(
+                    conn,
+                    thread_id=thread.id,
+                    role="system",
+                    text=_CAP_REACHED_MESSAGE,
+                    now=now(),
+                    bundle_sha256=report.bundle_sha256,
+                    pdf_revision=report.current_pdf,
+                )
+                return
+
+            try:
+                if thread.handle is None:
+                    started = await seam.start_turn(
+                        token=report.seam_token, message=message, bundle=report.bundle_handle
+                    )
+                else:
+                    started = await seam.continue_turn(
+                        token=report.seam_token, handle=thread.handle, message=message
+                    )
+            except BundleExpiredError:
+                archive_path = _resolve_archive_path(settings=settings, report=report)
+                if archive_path is None:
+                    threads_store.add_message(
+                        conn,
+                        thread_id=thread.id,
+                        role="system",
+                        text=BUNDLE_MISSING_MESSAGE,
+                        now=now(),
+                        bundle_sha256=report.bundle_sha256,
+                        pdf_revision=report.current_pdf,
+                    )
+                    _settle_reservation(
+                        conn, slug=report.slug, reserved=settings.reserve_usd, actual=Decimal(0)
+                    )
+                    return
+
+                archive_bytes = archive_path.read_bytes()
+                pushed = await seam.push_bundle(
+                    token=report.seam_token,
+                    archive=archive_bytes,
+                    size_bytes=len(archive_bytes),
+                )
+                assert report.archive_path is not None  # archive_path above is its resolution
+                reports_store.save_bundle_reference(
+                    conn,
+                    slug=report.slug,
+                    handle=pushed.handle,
+                    sha256=pushed.sha256,
+                    expires_at=reports_store.text_to_dt(pushed.expires_at),
+                    archive_path=report.archive_path,  # same file: it never moved
+                )
+
+                try:
+                    started = await seam.start_turn(
+                        token=report.seam_token, message=message, bundle=pushed.handle
+                    )
+                except BundleExpiredError:
+                    # The one retry the host performs. A second failure is
+                    # surfaced to the reader with the same fixed message;
+                    # nothing about the archive is retried again.
+                    threads_store.add_message(
+                        conn,
+                        thread_id=thread.id,
+                        role="system",
+                        text=BUNDLE_MISSING_MESSAGE,
+                        now=now(),
+                        bundle_sha256=report.bundle_sha256,
+                        pdf_revision=report.current_pdf,
+                    )
+                    _settle_reservation(
+                        conn, slug=report.slug, reserved=settings.reserve_usd, actual=Decimal(0)
+                    )
+                    return
+            except SeamUnauthorizedError:
+                reports_store.set_seam_status(conn, slug=report.slug, status="unauthorized")
+                threads_store.add_message(
+                    conn,
+                    thread_id=thread.id,
+                    role="system",
+                    text=_UNAUTHORIZED_MESSAGE,
+                    now=now(),
+                    bundle_sha256=report.bundle_sha256,
+                    pdf_revision=report.current_pdf,
+                )
+                _settle_reservation(
+                    conn, slug=report.slug, reserved=settings.reserve_usd, actual=Decimal(0)
+                )
+                return
+
+            handle = started.handle
+            turn_event_id = started.turn_event_id
+            turn_started_at_text = started.turn_started_at
+            threads_store.bind_turn_boundary(
+                conn,
+                thread_id=thread.id,
+                handle=handle,
+                turn_event_id=turn_event_id,
+                turn_started_at=reports_store.text_to_dt(turn_started_at_text),
+            )
+        else:
+            assert thread.handle is not None, "re-attach requires an already-bound handle"
+            assert thread.turn_event_id is not None, "re-attach requires a bound turn boundary"
+            assert thread.turn_started_at is not None, "re-attach requires a bound turn boundary"
+            handle = thread.handle
+            turn_event_id = thread.turn_event_id
+            turn_started_at_text = reports_store.dt_to_text(thread.turn_started_at)
+
+        seen_event_ids: frozenset[str] = frozenset()
+        cancelled_at_deadline = False
+        while True:
+            status_result = await seam.get_session(token=report.seam_token, handle=handle)
+            events_result = await seam.list_events(
+                token=report.seam_token,
+                handle=handle,
+                created_at_gte=turn_started_at_text,
+                types=["agent.message", "session.status_idle"],
+            )
+            progress = read_turn_progress(
+                status=status_result.status,
+                events=events_result.items,
+                turn_event_id=turn_event_id,
+                seen_event_ids=seen_event_ids,
+            )
+            seen_event_ids = seen_event_ids | progress.new_event_ids
+            for text in progress.new_texts:
+                threads_store.add_message(
+                    conn,
+                    thread_id=thread.id,
+                    role="assistant",
+                    text=text,
+                    now=now(),
+                    bundle_sha256=report.bundle_sha256,
+                    pdf_revision=report.current_pdf,
+                )
+            if progress.is_done:
+                break
+            if (
+                not cancelled_at_deadline
+                and thread.turn_deadline_at is not None
+                and now() >= thread.turn_deadline_at
+            ):
+                await seam.cancel_turn(token=report.seam_token, handle=handle)
+                threads_store.add_message(
+                    conn,
+                    thread_id=thread.id,
+                    role="system",
+                    text=_DEADLINE_MESSAGE,
+                    now=now(),
+                    bundle_sha256=report.bundle_sha256,
+                    pdf_revision=report.current_pdf,
+                )
+                cancelled_at_deadline = True
+            await asyncio.sleep(settings.poll_interval_seconds)
+
+        cost = await seam.get_turn_cost(
+            token=report.seam_token,
+            handle=handle,
+            turn_started_at=turn_started_at_text,
+            turn_event_id=turn_event_id,
+        )
+        _settle_reservation(
+            conn, slug=report.slug, reserved=settings.reserve_usd, actual=cost.cost_usd
+        )
+    except SeamError as err:
+        threads_store.add_message(
+            conn,
+            thread_id=thread.id,
+            role="system",
+            text=(
+                f"daimon could not answer this ({type(err).__name__}). "
+                "Ask again; if it repeats, tell the report's publisher."
+            ),
+            now=now(),
+            bundle_sha256=None,
+            pdf_revision=None,
+        )
+    finally:
+        if not shutting_down():
+            threads_store.end_turn(conn, thread_id=thread.id, now=now())

--- a/apps/report-host/src/report_host/turns.py
+++ b/apps/report-host/src/report_host/turns.py
@@ -1,0 +1,104 @@
+"""The per-thread turn driver: send, poll, stream text, terminate, settle.
+
+Split functional-core / imperative-shell. ``read_turn_progress`` is the pure
+decision: given a session's status and its events since a turn's boundary,
+what new text arrived and is the turn over. ``run_turn`` (the imperative
+shell around it — the only place that calls the seam, sleeps, or touches the
+clock or the database) lands alongside it in this module.
+
+**The done rule** (SPEC D-07, §1.3): a turn is finished only when a
+``session.status_idle`` event survives the boundary filter, or
+``get_my_session`` reports ``terminated``. A bare ``status == "idle"`` is
+never trusted — right after a send the session has not started yet and
+reads idle — and ``rescheduling`` counts as running. This is the exact bug
+the prototype (``spikes/report-host/host/app.py``) hit: it trusted a bare
+idle status and ended a follow-up question in three seconds with nothing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal, cast
+
+
+@dataclass(frozen=True)
+class TurnProgress:
+    """One poll's worth of decision: what new text arrived, and is it over."""
+
+    new_texts: tuple[str, ...]
+    is_done: bool
+    terminal_reason: Literal["idle", "terminated"] | None
+    new_event_ids: frozenset[str]
+
+
+def _agent_message_text(event: dict[str, object]) -> str | None:
+    """Fold an ``agent.message`` event's text blocks, the way the seam's own
+    transcript reader does (``daimon.adapters.mcp.tools.agent_chat``)."""
+    content = event.get("content")
+    if not isinstance(content, list):
+        return None
+    texts: list[str] = []
+    for raw_block in cast("list[object]", content):
+        if not isinstance(raw_block, dict):
+            continue
+        block = cast("dict[str, object]", raw_block)
+        if block.get("type") == "text" and block.get("text") is not None:
+            texts.append(str(block["text"]))
+    text = "\n".join(texts)
+    return text or None
+
+
+def read_turn_progress(
+    *,
+    status: str,
+    events: Sequence[dict[str, object]],
+    turn_event_id: str,
+    seen_event_ids: frozenset[str],
+) -> TurnProgress:
+    """Pure: decide what is new and whether the turn is over.
+
+    No clock, no I/O. Every event whose id is ``turn_event_id`` (the
+    boundary — ``created_at_gte`` is inclusive, so it comes back on every
+    poll) or is already in ``seen_event_ids`` is dropped before anything
+    else is decided, so a boundary that is itself an idle event, or an
+    already-reported answer, can never end or re-report a turn.
+
+    A bare ``status == "idle"`` with no surviving ``session.status_idle``
+    event is NOT done — a session that has not started yet reads idle right
+    after a send. Neither is ``status == "rescheduling"``. The turn is done
+    only when an idle event survives the filter, or ``status == "terminated"``.
+    """
+    new_texts: list[str] = []
+    new_ids: set[str] = set()
+    idle_event_survived = False
+
+    for event in events:
+        event_id = event.get("id")
+        if not isinstance(event_id, str):
+            continue
+        if event_id == turn_event_id or event_id in seen_event_ids:
+            continue
+        new_ids.add(event_id)
+
+        event_type = event.get("type")
+        if event_type == "agent.message":
+            text = _agent_message_text(event)
+            if text is not None:
+                new_texts.append(text)
+        elif event_type == "session.status_idle":
+            idle_event_survived = True
+
+    if idle_event_survived:
+        is_done, terminal_reason = True, "idle"
+    elif status == "terminated":
+        is_done, terminal_reason = True, "terminated"
+    else:
+        is_done, terminal_reason = False, None
+
+    return TurnProgress(
+        new_texts=tuple(new_texts),
+        is_done=is_done,
+        terminal_reason=terminal_reason,
+        new_event_ids=frozenset(new_ids),
+    )

--- a/apps/report-host/src/report_host/uploads.py
+++ b/apps/report-host/src/report_host/uploads.py
@@ -1,0 +1,420 @@
+"""Bytes-in routes: the publish archive and a reader-turn revised PDF.
+
+Two separate `PUT` routes, one credential and one body format each — this is
+what the prototype (`spikes/report-host/host/app.py`) got wrong, running
+both through one handler with two token formats and two body formats. A
+single handler that branches on what it received is the exact design this
+replaces (T-21-17-F).
+
+`PUT /publish/{capability_token}` (`application/gzip`) is the highest-risk
+route in this module: it is authorised by a capability token signed with the
+same secret set as the admin bearer, extracts one report PDF from an
+untrusted archive without ever calling `TarFile.extract()`/`extractall()`,
+persists the whole archive on the host's own volume (so the one re-push
+after the seam's copy expires — SPEC D-03 — has something to send), and only
+then hands it to the seam under the report's own token.
+
+`PUT /upload/{turn_token}` (`application/pdf`) is the much smaller sibling:
+a per-turn, single-use token minted by `routes.ask` authorises exactly one
+revised-PDF upload for the thread that requested it.
+
+Both tokens are burnt BEFORE the request body is read — a client that
+disconnects mid-upload must not leave a token still usable (T-21-17-B). The
+capability token's `jti` is burnt durably via `consumed_store` (mirroring
+`notebook_host.consumed_store`, so a burn survives a host restart); the
+per-turn upload token's burn is `reports_store.consume_upload_token`, an
+atomic `DELETE ... RETURNING` — the row itself is the single-use record.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import tarfile
+import tempfile
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import IO
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel
+
+from report_host import reports_store, threads_store
+from report_host.capability import verify_token
+from report_host.config import Settings
+from report_host.consumed_store import burn_jti
+from report_host.mcp_client import SeamClient, SeamError, SeamUnauthorizedError
+
+# One message per route, covering every failure reason that route has —
+# unknown, tampered, expired, wrong-operation, already-used, and (for the
+# publish route) a slug with no report all collapse into the same 404. A
+# caller learns nothing about which reason applied (T-21-17-H).
+_PUBLISH_INVALID_MESSAGE = "this publish link is invalid, expired, or already used"
+_UPLOAD_INVALID_MESSAGE = "this upload link is invalid, expired, or already used"
+_REPORT_UNAUTHORIZED_MESSAGE = (
+    "this report's connection to daimon has expired; ask the publisher to re-publish it"
+)
+
+_REPORT_PDF_NAME = "report.pdf"
+_BUNDLE_FILE_NAME = "bundle.tar.gz"
+
+# In-memory threshold before a spooled upload spills to disk — neither route
+# ever holds the full request body in memory beyond this, regardless of the
+# eventual size cap enforced on top of it.
+_SPOOL_MEMORY_BYTES = 1024 * 1024
+
+
+class _ArchiveRejected(Exception):
+    """A publish archive failed a structural check. Never escapes this module."""
+
+
+class PublishLink(BaseModel):
+    name: str
+    link: str
+
+
+class PublishUploadResponse(BaseModel):
+    slug: str
+    links: list[PublishLink]
+
+
+class TurnUploadResponse(BaseModel):
+    shown_as: str
+
+
+async def _spool_body(
+    request: Request, *, max_bytes: int
+) -> tuple[tempfile.SpooledTemporaryFile[bytes], int]:
+    """Stream the body into a spooled temp file, refusing mid-stream over ``max_bytes``.
+
+    Never buffers the whole body before checking size — the running total is
+    checked on every chunk, so an oversize upload is refused as soon as it
+    crosses the cap rather than after it has all arrived (T-21-17-E).
+    """
+    # Not a `with` block: the caller owns this file's lifetime past this
+    # function's return (it is read, rewound, and eventually `.close()`d by
+    # the route handler once the upload is fully processed).
+    spool: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # noqa: SIM115
+        max_size=_SPOOL_MEMORY_BYTES
+    )
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > max_bytes:
+            spool.close()
+            raise HTTPException(
+                status.HTTP_413_CONTENT_TOO_LARGE, detail="upload exceeds the size cap"
+            )
+        spool.write(chunk)
+    spool.seek(0)
+    return spool, total
+
+
+def _check_gzip_magic(spool: IO[bytes]) -> None:
+    spool.seek(0)
+    magic = spool.read(2)
+    spool.seek(0)
+    if magic != b"\x1f\x8b":
+        raise HTTPException(
+            status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, detail="expected a gzip archive"
+        )
+
+
+def _check_pdf_magic(spool: IO[bytes]) -> None:
+    spool.seek(0)
+    magic = spool.read(4)
+    spool.seek(0)
+    if magic != b"%PDF":
+        raise HTTPException(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, detail="expected a PDF")
+
+
+def _is_hostile_member(member: tarfile.TarInfo) -> bool:
+    """Whether ``member`` could write, link, or resolve outside the report's directory.
+
+    Checked against the member's raw, un-normalised name — the interpreter's
+    own extraction filter (``tarfile.data_filter``, applied afterwards as a
+    second layer) strips a leading ``/`` before deciding whether a name is
+    absolute, so a raw absolute-path member survives it; these explicit
+    checks are the real guard (T-21-17-C).
+    """
+    if member.name.startswith("/") or os.path.isabs(member.name):
+        return True
+    if ".." in Path(member.name).parts:
+        return True
+    if member.issym() or member.islnk():
+        return True
+    return bool(member.isdev())
+
+
+def _extract_report_pdf(spool: IO[bytes], *, decompressed_ceiling: int) -> bytes:
+    """Return the ``report.pdf`` member's bytes, extracted defensively.
+
+    Never calls ``TarFile.extract()``/``extractall()`` — every member is
+    validated (and, for a device/link/traversal member, rejected outright)
+    before any single member is read, and only the one report-PDF member is
+    ever decoded into memory. A malformed archive is a publisher bug worth
+    surfacing, not a member to silently skip: the whole upload is refused.
+    """
+    spool.seek(0)
+    try:
+        with tarfile.open(fileobj=spool, mode="r:gz") as tar:
+            return _read_report_member(tar, decompressed_ceiling=decompressed_ceiling)
+    except tarfile.ReadError as err:
+        raise _ArchiveRejected(f"not a valid gzip tar archive: {err}") from err
+
+
+def _read_report_member(tar: tarfile.TarFile, *, decompressed_ceiling: int) -> bytes:
+    """Validate every member, then read exactly the report-PDF member's bytes.
+
+    Split out of `_extract_report_pdf` so the `tarfile.open` context manager
+    can wrap this call directly (satisfying ruff's SIM115 without losing the
+    `tarfile.ReadError` catch, which must wrap the `open()` call itself).
+    """
+    members = tar.getmembers()
+    for member in members:
+        if _is_hostile_member(member):
+            raise _ArchiveRejected(f"archive contains an unsafe member: {member.name!r}")
+        # The interpreter's own extraction filter (PEP 706), applied as a
+        # second layer. Its behaviour is version-dependent (it silently
+        # normalises a leading "/" rather than rejecting it, confirmed
+        # against this interpreter — see `_is_hostile_member`'s
+        # docstring), so the explicit checks above remain the real guard.
+        try:
+            tarfile.data_filter(member, "")
+        except tarfile.FilterError as err:
+            raise _ArchiveRejected(f"archive contains an unsafe member: {err}") from err
+
+    report_member = next(
+        (m for m in members if m.isfile() and m.name.removeprefix("./") == _REPORT_PDF_NAME),
+        None,
+    )
+    if report_member is None:
+        raise _ArchiveRejected(f"archive has no {_REPORT_PDF_NAME!r} at its root")
+    if report_member.size > decompressed_ceiling:
+        raise _ArchiveRejected(f"{_REPORT_PDF_NAME!r} exceeds the decompressed size ceiling")
+    extracted = tar.extractfile(report_member)
+    if extracted is None:
+        raise _ArchiveRejected(f"{_REPORT_PDF_NAME!r} could not be read")
+    # A compression bomb whose declared size lied would still be bounded
+    # here: extractfile() never reads past the header's declared size,
+    # so this loop can only ever read up to `report_member.size` bytes —
+    # already checked above — regardless of the archive's compressed
+    # size on disk.
+    chunks: list[bytes] = []
+    read_total = 0
+    while True:
+        chunk = extracted.read(65536)
+        if not chunk:
+            break
+        read_total += len(chunk)
+        if read_total > decompressed_ceiling:
+            raise _ArchiveRejected(f"{_REPORT_PDF_NAME!r} exceeds the decompressed size ceiling")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write via tmp + ``os.replace`` so a concurrent reader never sees a torn file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp")
+    tmp_path.write_bytes(data)
+    os.replace(tmp_path, path)
+
+
+def _persist_archive_for_publish(*, spool: IO[bytes], archive_path: Path) -> None:
+    """Persist the spooled archive at ``archive_path``, tmp + fsync + ``os.replace``.
+
+    ``bundle_ttl_days`` and ``recipient_link_ttl_days`` are both 90, so the
+    seam's copy of a bundle expiring while a recipient link is still live is
+    the normal case, not a rare one — this file is what the turn driver
+    re-pushes when that happens (SPEC D-03). A crash mid-write must never
+    leave a truncated archive standing at ``archive_path``: the write goes
+    to a temp name in the same directory, is fsynced, and only then replaces
+    the final name. Do not "clean this up" into a direct write — the fsync
+    and the temp name are load-bearing, not redundant with the seam push
+    that follows.
+    """
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = archive_path.with_name(f".{archive_path.name}.tmp")
+    spool.seek(0)
+    with open(tmp_path, "wb") as tmp_file:
+        shutil.copyfileobj(spool, tmp_file)
+        tmp_file.flush()
+        os.fsync(tmp_file.fileno())
+    os.replace(tmp_path, archive_path)
+    spool.seek(0)
+
+
+def _report_dir(*, data_dir: Path, slug: str) -> Path:
+    """Compose and containment-check the report's directory.
+
+    Composed only from ``data_dir`` and the slug the signed capability
+    named — never from anything in the request path or the archive's own
+    member names (T-21-17-I).
+    """
+    data_dir_resolved = data_dir.resolve()
+    candidate = (data_dir_resolved / slug).resolve()
+    if not candidate.is_relative_to(data_dir_resolved):
+        raise _ArchiveRejected("resolved report directory escapes data_dir")
+    return candidate
+
+
+def _next_revision_name(conn: sqlite3.Connection, *, slug: str) -> str:
+    existing = reports_store.list_revisions(conn, slug=slug)
+    return f"v{len(existing) + 1}.pdf"
+
+
+def build_uploads_router(
+    *, settings: Settings, conn_factory: Callable[[], sqlite3.Connection], seam: SeamClient
+) -> APIRouter:
+    """Build the router carrying both upload routes.
+
+    ``conn_factory`` is called exactly once, here, mirroring the reader and
+    admin routers' single-shared-connection design.
+    """
+    conn = conn_factory()
+    consumed_file = settings.data_dir / "consumed.json"
+    router = APIRouter()
+
+    @router.put("/publish/{capability_token}")
+    async def publish_upload(capability_token: str, request: Request) -> PublishUploadResponse:  # pyright: ignore[reportUnusedFunction]
+        claims = verify_token(settings.admin_secrets, capability_token, now=datetime.now(UTC))
+        if claims is None or claims.op != "report":
+            # Unknown, tampered, expired, and wrong-operation are the same
+            # `verify_token` outcome (`None`) except wrong-operation, which
+            # this explicit check catches for defence-in-depth even though
+            # `CapabilityClaims.op`'s own type already excludes it — one 404
+            # either way (T-21-17-A).
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=_PUBLISH_INVALID_MESSAGE)
+
+        # Burn before reading the body: a client that disconnects mid-upload
+        # must not leave the capability still usable (T-21-17-B).
+        burned = burn_jti(
+            consumed_file,
+            claims.jti,
+            exp=claims.exp,
+            now=int(datetime.now(UTC).timestamp()),
+        )
+        if not burned:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=_PUBLISH_INVALID_MESSAGE)
+
+        report = reports_store.load_report(conn, slug=claims.slug)
+        if report is None:
+            # The publisher's admin PUT always runs first, so a missing
+            # report here is a genuine error, not a race — but the response
+            # is identical to every other invalid-capability case
+            # (T-21-17-H).
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=_PUBLISH_INVALID_MESSAGE)
+
+        ceiling = min(claims.max_bytes, settings.max_bundle_bytes)
+        spool, size_bytes = await _spool_body(request, max_bytes=ceiling)
+        try:
+            _check_gzip_magic(spool)
+            try:
+                pdf_bytes = _extract_report_pdf(spool, decompressed_ceiling=settings.max_pdf_bytes)
+            except _ArchiveRejected as err:
+                raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(err)) from err
+
+            report_dir = _report_dir(data_dir=settings.data_dir, slug=report.slug)
+            revision_name = _next_revision_name(conn, slug=report.slug)
+            _atomic_write_bytes(report_dir / revision_name, pdf_bytes)
+            reports_store.add_revision(
+                conn,
+                slug=report.slug,
+                name=revision_name,
+                by_thread=None,
+                note="published",
+                now=datetime.now(UTC),
+            )
+            reports_store.set_current_pdf(conn, slug=report.slug, name=revision_name)
+
+            # Persist the archive itself, before touching the seam — this is
+            # the file a later re-push reads (SPEC D-03). Written under the
+            # same containment-checked directory the revision PDF just used.
+            archive_path = report_dir / _BUNDLE_FILE_NAME
+            _persist_archive_for_publish(spool=spool, archive_path=archive_path)
+
+            # Read into bytes rather than handing httpx the still-open spooled
+            # file: httpx's `AsyncClient` requires request content to be an
+            # async byte stream, and a plain (sync) file-like object gets
+            # wrapped as a *sync* iterator instead — raising at request time,
+            # not at type-check time. The archive is already bounded by
+            # `ceiling` above (at most `settings.max_bundle_bytes`), so
+            # holding it in memory for this one push is the same order of
+            # magnitude the cap already assumes.
+            spool.seek(0)
+            archive_bytes = spool.read()
+            try:
+                pushed = await seam.push_bundle(
+                    token=report.seam_token, archive=archive_bytes, size_bytes=size_bytes
+                )
+            except SeamUnauthorizedError as err:
+                reports_store.set_seam_status(conn, slug=report.slug, status="unauthorized")
+                raise HTTPException(
+                    status.HTTP_409_CONFLICT, detail=_REPORT_UNAUTHORIZED_MESSAGE
+                ) from err
+            except SeamError as err:
+                # The archive stays on disk in this failure case too — a
+                # re-publish is what replaces it, not this handler cleaning
+                # up after itself.
+                raise HTTPException(
+                    status.HTTP_502_BAD_GATEWAY, detail="the seam refused the archive"
+                ) from err
+
+            reports_store.save_bundle_reference(
+                conn,
+                slug=report.slug,
+                handle=pushed.handle,
+                sha256=pushed.sha256,
+                expires_at=datetime.fromisoformat(pushed.expires_at),
+                archive_path=str(archive_path),
+            )
+        finally:
+            spool.close()
+
+        links = [
+            PublishLink(
+                name=recipient.name,
+                link=f"{settings.public_url_base}r/{report.slug}?k={recipient.token}",
+            )
+            for recipient in reports_store.list_recipients(conn, slug=report.slug)
+            if recipient.revoked_at is None
+        ]
+        return PublishUploadResponse(slug=report.slug, links=links)
+
+    @router.put("/upload/{turn_token}")
+    async def turn_upload(turn_token: str, request: Request) -> TurnUploadResponse:  # pyright: ignore[reportUnusedFunction]
+        consumed = reports_store.consume_upload_token(conn, token=turn_token)
+        if consumed is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=_UPLOAD_INVALID_MESSAGE)
+        thread = threads_store.load_thread_by_id(conn, thread_id=consumed.thread_id)
+        if thread is None or thread.status != "running":
+            # A token whose turn has already ended (thread back to idle, or
+            # archived) is stale even though it was never spent — refused
+            # with the same message as unknown-or-used.
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail=_UPLOAD_INVALID_MESSAGE)
+
+        spool, _size_bytes = await _spool_body(request, max_bytes=settings.max_pdf_bytes)
+        try:
+            _check_pdf_magic(spool)
+            spool.seek(0)
+            pdf_bytes = spool.read()
+        finally:
+            spool.close()
+
+        revision_name = _next_revision_name(conn, slug=consumed.slug)
+        _atomic_write_bytes(settings.data_dir / consumed.slug / revision_name, pdf_bytes)
+        reports_store.add_revision(
+            conn,
+            slug=consumed.slug,
+            name=revision_name,
+            by_thread=str(consumed.thread_id),
+            note="revised by daimon",
+            now=datetime.now(UTC),
+        )
+        reports_store.set_current_pdf(conn, slug=consumed.slug, name=revision_name)
+        return TurnUploadResponse(shown_as=revision_name)
+
+    return router

--- a/apps/report-host/src/report_host/viewer/app.css
+++ b/apps/report-host/src/report_host/viewer/app.css
@@ -1,0 +1,82 @@
+:root {
+  --navy: #0C1F40; --navy-light: #798496; --peri: #9FAAE2; --peri-light: #CAD0EF;
+  --aqua: #B4E7DD; --aqua-light: #D6F2EC; --peach: #F6AE72; --paper: #F7F7F7; --dock-w: 400px;
+}
+/* Opt out of Chrome Android auto-dark: it inverted text to white inside the light bubbles. */
+:root { color-scheme: only light; }
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; background: #E9EBF1; color: var(--navy); font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif; }
+body { display: grid; grid-template-columns: minmax(0, 1fr) var(--dock-w); height: 100vh; }
+
+.viewer { display: flex; flex-direction: column; min-width: 0; height: 100vh; }
+.viewer-bar { display: flex; align-items: center; gap: 14px; padding: 10px 18px; background: white; border-bottom: 1px solid var(--peri-light); }
+.viewer-bar .title { font-weight: 600; font-size: 0.95rem; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.versions { display: flex; gap: 6px; }
+.versions button { font: inherit; font-size: 0.74rem; padding: 3px 9px; border-radius: 999px; border: 1px solid var(--peri-light); background: white; color: var(--navy-light); cursor: pointer; }
+.versions button.current { background: var(--navy); color: white; border-color: var(--navy); }
+.versions button.new { border-color: var(--peach); color: var(--navy); animation: pulse 1.2s ease-in-out 3; }
+@keyframes pulse { 50% { background: #FAD2B1; } }
+.pages { flex: 1; overflow: auto; padding: 22px 0 60px; display: flex; flex-direction: column; align-items: center; gap: 18px; }
+.pages canvas { background: white; box-shadow: 0 2px 10px rgba(12,31,64,0.14); max-width: calc(100% - 40px); height: auto; }
+
+.dock { display: flex; flex-direction: column; height: 100vh; background: var(--paper); border-left: 1px solid var(--peri-light); }
+.dock-head { padding: 14px 18px 10px; border-bottom: 2px solid var(--navy); display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; }
+.dock-close, .dock-open { display: none; font: inherit; border: 0; cursor: pointer; border-radius: 8px; }
+.dock-close { background: transparent; color: var(--navy); font-size: 1.1rem; padding: 2px 6px; }
+.dock-open { background: var(--navy); color: white; font-weight: 600; font-size: 0.82rem; padding: 7px 12px; white-space: nowrap; }
+.dock-open .badge { display: inline-block; margin-left: 6px; width: 8px; height: 8px; border-radius: 50%; background: var(--peach); vertical-align: 1px; }
+.dock-kicker { color: var(--navy); font-weight: 600; font-size: 0.9rem; }
+.dock-reader { font-size: 0.74rem; color: var(--navy-light); }
+.banner { background: #FAD2B1; color: #A0714A; font-size: 0.78rem; padding: 8px 14px; }
+.threads { display: flex; gap: 6px; padding: 10px 14px; overflow-x: auto; border-bottom: 1px solid var(--peri-light); flex: none; }
+.threads button { flex: none; font: inherit; font-size: 0.74rem; max-width: 190px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 4px 10px; border-radius: 999px; border: 1px solid var(--peri-light); background: white; color: var(--navy-light); cursor: pointer; }
+.threads button.active { background: var(--navy); color: white; border-color: var(--navy); }
+.threads button.running::before { content: "● "; color: var(--peach); }
+.messages { flex: 1; overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 10px; }
+.messages .empty { color: var(--navy-light); font-size: 0.86rem; padding: 12px 6px; }
+.msg { max-width: 92%; padding: 9px 12px; border-radius: 10px; font-size: 0.88rem; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; }
+.msg.user { align-self: flex-end; background: var(--navy); color: white; border-bottom-right-radius: 3px; }
+.msg.assistant { align-self: flex-start; color: var(--navy); background: white; border: 1px solid var(--peri-light); border-bottom-left-radius: 3px; }
+.msg.assistant code { background: var(--paper); font-size: 0.8em; padding: 0 3px; border-radius: 3px; }
+.msg.assistant table { border-collapse: collapse; font-size: 0.8em; margin: 6px 0; }
+.msg.assistant td, .msg.assistant th { border-bottom: 1px solid var(--peri-light); padding: 2px 6px; text-align: left; }
+.msg.system { align-self: center; color: #A0714A; font-size: 0.78rem; background: #FAD2B1; }
+.status { min-height: 22px; padding: 0 16px 6px; font-size: 0.76rem; color: var(--navy-light); font-variant-numeric: tabular-nums; }
+.status .spin { display: inline-block; width: 9px; height: 9px; border: 2px solid var(--peri-light); border-top-color: var(--navy); border-radius: 50%; animation: spin 0.9s linear infinite; margin-right: 6px; vertical-align: -1px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.stop-row { display: flex; align-items: center; gap: 8px; padding: 0 14px 6px; }
+.stop-btn { font: inherit; font-size: 0.78rem; padding: 4px 10px; border-radius: 8px; border: 1px solid var(--peri-light); background: white; color: var(--navy); cursor: pointer; }
+.stop-btn:hover { background: var(--paper); }
+.stop-hint { font-size: 0.72rem; color: var(--navy-light); }
+.composer { display: flex; gap: 8px; padding: 0 14px 10px; }
+.composer textarea { flex: 1; font: inherit; font-size: 0.88rem; padding: 8px 10px; border: 1px solid var(--peri-light); border-radius: 8px; resize: none; background: white; }
+.composer button { font: inherit; font-weight: 600; padding: 0 16px; border: 0; border-radius: 8px; background: var(--navy); color: white; cursor: pointer; }
+.composer button:disabled { background: var(--peri-light); cursor: default; }
+.meter { padding: 10px 16px 14px; border-top: 1px solid var(--peri-light); font-size: 0.76rem; color: var(--navy-light); }
+.meter .bar { height: 6px; background: var(--peri-light); border-radius: 3px; overflow: hidden; margin-top: 5px; }
+.meter .fill { height: 100%; background: var(--navy); }
+.meter .fill.warn { background: var(--peach); }
+.meter .fill.over { background: #A0714A; }
+
+/* Phones and narrow tablets: the sidebar is a slide-up sheet, closed by default. */
+@media (max-width: 900px) {
+  /* minmax(0,1fr): a plain 1fr lets the nowrap title push the column wider than the phone. */
+  body { grid-template-columns: minmax(0, 1fr); }
+  .viewer { height: 100vh; height: 100dvh; }
+  .viewer-bar .title { min-width: 0; }
+  .viewer-bar { padding: 8px 12px; gap: 10px; }
+  .viewer-bar .title { font-size: 0.8rem; }
+  .versions { display: none; }
+  .pages { padding: 12px 0 90px; gap: 12px; }
+  .pages canvas { max-width: calc(100% - 20px); }
+  .dock-open { display: inline-block; }
+  .dock-close { display: inline-block; }
+  html, body { overflow-x: hidden; max-width: 100vw; }
+  .dock-head, .threads, .messages, .status, .composer, .meter, .msg, .messages .empty { min-width: 0; max-width: 100vw; }
+  .dock { position: fixed; inset: 0; width: 100vw; z-index: 20; height: 100vh; height: 100dvh; border-left: 0; transform: translateY(100%); transition: transform 0.22s ease; box-shadow: 0 -6px 24px rgba(12,31,64,0.18); }
+  body.dock-open .dock { transform: translateY(0); }
+  .messages { padding: 12px; }
+  .msg { max-width: 96%; font-size: 0.9rem; }
+  .composer textarea { font-size: 16px; } /* 16px stops iOS zooming the page on focus */
+  .meter { padding: 8px 14px calc(10px + env(safe-area-inset-bottom)); }
+}

--- a/apps/report-host/src/report_host/viewer/app.js
+++ b/apps/report-host/src/report_host/viewer/app.js
@@ -1,0 +1,158 @@
+// Report viewer + chat sidebar. Plain JS, no build step.
+const slug = location.pathname.split("/")[2];
+const api = (p, opts) => fetch(`/api/${slug}${p}`, opts).then(async (r) => {
+  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).detail || r.statusText);
+  return r.json();
+});
+const $ = (id) => document.getElementById(id);
+let state = null, thread = null, lastId = 0, pollTimer = null, shownPdf = null, seenVersions = new Set();
+
+// --- pdf ----------------------------------------------------------------
+async function showPdf(name) {
+  if (!window.pdfjsLib) return window.addEventListener("pdfjs-ready", () => showPdf(name), { once: true });
+  if (name === shownPdf) return;
+  shownPdf = name;
+  const pages = $("pages");
+  pages.innerHTML = "";
+  const doc = await pdfjsLib.getDocument(`/files/${slug}/${name}`).promise;
+  const scale = Math.min(1.6, (pages.clientWidth - 60) / 595);
+  for (let i = 1; i <= doc.numPages; i++) {
+    const page = await doc.getPage(i);
+    const vp = page.getViewport({ scale: scale * window.devicePixelRatio });
+    const canvas = document.createElement("canvas");
+    canvas.width = vp.width; canvas.height = vp.height;
+    canvas.style.width = `${vp.width / window.devicePixelRatio}px`;
+    pages.appendChild(canvas);
+    await page.render({ canvasContext: canvas.getContext("2d"), viewport: vp }).promise;
+  }
+  renderVersions();
+}
+function renderVersions() {
+  const box = $("versions");
+  box.innerHTML = "";
+  for (const v of state.revisions) {
+    const b = document.createElement("button");
+    b.textContent = v.note === "published" ? "original" : `revision ${v.name.replace(/\D/g, "")}`;
+    b.title = `${v.name} · ${new Date(v.created_at).toLocaleString()}`;
+    if (v.name === shownPdf) b.classList.add("current");
+    else if (!seenVersions.has(v.name)) b.classList.add("new");
+    b.onclick = () => { seenVersions.add(v.name); showPdf(v.name); };
+    box.appendChild(b);
+  }
+}
+
+// --- state --------------------------------------------------------------
+function applyState(s) {
+  const prevCurrent = state?.current_pdf;
+  state = s;
+  $("title").textContent = s.title;
+  if (s.recipient_name) $("reader").textContent = `Reading as ${s.recipient_name}`;
+  const b = s.budget, frac = b.cap_usd ? Math.min(1, b.spent_usd / b.cap_usd) : 1;
+  $("meter").innerHTML = `Question budget · $${b.spent_usd.toFixed(2)} of $${b.cap_usd.toFixed(2)} · up to $${b.reserve_usd.toFixed(2)} per answer` +
+    `<div class="bar"><div class="fill ${frac >= 1 ? "over" : frac >= 0.75 ? "warn" : ""}" style="width:${(frac * 100).toFixed(0)}%"></div></div>`;
+  const banner = $("banner");
+  if (s.seam_status === "unauthorized") {
+    banner.textContent = "This report needs to be re-published before it can answer new questions.";
+    banner.hidden = false;
+  } else banner.hidden = true;
+  if (s.threads) renderThreads(s.threads);
+  if (shownPdf === null) { for (const v of s.revisions) seenVersions.add(v.name); showPdf(s.current_pdf); }
+  else if (s.current_pdf !== prevCurrent && s.current_pdf !== shownPdf) {
+    // daimon uploaded a revision: swap the viewer to it, keep the old one a click away.
+    showPdf(s.current_pdf);
+    setStatus(`daimon revised the report · now showing revision ${s.current_pdf.replace(/\D/g, "")}`);
+  } else renderVersions();
+}
+function renderThreads(threads) {
+  const box = $("threads");
+  box.innerHTML = "";
+  const nb = document.createElement("button");
+  nb.textContent = "+ new thread";
+  nb.onclick = () => selectThread(null);
+  if (thread === null) nb.classList.add("active");
+  box.appendChild(nb);
+  for (const t of threads) {
+    const b = document.createElement("button");
+    b.textContent = t.title;
+    b.className = (t.id === thread ? "active " : "") + (t.status === "running" ? "running" : "");
+    b.onclick = () => selectThread(t.id);
+    box.appendChild(b);
+  }
+}
+function setStatus(html, busy = false) { $("status").innerHTML = (busy ? '<span class="spin"></span>' : "") + html; }
+
+// --- threads ------------------------------------------------------------
+async function selectThread(id) {
+  thread = id; lastId = 0;
+  $("messages").innerHTML = id ? "" : '<div class="empty">Ask why any number is what it is. daimon answers from the analysis files behind this report.</div>';
+  setStatus("");
+  $("stop").hidden = true;
+  clearInterval(pollTimer); pollTimer = null;
+  const s = await api("/state"); applyState(s);
+  if (id) await poll(true);
+}
+function addMessage(m) {
+  const box = $("messages");
+  box.querySelector(".empty")?.remove();
+  const div = document.createElement("div");
+  div.className = `msg ${m.role}`;
+  div.innerHTML = m.role === "assistant" ? renderMd(m.text) : m.text.replace(/</g, "&lt;");
+  box.appendChild(div);
+  box.scrollTop = box.scrollHeight;
+}
+function renderMd(t) {
+  // ponytail: enough markdown for daimon's answers (bold, code, tables, bullets); swap for marked if it grows.
+  let h = t.replace(/</g, "&lt;");
+  h = h.replace(/```[\s\S]*?```/g, (m) => `<pre><code>${m.slice(3, -3)}</code></pre>`);
+  h = h.replace(/`([^`]+)`/g, "<code>$1</code>").replace(/\*\*([^*]+)\*\*/g, "<b>$1</b>");
+  h = h.replace(/((?:^\|.*\|\s*$\n?)+)/gm, (block) => {
+    const rows = block.trim().split("\n").filter((r) => !/^\|\s*-/.test(r));
+    return "<table>" + rows.map((r, i) => "<tr>" + r.split("|").slice(1, -1).map((c) => `<${i ? "td" : "th"}>${c.trim()}</${i ? "td" : "th"}>`).join("") + "</tr>").join("") + "</table>";
+  });
+  return h.replace(/^\s*[-*] (.*)$/gm, "• $1");
+}
+async function poll(first = false) {
+  if (!thread) return;
+  const t = await api(`/threads/${thread}?after=${lastId}`);
+  for (const m of t.messages) { addMessage(m); lastId = m.id; }
+  const s = await api("/state"); applyState(s);
+  if (t.status === "running") {
+    const secs = Math.round(t.elapsed_seconds || 0);
+    setStatus(`daimon is working · ${Math.floor(secs / 60)}:${String(secs % 60).padStart(2, "0")} elapsed${secs > 90 ? " · long answers can take several minutes; you can keep reading or come back later" : ""}`, true);
+    $("send").disabled = true;
+    $("stop").hidden = false;
+    if (!pollTimer) pollTimer = setInterval(poll, 2000);
+  } else {
+    if (!first || t.messages.length) setStatus(pollTimer ? "answered" : "");
+    if (pollTimer && !document.body.classList.contains("dock-open") && !$("dock-open").querySelector(".badge")) $("dock-open").insertAdjacentHTML("beforeend", '<span class="badge"></span>');
+    $("send").disabled = false;
+    $("stop").hidden = true;
+    clearInterval(pollTimer); pollTimer = null;
+  }
+}
+$("composer").onsubmit = async (e) => {
+  e.preventDefault();
+  const message = $("input").value.trim();
+  if (!message) return;
+  $("input").value = "";
+  try {
+    const r = await api("/ask", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ message, thread }) });
+    if (!thread) { thread = r.thread; lastId = 0; $("messages").innerHTML = ""; }
+    await poll();
+  } catch (err) { setStatus(err.message); }
+};
+$("stop").onclick = async () => {
+  if (!thread) return;
+  try { await api(`/threads/${thread}/cancel`, { method: "POST" }); }
+  catch (err) { setStatus(err.message); }
+};
+// Mobile: the sidebar is a sheet. Open on demand, close back to the report; a running
+// thread keeps polling while closed and the open button shows a dot when it answers.
+const openDock = () => { document.body.classList.add("dock-open"); $("dock-open").querySelector(".badge")?.remove(); };
+const closeDock = () => document.body.classList.remove("dock-open");
+$("dock-open").onclick = openDock;
+$("dock-close").onclick = closeDock;
+document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeDock(); });
+$("input").addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); $("composer").requestSubmit(); } });
+
+api("/state").then((s) => { applyState(s); const running = s.threads.find((t) => t.status === "running"); if (running) selectThread(running.id); }).catch((e) => setStatus(e.message));

--- a/apps/report-host/src/report_host/viewer/index.html
+++ b/apps/report-host/src/report_host/viewer/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="only light">
+<title>Report</title>
+<link rel="stylesheet" href="/viewer/app.css">
+<script type="module">
+import * as pdfjsLib from "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.10.38/pdf.min.mjs";
+pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.10.38/pdf.worker.min.mjs";
+window.pdfjsLib = pdfjsLib;
+window.dispatchEvent(new Event("pdfjs-ready"));
+</script>
+</head>
+<body>
+<main class="viewer">
+  <div class="viewer-bar">
+    <div class="title" id="title">Loading…</div>
+    <div class="versions" id="versions"></div>
+    <button class="dock-open" id="dock-open" type="button" aria-label="Open chat">Ask daimon</button>
+  </div>
+  <div class="pages" id="pages"></div>
+</main>
+<aside class="dock">
+  <header class="dock-head">
+    <div>
+      <div class="dock-kicker">Ask about this report</div>
+      <div class="dock-reader" id="reader"></div>
+    </div>
+    <button class="dock-close" id="dock-close" type="button" aria-label="Close chat">&#x2715;</button>
+  </header>
+  <div class="banner" id="banner" hidden></div>
+  <section class="threads" id="threads"></section>
+  <section class="messages" id="messages"><div class="empty">Ask why any number is what it is. daimon answers from the analysis files behind this report.</div></section>
+  <div class="status" id="status"></div>
+  <div class="stop-row">
+    <button type="button" id="stop" class="stop-btn" hidden>Stop</button>
+    <span class="stop-hint">Stopping is still billed for the work daimon has already done.</span>
+  </div>
+  <form class="composer" id="composer">
+    <textarea id="input" rows="2" placeholder="Ask about any number or claim in this report"></textarea>
+    <button type="submit" id="send">Ask</button>
+  </form>
+  <footer class="meter" id="meter"></footer>
+</aside>
+<script src="/viewer/app.js"></script>
+</body>
+</html>

--- a/apps/report-host/tests/conftest.py
+++ b/apps/report-host/tests/conftest.py
@@ -1,1 +1,156 @@
-"""Shared test fixtures for report_host. Empty for now."""
+"""Shared test fixtures for report_host.
+
+The in-process fake-seam harness (a small ``mcp.server.lowlevel.Server``
+mounted on the real streamable-HTTP ASGI transport, optionally paired with a
+``PUT /bundles`` route) lives here so more than one test module can drive a
+``SeamClient`` against it without duplicating the MCP wire-protocol plumbing.
+Exposed as fixtures (``build_fake_seam`` / ``fake_seam_lifespan``) rather than
+plain module imports, since pytest's ``--import-mode=importlib`` (this
+project's configuration) gives every test file its own module namespace with
+no shared ``sys.path`` entry a sibling test file could import from directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+import pytest
+from mcp import types as mcp_types
+from mcp.server.lowlevel import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.types import Message, Receive, Scope, Send
+
+FakeToolBehavior = Callable[[dict[str, object]], dict[str, object]]
+FakeBundlePut = Callable[[bytes], dict[str, object]]
+FakeASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+FakeSeamBuilder = Callable[..., FakeASGIApp]
+FakeSeamLifespan = Callable[[FakeASGIApp], "contextlib.AbstractAsyncContextManager[None]"]
+
+
+class _StreamableHTTPEndpoint:
+    """ASGI endpoint that hands every request to the session manager."""
+
+    def __init__(self, manager: StreamableHTTPSessionManager) -> None:
+        self._manager = manager
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await self._manager.handle_request(scope, receive, send)
+
+
+def _build_fake_seam(
+    *,
+    behaviors: dict[str, FakeToolBehavior],
+    captured_auth: list[str],
+    captured_arguments: dict[str, dict[str, object]] | None = None,
+    unauthorized_tokens: frozenset[str] = frozenset(),
+    push_bundle_handler: FakeBundlePut | None = None,
+    captured_bundle_puts: list[bytes] | None = None,
+) -> FakeASGIApp:
+    """Build a minimal MCP server exposing exactly the tools under test.
+
+    Raising inside a behavior maps to an ``isError`` CallToolResult carrying
+    exactly ``str(exception)`` as its text — the low-level server's own
+    ``except Exception as e: return self._make_error_result(str(e))``, with
+    no wrapping — so tests can pin exact tool-error wording.
+
+    ``push_bundle_handler``, when given, adds a ``PUT /bundles`` route on the
+    same ASGI app (returning ``push_bundle_handler(body)`` as JSON) so a
+    ``SeamClient`` built with the same transport for both its MCP session and
+    its plain-HTTP client can exercise ``push_bundle`` against this fake too.
+    """
+    server = Server("fake-seam")
+
+    @server.call_tool()
+    async def handle_call_tool(  # pyright: ignore[reportUnusedFunction]
+        name: str, arguments: dict[str, object]
+    ) -> dict[str, object]:
+        if captured_arguments is not None:
+            captured_arguments[name] = arguments
+        behavior = behaviors[name]
+        return behavior(arguments)
+
+    @server.list_tools()
+    async def handle_list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
+        # No outputSchema: the mcp client's own call_tool() fetches this list
+        # to validate structuredContent against a declared schema, and skips
+        # validation entirely when a tool has none — exactly what these tests
+        # want, since they assert on the client's own decoding, not a schema.
+        return [
+            mcp_types.Tool(name=name, inputSchema={"type": "object", "properties": {}})
+            for name in behaviors
+        ]
+
+    manager = StreamableHTTPSessionManager(app=server, stateless=True)
+    routes = [Route("/mcp", endpoint=_StreamableHTTPEndpoint(manager))]
+
+    if push_bundle_handler is not None:
+
+        async def handle_bundle_put(request: Request) -> JSONResponse:
+            body = await request.body()
+            if captured_bundle_puts is not None:
+                captured_bundle_puts.append(body)
+            return JSONResponse(push_bundle_handler(body))
+
+        routes.append(Route("/bundles", endpoint=handle_bundle_put, methods=["PUT"]))
+
+    starlette_app = Starlette(routes=routes, lifespan=lambda _app: manager.run())
+
+    async def wrapped(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            headers = dict(scope["headers"])
+            auth_header = headers.get(b"authorization", b"").decode()
+            captured_auth.append(auth_header)
+            token = auth_header.removeprefix("Bearer ")
+            if token in unauthorized_tokens:
+                await send({"type": "http.response.start", "status": 401, "headers": []})
+                await send({"type": "http.response.body", "body": b""})
+                return
+        await starlette_app(scope, receive, send)
+
+    return wrapped
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: FakeASGIApp) -> AsyncIterator[None]:
+    send_queue: asyncio.Queue[Message] = asyncio.Queue()
+    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await receive_queue.get()
+
+    async def send(message: Message) -> None:
+        await send_queue.put(message)
+
+    async def run_lifespan() -> None:
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+
+    task = asyncio.create_task(run_lifespan())
+
+    await receive_queue.put({"type": "lifespan.startup"})
+    msg = await send_queue.get()
+    assert msg["type"] == "lifespan.startup.complete", msg
+    try:
+        yield
+    finally:
+        await receive_queue.put({"type": "lifespan.shutdown"})
+        msg = await send_queue.get()
+        assert msg["type"] == "lifespan.shutdown.complete", msg
+        await task
+
+
+@pytest.fixture
+def build_fake_seam() -> FakeSeamBuilder:
+    """The fake-seam ASGI app builder, injected so test files never duplicate it."""
+    return _build_fake_seam
+
+
+@pytest.fixture
+def fake_seam_lifespan() -> FakeSeamLifespan:
+    """The fake seam's ASGI lifespan context manager, injected the same way."""
+    return _lifespan

--- a/apps/report-host/tests/conftest.py
+++ b/apps/report-host/tests/conftest.py
@@ -1,0 +1,1 @@
+"""Shared test fixtures for report_host. Empty for now."""

--- a/apps/report-host/tests/test_admin.py
+++ b/apps/report-host/tests/test_admin.py
@@ -1,0 +1,485 @@
+"""Tests for the admin router: publish (create-or-update), delete, revoke.
+
+Drives `build_admin_router` under `httpx.ASGITransport` with a real SQLite
+file in `tmp_path` and two configured admin secrets (proving the CSV
+rotation property). Never imports daimon.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+from report_host import reports_store
+from report_host.admin import (
+    _validate_slug,  # pyright: ignore[reportPrivateUsage]
+    build_admin_router,
+)
+from report_host.config import Settings, load_settings
+
+AUTH = "Bearer admin-secret"
+BACKUP_AUTH = "Bearer backup-secret"
+WRONG_AUTH = "Bearer wrong-secret"
+
+
+def _settings(*, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **overrides: object) -> Settings:
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", "admin-secret,backup-secret")
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "http://testserver/mcp")
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "http://reports.example.com")
+    settings = load_settings(_env_file=None)
+    fields: dict[str, object] = {"data_dir": tmp_path / "data"}
+    fields.update(overrides)
+    return settings.model_copy(update=fields)
+
+
+def _make_app(*, settings: Settings, conn: sqlite3.Connection) -> FastAPI:
+    app = FastAPI()
+    app.include_router(build_admin_router(settings=settings, conn_factory=lambda: conn))
+    return app
+
+
+async def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver")
+
+
+def _publish_body(
+    *,
+    title: str = "Acme Q3",
+    tenant_id: str = "tenant-1",
+    agent_name: str = "analyst",
+    cap_usd: str = "10",
+    seam_token: str = "seam-token-secret-1",
+    recipients: list[dict[str, str]] | None = None,
+) -> dict[str, object]:
+    return {
+        "title": title,
+        "tenant_id": tenant_id,
+        "agent_name": agent_name,
+        "cap_usd": cap_usd,
+        "seam_token": seam_token,
+        "recipients": (
+            recipients if recipients is not None else [{"name": "Jane", "label": "reader"}]
+        ),
+    }
+
+
+# --------------------------------------------------------------------------
+# Slug validation (pure, unit-level — real slashes can't reach the handler
+# through single-segment HTTP routing, so this path is asserted directly)
+# --------------------------------------------------------------------------
+
+
+def test_validate_slug_rejects_a_slug_containing_a_path_separator() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        _validate_slug("foo/bar")
+    assert excinfo.value.status_code in (400, 422)
+
+
+def test_validate_slug_rejects_dotdot() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        _validate_slug("..")
+    assert excinfo.value.status_code in (400, 422)
+
+
+def test_validate_slug_rejects_uppercase() -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        _validate_slug("Acme")
+    assert excinfo.value.status_code in (400, 422)
+
+
+def test_validate_slug_accepts_a_conservative_slug() -> None:
+    assert _validate_slug("acme-q3") == "acme-q3"
+
+
+# --------------------------------------------------------------------------
+# Bearer rejection and rotation
+# --------------------------------------------------------------------------
+
+
+async def test_put_without_authorization_header_returns_401(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        resp = await client.put("/admin/reports/acme", json=_publish_body())
+    assert resp.status_code == 401
+
+
+async def test_delete_report_without_authorization_header_returns_401(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        resp = await client.delete("/admin/reports/acme", params={"tenant_id": "tenant-1"})
+    assert resp.status_code == 401
+
+
+async def test_delete_recipient_without_authorization_header_returns_401(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        resp = await client.delete("/admin/reports/acme/recipients/tok-1")
+    assert resp.status_code == 401
+
+
+async def test_put_with_wrong_bearer_returns_401(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        resp = await client.put(
+            "/admin/reports/acme",
+            json=_publish_body(),
+            headers={"authorization": WRONG_AUTH},
+        )
+    assert resp.status_code == 401
+
+
+async def test_put_with_second_configured_secret_is_accepted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The backup secret in the CSV rotation list is honoured, not just the first."""
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        resp = await client.put(
+            "/admin/reports/acme",
+            json=_publish_body(),
+            headers={"authorization": BACKUP_AUTH},
+        )
+    assert resp.status_code == 200, "the second configured admin secret should be accepted"
+
+
+# --------------------------------------------------------------------------
+# Publish: create, replace recipients, tenant ownership, spend preservation
+# --------------------------------------------------------------------------
+
+
+async def test_put_creates_report_and_returns_one_link_per_recipient(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    body = _publish_body(
+        recipients=[{"name": "Jane", "label": "reader"}, {"name": "Bob", "label": "reader"}]
+    )
+    async with await _client(app) as client:
+        resp = await client.put("/admin/reports/acme", json=body, headers={"authorization": AUTH})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["slug"] == "acme"
+    links = payload["links"]
+    assert len(links) == 2
+    tokens: set[str] = set()
+    for link in links:
+        assert link["link"].startswith("http://reports.example.com/r/acme?k=")
+        token = link["link"].rsplit("k=", 1)[1]
+        tokens.add(token)
+    assert len(tokens) == 2, "each recipient must get a distinct token"
+    assert "seam_token" not in payload, "the seam token must never be echoed back"
+
+    report = reports_store.load_report(conn, slug="acme")
+    assert report is not None
+    assert report.title == "Acme Q3"
+    assert report.tenant_id == "tenant-1"
+
+
+async def test_second_put_same_tenant_updates_title_and_replaces_recipients(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        first = await client.put(
+            "/admin/reports/acme", json=_publish_body(title="Q3"), headers={"authorization": AUTH}
+        )
+        old_token = first.json()["links"][0]["link"].rsplit("k=", 1)[1]
+
+        second = await client.put(
+            "/admin/reports/acme",
+            json=_publish_body(title="Q4", recipients=[{"name": "New Reader", "label": "reader"}]),
+            headers={"authorization": AUTH},
+        )
+    assert second.status_code == 200
+    report = reports_store.load_report(conn, slug="acme")
+    assert report is not None
+    assert report.title == "Q4"
+
+    assert (
+        reports_store.load_recipient(conn, slug="acme", token=old_token, now=datetime.now(UTC))
+        is None
+    ), "the previously issued link must stop resolving after a re-publish"
+    new_recipients = [
+        r for r in reports_store.list_recipients(conn, slug="acme") if r.revoked_at is None
+    ]
+    assert len(new_recipients) == 1
+    assert new_recipients[0].name == "New Reader"
+
+
+async def test_second_put_same_tenant_preserves_spend_pdf_and_bundle_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-publishing metadata must not refund the cap or blank a served PDF.
+
+    Mutation-checked: making `save_report` reset `spent_usd` on conflict
+    (temporarily editing `reports_store.py`'s `ON CONFLICT` clause to add
+    `spent_usd = 0` and re-running this test) turns this assertion red;
+    reverting turns it green again.
+    """
+    conn = reports_store.connect(tmp_path / "data")
+    reports_store.save_report(
+        conn,
+        slug="acme",
+        title="Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("10"),
+        agent_token="seam-token-secret-1",
+        now=datetime.now(UTC),
+    )
+    reports_store.reserve_budget(conn, slug="acme", amount=Decimal("2"))
+    reports_store.set_current_pdf(conn, slug="acme", name="report.pdf")
+    reports_store.save_bundle_reference(
+        conn,
+        slug="acme",
+        handle="bundle-handle-1",
+        sha256="a" * 64,
+        expires_at=datetime.now(UTC),
+        archive_path="acme/archive.tar.gz",
+    )
+
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        resp = await client.put(
+            "/admin/reports/acme", json=_publish_body(title="Q4"), headers={"authorization": AUTH}
+        )
+    assert resp.status_code == 200
+
+    report = reports_store.load_report(conn, slug="acme")
+    assert report is not None
+    assert report.spent_usd == Decimal("2"), "a metadata re-publish must not reset spend"
+    assert report.current_pdf == "report.pdf", "a metadata re-publish must not blank the served PDF"
+    assert report.bundle_handle == "bundle-handle-1", (
+        "a metadata re-publish must not orphan the bundle reference"
+    )
+
+
+async def test_put_from_different_tenant_returns_403_and_leaves_existing_row_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Slug squatting: a different tenant's PUT must not take over the slug.
+
+    Mutation-checked: commenting out the tenant-mismatch check in
+    `admin.py`'s `put_report` turns this assertion red (the second PUT would
+    succeed and silently rewrite `tenant_id`/`title`); restoring it turns it
+    green again.
+    """
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        await client.put(
+            "/admin/reports/acme",
+            json=_publish_body(title="Q3", tenant_id="tenant-1"),
+            headers={"authorization": AUTH},
+        )
+        resp = await client.put(
+            "/admin/reports/acme",
+            json=_publish_body(title="Hijacked", tenant_id="tenant-2"),
+            headers={"authorization": AUTH},
+        )
+    assert resp.status_code == 403
+    assert "tenant-1" not in resp.text and "tenant-2" not in resp.text, (
+        "the refusal must not reveal either tenant"
+    )
+
+    report = reports_store.load_report(conn, slug="acme")
+    assert report is not None
+    assert report.title == "Q3", "the existing row must be unchanged, not merely refused"
+    assert report.tenant_id == "tenant-1"
+
+
+async def test_put_rejects_slug_with_uppercase_and_creates_no_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    app = _make_app(settings=settings, conn=conn)
+    async with await _client(app) as client:
+        resp = await client.put(
+            "/admin/reports/Acme", json=_publish_body(), headers={"authorization": AUTH}
+        )
+    assert resp.status_code in (400, 422)
+    assert not (settings.data_dir / "Acme").exists()
+    assert reports_store.load_report(conn, slug="Acme") is None
+
+
+async def test_put_rejects_a_percent_encoded_dotdot_slug(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    app = _make_app(settings=settings, conn=conn)
+    async with await _client(app) as client:
+        resp = await client.put(
+            "/admin/reports/%2e%2e", json=_publish_body(), headers={"authorization": AUTH}
+        )
+    assert resp.status_code in (400, 422)
+    assert reports_store.load_report(conn, slug="..") is None
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+
+
+async def test_delete_with_matching_tenant_removes_report_and_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    app = _make_app(settings=settings, conn=conn)
+    report_dir = settings.data_dir / "acme"
+    report_dir.mkdir(parents=True)
+    (report_dir / "report.pdf").write_bytes(b"%PDF-1.4")
+
+    async with await _client(app) as client:
+        await client.put(
+            "/admin/reports/acme", json=_publish_body(), headers={"authorization": AUTH}
+        )
+        resp = await client.delete(
+            "/admin/reports/acme",
+            params={"tenant_id": "tenant-1"},
+            headers={"authorization": AUTH},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+    assert reports_store.load_report(conn, slug="acme") is None
+    assert not report_dir.exists()
+
+
+async def test_delete_with_mismatched_tenant_returns_403_and_report_still_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        await client.put(
+            "/admin/reports/acme",
+            json=_publish_body(tenant_id="tenant-1"),
+            headers={"authorization": AUTH},
+        )
+        resp = await client.delete(
+            "/admin/reports/acme",
+            params={"tenant_id": "tenant-2"},
+            headers={"authorization": AUTH},
+        )
+    assert resp.status_code == 403
+    assert reports_store.load_report(conn, slug="acme") is not None
+
+
+async def test_delete_of_unknown_slug_reports_nothing_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        resp = await client.delete(
+            "/admin/reports/ghost",
+            params={"tenant_id": "tenant-1"},
+            headers={"authorization": AUTH},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is False
+
+
+async def test_successful_and_unknown_slug_deletes_report_different_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        await client.put(
+            "/admin/reports/acme",
+            json=_publish_body(tenant_id="tenant-1"),
+            headers={"authorization": AUTH},
+        )
+        success = await client.delete(
+            "/admin/reports/acme",
+            params={"tenant_id": "tenant-1"},
+            headers={"authorization": AUTH},
+        )
+        unknown = await client.delete(
+            "/admin/reports/acme",
+            params={"tenant_id": "tenant-1"},
+            headers={"authorization": AUTH},
+        )
+    assert success.json()["deleted"] != unknown.json()["deleted"], (
+        "a real deletion must be distinguishable from a no-op delete of the same slug"
+    )
+
+
+# --------------------------------------------------------------------------
+# Recipient revocation
+# --------------------------------------------------------------------------
+
+
+async def test_recipient_revoke_stops_that_link_while_siblings_still_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        published = await client.put(
+            "/admin/reports/acme",
+            json=_publish_body(
+                recipients=[{"name": "Jane", "label": "reader"}, {"name": "Bob", "label": "reader"}]
+            ),
+            headers={"authorization": AUTH},
+        )
+        links = published.json()["links"]
+        jane_token = next(link for link in links if link["name"] == "Jane")["link"].rsplit("k=", 1)[
+            1
+        ]
+        bob_token = next(link for link in links if link["name"] == "Bob")["link"].rsplit("k=", 1)[1]
+
+        resp = await client.delete(
+            f"/admin/reports/acme/recipients/{jane_token}", headers={"authorization": AUTH}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+    now = datetime.now(UTC)
+    assert reports_store.load_recipient(conn, slug="acme", token=jane_token, now=now) is None
+    assert reports_store.load_recipient(conn, slug="acme", token=bob_token, now=now) is not None
+
+
+async def test_revoking_the_same_recipient_twice_is_not_an_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    app = _make_app(settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch), conn=conn)
+    async with await _client(app) as client:
+        published = await client.put(
+            "/admin/reports/acme", json=_publish_body(), headers={"authorization": AUTH}
+        )
+        token = published.json()["links"][0]["link"].rsplit("k=", 1)[1]
+
+        first = await client.delete(
+            f"/admin/reports/acme/recipients/{token}", headers={"authorization": AUTH}
+        )
+        second = await client.delete(
+            f"/admin/reports/acme/recipients/{token}", headers={"authorization": AUTH}
+        )
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["deleted"] is True
+    assert second.json()["deleted"] is False

--- a/apps/report-host/tests/test_capability.py
+++ b/apps/report-host/tests/test_capability.py
@@ -1,0 +1,108 @@
+"""Tests for the host-side capability-token verifier — never imports daimon.
+
+Mirrors the core mint side; uses the same wire format so a token minted by
+daimon-core verifies here. The mint helper is inlined here (report-host
+cannot import daimon-core) to prove cross-side compatibility from the wire
+bytes alone.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from datetime import UTC, datetime
+
+from pydantic import SecretStr
+from report_host.capability import CapabilityClaims, verify_token
+
+_NOW = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_SECRETS = [SecretStr("primary-admin-secret"), SecretStr("rotation-secret-2")]
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _mint(secret: str, payload: dict[str, object]) -> str:
+    payload_b64 = _b64(json.dumps(payload, separators=(",", ":")).encode())
+    sig = hmac.new(secret.encode(), payload_b64.encode(), hashlib.sha256).digest()
+    return f"{payload_b64}.{_b64(sig)}"
+
+
+def _payload(**over: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "slug": "my-report",
+        "op": "report",
+        "name": None,
+        "max_bytes": 1_000_000,
+        "exp": int(_NOW.timestamp()) + 300,
+        "jti": "j1",
+    }
+    base.update(over)
+    return base
+
+
+def test_verify_token_accepts_valid_token_and_returns_typed_claims() -> None:
+    claims = verify_token(_SECRETS, _mint(_SECRETS[0].get_secret_value(), _payload()), now=_NOW)
+    assert isinstance(claims, CapabilityClaims), "returns a typed claims model, not a raw dict"
+    assert claims.slug == "my-report" and claims.op == "report", (
+        "destination read off the verified payload"
+    )
+
+
+def test_verify_token_accepts_second_of_two_configured_secrets() -> None:
+    claims = verify_token(_SECRETS, _mint(_SECRETS[1].get_secret_value(), _payload()), now=_NOW)
+    assert claims is not None, "a token signed by any configured secret verifies"
+    assert claims.slug == "my-report"
+
+
+def test_verify_token_rejects_forged_signature() -> None:
+    token = _mint("attacker-guess", _payload())
+    assert verify_token(_SECRETS, token, now=_NOW) is None, "unknown signing key must fail closed"
+
+
+def test_verify_token_rejects_tampered_payload() -> None:
+    good = _mint(_SECRETS[0].get_secret_value(), _payload())
+    payload_b64, sig_b64 = good.split(".", 1)
+    tampered = json.loads(base64.urlsafe_b64decode(payload_b64 + "=="))
+    tampered["slug"] = "victim-report"
+    forged = f"{_b64(json.dumps(tampered, separators=(',', ':')).encode())}.{sig_b64}"
+    assert verify_token(_SECRETS, forged, now=_NOW) is None, (
+        "swapping the slug invalidates the signature"
+    )
+
+
+def test_verify_token_rejects_tampered_signature() -> None:
+    good = _mint(_SECRETS[0].get_secret_value(), _payload())
+    payload_b64, _sig_b64 = good.split(".", 1)
+    corrupted_sig = _b64(b"not-the-real-signature-bytes")
+    forged = f"{payload_b64}.{corrupted_sig}"
+    assert verify_token(_SECRETS, forged, now=_NOW) is None, "a corrupted signature must fail"
+
+
+def test_verify_token_rejects_expired_token() -> None:
+    expired = _mint(_SECRETS[0].get_secret_value(), _payload(exp=int(_NOW.timestamp()) - 1))
+    assert verify_token(_SECRETS, expired, now=_NOW) is None, "exp in the past must fail"
+
+
+def test_verify_token_rejects_secret_not_in_list() -> None:
+    token = _mint("not-a-configured-secret", _payload())
+    assert verify_token(_SECRETS, token, now=_NOW) is None
+
+
+def test_verify_token_rejects_blog_op() -> None:
+    token = _mint(_SECRETS[0].get_secret_value(), _payload(op="blog"))
+    assert verify_token(_SECRETS, token, now=_NOW) is None, (
+        "report-host accepts exactly the report operation"
+    )
+
+
+def test_verify_token_rejects_malformed_token() -> None:
+    assert verify_token(_SECRETS, "no-dot-here", now=_NOW) is None
+
+
+def test_verify_token_rejects_garbage_signature_base64() -> None:
+    payload_b64 = _b64(json.dumps(_payload(), separators=(",", ":")).encode())
+    assert verify_token(_SECRETS, f"{payload_b64}.!!!not-base64!!!", now=_NOW) is None

--- a/apps/report-host/tests/test_config.py
+++ b/apps/report-host/tests/test_config.py
@@ -1,0 +1,84 @@
+"""Tests for report_host.config — never imports daimon."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+
+def _set_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", "primary,backup")
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "https://seam.example.com/mcp")
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "https://reports.example.com")
+
+
+def test_admin_secrets_csv_parses_into_list_of_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    from report_host.config import load_settings
+
+    _set_required(monkeypatch)
+    settings = load_settings(_env_file=None)
+    values = [s.get_secret_value() for s in settings.admin_secrets]
+    assert values == ["primary", "backup"], "CSV admin secrets should parse into a two-item list"
+
+
+def test_missing_admin_secrets_raises_validation_error_naming_the_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from report_host.config import load_settings
+
+    monkeypatch.delenv("DAIMON_REPORT__ADMIN_SECRETS", raising=False)
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "https://seam.example.com/mcp")
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "https://reports.example.com")
+
+    with pytest.raises(ValidationError, match="DAIMON_REPORT__ADMIN_SECRETS"):
+        load_settings(_env_file=None)
+
+
+def test_missing_mcp_url_raises_rather_than_defaulting(monkeypatch: pytest.MonkeyPatch) -> None:
+    from report_host.config import load_settings
+
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", "primary")
+    monkeypatch.delenv("DAIMON_REPORT__MCP_URL", raising=False)
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "https://reports.example.com")
+
+    with pytest.raises(ValidationError):
+        load_settings(_env_file=None)
+
+
+def test_missing_public_url_base_raises_rather_than_defaulting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from report_host.config import load_settings
+
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", "primary")
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "https://seam.example.com/mcp")
+    monkeypatch.delenv("DAIMON_REPORT__PUBLIC_URL_BASE", raising=False)
+
+    with pytest.raises(ValidationError):
+        load_settings(_env_file=None)
+
+
+def test_reserve_usd_is_decimal_and_equals_default_from_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from report_host.config import load_settings
+
+    _set_required(monkeypatch)
+    settings = load_settings(_env_file=None)
+    assert isinstance(settings.reserve_usd, Decimal), "reserve_usd must be a Decimal, not a float"
+    assert settings.reserve_usd == Decimal("0.60"), "default reserve should be exactly $0.60"
+
+
+def test_cap_and_interval_defaults_match_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    from report_host.config import load_settings
+
+    _set_required(monkeypatch)
+    settings = load_settings(_env_file=None)
+    assert settings.max_pdf_bytes == 50 * 1024 * 1024
+    assert settings.max_bundle_bytes == 25 * 1024 * 1024
+    assert settings.max_open_threads_per_recipient == 3
+    assert settings.max_running_turns_per_report == 4
+    assert settings.poll_interval_seconds == 2.0
+    assert settings.turn_timeout_seconds == 1200

--- a/apps/report-host/tests/test_main.py
+++ b/apps/report-host/tests/test_main.py
@@ -1,0 +1,130 @@
+"""Tests for report_host.main — the app factory and its lifespan.
+
+Drives `create_app`'s assembled `FastAPI` app the same way every other
+report-host router test does: `httpx.ASGITransport` inside the test's own
+event loop, plus the shared `fake_seam_lifespan` fixture (generic over any
+ASGI app, not just the fake seam) to run the real lifespan's startup and
+shutdown. `main.py` opens its own `sqlite3.Connection` synchronously inside
+`create_app`, which `fastapi.testclient.TestClient` cannot drive — it runs
+the ASGI app in a separate portal thread, and sqlite3 connections are
+thread-bound; production never hits this because `uvicorn.run` shares the
+one thread `create_app` ran in.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from pathlib import Path
+
+import httpx
+import pytest
+from report_host import main as main_mod
+from report_host.config import Settings, load_settings
+from starlette.types import Receive, Scope, Send
+
+# Local alias mirroring conftest's fixture type (see test_mcp_client.py for
+# why this can't just be imported: `--import-mode=importlib` gives every
+# test module its own namespace with no shared sys.path entry).
+FakeASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+FakeSeamLifespan = Callable[[FakeASGIApp], AbstractAsyncContextManager[None]]
+
+
+def _settings(*, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **overrides: object) -> Settings:
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", "admin-secret")
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "http://testserver/mcp")
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "http://reports.example.com")
+    settings = load_settings(_env_file=None)
+    fields: dict[str, object] = {"data_dir": tmp_path / "data"}
+    fields.update(overrides)
+    return settings.model_copy(update=fields)
+
+
+async def _client(app: FakeASGIApp) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver")
+
+
+async def test_health_returns_200_with_no_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
+    app = main_mod.create_app(_settings(tmp_path=tmp_path, monkeypatch=monkeypatch))
+    async with fake_seam_lifespan(app), await _client(app) as client:
+        resp = await client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+async def test_lifespan_runs_resume_pass_exactly_once_and_starts_stops_the_sweep_cleanly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_seam_lifespan: FakeSeamLifespan,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    resume_calls: list[dict[str, object]] = []
+
+    async def fake_resume(**kwargs: object) -> int:
+        resume_calls.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(main_mod, "resume_running_threads", fake_resume)
+    app = main_mod.create_app(_settings(tmp_path=tmp_path, monkeypatch=monkeypatch))
+
+    with caplog.at_level(logging.ERROR, logger="asyncio"):
+        async with fake_seam_lifespan(app), await _client(app) as client:
+            resp = await client.get("/health")
+            assert resp.status_code == 200
+
+    assert len(resume_calls) == 1, "the resume pass must run exactly once, at startup"
+    destroyed = [r for r in caplog.records if "destroyed" in r.getMessage().lower()]
+    assert destroyed == [], "the sweep task must be cancelled and awaited, not abandoned"
+
+
+async def test_exposes_reader_admin_and_upload_routes_at_their_documented_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = main_mod.create_app(_settings(tmp_path=tmp_path, monkeypatch=monkeypatch))
+    paths = {getattr(route, "path", None) for route in app.routes}
+    for expected in (
+        "/health",
+        "/r/{slug}",
+        "/api/{slug}/state",
+        "/api/{slug}/threads/{thread_id}",
+        "/api/{slug}/ask",
+        "/api/{slug}/threads/{thread_id}/cancel",
+        "/api/{slug}/threads/{thread_id}/close",
+        "/files/{slug}/{name}",
+        "/admin/reports/{slug}",
+        "/admin/reports/{slug}/recipients/{token}",
+        "/publish/{capability_token}",
+        "/upload/{turn_token}",
+    ):
+        assert expected in paths, f"missing documented route: {expected}"
+
+
+async def test_admin_route_without_bearer_is_401_through_the_assembled_app(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
+    app = main_mod.create_app(_settings(tmp_path=tmp_path, monkeypatch=monkeypatch))
+    async with fake_seam_lifespan(app), await _client(app) as client:
+        resp = await client.put(
+            "/admin/reports/some-report",
+            json={
+                "title": "t",
+                "tenant_id": "tenant-1",
+                "agent_name": "analyst",
+                "cap_usd": "10",
+                "seam_token": "seam-token-1",
+                "recipients": [],
+            },
+        )
+    assert resp.status_code == 401, "the admin bearer dependency must survive the app wiring"
+
+
+async def test_schema_is_applied_on_construction_and_unknown_token_is_403_not_a_db_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
+    app = main_mod.create_app(_settings(tmp_path=tmp_path, monkeypatch=monkeypatch))
+    async with fake_seam_lifespan(app), await _client(app) as client:
+        resp = await client.get("/r/no-such-report", params={"k": "bogus"})
+    assert resp.status_code == 403, "an empty, freshly-applied schema must not surface as a 500"

--- a/apps/report-host/tests/test_mcp_client.py
+++ b/apps/report-host/tests/test_mcp_client.py
@@ -4,20 +4,20 @@ The fake seam is a small `mcp.server.lowlevel.Server` mounted on the real
 streamable-HTTP ASGI transport (`StreamableHTTPSessionManager`), driven over
 `httpx.ASGITransport` — never a monkeypatch of `SeamClient`'s own methods, so
 every test exercises the real MCP wire protocol our client actually speaks.
+
+The harness itself (`build_fake_seam` / `fake_seam_lifespan`) is a shared
+fixture from `conftest.py`, not defined here, so plan 21-14's shell tests for
+`turns.py` can drive the same fake seam without a second implementation.
 """
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
 from decimal import Decimal
 
 import httpx
 import pytest
-from mcp import types as mcp_types
-from mcp.server.lowlevel import Server
-from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from report_host.mcp_client import (
     BundleExpiredError,
     BundlePushed,
@@ -26,109 +26,17 @@ from report_host.mcp_client import (
     SeamUnauthorizedError,
     StartedTurn,
 )
-from starlette.applications import Starlette
-from starlette.routing import Route
-from starlette.types import Message, Receive, Scope, Send
+from starlette.types import Receive, Scope, Send
 
 pytestmark = pytest.mark.asyncio
 
-FakeToolBehavior = Callable[[dict[str, object]], dict[str, object]]
+# Local aliases for the fixture types `conftest.py` provides (`build_fake_seam`,
+# `fake_seam_lifespan`) — a plain `from conftest import ...` doesn't work under
+# this project's `--import-mode=importlib` pytest config, so these mirror
+# conftest's own aliases for type-hint purposes only, not a second harness.
 FakeASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
-
-
-class _StreamableHTTPEndpoint:
-    """ASGI endpoint that hands every request to the session manager."""
-
-    def __init__(self, manager: StreamableHTTPSessionManager) -> None:
-        self._manager = manager
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        await self._manager.handle_request(scope, receive, send)
-
-
-def _build_fake_seam(
-    *,
-    behaviors: dict[str, FakeToolBehavior],
-    captured_auth: list[str],
-    captured_arguments: dict[str, dict[str, object]] | None = None,
-    unauthorized_tokens: frozenset[str] = frozenset(),
-) -> FakeASGIApp:
-    """Build a minimal MCP server exposing exactly the tools under test.
-
-    Raising inside a behavior maps to an ``isError`` CallToolResult carrying
-    exactly ``str(exception)`` as its text — the low-level server's own
-    ``except Exception as e: return self._make_error_result(str(e))``, with
-    no wrapping — so tests can pin exact tool-error wording.
-    """
-    server = Server("fake-seam")
-
-    @server.call_tool()
-    async def handle_call_tool(  # pyright: ignore[reportUnusedFunction]
-        name: str, arguments: dict[str, object]
-    ) -> dict[str, object]:
-        if captured_arguments is not None:
-            captured_arguments[name] = arguments
-        behavior = behaviors[name]
-        return behavior(arguments)
-
-    @server.list_tools()
-    async def handle_list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
-        # No outputSchema: the mcp client's own call_tool() fetches this list
-        # to validate structuredContent against a declared schema, and skips
-        # validation entirely when a tool has none — exactly what these tests
-        # want, since they assert on the client's own decoding, not a schema.
-        return [
-            mcp_types.Tool(name=name, inputSchema={"type": "object", "properties": {}})
-            for name in behaviors
-        ]
-
-    manager = StreamableHTTPSessionManager(app=server, stateless=True)
-    starlette_app = Starlette(
-        routes=[Route("/mcp", endpoint=_StreamableHTTPEndpoint(manager))],
-        lifespan=lambda _app: manager.run(),
-    )
-
-    async def wrapped(scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "http":
-            headers = dict(scope["headers"])
-            auth_header = headers.get(b"authorization", b"").decode()
-            captured_auth.append(auth_header)
-            token = auth_header.removeprefix("Bearer ")
-            if token in unauthorized_tokens:
-                await send({"type": "http.response.start", "status": 401, "headers": []})
-                await send({"type": "http.response.body", "body": b""})
-                return
-        await starlette_app(scope, receive, send)
-
-    return wrapped
-
-
-@contextlib.asynccontextmanager
-async def _lifespan(app: FakeASGIApp) -> AsyncIterator[None]:
-    send_queue: asyncio.Queue[Message] = asyncio.Queue()
-    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
-
-    async def receive() -> Message:
-        return await receive_queue.get()
-
-    async def send(message: Message) -> None:
-        await send_queue.put(message)
-
-    async def run_lifespan() -> None:
-        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
-
-    task = asyncio.create_task(run_lifespan())
-
-    await receive_queue.put({"type": "lifespan.startup"})
-    msg = await send_queue.get()
-    assert msg["type"] == "lifespan.startup.complete", msg
-    try:
-        yield
-    finally:
-        await receive_queue.put({"type": "lifespan.shutdown"})
-        msg = await send_queue.get()
-        assert msg["type"] == "lifespan.shutdown.complete", msg
-        await task
+FakeSeamBuilder = Callable[..., FakeASGIApp]
+FakeSeamLifespan = Callable[[FakeASGIApp], AbstractAsyncContextManager[None]]
 
 
 def _seam_client(app: FakeASGIApp) -> SeamClient:
@@ -140,7 +48,9 @@ def _seam_client(app: FakeASGIApp) -> SeamClient:
     )
 
 
-async def test_start_turn_returns_all_three_boundary_fields() -> None:
+async def test_start_turn_returns_all_three_boundary_fields(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     def start_turn(_args: dict[str, object]) -> dict[str, object]:
         return {
             "handle": "ses_1",
@@ -149,58 +59,64 @@ async def test_start_turn_returns_all_three_boundary_fields() -> None:
         }
 
     captured: list[str] = []
-    app = _build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
-    async with _lifespan(app):
+    app = build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    async with fake_seam_lifespan(app):
         result = await _seam_client(app).start_turn(token="tok", message="hello")
     assert result == StartedTurn(
         handle="ses_1", turn_event_id="evt_1", turn_started_at="2026-01-01T00:00:00Z"
     ), "start_turn must return all three boundary fields the seam sent"
 
 
-async def test_start_turn_with_bundle_passes_it_through() -> None:
+async def test_start_turn_with_bundle_passes_it_through(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     seen: dict[str, dict[str, object]] = {}
 
     def start_turn(args: dict[str, object]) -> dict[str, object]:
         return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
 
     captured: list[str] = []
-    app = _build_fake_seam(
+    app = build_fake_seam(
         behaviors={"start_turn": start_turn}, captured_auth=captured, captured_arguments=seen
     )
-    async with _lifespan(app):
+    async with fake_seam_lifespan(app):
         await _seam_client(app).start_turn(token="tok", message="hello", bundle="bundle-handle-1")
     assert seen["start_turn"].get("bundle") == "bundle-handle-1", (
         "a provided bundle handle must be forwarded to the seam"
     )
 
 
-async def test_start_turn_without_bundle_omits_the_parameter() -> None:
+async def test_start_turn_without_bundle_omits_the_parameter(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     seen: dict[str, dict[str, object]] = {}
 
     def start_turn(_args: dict[str, object]) -> dict[str, object]:
         return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
 
     captured: list[str] = []
-    app = _build_fake_seam(
+    app = build_fake_seam(
         behaviors={"start_turn": start_turn}, captured_auth=captured, captured_arguments=seen
     )
-    async with _lifespan(app):
+    async with fake_seam_lifespan(app):
         await _seam_client(app).start_turn(token="tok", message="hello")
     assert "bundle" not in seen["start_turn"], (
         "omitting bundle must omit the wire argument entirely, not send bundle=null"
     )
 
 
-async def test_authorization_header_carries_the_per_call_token() -> None:
+async def test_authorization_header_carries_the_per_call_token(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     """The load-bearing test: two calls on ONE client, two different tokens."""
 
     def start_turn(_args: dict[str, object]) -> dict[str, object]:
         return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
 
     captured: list[str] = []
-    app = _build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    app = build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
     client = _seam_client(app)
-    async with _lifespan(app):
+    async with fake_seam_lifespan(app):
         await client.start_turn(token="token-a", message="hello")
         headers_after_first = list(captured)
         captured.clear()
@@ -217,7 +133,9 @@ async def test_authorization_header_carries_the_per_call_token() -> None:
     )
 
 
-async def test_list_events_forwards_created_at_gte_and_types_and_returns_items() -> None:
+async def test_list_events_forwards_created_at_gte_and_types_and_returns_items(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     seen: dict[str, dict[str, object]] = {}
 
     def list_events(_args: dict[str, object]) -> dict[str, object]:
@@ -227,10 +145,10 @@ async def test_list_events_forwards_created_at_gte_and_types_and_returns_items()
         }
 
     captured: list[str] = []
-    app = _build_fake_seam(
+    app = build_fake_seam(
         behaviors={"list_events": list_events}, captured_auth=captured, captured_arguments=seen
     )
-    async with _lifespan(app):
+    async with fake_seam_lifespan(app):
         result = await _seam_client(app).list_events(
             token="tok",
             handle="ses_1",
@@ -243,13 +161,15 @@ async def test_list_events_forwards_created_at_gte_and_types_and_returns_items()
     assert result.next_page is None
 
 
-async def test_get_turn_cost_parses_string_cost_usd_into_exact_decimal() -> None:
+async def test_get_turn_cost_parses_string_cost_usd_into_exact_decimal(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
         return {"cost_usd": "0.123456", "event_count": 7}
 
     captured: list[str] = []
-    app = _build_fake_seam(behaviors={"get_turn_cost": get_turn_cost}, captured_auth=captured)
-    async with _lifespan(app):
+    app = build_fake_seam(behaviors={"get_turn_cost": get_turn_cost}, captured_auth=captured)
+    async with fake_seam_lifespan(app):
         result = await _seam_client(app).get_turn_cost(
             token="tok", handle="ses_1", turn_started_at="t0", turn_event_id="evt_1"
         )
@@ -259,37 +179,43 @@ async def test_get_turn_cost_parses_string_cost_usd_into_exact_decimal() -> None
     assert result.event_count == 7
 
 
-async def test_get_turn_cost_with_null_cost_usd_returns_none() -> None:
+async def test_get_turn_cost_with_null_cost_usd_returns_none(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
         return {"cost_usd": None, "event_count": 3}
 
     captured: list[str] = []
-    app = _build_fake_seam(behaviors={"get_turn_cost": get_turn_cost}, captured_auth=captured)
-    async with _lifespan(app):
+    app = build_fake_seam(behaviors={"get_turn_cost": get_turn_cost}, captured_auth=captured)
+    async with fake_seam_lifespan(app):
         result = await _seam_client(app).get_turn_cost(
             token="tok", handle="ses_1", turn_started_at="t0", turn_event_id="evt_1"
         )
     assert result.cost_usd is None, "a null cost_usd must stay None, never coerce to zero"
 
 
-async def test_tool_error_with_bundle_expired_wording_raises_bundle_expired_error() -> None:
+async def test_tool_error_with_bundle_expired_wording_raises_bundle_expired_error(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     def start_turn(_args: dict[str, object]) -> dict[str, object]:
         raise Exception("bundle expired; re-upload")  # noqa: TRY002
 
     captured: list[str] = []
-    app = _build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
-    async with _lifespan(app):
+    app = build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    async with fake_seam_lifespan(app):
         with pytest.raises(BundleExpiredError):
             await _seam_client(app).start_turn(token="tok", message="hello", bundle="stale")
 
 
-async def test_tool_error_with_other_wording_raises_seam_error_not_bundle_expired() -> None:
+async def test_tool_error_with_other_wording_raises_seam_error_not_bundle_expired(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     def start_turn(_args: dict[str, object]) -> dict[str, object]:
         raise Exception("bundle not found")  # noqa: TRY002
 
     captured: list[str] = []
-    app = _build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
-    async with _lifespan(app):
+    app = build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    async with fake_seam_lifespan(app):
         with pytest.raises(SeamError) as excinfo:
             await _seam_client(app).start_turn(token="tok", message="hello", bundle="bad")
     assert not isinstance(excinfo.value, BundleExpiredError), (
@@ -297,22 +223,26 @@ async def test_tool_error_with_other_wording_raises_seam_error_not_bundle_expire
     )
 
 
-async def test_unauthorized_bearer_raises_seam_unauthorized_error() -> None:
+async def test_unauthorized_bearer_raises_seam_unauthorized_error(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     def start_turn(_args: dict[str, object]) -> dict[str, object]:
         return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
 
     captured: list[str] = []
-    app = _build_fake_seam(
+    app = build_fake_seam(
         behaviors={"start_turn": start_turn},
         captured_auth=captured,
         unauthorized_tokens=frozenset({"revoked-token"}),
     )
-    async with _lifespan(app):
+    async with fake_seam_lifespan(app):
         with pytest.raises(SeamUnauthorizedError):
             await _seam_client(app).start_turn(token="revoked-token", message="hello")
 
 
-async def test_archive_session_returns_none_and_issues_exactly_one_call() -> None:
+async def test_archive_session_returns_none_and_issues_exactly_one_call(
+    build_fake_seam: FakeSeamBuilder, fake_seam_lifespan: FakeSeamLifespan
+) -> None:
     calls: list[dict[str, object]] = []
 
     def archive_my_session(args: dict[str, object]) -> dict[str, object]:
@@ -320,10 +250,10 @@ async def test_archive_session_returns_none_and_issues_exactly_one_call() -> Non
         return {"handle": args["handle"], "archived": "true"}
 
     captured: list[str] = []
-    app = _build_fake_seam(
+    app = build_fake_seam(
         behaviors={"archive_my_session": archive_my_session}, captured_auth=captured
     )
-    async with _lifespan(app):
+    async with fake_seam_lifespan(app):
         result = await _seam_client(app).archive_session(token="tok", handle="ses_1")
     assert result is None
     assert len(calls) == 1, "archive_session must issue exactly one tool call"

--- a/apps/report-host/tests/test_mcp_client.py
+++ b/apps/report-host/tests/test_mcp_client.py
@@ -1,0 +1,378 @@
+"""Tests for SeamClient against an in-process fake seam.
+
+The fake seam is a small `mcp.server.lowlevel.Server` mounted on the real
+streamable-HTTP ASGI transport (`StreamableHTTPSessionManager`), driven over
+`httpx.ASGITransport` — never a monkeypatch of `SeamClient`'s own methods, so
+every test exercises the real MCP wire protocol our client actually speaks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Awaitable, Callable
+from decimal import Decimal
+
+import httpx
+import pytest
+from mcp import types as mcp_types
+from mcp.server.lowlevel import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from report_host.mcp_client import (
+    BundleExpiredError,
+    BundlePushed,
+    SeamClient,
+    SeamError,
+    SeamUnauthorizedError,
+    StartedTurn,
+)
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.types import Message, Receive, Scope, Send
+
+pytestmark = pytest.mark.asyncio
+
+FakeToolBehavior = Callable[[dict[str, object]], dict[str, object]]
+FakeASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+
+
+class _StreamableHTTPEndpoint:
+    """ASGI endpoint that hands every request to the session manager."""
+
+    def __init__(self, manager: StreamableHTTPSessionManager) -> None:
+        self._manager = manager
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        await self._manager.handle_request(scope, receive, send)
+
+
+def _build_fake_seam(
+    *,
+    behaviors: dict[str, FakeToolBehavior],
+    captured_auth: list[str],
+    captured_arguments: dict[str, dict[str, object]] | None = None,
+    unauthorized_tokens: frozenset[str] = frozenset(),
+) -> FakeASGIApp:
+    """Build a minimal MCP server exposing exactly the tools under test.
+
+    Raising inside a behavior maps to an ``isError`` CallToolResult carrying
+    exactly ``str(exception)`` as its text — the low-level server's own
+    ``except Exception as e: return self._make_error_result(str(e))``, with
+    no wrapping — so tests can pin exact tool-error wording.
+    """
+    server = Server("fake-seam")
+
+    @server.call_tool()
+    async def handle_call_tool(  # pyright: ignore[reportUnusedFunction]
+        name: str, arguments: dict[str, object]
+    ) -> dict[str, object]:
+        if captured_arguments is not None:
+            captured_arguments[name] = arguments
+        behavior = behaviors[name]
+        return behavior(arguments)
+
+    @server.list_tools()
+    async def handle_list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
+        # No outputSchema: the mcp client's own call_tool() fetches this list
+        # to validate structuredContent against a declared schema, and skips
+        # validation entirely when a tool has none — exactly what these tests
+        # want, since they assert on the client's own decoding, not a schema.
+        return [
+            mcp_types.Tool(name=name, inputSchema={"type": "object", "properties": {}})
+            for name in behaviors
+        ]
+
+    manager = StreamableHTTPSessionManager(app=server, stateless=True)
+    starlette_app = Starlette(
+        routes=[Route("/mcp", endpoint=_StreamableHTTPEndpoint(manager))],
+        lifespan=lambda _app: manager.run(),
+    )
+
+    async def wrapped(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            headers = dict(scope["headers"])
+            auth_header = headers.get(b"authorization", b"").decode()
+            captured_auth.append(auth_header)
+            token = auth_header.removeprefix("Bearer ")
+            if token in unauthorized_tokens:
+                await send({"type": "http.response.start", "status": 401, "headers": []})
+                await send({"type": "http.response.body", "body": b""})
+                return
+        await starlette_app(scope, receive, send)
+
+    return wrapped
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: FakeASGIApp) -> AsyncIterator[None]:
+    send_queue: asyncio.Queue[Message] = asyncio.Queue()
+    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await receive_queue.get()
+
+    async def send(message: Message) -> None:
+        await send_queue.put(message)
+
+    async def run_lifespan() -> None:
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+
+    task = asyncio.create_task(run_lifespan())
+
+    await receive_queue.put({"type": "lifespan.startup"})
+    msg = await send_queue.get()
+    assert msg["type"] == "lifespan.startup.complete", msg
+    try:
+        yield
+    finally:
+        await receive_queue.put({"type": "lifespan.shutdown"})
+        msg = await send_queue.get()
+        assert msg["type"] == "lifespan.shutdown.complete", msg
+        await task
+
+
+def _seam_client(app: FakeASGIApp) -> SeamClient:
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    return SeamClient(
+        mcp_url="http://testserver/mcp",
+        http_client=httpx.AsyncClient(),
+        transport=transport,
+    )
+
+
+async def test_start_turn_returns_all_three_boundary_fields() -> None:
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {
+            "handle": "ses_1",
+            "turn_event_id": "evt_1",
+            "turn_started_at": "2026-01-01T00:00:00Z",
+        }
+
+    captured: list[str] = []
+    app = _build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    async with _lifespan(app):
+        result = await _seam_client(app).start_turn(token="tok", message="hello")
+    assert result == StartedTurn(
+        handle="ses_1", turn_event_id="evt_1", turn_started_at="2026-01-01T00:00:00Z"
+    ), "start_turn must return all three boundary fields the seam sent"
+
+
+async def test_start_turn_with_bundle_passes_it_through() -> None:
+    seen: dict[str, dict[str, object]] = {}
+
+    def start_turn(args: dict[str, object]) -> dict[str, object]:
+        return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
+
+    captured: list[str] = []
+    app = _build_fake_seam(
+        behaviors={"start_turn": start_turn}, captured_auth=captured, captured_arguments=seen
+    )
+    async with _lifespan(app):
+        await _seam_client(app).start_turn(token="tok", message="hello", bundle="bundle-handle-1")
+    assert seen["start_turn"].get("bundle") == "bundle-handle-1", (
+        "a provided bundle handle must be forwarded to the seam"
+    )
+
+
+async def test_start_turn_without_bundle_omits_the_parameter() -> None:
+    seen: dict[str, dict[str, object]] = {}
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
+
+    captured: list[str] = []
+    app = _build_fake_seam(
+        behaviors={"start_turn": start_turn}, captured_auth=captured, captured_arguments=seen
+    )
+    async with _lifespan(app):
+        await _seam_client(app).start_turn(token="tok", message="hello")
+    assert "bundle" not in seen["start_turn"], (
+        "omitting bundle must omit the wire argument entirely, not send bundle=null"
+    )
+
+
+async def test_authorization_header_carries_the_per_call_token() -> None:
+    """The load-bearing test: two calls on ONE client, two different tokens."""
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
+
+    captured: list[str] = []
+    app = _build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    client = _seam_client(app)
+    async with _lifespan(app):
+        await client.start_turn(token="token-a", message="hello")
+        headers_after_first = list(captured)
+        captured.clear()
+        await client.start_turn(token="token-b", message="hello")
+        headers_after_second = list(captured)
+
+    assert headers_after_first, "the first call must have reached the transport"
+    assert headers_after_second, "the second call must have reached the transport"
+    assert set(headers_after_first) == {"Bearer token-a"}, headers_after_first
+    assert set(headers_after_second) == {"Bearer token-b"}, headers_after_second
+    assert set(headers_after_first) != set(headers_after_second), (
+        "the same client object must carry a DIFFERENT bearer per call, "
+        "proving the token is not held as instance state"
+    )
+
+
+async def test_list_events_forwards_created_at_gte_and_types_and_returns_items() -> None:
+    seen: dict[str, dict[str, object]] = {}
+
+    def list_events(_args: dict[str, object]) -> dict[str, object]:
+        return {
+            "items": [{"type": "agent.message", "text": "hi"}],
+            "next_page": None,
+        }
+
+    captured: list[str] = []
+    app = _build_fake_seam(
+        behaviors={"list_events": list_events}, captured_auth=captured, captured_arguments=seen
+    )
+    async with _lifespan(app):
+        result = await _seam_client(app).list_events(
+            token="tok",
+            handle="ses_1",
+            created_at_gte="2026-01-01T00:00:00Z",
+            types=["agent.message", "session.status_idle"],
+        )
+    assert seen["list_events"]["created_at_gte"] == "2026-01-01T00:00:00Z"
+    assert seen["list_events"]["types"] == ["agent.message", "session.status_idle"]
+    assert result.items == [{"type": "agent.message", "text": "hi"}]
+    assert result.next_page is None
+
+
+async def test_get_turn_cost_parses_string_cost_usd_into_exact_decimal() -> None:
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": "0.123456", "event_count": 7}
+
+    captured: list[str] = []
+    app = _build_fake_seam(behaviors={"get_turn_cost": get_turn_cost}, captured_auth=captured)
+    async with _lifespan(app):
+        result = await _seam_client(app).get_turn_cost(
+            token="tok", handle="ses_1", turn_started_at="t0", turn_event_id="evt_1"
+        )
+    assert result.cost_usd == Decimal("0.123456"), (
+        "cost_usd must parse to an exact Decimal, not a float-rounded value"
+    )
+    assert result.event_count == 7
+
+
+async def test_get_turn_cost_with_null_cost_usd_returns_none() -> None:
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": None, "event_count": 3}
+
+    captured: list[str] = []
+    app = _build_fake_seam(behaviors={"get_turn_cost": get_turn_cost}, captured_auth=captured)
+    async with _lifespan(app):
+        result = await _seam_client(app).get_turn_cost(
+            token="tok", handle="ses_1", turn_started_at="t0", turn_event_id="evt_1"
+        )
+    assert result.cost_usd is None, "a null cost_usd must stay None, never coerce to zero"
+
+
+async def test_tool_error_with_bundle_expired_wording_raises_bundle_expired_error() -> None:
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        raise Exception("bundle expired; re-upload")  # noqa: TRY002
+
+    captured: list[str] = []
+    app = _build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    async with _lifespan(app):
+        with pytest.raises(BundleExpiredError):
+            await _seam_client(app).start_turn(token="tok", message="hello", bundle="stale")
+
+
+async def test_tool_error_with_other_wording_raises_seam_error_not_bundle_expired() -> None:
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        raise Exception("bundle not found")  # noqa: TRY002
+
+    captured: list[str] = []
+    app = _build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    async with _lifespan(app):
+        with pytest.raises(SeamError) as excinfo:
+            await _seam_client(app).start_turn(token="tok", message="hello", bundle="bad")
+    assert not isinstance(excinfo.value, BundleExpiredError), (
+        "only the exact bundle-expired wording may raise BundleExpiredError"
+    )
+
+
+async def test_unauthorized_bearer_raises_seam_unauthorized_error() -> None:
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
+
+    captured: list[str] = []
+    app = _build_fake_seam(
+        behaviors={"start_turn": start_turn},
+        captured_auth=captured,
+        unauthorized_tokens=frozenset({"revoked-token"}),
+    )
+    async with _lifespan(app):
+        with pytest.raises(SeamUnauthorizedError):
+            await _seam_client(app).start_turn(token="revoked-token", message="hello")
+
+
+async def test_archive_session_returns_none_and_issues_exactly_one_call() -> None:
+    calls: list[dict[str, object]] = []
+
+    def archive_my_session(args: dict[str, object]) -> dict[str, object]:
+        calls.append(args)
+        return {"handle": args["handle"], "archived": "true"}
+
+    captured: list[str] = []
+    app = _build_fake_seam(
+        behaviors={"archive_my_session": archive_my_session}, captured_auth=captured
+    )
+    async with _lifespan(app):
+        result = await _seam_client(app).archive_session(token="tok", handle="ses_1")
+    assert result is None
+    assert len(calls) == 1, "archive_session must issue exactly one tool call"
+
+
+async def test_push_bundle_sends_gzip_content_type_and_returns_parsed_fields() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "bundle": "bundle-handle-xyz",
+                "sha256": "deadbeef",
+                "size_bytes": 5,
+                "expires_at": "2026-02-01T00:00:00Z",
+            },
+        )
+
+    client = SeamClient(
+        mcp_url="http://testserver/mcp",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        max_bundle_bytes=1024,
+    )
+    result = await client.push_bundle(token="tok", archive=b"12345", size_bytes=5)
+    assert result == BundlePushed(
+        handle="bundle-handle-xyz",
+        sha256="deadbeef",
+        size_bytes=5,
+        expires_at="2026-02-01T00:00:00Z",
+    )
+    assert len(requests) == 1
+    assert requests[0].headers["content-type"] == "application/gzip"
+    assert requests[0].url.path == "/bundles"
+
+
+async def test_push_bundle_over_cap_raises_before_any_request_is_issued() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={})
+
+    client = SeamClient(
+        mcp_url="http://testserver/mcp",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        max_bundle_bytes=10,
+    )
+    with pytest.raises(SeamError):
+        await client.push_bundle(token="tok", archive=b"x" * 20, size_bytes=20)
+    assert requests == [], "an over-cap bundle must never open a connection to the seam"

--- a/apps/report-host/tests/test_reports_store.py
+++ b/apps/report-host/tests/test_reports_store.py
@@ -1,0 +1,356 @@
+"""Tests for report_host.reports_store — reports, recipients and revisions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+from report_host import reports_store
+
+NOW = datetime(2026, 9, 8, 12, 0, 0, tzinfo=UTC)
+
+
+def _connect(tmp_path: Path):
+    return reports_store.connect(tmp_path / "data")
+
+
+def test_save_report_then_load_round_trips(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    saved = reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    assert saved.slug == "acme-q3"
+    assert saved.spent_usd == Decimal("0")
+    assert saved.seam_status == "ok"
+
+    loaded = reports_store.load_report(conn, slug="acme-q3")
+    assert loaded is not None, "report should be durable across a fresh load"
+    assert loaded == saved
+
+
+def test_load_report_returns_none_for_unknown_slug(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    assert reports_store.load_report(conn, slug="nope") is None
+
+
+def test_resave_report_preserves_spend_current_pdf_and_bundle_fields(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.reserve_budget(conn, slug="acme-q3", amount=Decimal("1.50"))
+    reports_store.set_current_pdf(conn, slug="acme-q3", name="v1.pdf")
+    reports_store.save_bundle_reference(
+        conn,
+        slug="acme-q3",
+        handle="bundle-handle-1",
+        sha256="a" * 64,
+        expires_at=NOW + timedelta(days=90),
+        archive_path="/data/reports/acme-q3/archive.tar.gz",
+    )
+
+    resaved = reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3 (revised title)",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-2",
+        now=NOW + timedelta(days=1),
+    )
+
+    assert resaved.title == "Acme Q3 (revised title)"
+    assert resaved.seam_token == "seam-token-2"
+    assert resaved.spent_usd == Decimal("1.50"), "re-save must not zero an existing spend"
+    assert resaved.current_pdf == "v1.pdf", "re-save must not orphan the published PDF"
+    assert resaved.bundle_handle == "bundle-handle-1"
+    assert resaved.bundle_sha256 == "a" * 64
+    assert resaved.archive_path == "/data/reports/acme-q3/archive.tar.gz", (
+        "a subsequent save_report must leave archive_path intact"
+    )
+
+
+def test_save_bundle_reference_round_trips_archive_path(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.save_bundle_reference(
+        conn,
+        slug="acme-q3",
+        handle="bundle-handle-1",
+        sha256="b" * 64,
+        expires_at=NOW + timedelta(days=90),
+        archive_path="/data/reports/acme-q3/archive.tar.gz",
+    )
+    loaded = reports_store.load_report(conn, slug="acme-q3")
+    assert loaded is not None
+    assert loaded.archive_path == "/data/reports/acme-q3/archive.tar.gz"
+    assert loaded.bundle_handle == "bundle-handle-1"
+    assert loaded.bundle_sha256 == "b" * 64
+    assert loaded.bundle_expires_at == NOW + timedelta(days=90)
+
+
+def test_delete_report_returns_true_once_then_false(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    assert reports_store.delete_report(conn, slug="acme-q3") is True
+    assert reports_store.delete_report(conn, slug="acme-q3") is False
+    assert reports_store.load_report(conn, slug="acme-q3") is None
+
+
+def test_delete_report_returns_false_for_unknown_slug(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    assert reports_store.delete_report(conn, slug="never-existed") is False
+
+
+def test_reserve_budget_succeeds_under_cap(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    new_spend = reports_store.reserve_budget(conn, slug="acme-q3", amount=Decimal("2.00"))
+    assert new_spend == Decimal("2.00")
+
+
+def test_reserve_budget_returns_none_exactly_at_cap_boundary(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("2.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    # Exactly at the cap succeeds (<=); one cent over fails.
+    assert reports_store.reserve_budget(conn, slug="acme-q3", amount=Decimal("2.00")) == Decimal(
+        "2.00"
+    )
+    assert reports_store.reserve_budget(conn, slug="acme-q3", amount=Decimal("0.01")) is None
+
+
+def test_two_sequential_reserves_exceeding_cap_leave_second_refused_and_spend_unchanged(
+    tmp_path: Path,
+) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("3.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    first = reports_store.reserve_budget(conn, slug="acme-q3", amount=Decimal("2.00"))
+    assert first == Decimal("2.00")
+    second = reports_store.reserve_budget(conn, slug="acme-q3", amount=Decimal("2.00"))
+    assert second is None, "a reserve that would cross the cap must be refused"
+    loaded = reports_store.load_report(conn, slug="acme-q3")
+    assert loaded is not None
+    assert loaded.spent_usd == Decimal("2.00"), "a refused reserve must not change the spend"
+
+
+def test_settle_budget_replaces_reservation_with_smaller_actual(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.reserve_budget(conn, slug="acme-q3", amount=Decimal("0.60"))
+    reports_store.settle_budget(
+        conn, slug="acme-q3", reserved=Decimal("0.60"), actual=Decimal("0.23")
+    )
+    loaded = reports_store.load_report(conn, slug="acme-q3")
+    assert loaded is not None
+    assert loaded.spent_usd == Decimal("0.23")
+
+
+def test_settle_budget_with_actual_none_leaves_reservation_in_place(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.reserve_budget(conn, slug="acme-q3", amount=Decimal("0.60"))
+    reports_store.settle_budget(conn, slug="acme-q3", reserved=Decimal("0.60"), actual=None)
+    loaded = reports_store.load_report(conn, slug="acme-q3")
+    assert loaded is not None
+    assert loaded.spent_usd == Decimal("0.60"), (
+        "an unpriced turn is not a zero-cost turn; the reservation must stand"
+    )
+
+
+def test_recipient_past_expiry_loads_as_none(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.add_recipient(
+        conn, slug="acme-q3", name="Jane", label="CFO", token="tok-1", now=NOW, ttl_days=1
+    )
+    still_valid = reports_store.load_recipient(
+        conn, slug="acme-q3", token="tok-1", now=NOW + timedelta(hours=12)
+    )
+    assert still_valid is not None
+    expired = reports_store.load_recipient(
+        conn, slug="acme-q3", token="tok-1", now=NOW + timedelta(days=2)
+    )
+    assert expired is None
+
+
+def test_revoked_recipient_loads_as_none(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.add_recipient(
+        conn, slug="acme-q3", name="Jane", label="CFO", token="tok-1", now=NOW, ttl_days=90
+    )
+    assert reports_store.revoke_recipient(conn, slug="acme-q3", token="tok-1", now=NOW) is True
+    assert reports_store.revoke_recipient(conn, slug="acme-q3", token="tok-1", now=NOW) is False, (
+        "revoking an already-revoked token is a no-op, not a second success"
+    )
+    assert reports_store.load_recipient(conn, slug="acme-q3", token="tok-1", now=NOW) is None
+
+
+def test_list_recipients_lists_all_for_slug(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.add_recipient(
+        conn, slug="acme-q3", name="Jane", label="CFO", token="tok-1", now=NOW, ttl_days=90
+    )
+    reports_store.add_recipient(
+        conn,
+        slug="acme-q3",
+        name="Bob",
+        label="CEO",
+        token="tok-2",
+        now=NOW + timedelta(seconds=1),
+        ttl_days=90,
+    )
+    recipients = reports_store.list_recipients(conn, slug="acme-q3")
+    assert [r.token for r in recipients] == ["tok-1", "tok-2"]
+
+
+def test_revisions_list_in_creation_order(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.add_revision(
+        conn, slug="acme-q3", name="v1.pdf", by_thread=None, note="published", now=NOW
+    )
+    reports_store.add_revision(
+        conn,
+        slug="acme-q3",
+        name="v2.pdf",
+        by_thread="thread-1",
+        note="revised",
+        now=NOW + timedelta(minutes=5),
+    )
+    revisions = reports_store.list_revisions(conn, slug="acme-q3")
+    assert [r.name for r in revisions] == ["v1.pdf", "v2.pdf"]
+
+
+def test_set_seam_status_persists(tmp_path: Path) -> None:
+    conn = _connect(tmp_path)
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.set_seam_status(conn, slug="acme-q3", status="unauthorized")
+    loaded = reports_store.load_report(conn, slug="acme-q3")
+    assert loaded is not None
+    assert loaded.seam_status == "unauthorized"

--- a/apps/report-host/tests/test_routes.py
+++ b/apps/report-host/tests/test_routes.py
@@ -1,0 +1,627 @@
+"""Tests for the reader-facing routes.
+
+Drives `build_reader_router` under `httpx.ASGITransport` with a real SQLite
+file in `tmp_path`, a fake seam (the shared `build_fake_seam` fixture from
+`conftest.py`), and a fake `run_turn` collaborator that only records its call
+— `ask` is asserted to schedule exactly one turn without driving a real one
+end to end.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from report_host import reports_store, threads_store
+from report_host.config import Settings, load_settings
+from report_host.mcp_client import SeamClient
+from report_host.routes import build_reader_router
+from starlette.types import Receive, Scope, Send
+
+pytestmark = pytest.mark.asyncio
+
+NOW = datetime(2026, 9, 8, 12, 0, 0, tzinfo=UTC)
+
+# Local aliases mirroring conftest's fixture types (see test_mcp_client.py for
+# why these can't just be imported: `--import-mode=importlib` gives every
+# test module its own namespace with no shared sys.path entry).
+FakeASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+FakeSeamBuilder = Callable[..., FakeASGIApp]
+FakeSeamLifespan = Callable[[FakeASGIApp], AbstractAsyncContextManager[None]]
+
+
+class _RunTurnRecorder:
+    """A fake `run_turn` collaborator: records its call, never drives a turn."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def __call__(self, **kwargs: object) -> None:
+        self.calls.append(kwargs)
+
+
+def _settings(*, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **overrides: object) -> Settings:
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", "admin-secret")
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "http://testserver/mcp")
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "http://reports.example.com")
+    settings = load_settings(_env_file=None)
+    fields: dict[str, object] = {"data_dir": tmp_path / "data"}
+    fields.update(overrides)
+    return settings.model_copy(update=fields)
+
+
+def _poisoned_seam() -> SeamClient:
+    """A SeamClient that fails loudly if any test in this file actually calls it."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"unexpected seam call: {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    return SeamClient(
+        mcp_url="http://poisoned/mcp", http_client=httpx.AsyncClient(transport=transport)
+    )
+
+
+def _seam_client(app: FakeASGIApp) -> SeamClient:
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    return SeamClient(
+        mcp_url="http://testserver/mcp",
+        http_client=httpx.AsyncClient(transport=transport),
+        transport=transport,
+    )
+
+
+def _seed_report(
+    conn: sqlite3.Connection,
+    *,
+    slug: str = "acme",
+    cap_usd: Decimal = Decimal("10"),
+    tenant_id: str = "tenant-secret-1",
+    agent_token: str = "seam-token-secret-1",
+) -> reports_store.ReportRow:
+    reports_store.save_report(
+        conn,
+        slug=slug,
+        title="Acme Q3",
+        tenant_id=tenant_id,
+        agent_name="analyst",
+        cap_usd=cap_usd,
+        agent_token=agent_token,
+        now=NOW,
+    )
+    report = reports_store.load_report(conn, slug=slug)
+    assert report is not None
+    return report
+
+
+def _seed_recipient(
+    conn: sqlite3.Connection,
+    *,
+    slug: str = "acme",
+    token: str = "tok-1",
+    name: str = "Jane",
+    ttl_days: int = 90,
+) -> reports_store.RecipientRow:
+    return reports_store.add_recipient(
+        conn, slug=slug, name=name, label="reader", token=token, now=NOW, ttl_days=ttl_days
+    )
+
+
+def _make_app(
+    *,
+    settings: Settings,
+    conn: sqlite3.Connection,
+    seam: SeamClient,
+    run_turn: Callable[..., Awaitable[None]] | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    kwargs: dict[str, Any] = {
+        "settings": settings,
+        "conn_factory": lambda: conn,
+        "seam": seam,
+        "now": lambda: NOW,
+    }
+    if run_turn is not None:
+        kwargs["run_turn"] = run_turn
+    app.include_router(build_reader_router(**kwargs))
+    return app
+
+
+async def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver")
+
+
+# --------------------------------------------------------------------------
+# Recipient resolution
+# --------------------------------------------------------------------------
+
+
+async def test_viewer_returns_403_with_no_token_and_no_cookie(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp = await client.get("/r/acme")
+    assert resp.status_code == 403
+
+
+async def test_viewer_returns_403_for_a_token_belonging_to_a_different_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn, slug="acme")
+    _seed_report(conn, slug="other")
+    _seed_recipient(conn, slug="other", token="tok-other")
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp = await client.get("/r/acme?k=tok-other")
+    assert resp.status_code == 403
+
+
+async def test_expired_recipient_returns_403_with_same_message_as_unknown_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-expired", ttl_days=-1)
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        unknown_resp = await client.get("/r/acme?k=does-not-exist")
+        expired_resp = await client.get("/r/acme?k=tok-expired")
+    assert unknown_resp.status_code == 403
+    assert expired_resp.status_code == 403
+    assert unknown_resp.json()["detail"] == expired_resp.json()["detail"], (
+        "unknown and expired tokens must be indistinguishable to the caller"
+    )
+
+
+async def test_viewer_sets_cookie_httponly_secure_samesite_lax(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp = await client.get("/r/acme?k=tok-1")
+    assert resp.status_code == 200
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "rh_acme=tok-1" in set_cookie
+    assert "httponly" in set_cookie.lower()
+    assert "secure" in set_cookie.lower()
+    assert "samesite=lax" in set_cookie.lower()
+
+
+# --------------------------------------------------------------------------
+# State and thread reads
+# --------------------------------------------------------------------------
+
+
+async def test_state_returns_only_this_recipients_threads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-a", name="Alice")
+    _seed_recipient(conn, token="tok-b", name="Bob")
+    threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-a", title="Alice's Q", now=NOW
+    )
+    threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-b", title="Bob's Q", now=NOW
+    )
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp_a = await client.get("/api/acme/state?k=tok-a")
+        resp_b = await client.get("/api/acme/state?k=tok-b")
+    assert len(resp_a.json()["threads"]) == 1
+    assert resp_a.json()["threads"][0]["title"] == "Alice's Q"
+    assert len(resp_b.json()["threads"]) == 1
+    assert resp_b.json()["threads"][0]["title"] == "Bob's Q"
+
+
+async def test_state_payload_excludes_seam_token_bundle_handle_and_tenant_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn, tenant_id="tenant-secret-1", agent_token="seam-token-secret-1")
+    reports_store.save_bundle_reference(
+        conn,
+        slug="acme",
+        handle="bundle-handle-secret-1",
+        sha256="sha-1",
+        expires_at=NOW + timedelta(days=90),
+        archive_path=str(tmp_path / "bundle.tar.gz"),
+    )
+    _seed_recipient(conn, token="tok-1")
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp = await client.get("/api/acme/state?k=tok-1")
+    assert "tenant-secret-1" not in resp.text
+    assert "seam-token-secret-1" not in resp.text
+    assert "bundle-handle-secret-1" not in resp.text
+
+
+async def test_thread_belonging_to_another_recipient_returns_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-a")
+    _seed_recipient(conn, token="tok-b")
+    thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-a", title="Q", now=NOW
+    )
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp = await client.get(f"/api/acme/threads/{thread.id}?k=tok-b")
+    assert resp.status_code == 404
+
+
+async def test_thread_messages_after_watermark_excludes_earlier_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-1", title="Q", now=NOW
+    )
+    m1 = threads_store.add_message(
+        conn,
+        thread_id=thread.id,
+        role="user",
+        text="first",
+        now=NOW,
+        bundle_sha256=None,
+        pdf_revision=None,
+    )
+    threads_store.add_message(
+        conn,
+        thread_id=thread.id,
+        role="assistant",
+        text="second",
+        now=NOW,
+        bundle_sha256=None,
+        pdf_revision=None,
+    )
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp = await client.get(f"/api/acme/threads/{thread.id}?k=tok-1&after={m1.id}")
+    texts = [m["text"] for m in resp.json()["messages"]]
+    assert texts == ["second"]
+
+
+# --------------------------------------------------------------------------
+# ask
+# --------------------------------------------------------------------------
+
+
+async def test_ask_at_running_turns_cap_returns_429_and_schedules_no_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch, max_running_turns_per_report=1)
+    other = threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-1", title="running", now=NOW
+    )
+    started = threads_store.begin_turn(
+        conn,
+        thread_id=other.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=60),
+        now=NOW,
+    )
+    assert started
+    recorder = _RunTurnRecorder()
+    app = _make_app(settings=settings, conn=conn, seam=_poisoned_seam(), run_turn=recorder)
+    async with await _client(app) as client:
+        resp = await client.post("/api/acme/ask?k=tok-1", json={"message": "hello"})
+    assert resp.status_code == 429
+    assert recorder.calls == []
+
+
+async def test_ask_at_open_thread_cap_on_new_thread_returns_429(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    settings = _settings(
+        tmp_path=tmp_path, monkeypatch=monkeypatch, max_open_threads_per_recipient=1
+    )
+    threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-1", title="existing", now=NOW
+    )
+    recorder = _RunTurnRecorder()
+    app = _make_app(settings=settings, conn=conn, seam=_poisoned_seam(), run_turn=recorder)
+    async with await _client(app) as client:
+        resp = await client.post("/api/acme/ask?k=tok-1", json={"message": "a new question"})
+    assert resp.status_code == 429
+    assert recorder.calls == []
+
+
+async def test_ask_followup_in_existing_thread_still_allowed_at_open_thread_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    settings = _settings(
+        tmp_path=tmp_path, monkeypatch=monkeypatch, max_open_threads_per_recipient=1
+    )
+    thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-1", title="existing", now=NOW
+    )
+    recorder = _RunTurnRecorder()
+    app = _make_app(settings=settings, conn=conn, seam=_poisoned_seam(), run_turn=recorder)
+    async with await _client(app) as client:
+        resp = await client.post(
+            "/api/acme/ask?k=tok-1", json={"message": "a follow-up", "thread": thread.id}
+        )
+    assert resp.status_code == 200
+    assert len(recorder.calls) == 1
+
+
+async def test_ask_on_unauthorized_report_is_refused_without_a_seam_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    reports_store.set_seam_status(conn, slug="acme", status="unauthorized")
+    _seed_recipient(conn, token="tok-1")
+    recorder = _RunTurnRecorder()
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+        run_turn=recorder,
+    )
+    async with await _client(app) as client:
+        resp = await client.post("/api/acme/ask?k=tok-1", json={"message": "hello"})
+    assert resp.status_code == 409
+    assert recorder.calls == []
+
+
+async def test_ask_schedules_exactly_one_turn_and_stores_readers_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1", name="Jane")
+    recorder = _RunTurnRecorder()
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+        run_turn=recorder,
+    )
+    async with await _client(app) as client:
+        resp = await client.post("/api/acme/ask?k=tok-1", json={"message": "why did revenue drop?"})
+    assert resp.status_code == 200
+    thread_id = resp.json()["thread"]
+    assert len(recorder.calls) == 1
+    scheduled_thread = recorder.calls[0]["thread"]
+    assert isinstance(scheduled_thread, threads_store.ThreadRow)
+    assert scheduled_thread.id == thread_id
+    messages = threads_store.list_messages(conn, thread_id=thread_id)
+    user_messages = [m for m in messages if m.role == "user"]
+    assert [m.text for m in user_messages] == ["why did revenue drop?"], (
+        "the stored message is the reader's raw question, not the seam preamble"
+    )
+
+
+# --------------------------------------------------------------------------
+# cancel
+# --------------------------------------------------------------------------
+
+
+async def test_cancel_on_running_thread_calls_seam_once_and_stores_billing_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-1", title="Q", now=NOW
+    )
+    threads_store.begin_turn(
+        conn,
+        thread_id=thread.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=60),
+        now=NOW,
+    )
+    threads_store.bind_turn_boundary(
+        conn, thread_id=thread.id, handle="ses-1", turn_event_id="evt-0", turn_started_at=NOW
+    )
+
+    calls: list[dict[str, object]] = []
+
+    def cancel_turn(args: dict[str, object]) -> dict[str, object]:
+        calls.append(args)
+        return {"status": "terminated"}
+
+    fake_app = build_fake_seam(behaviors={"cancel_turn": cancel_turn}, captured_auth=[])
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_seam_client(fake_app),
+    )
+    async with fake_seam_lifespan(fake_app), await _client(app) as client:
+        resp = await client.post(f"/api/acme/threads/{thread.id}/cancel?k=tok-1")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "terminated"
+    assert len(calls) == 1
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    system_texts = [m.text for m in messages if m.role == "system"]
+    assert len(system_texts) == 1
+    assert "billed" in system_texts[0].lower()
+
+
+async def test_cancel_on_idle_thread_returns_409(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-1", title="Q", now=NOW
+    )
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp = await client.post(f"/api/acme/threads/{thread.id}/cancel?k=tok-1")
+    assert resp.status_code == 409
+
+
+# --------------------------------------------------------------------------
+# close
+# --------------------------------------------------------------------------
+
+
+async def test_close_archives_thread_and_is_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="tok-1", title="Q", now=NOW
+    )
+    threads_store.begin_turn(
+        conn,
+        thread_id=thread.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=60),
+        now=NOW,
+    )
+    threads_store.bind_turn_boundary(
+        conn, thread_id=thread.id, handle="ses-1", turn_event_id="evt-0", turn_started_at=NOW
+    )
+    threads_store.end_turn(conn, thread_id=thread.id, now=NOW)
+
+    calls: list[dict[str, object]] = []
+
+    def archive_my_session(args: dict[str, object]) -> dict[str, object]:
+        calls.append(args)
+        return {}
+
+    fake_app = build_fake_seam(
+        behaviors={"archive_my_session": archive_my_session}, captured_auth=[]
+    )
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_seam_client(fake_app),
+    )
+    async with fake_seam_lifespan(fake_app), await _client(app) as client:
+        first = await client.post(f"/api/acme/threads/{thread.id}/close?k=tok-1")
+        second = await client.post(f"/api/acme/threads/{thread.id}/close?k=tok-1")
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert len(calls) == 1, "closing an already-archived thread must not call the seam again"
+    reloaded = threads_store.load_thread(
+        conn, thread_id=thread.id, slug="acme", recipient_token="tok-1"
+    )
+    assert reloaded is not None
+    assert reloaded.archived_at is not None
+
+
+# --------------------------------------------------------------------------
+# files
+# --------------------------------------------------------------------------
+
+
+async def test_file_route_rejects_a_dot_dot_segment_before_any_filesystem_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``..``-carrying name that still routes as one segment (Starlette's own
+    router already collapses a bare ``..`` path segment before it reaches any
+    handler — this pins the defense-in-depth check for a name that survives
+    routing intact, e.g. an embedded ``..`` next to legitimate-looking text)."""
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    secret = tmp_path / "secret.pdf"
+    secret.write_bytes(b"%PDF-top-secret")
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        resp = await client.get("/files/acme/..secret.pdf?k=tok-1")
+    assert resp.status_code == 400
+    assert secret.read_bytes() != b"", "the real file on disk must be untouched"
+
+
+async def test_file_route_rejects_name_with_separator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _seed_recipient(conn, token="tok-1")
+    app = _make_app(
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        conn=conn,
+        seam=_poisoned_seam(),
+    )
+    async with await _client(app) as client:
+        # A backslash is not a URL path separator, so this still routes as one
+        # segment and reaches the handler with the separator intact.
+        resp = await client.get("/files/acme/sub%5Cfile.pdf?k=tok-1")
+    assert resp.status_code == 400

--- a/apps/report-host/tests/test_sweeps.py
+++ b/apps/report-host/tests/test_sweeps.py
@@ -1,0 +1,497 @@
+"""Tests for report_host.sweeps: resume, deadline cancel, idle archive, prune.
+
+A real SQLite file in `tmp_path`, a fake seam (the shared `build_fake_seam` /
+`fake_seam_lifespan` fixtures from `conftest.py`) for the two sweeps that
+call the seam, and a fake `run_turn` recorder for the resume sweep — resume
+is asserted to schedule the right calls, never to drive a real turn end to
+end.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from report_host import reports_store, sweeps, threads_store
+from report_host.config import Settings, load_settings
+from report_host.mcp_client import SeamClient
+from starlette.types import Receive, Scope, Send
+
+NOW = datetime(2026, 9, 8, 12, 0, 0, tzinfo=UTC)
+
+# Local aliases mirroring conftest's fixture types (see test_mcp_client.py for
+# why these can't just be imported: `--import-mode=importlib` gives every
+# test module its own namespace with no shared sys.path entry).
+FakeASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+FakeSeamBuilder = Callable[..., FakeASGIApp]
+FakeSeamLifespan = Callable[[FakeASGIApp], AbstractAsyncContextManager[None]]
+
+
+class _RunTurnRecorder:
+    """A fake `run_turn` collaborator: records its call, never drives a turn."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def __call__(self, **kwargs: object) -> None:
+        self.calls.append(kwargs)
+
+
+class _RaisingSchedule:
+    """A `schedule` collaborator whose first call raises, to prove one bad
+    row never aborts the rest of the resume pass."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, coro: Awaitable[None]) -> None:
+        self.calls += 1
+        coro.close()  # type: ignore[attr-defined]  # never actually scheduled
+        if self.calls == 1:
+            raise RuntimeError("scheduling blew up")
+
+
+def _settings(*, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **overrides: object) -> Settings:
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", "admin-secret")
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "http://testserver/mcp")
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "http://reports.example.com")
+    settings = load_settings(_env_file=None)
+    fields: dict[str, object] = {
+        "data_dir": tmp_path / "data",
+        "thread_idle_archive_hours": 24,
+    }
+    fields.update(overrides)
+    return settings.model_copy(update=fields)
+
+
+def _seed_report(
+    conn: sqlite3.Connection, *, slug: str = "acme", cap_usd: Decimal = Decimal("100")
+) -> reports_store.ReportRow:
+    reports_store.save_report(
+        conn,
+        slug=slug,
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=cap_usd,
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    report = reports_store.load_report(conn, slug=slug)
+    assert report is not None
+    return report
+
+
+def _seed_running_thread(
+    conn: sqlite3.Connection,
+    *,
+    slug: str = "acme",
+    with_handle: bool,
+    deadline_at: datetime,
+    reserved_usd: Decimal = Decimal("0.60"),
+) -> threads_store.ThreadRow:
+    thread = threads_store.create_thread(
+        conn, slug=slug, recipient_token="rcpt-1", title="Q1", now=NOW
+    )
+    ok = threads_store.begin_turn(
+        conn, thread_id=thread.id, reserved_usd=reserved_usd, deadline_at=deadline_at, now=NOW
+    )
+    assert ok
+    if with_handle:
+        threads_store.bind_turn_boundary(
+            conn, thread_id=thread.id, handle="ses-1", turn_event_id="evt-0", turn_started_at=NOW
+        )
+    reloaded = threads_store.load_thread(
+        conn, thread_id=thread.id, slug=slug, recipient_token="rcpt-1"
+    )
+    assert reloaded is not None
+    return reloaded
+
+
+def _poisoned_seam() -> SeamClient:
+    """A SeamClient no test in this file's resume tests should ever call."""
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"unexpected seam call: {request.url}")
+
+    transport = httpx.MockTransport(handler)
+    return SeamClient(
+        mcp_url="http://poisoned/mcp", http_client=httpx.AsyncClient(transport=transport)
+    )
+
+
+def _seam_client(app: FakeASGIApp) -> SeamClient:
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    return SeamClient(
+        mcp_url="http://testserver/mcp",
+        http_client=httpx.AsyncClient(transport=transport),
+        transport=transport,
+    )
+
+
+# --------------------------------------------------------------------------
+# resume_running_threads
+# --------------------------------------------------------------------------
+
+
+async def test_resume_schedules_exactly_one_reattach_per_running_thread_with_a_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    thread = _seed_running_thread(conn, with_handle=True, deadline_at=NOW + timedelta(seconds=1200))
+    recorder = _RunTurnRecorder()
+    scheduled: list[Awaitable[None]] = []
+
+    resumed = await sweeps.resume_running_threads(
+        conn=conn,
+        seam=_poisoned_seam(),
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        now=lambda: NOW,
+        schedule=scheduled.append,
+        run_turn=recorder,
+    )
+    for coro in scheduled:
+        await coro  # run the recorder synchronously; it makes no real seam call
+
+    assert resumed == 1
+    assert len(recorder.calls) == 1, "exactly one re-attach must be scheduled"
+    assert recorder.calls[0]["message"] is None, "a re-attach never sends a new message"
+    scheduled_thread = recorder.calls[0]["thread"]
+    assert isinstance(scheduled_thread, threads_store.ThreadRow)
+    assert scheduled_thread.id == thread.id
+
+
+async def test_resume_stores_ask_again_and_does_not_schedule_for_a_handleless_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    report = _seed_report(conn)
+    reserved = reports_store.reserve_budget(conn, slug=report.slug, amount=Decimal("0.60"))
+    assert reserved is not None
+    thread = _seed_running_thread(
+        conn, with_handle=False, deadline_at=NOW + timedelta(seconds=1200)
+    )
+    recorder = _RunTurnRecorder()
+    scheduled: list[Awaitable[None]] = []
+
+    resumed = await sweeps.resume_running_threads(
+        conn=conn,
+        seam=_poisoned_seam(),
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        now=lambda: NOW,
+        schedule=scheduled.append,
+        run_turn=recorder,
+    )
+
+    assert resumed == 0
+    assert scheduled == [], "a thread that never reached the seam must never be scheduled"
+    assert recorder.calls == []
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    assert len(messages) == 1
+    assert messages[0].role == "system"
+    assert "ask it again" in messages[0].text
+    reloaded = threads_store.load_thread(
+        conn, thread_id=thread.id, slug=thread.slug, recipient_token=thread.recipient_token
+    )
+    assert reloaded is not None
+    assert reloaded.status == "idle", "a lost question must not be left running forever"
+    settled = reports_store.load_report(conn, slug=report.slug)
+    assert settled is not None
+    assert settled.spent_usd == Decimal("0"), "the reservation for a lost question is released"
+
+
+async def test_resume_continues_past_a_thread_whose_scheduling_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    _bad_thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="rcpt-bad", title="bad", now=NOW
+    )
+    ok = threads_store.begin_turn(
+        conn,
+        thread_id=_bad_thread.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=1200),
+        now=NOW,
+    )
+    assert ok
+    threads_store.bind_turn_boundary(
+        conn,
+        thread_id=_bad_thread.id,
+        handle="ses-bad",
+        turn_event_id="evt-0",
+        turn_started_at=NOW,
+    )
+    _good_thread = _seed_running_thread(
+        conn, with_handle=True, deadline_at=NOW + timedelta(seconds=1200)
+    )
+    recorder = _RunTurnRecorder()
+    schedule = _RaisingSchedule()
+
+    resumed = await sweeps.resume_running_threads(
+        conn=conn,
+        seam=_poisoned_seam(),
+        settings=_settings(tmp_path=tmp_path, monkeypatch=monkeypatch),
+        now=lambda: NOW,
+        schedule=schedule,
+        run_turn=recorder,
+    )
+
+    assert schedule.calls == 2, "the second thread must still be attempted after the first raises"
+    assert resumed == 1, "only the successfully scheduled thread is counted"
+
+
+# --------------------------------------------------------------------------
+# cancel_expired_turns
+# --------------------------------------------------------------------------
+
+
+async def test_cancel_expired_turns_calls_seam_once_per_expired_turn_and_none_inside_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    expired = _seed_running_thread(conn, with_handle=True, deadline_at=NOW - timedelta(seconds=1))
+    threads_store.create_thread(conn, slug="acme", recipient_token="rcpt-2", title="Q2", now=NOW)
+    within_deadline_thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="rcpt-3", title="Q3", now=NOW
+    )
+    ok = threads_store.begin_turn(
+        conn,
+        thread_id=within_deadline_thread.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=1200),
+        now=NOW,
+    )
+    assert ok
+    threads_store.bind_turn_boundary(
+        conn,
+        thread_id=within_deadline_thread.id,
+        handle="ses-within",
+        turn_event_id="evt-0",
+        turn_started_at=NOW,
+    )
+
+    cancel_calls: list[dict[str, object]] = []
+
+    def cancel_turn(args: dict[str, object]) -> dict[str, object]:
+        cancel_calls.append(args)
+        return {"handle": args["handle"], "status": "running"}
+
+    app = build_fake_seam(behaviors={"cancel_turn": cancel_turn}, captured_auth=[])
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        cancelled = await sweeps.cancel_expired_turns(
+            conn=conn, seam=_seam_client(app), settings=settings, now=lambda: NOW
+        )
+
+    assert cancelled == 1
+    assert len(cancel_calls) == 1
+    assert cancel_calls[0]["handle"] == "ses-1"
+    messages = threads_store.list_messages(conn, thread_id=expired.id)
+    assert len(messages) == 1
+    assert "still billed" in messages[0].text
+    reloaded = threads_store.load_thread(
+        conn, thread_id=expired.id, slug="acme", recipient_token="rcpt-1"
+    )
+    assert reloaded is not None
+    assert reloaded.status == "running", "the thread stays running so the poller settles it"
+
+
+# --------------------------------------------------------------------------
+# archive_idle_threads
+# --------------------------------------------------------------------------
+
+
+async def test_archive_idle_threads_archives_only_past_the_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    old_thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="rcpt-old", title="old", now=NOW - timedelta(hours=48)
+    )
+    threads_store.bind_turn_boundary(
+        conn,
+        thread_id=old_thread.id,
+        handle="ses-old",
+        turn_event_id="evt-0",
+        turn_started_at=NOW - timedelta(hours=48),
+    )
+    # idle_since only moves on create_thread/end_turn; simulate an old idle
+    # thread directly rather than driving a full turn through it.
+    with conn:
+        conn.execute(
+            "UPDATE threads SET idle_since = ? WHERE id = ?",
+            (reports_store.dt_to_text(NOW - timedelta(hours=48)), old_thread.id),
+        )
+    recent_thread = threads_store.create_thread(
+        conn,
+        slug="acme",
+        recipient_token="rcpt-recent",
+        title="recent",
+        now=NOW - timedelta(hours=1),
+    )
+
+    archive_calls: list[dict[str, object]] = []
+
+    def archive_session(args: dict[str, object]) -> dict[str, object]:
+        archive_calls.append(args)
+        return {}
+
+    app = build_fake_seam(behaviors={"archive_my_session": archive_session}, captured_auth=[])
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        archived = await sweeps.archive_idle_threads(
+            conn=conn, seam=_seam_client(app), settings=settings, now=lambda: NOW
+        )
+
+    assert archived == 1
+    assert len(archive_calls) == 1
+    assert archive_calls[0]["handle"] == "ses-old"
+    old_reloaded = threads_store.load_thread(
+        conn, thread_id=old_thread.id, slug="acme", recipient_token="rcpt-old"
+    )
+    assert old_reloaded is not None
+    assert old_reloaded.archived_at is not None
+    recent_reloaded = threads_store.load_thread(
+        conn, thread_id=recent_thread.id, slug="acme", recipient_token="rcpt-recent"
+    )
+    assert recent_reloaded is not None
+    assert recent_reloaded.archived_at is None, "a recently idle thread must not be archived yet"
+
+
+async def test_archive_idle_threads_skips_an_already_archived_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="rcpt-1", title="Q1", now=NOW - timedelta(hours=48)
+    )
+    with conn:
+        conn.execute(
+            "UPDATE threads SET idle_since = ? WHERE id = ?",
+            (reports_store.dt_to_text(NOW - timedelta(hours=48)), thread.id),
+        )
+    threads_store.archive_thread(conn, thread_id=thread.id, now=NOW - timedelta(hours=2))
+
+    app = build_fake_seam(behaviors={}, captured_auth=[])
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        archived = await sweeps.archive_idle_threads(
+            conn=conn, seam=_seam_client(app), settings=settings, now=lambda: NOW
+        )
+
+    assert archived == 0, "an already-archived thread is not surfaced again"
+
+
+async def test_archive_idle_threads_seam_failure_leaves_thread_unarchived_locally(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    failing_thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="rcpt-fail", title="fail", now=NOW - timedelta(hours=48)
+    )
+    threads_store.bind_turn_boundary(
+        conn,
+        thread_id=failing_thread.id,
+        handle="ses-fail",
+        turn_event_id="evt-0",
+        turn_started_at=NOW - timedelta(hours=48),
+    )
+    next_thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="rcpt-next", title="next", now=NOW - timedelta(hours=48)
+    )
+    threads_store.bind_turn_boundary(
+        conn,
+        thread_id=next_thread.id,
+        handle="ses-next",
+        turn_event_id="evt-0",
+        turn_started_at=NOW - timedelta(hours=48),
+    )
+    with conn:
+        conn.executemany(
+            "UPDATE threads SET idle_since = ? WHERE id = ?",
+            [
+                (reports_store.dt_to_text(NOW - timedelta(hours=48)), failing_thread.id),
+                (reports_store.dt_to_text(NOW - timedelta(hours=48)), next_thread.id),
+            ],
+        )
+
+    def archive_session(args: dict[str, object]) -> dict[str, object]:
+        if args["handle"] == "ses-fail":
+            raise RuntimeError("seam is down")
+        return {}
+
+    app = build_fake_seam(behaviors={"archive_my_session": archive_session}, captured_auth=[])
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        archived = await sweeps.archive_idle_threads(
+            conn=conn, seam=_seam_client(app), settings=settings, now=lambda: NOW
+        )
+
+    assert archived == 1, "the failing thread does not count, the next one does"
+    failing_reloaded = threads_store.load_thread(
+        conn, thread_id=failing_thread.id, slug="acme", recipient_token="rcpt-fail"
+    )
+    assert failing_reloaded is not None
+    assert failing_reloaded.archived_at is None, (
+        "a seam failure must never let the local archive happen anyway"
+    )
+    next_reloaded = threads_store.load_thread(
+        conn, thread_id=next_thread.id, slug="acme", recipient_token="rcpt-next"
+    )
+    assert next_reloaded is not None
+    assert next_reloaded.archived_at is not None, "one bad row must not stop the next thread"
+
+
+# --------------------------------------------------------------------------
+# prune_expired_recipients
+# --------------------------------------------------------------------------
+
+
+def test_prune_expired_recipients_removes_only_expired_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    _seed_report(conn)
+    reports_store.add_recipient(
+        conn, slug="acme", name="Expired", label="reader", token="expired-1", now=NOW, ttl_days=-1
+    )
+    reports_store.add_recipient(
+        conn, slug="acme", name="Live", label="reader", token="live-1", now=NOW, ttl_days=90
+    )
+
+    removed = sweeps.prune_expired_recipients(conn=conn, now=lambda: NOW)
+
+    assert removed == 1
+    remaining = reports_store.list_recipients(conn, slug="acme")
+    assert [r.token for r in remaining] == ["live-1"]

--- a/apps/report-host/tests/test_sweeps.py
+++ b/apps/report-host/tests/test_sweeps.py
@@ -10,11 +10,12 @@ end.
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 import pytest
 from report_host import reports_store, sweeps, threads_store
@@ -49,9 +50,9 @@ class _RaisingSchedule:
     def __init__(self) -> None:
         self.calls = 0
 
-    def __call__(self, coro: Awaitable[None]) -> None:
+    def __call__(self, coro: Coroutine[Any, Any, None]) -> None:
         self.calls += 1
-        coro.close()  # type: ignore[attr-defined]  # never actually scheduled
+        coro.close()  # never actually scheduled
         if self.calls == 1:
             raise RuntimeError("scheduling blew up")
 
@@ -149,7 +150,7 @@ async def test_resume_schedules_exactly_one_reattach_per_running_thread_with_a_h
     _seed_report(conn)
     thread = _seed_running_thread(conn, with_handle=True, deadline_at=NOW + timedelta(seconds=1200))
     recorder = _RunTurnRecorder()
-    scheduled: list[Awaitable[None]] = []
+    scheduled: list[Coroutine[Any, Any, None]] = []
 
     resumed = await sweeps.resume_running_threads(
         conn=conn,
@@ -181,7 +182,7 @@ async def test_resume_stores_ask_again_and_does_not_schedule_for_a_handleless_th
         conn, with_handle=False, deadline_at=NOW + timedelta(seconds=1200)
     )
     recorder = _RunTurnRecorder()
-    scheduled: list[Awaitable[None]] = []
+    scheduled: list[Coroutine[Any, Any, None]] = []
 
     resumed = await sweeps.resume_running_threads(
         conn=conn,

--- a/apps/report-host/tests/test_threads_store.py
+++ b/apps/report-host/tests/test_threads_store.py
@@ -1,0 +1,262 @@
+"""Tests for report_host.threads_store — threads, turn boundaries, messages."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+from report_host import reports_store, threads_store
+
+NOW = datetime(2026, 9, 8, 12, 0, 0, tzinfo=UTC)
+
+
+def _connect_with_report(tmp_path: Path, slug: str = "acme-q3"):
+    conn = reports_store.connect(tmp_path / "data")
+    reports_store.save_report(
+        conn,
+        slug=slug,
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    return conn
+
+
+def test_create_thread_then_load_round_trips(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    created = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Why did revenue drop?", now=NOW
+    )
+    assert created.status == "idle"
+    loaded = threads_store.load_thread(
+        conn, thread_id=created.id, slug="acme-q3", recipient_token="tok-1"
+    )
+    assert loaded == created
+
+
+def test_load_thread_returns_none_for_wrong_recipient_token(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    created = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q", now=NOW
+    )
+    assert (
+        threads_store.load_thread(
+            conn, thread_id=created.id, slug="acme-q3", recipient_token="someone-elses-token"
+        )
+        is None
+    )
+
+
+def test_load_thread_returns_none_for_wrong_slug(tmp_path: Path) -> None:
+    conn = reports_store.connect(tmp_path / "data")
+    reports_store.save_report(
+        conn,
+        slug="acme-q3",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    reports_store.save_report(
+        conn,
+        slug="other-report",
+        title="Other",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=Decimal("5.00"),
+        agent_token="seam-token-2",
+        now=NOW,
+    )
+    created = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q", now=NOW
+    )
+    assert (
+        threads_store.load_thread(
+            conn, thread_id=created.id, slug="other-report", recipient_token="tok-1"
+        )
+        is None
+    )
+
+
+def test_begin_turn_returns_true_once_then_false_while_running(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    created = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q", now=NOW
+    )
+    started = threads_store.begin_turn(
+        conn,
+        thread_id=created.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=1200),
+        now=NOW,
+    )
+    assert started is True
+    still_running = threads_store.begin_turn(
+        conn,
+        thread_id=created.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=1200),
+        now=NOW,
+    )
+    assert still_running is False, "a second question must be refused while one is running"
+
+
+def test_end_turn_clears_boundary_reservation_and_deadline(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    created = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q", now=NOW
+    )
+    threads_store.begin_turn(
+        conn,
+        thread_id=created.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=1200),
+        now=NOW,
+    )
+    threads_store.bind_turn_boundary(
+        conn,
+        thread_id=created.id,
+        handle="session-abc",
+        turn_event_id="evt-1",
+        turn_started_at=NOW,
+    )
+    threads_store.end_turn(conn, thread_id=created.id, now=NOW + timedelta(minutes=1))
+
+    loaded = threads_store.load_thread(
+        conn, thread_id=created.id, slug="acme-q3", recipient_token="tok-1"
+    )
+    assert loaded is not None
+    assert loaded.status == "idle"
+    assert loaded.turn_started_at is None
+    assert loaded.turn_event_id is None
+    assert loaded.turn_deadline_at is None
+    assert loaded.reserved_usd is None
+    assert loaded.handle == "session-abc", "the seam session handle survives past the turn"
+
+
+def test_bind_turn_boundary_records_handle_and_event(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    created = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q", now=NOW
+    )
+    threads_store.bind_turn_boundary(
+        conn,
+        thread_id=created.id,
+        handle="session-abc",
+        turn_event_id="evt-1",
+        turn_started_at=NOW,
+    )
+    loaded = threads_store.load_thread(
+        conn, thread_id=created.id, slug="acme-q3", recipient_token="tok-1"
+    )
+    assert loaded is not None
+    assert loaded.handle == "session-abc"
+    assert loaded.turn_event_id == "evt-1"
+    assert loaded.turn_started_at == NOW
+
+
+def test_count_open_threads_and_count_running_turns_respect_scope(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    t1 = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q1", now=NOW
+    )
+    threads_store.create_thread(conn, slug="acme-q3", recipient_token="tok-1", title="Q2", now=NOW)
+    threads_store.create_thread(conn, slug="acme-q3", recipient_token="tok-2", title="Q3", now=NOW)
+
+    assert threads_store.count_open_threads(conn, slug="acme-q3", recipient_token="tok-1") == 2
+    assert threads_store.count_open_threads(conn, slug="acme-q3", recipient_token="tok-2") == 1
+
+    threads_store.begin_turn(
+        conn,
+        thread_id=t1.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=1200),
+        now=NOW,
+    )
+    assert threads_store.count_running_turns(conn, slug="acme-q3") == 1
+
+
+def test_list_running_threads_returns_exactly_the_running_ones(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    t1 = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q1", now=NOW
+    )
+    threads_store.create_thread(conn, slug="acme-q3", recipient_token="tok-1", title="Q2", now=NOW)
+    threads_store.begin_turn(
+        conn,
+        thread_id=t1.id,
+        reserved_usd=Decimal("0.60"),
+        deadline_at=NOW + timedelta(seconds=1200),
+        now=NOW,
+    )
+    running = threads_store.list_running_threads(conn)
+    assert [t.id for t in running] == [t1.id]
+
+
+def test_add_message_records_bundle_digest_and_revision(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    created = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q", now=NOW
+    )
+    message = threads_store.add_message(
+        conn,
+        thread_id=created.id,
+        role="assistant",
+        text="Revenue dropped because of X.",
+        now=NOW,
+        bundle_sha256="c" * 64,
+        pdf_revision="v2.pdf",
+    )
+    assert message.bundle_sha256 == "c" * 64
+    assert message.pdf_revision == "v2.pdf"
+
+
+def test_list_messages_after_id_returns_only_newer_rows(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    created = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Q", now=NOW
+    )
+    m1 = threads_store.add_message(
+        conn,
+        thread_id=created.id,
+        role="user",
+        text="Why?",
+        now=NOW,
+        bundle_sha256=None,
+        pdf_revision=None,
+    )
+    m2 = threads_store.add_message(
+        conn,
+        thread_id=created.id,
+        role="assistant",
+        text="Because X.",
+        now=NOW + timedelta(seconds=1),
+        bundle_sha256="d" * 64,
+        pdf_revision="v1.pdf",
+    )
+    all_messages = threads_store.list_messages(conn, thread_id=created.id)
+    assert [m.id for m in all_messages] == [m1.id, m2.id]
+
+    only_new = threads_store.list_messages(conn, thread_id=created.id, after_id=m1.id)
+    assert [m.id for m in only_new] == [m2.id]
+
+
+def test_list_threads_idle_since_excludes_already_archived_threads(tmp_path: Path) -> None:
+    conn = _connect_with_report(tmp_path)
+    old_idle = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Old idle", now=NOW
+    )
+    archived = threads_store.create_thread(
+        conn, slug="acme-q3", recipient_token="tok-1", title="Archived", now=NOW
+    )
+    threads_store.archive_thread(conn, thread_id=archived.id, now=NOW + timedelta(hours=1))
+
+    cutoff = NOW + timedelta(hours=24)
+    idle = threads_store.list_threads_idle_since(conn, cutoff=cutoff)
+    assert [t.id for t in idle] == [old_idle.id]

--- a/apps/report-host/tests/test_turns.py
+++ b/apps/report-host/tests/test_turns.py
@@ -1,0 +1,102 @@
+"""Tests for report_host.turns — the pure decision, then the shell around it.
+
+The shell tests (added alongside `run_turn`) drive it against a real SQLite
+file in `tmp_path` and an in-process fake seam — never a monkeypatch of
+`run_turn`'s own collaborators.
+"""
+
+from __future__ import annotations
+
+from report_host.turns import read_turn_progress
+
+# --------------------------------------------------------------------------
+# Task 1: the pure half — read_turn_progress
+# --------------------------------------------------------------------------
+
+
+def _event(id_: str, type_: str, text: str | None = None) -> dict[str, object]:
+    content: list[dict[str, object]] | None = None
+    if text is not None:
+        content = [{"type": "text", "text": text}]
+    return {"id": id_, "type": type_, "content": content}
+
+
+def test_read_turn_progress_with_only_boundary_event_is_not_done_and_has_no_text() -> None:
+    events = [_event("evt-0", "agent.message", "should never appear")]
+    result = read_turn_progress(
+        status="running", events=events, turn_event_id="evt-0", seen_event_ids=frozenset()
+    )
+    assert result.is_done is False, "a turn with only its own boundary event is not finished"
+    assert result.new_texts == (), "the boundary event's own text must never be replayed"
+
+
+def test_read_turn_progress_returns_text_from_agent_message_after_boundary() -> None:
+    events = [
+        _event("evt-0", "agent.message", "boundary text"),
+        _event("evt-1", "agent.message", "hello there"),
+    ]
+    result = read_turn_progress(
+        status="running", events=events, turn_event_id="evt-0", seen_event_ids=frozenset()
+    )
+    assert result.new_texts == ("hello there",)
+    assert result.is_done is False
+
+
+def test_read_turn_progress_does_not_repeat_a_previously_seen_event() -> None:
+    """The pin against duplicated answers: an id already reported is dropped."""
+    events = [
+        _event("evt-0", "agent.message", "boundary"),
+        _event("evt-1", "agent.message", "hello"),
+    ]
+    result = read_turn_progress(
+        status="running",
+        events=events,
+        turn_event_id="evt-0",
+        seen_event_ids=frozenset({"evt-1"}),
+    )
+    assert result.new_texts == (), "an id already in seen_event_ids must not be replayed"
+
+
+def test_read_turn_progress_is_done_when_idle_event_survives_the_filter() -> None:
+    events = [_event("evt-0", "agent.message", "boundary"), _event("evt-2", "session.status_idle")]
+    result = read_turn_progress(
+        status="idle", events=events, turn_event_id="evt-0", seen_event_ids=frozenset()
+    )
+    assert result.is_done is True
+    assert result.terminal_reason == "idle"
+
+
+def test_read_turn_progress_bare_idle_status_with_no_idle_event_is_not_done() -> None:
+    """The pin against the prototype's bug: a session that hasn't started yet
+    reads idle right after the send, and that bare status must never be
+    trusted without a surviving idle EVENT."""
+    events = [_event("evt-0", "agent.message", "boundary")]
+    result = read_turn_progress(
+        status="idle", events=events, turn_event_id="evt-0", seen_event_ids=frozenset()
+    )
+    assert result.is_done is False, "a bare idle status with no idle event must not end the turn"
+
+
+def test_read_turn_progress_rescheduling_status_is_not_done() -> None:
+    result = read_turn_progress(
+        status="rescheduling", events=[], turn_event_id="evt-0", seen_event_ids=frozenset()
+    )
+    assert result.is_done is False, "rescheduling counts as still running"
+
+
+def test_read_turn_progress_terminated_status_with_no_idle_event_is_done() -> None:
+    result = read_turn_progress(
+        status="terminated", events=[], turn_event_id="evt-0", seen_event_ids=frozenset()
+    )
+    assert result.is_done is True
+    assert result.terminal_reason == "terminated"
+
+
+def test_read_turn_progress_idle_event_that_is_itself_the_boundary_is_not_done() -> None:
+    events = [_event("evt-0", "session.status_idle")]
+    result = read_turn_progress(
+        status="idle", events=events, turn_event_id="evt-0", seen_event_ids=frozenset()
+    )
+    assert result.is_done is False, (
+        "a boundary that is itself an idle event must not end the turn it starts"
+    )

--- a/apps/report-host/tests/test_turns.py
+++ b/apps/report-host/tests/test_turns.py
@@ -1,13 +1,37 @@
 """Tests for report_host.turns — the pure decision, then the shell around it.
 
-The shell tests (added alongside `run_turn`) drive it against a real SQLite
-file in `tmp_path` and an in-process fake seam — never a monkeypatch of
-`run_turn`'s own collaborators.
+The shell tests drive `run_turn` against a real SQLite file in `tmp_path` and
+an in-process fake seam (the shared `build_fake_seam` / `fake_seam_lifespan`
+fixtures from `conftest.py`, the same harness plan 21-13 built for
+`test_mcp_client.py`) — never a monkeypatch of `run_turn`'s own collaborators.
 """
 
 from __future__ import annotations
 
-from report_host.turns import read_turn_progress
+import sqlite3
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import httpx
+import pytest
+from report_host import reports_store, threads_store, turns
+from report_host.config import Settings, load_settings
+from report_host.mcp_client import SeamClient
+from report_host.turns import read_turn_progress, run_turn
+from starlette.types import Receive, Scope, Send
+
+NOW = datetime(2026, 9, 8, 12, 0, 0, tzinfo=UTC)
+
+# Local aliases mirroring conftest's fixture types (see test_mcp_client.py for
+# why these can't just be imported: `--import-mode=importlib` gives every test
+# module its own namespace with no shared sys.path entry).
+FakeASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+FakeSeamBuilder = Callable[..., FakeASGIApp]
+FakeSeamLifespan = Callable[[FakeASGIApp], AbstractAsyncContextManager[None]]
+
 
 # --------------------------------------------------------------------------
 # Task 1: the pure half — read_turn_progress
@@ -100,3 +124,726 @@ def test_read_turn_progress_idle_event_that_is_itself_the_boundary_is_not_done()
     assert result.is_done is False, (
         "a boundary that is itself an idle event must not end the turn it starts"
     )
+
+
+# --------------------------------------------------------------------------
+# Task 3: the shell — run_turn against a fake seam and a real SQLite file
+# --------------------------------------------------------------------------
+
+
+def _settings(*, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **overrides: object) -> Settings:
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", "admin-secret")
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "http://testserver/mcp")
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "http://reports.example.com")
+    settings = load_settings(_env_file=None)
+    fields: dict[str, object] = {
+        "data_dir": tmp_path / "data",
+        "poll_interval_seconds": 0.0,
+        "reserve_usd": Decimal("0.60"),
+        "turn_timeout_seconds": 1200,
+    }
+    fields.update(overrides)
+    return settings.model_copy(update=fields)
+
+
+def _setup(
+    tmp_path: Path, *, cap_usd: Decimal = Decimal("100"), with_bundle: bool = True
+) -> tuple[sqlite3.Connection, reports_store.ReportRow, threads_store.ThreadRow]:
+    data_dir = tmp_path / "data"
+    conn = reports_store.connect(data_dir)
+    reports_store.save_report(
+        conn,
+        slug="acme",
+        title="Acme Q3",
+        tenant_id="tenant-1",
+        agent_name="analyst",
+        cap_usd=cap_usd,
+        agent_token="seam-token-1",
+        now=NOW,
+    )
+    if with_bundle:
+        archive_dir = data_dir / "acme"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        archive_path = archive_dir / "bundle.tar.gz"
+        archive_path.write_bytes(b"bundle-bytes")
+        reports_store.save_bundle_reference(
+            conn,
+            slug="acme",
+            handle="bundle-handle-1",
+            sha256="sha-1",
+            expires_at=NOW + timedelta(days=90),
+            archive_path=str(archive_path),
+        )
+        reports_store.set_current_pdf(conn, slug="acme", name="report.pdf")
+    report = reports_store.load_report(conn, slug="acme")
+    assert report is not None
+    thread = threads_store.create_thread(
+        conn, slug="acme", recipient_token="rcpt-1", title="Q1", now=NOW
+    )
+    return conn, report, thread
+
+
+def _begin(
+    conn: sqlite3.Connection, thread: threads_store.ThreadRow, *, deadline_at: datetime
+) -> threads_store.ThreadRow:
+    ok = threads_store.begin_turn(
+        conn, thread_id=thread.id, reserved_usd=Decimal("0.60"), deadline_at=deadline_at, now=NOW
+    )
+    assert ok, "begin_turn should succeed on a freshly created thread"
+    reloaded = threads_store.load_thread(
+        conn, thread_id=thread.id, slug=thread.slug, recipient_token=thread.recipient_token
+    )
+    assert reloaded is not None
+    return reloaded
+
+
+def _scripted(
+    sequence: list[tuple[str, list[dict[str, object]]]],
+) -> tuple[
+    Callable[[dict[str, object]], dict[str, object]],
+    Callable[[dict[str, object]], dict[str, object]],
+]:
+    """Step through ``sequence`` one (status, events) pair per poll iteration.
+
+    ``get_my_session`` reads the current index; ``list_events`` reads the same
+    index and then advances it — matching ``run_turn``'s own call order (status
+    first, events second) so both calls in one iteration see the same entry.
+    The last entry repeats if the loop polls more times than scripted.
+    """
+    state = {"i": 0}
+
+    def get_my_session(_args: dict[str, object]) -> dict[str, object]:
+        i = min(state["i"], len(sequence) - 1)
+        status, _events = sequence[i]
+        return {"status": status}
+
+    def list_events(_args: dict[str, object]) -> dict[str, object]:
+        i = min(state["i"], len(sequence) - 1)
+        _status, events = sequence[i]
+        state["i"] += 1
+        return {"items": events, "next_page": None}
+
+    return get_my_session, list_events
+
+
+def _seam_client(app: FakeASGIApp) -> SeamClient:
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    return SeamClient(
+        mcp_url="http://testserver/mcp",
+        http_client=httpx.AsyncClient(transport=transport),
+        transport=transport,
+    )
+
+
+async def test_run_turn_happy_path_streams_two_messages_then_settles_actual_cost(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    get_my_session, list_events = _scripted(
+        [
+            ("running", [_event("evt-1", "agent.message", "first chunk")]),
+            ("running", [_event("evt-2", "agent.message", "second chunk")]),
+            ("idle", [_event("evt-3", "session.status_idle")]),
+        ]
+    )
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": "0.234500", "event_count": 4}
+
+    app = build_fake_seam(
+        behaviors={
+            "start_turn": start_turn,
+            "get_my_session": get_my_session,
+            "list_events": list_events,
+            "get_turn_cost": get_turn_cost,
+        },
+        captured_auth=[],
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="what does this mean?",
+            now=lambda: NOW,
+        )
+
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    assistant_messages = [m for m in messages if m.role == "assistant"]
+    assert [m.text for m in assistant_messages] == ["first chunk", "second chunk"]
+    for m in assistant_messages:
+        assert m.bundle_sha256 == "sha-1", "every assistant message must carry the bundle digest"
+        assert m.pdf_revision == "report.pdf", "every assistant message must carry the PDF revision"
+
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0.2345"), (
+        "spend must equal the seam's real cost, not the 0.60 reserve"
+    )
+
+    updated_thread = threads_store.load_thread(
+        conn, thread_id=thread.id, slug="acme", recipient_token="rcpt-1"
+    )
+    assert updated_thread is not None
+    assert updated_thread.status == "idle"
+
+
+async def test_run_turn_settles_actual_cost_on_terminated_status_with_no_idle_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    """The pin for D-06: reconciliation happens on ANY terminal, not only idle."""
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    get_my_session, list_events = _scripted([("running", []), ("terminated", [])])
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": "0.10", "event_count": 1}
+
+    app = build_fake_seam(
+        behaviors={
+            "start_turn": start_turn,
+            "get_my_session": get_my_session,
+            "list_events": list_events,
+            "get_turn_cost": get_turn_cost,
+        },
+        captured_auth=[],
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0.10"), (
+        "a terminated turn (no idle event) must still be settled against its real cost"
+    )
+    updated_thread = threads_store.load_thread(
+        conn, thread_id=thread.id, slug="acme", recipient_token="rcpt-1"
+    )
+    assert updated_thread is not None
+    assert updated_thread.status == "idle"
+
+
+async def test_run_turn_with_unpriced_turn_keeps_the_reservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    get_my_session, list_events = _scripted([("idle", [_event("evt-1", "session.status_idle")])])
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": None, "event_count": 1}
+
+    app = build_fake_seam(
+        behaviors={
+            "start_turn": start_turn,
+            "get_my_session": get_my_session,
+            "list_events": list_events,
+            "get_turn_cost": get_turn_cost,
+        },
+        captured_auth=[],
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0.60"), (
+        "an unpriced turn (cost_usd null) must keep the reservation, never coerce to zero"
+    )
+
+
+async def test_run_turn_cancels_exactly_once_at_the_deadline_and_keeps_polling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    get_my_session, list_events = _scripted(
+        [
+            ("running", []),
+            ("running", []),
+            ("idle", [_event("evt-1", "session.status_idle")]),
+        ]
+    )
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": "0.30", "event_count": 2}
+
+    cancel_calls: list[dict[str, object]] = []
+
+    def cancel_turn(args: dict[str, object]) -> dict[str, object]:
+        cancel_calls.append(args)
+        return {"handle": args["handle"], "status": "running"}
+
+    app = build_fake_seam(
+        behaviors={
+            "start_turn": start_turn,
+            "get_my_session": get_my_session,
+            "list_events": list_events,
+            "get_turn_cost": get_turn_cost,
+            "cancel_turn": cancel_turn,
+        },
+        captured_auth=[],
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    # now() is always past the deadline: every non-terminal iteration is
+    # eligible to cancel, so a loop that cancelled on every iteration (rather
+    # than once) would show up as more than one call.
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW + timedelta(seconds=2000),
+        )
+
+    assert len(cancel_calls) == 1, "the deadline must cancel exactly once, not on every iteration"
+
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    system_texts = [m.text for m in messages if m.role == "system"]
+    assert len(system_texts) == 1
+    assert "billed" in system_texts[0].lower(), (
+        "the reader must be told a cancelled turn is still billed for what it consumed"
+    )
+
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0.30"), (
+        "the deadline path must still settle against the real cost, not abandon the reserve"
+    )
+
+
+async def test_run_turn_at_the_cap_refuses_without_calling_the_seam(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path, cap_usd=Decimal("0.10"))
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    start_calls: list[dict[str, object]] = []
+
+    def start_turn(args: dict[str, object]) -> dict[str, object]:
+        start_calls.append(args)
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    app = build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=[])
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    assert start_calls == [], "the seam must never be called once the cap is reached"
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    assert any(m.role == "system" for m in messages), "the reader must be told the cap was hit"
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0"), "a refused reservation must not touch spend"
+
+
+async def test_run_turn_repushes_expired_bundle_once_and_retries_the_send(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    start_calls: list[dict[str, object]] = []
+
+    def start_turn(args: dict[str, object]) -> dict[str, object]:
+        start_calls.append(args)
+        if len(start_calls) == 1:
+            raise Exception("bundle expired; re-upload")  # noqa: TRY002
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    get_my_session, list_events = _scripted([("idle", [_event("evt-1", "session.status_idle")])])
+
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": "0.05", "event_count": 1}
+
+    push_calls: list[bytes] = []
+
+    def push_bundle_handler(body: bytes) -> dict[str, object]:
+        return {
+            "bundle": "bundle-handle-2",
+            "sha256": "sha-2",
+            "size_bytes": len(body),
+            "expires_at": "2026-12-01T00:00:00+00:00",
+        }
+
+    app = build_fake_seam(
+        behaviors={
+            "start_turn": start_turn,
+            "get_my_session": get_my_session,
+            "list_events": list_events,
+            "get_turn_cost": get_turn_cost,
+        },
+        captured_auth=[],
+        push_bundle_handler=push_bundle_handler,
+        captured_bundle_puts=push_calls,
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    assert len(start_calls) == 2, "exactly two send attempts: the failure and the retry"
+    assert len(push_calls) == 1, "exactly one bundle re-push"
+    assert push_calls[0] == b"bundle-bytes", "the re-push must send the archive's real bytes"
+
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.bundle_handle == "bundle-handle-2"
+    assert updated_report.spent_usd == Decimal("0.05")
+
+
+async def test_run_turn_with_deleted_archive_stores_bundle_missing_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    """A real mutation of state (the file is deleted), not of code."""
+    conn, report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+    assert report.archive_path is not None
+    Path(report.archive_path).unlink()
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        raise Exception("bundle expired; re-upload")  # noqa: TRY002
+
+    push_calls: list[bytes] = []
+
+    def push_bundle_handler(body: bytes) -> dict[str, object]:
+        return {
+            "bundle": "x",
+            "sha256": "x",
+            "size_bytes": 0,
+            "expires_at": "2026-12-01T00:00:00+00:00",
+        }
+
+    app = build_fake_seam(
+        behaviors={"start_turn": start_turn},
+        captured_auth=[],
+        push_bundle_handler=push_bundle_handler,
+        captured_bundle_puts=push_calls,
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    assert push_calls == [], "a missing archive must never be re-pushed"
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    system_texts = [m.text for m in messages if m.role == "system"]
+    assert system_texts == [turns.BUNDLE_MISSING_MESSAGE]
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0"), "the reservation must be released"
+
+
+async def test_run_turn_with_null_archive_path_stores_bundle_missing_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path, with_bundle=False)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        raise Exception("bundle expired; re-upload")  # noqa: TRY002
+
+    push_calls: list[bytes] = []
+
+    def push_bundle_handler(body: bytes) -> dict[str, object]:
+        return {
+            "bundle": "x",
+            "sha256": "x",
+            "size_bytes": 0,
+            "expires_at": "2026-12-01T00:00:00+00:00",
+        }
+
+    app = build_fake_seam(
+        behaviors={"start_turn": start_turn},
+        captured_auth=[],
+        push_bundle_handler=push_bundle_handler,
+        captured_bundle_puts=push_calls,
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    assert push_calls == [], "a null archive_path must never be re-pushed"
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    system_texts = [m.text for m in messages if m.role == "system"]
+    assert system_texts == [turns.BUNDLE_MISSING_MESSAGE]
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0")
+
+
+async def test_run_turn_bundle_expired_twice_gives_up_with_one_repush(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    start_calls: list[dict[str, object]] = []
+
+    def start_turn(args: dict[str, object]) -> dict[str, object]:
+        start_calls.append(args)
+        raise Exception("bundle expired; re-upload")  # noqa: TRY002
+
+    push_calls: list[bytes] = []
+
+    def push_bundle_handler(body: bytes) -> dict[str, object]:
+        return {
+            "bundle": "bundle-handle-2",
+            "sha256": "sha-2",
+            "size_bytes": len(body),
+            "expires_at": "2026-12-01T00:00:00+00:00",
+        }
+
+    app = build_fake_seam(
+        behaviors={"start_turn": start_turn},
+        captured_auth=[],
+        push_bundle_handler=push_bundle_handler,
+        captured_bundle_puts=push_calls,
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    assert len(start_calls) == 2, "no third attempt after the retry also fails"
+    assert len(push_calls) == 1, "exactly one re-push, not one per failure"
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    system_texts = [m.text for m in messages if m.role == "system"]
+    assert system_texts == [turns.BUNDLE_MISSING_MESSAGE]
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0"), "the reservation must be settled either way"
+
+
+async def test_run_turn_marks_report_unauthorized_on_401_and_makes_no_further_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    app = build_fake_seam(
+        behaviors={"start_turn": start_turn},
+        captured_auth=[],
+        unauthorized_tokens=frozenset({"seam-token-1"}),
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.seam_status == "unauthorized"
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    assert any(m.role == "system" for m in messages)
+    assert updated_report.spent_usd == Decimal("0"), "the reservation must be released"
+
+
+async def test_run_turn_reattach_sends_nothing_and_polls_straight_to_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+    # Simulate a prior process already having reserved and sent before a
+    # restart interrupted it: the reservation is already on the books and the
+    # boundary is already bound, exactly what a restart-resume sweep sees.
+    reserved = reports_store.reserve_budget(conn, slug="acme", amount=Decimal("0.60"))
+    assert reserved is not None
+    threads_store.bind_turn_boundary(
+        conn, thread_id=thread.id, handle="ses-1", turn_event_id="evt-0", turn_started_at=NOW
+    )
+    reloaded = threads_store.load_thread(
+        conn, thread_id=thread.id, slug=thread.slug, recipient_token=thread.recipient_token
+    )
+    assert reloaded is not None
+    thread = reloaded
+
+    start_calls: list[dict[str, object]] = []
+
+    def start_turn(args: dict[str, object]) -> dict[str, object]:
+        start_calls.append(args)
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    get_my_session, list_events = _scripted([("idle", [_event("evt-1", "session.status_idle")])])
+
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": "0.02", "event_count": 1}
+
+    app = build_fake_seam(
+        behaviors={
+            "start_turn": start_turn,
+            "get_my_session": get_my_session,
+            "list_events": list_events,
+            "get_turn_cost": get_turn_cost,
+        },
+        captured_auth=[],
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message=None,
+            now=lambda: NOW,
+        )
+
+    assert start_calls == [], "a re-attach must never call start_turn or continue_turn"
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0.02")

--- a/apps/report-host/tests/test_uploads.py
+++ b/apps/report-host/tests/test_uploads.py
@@ -1,0 +1,746 @@
+"""Tests for the two upload routes: publish archive and per-turn revised PDF.
+
+Drives `build_uploads_router` under `httpx.ASGITransport` with a real SQLite
+file in `tmp_path`, a fake seam (an `httpx.MockTransport` behind `SeamClient`
+— `push_bundle` is a plain HTTP PUT, so no MCP wire protocol is needed here),
+and hand-built `tarfile` archives, including the hostile ones, which is the
+only way to prove the extraction guards. Never imports daimon: capability
+tokens are minted inline, the same way `test_capability.py` does, using the
+identical HMAC wire format `report_host.capability.verify_token` checks.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import io
+import json
+import sqlite3
+import tarfile
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from report_host import reports_store, threads_store
+from report_host.config import Settings, load_settings
+from report_host.mcp_client import SeamClient
+from report_host.uploads import (
+    _PUBLISH_INVALID_MESSAGE,  # pyright: ignore[reportPrivateUsage]
+    _UPLOAD_INVALID_MESSAGE,  # pyright: ignore[reportPrivateUsage]
+    build_uploads_router,
+)
+
+pytestmark = pytest.mark.asyncio
+
+NOW = datetime(2026, 9, 8, 12, 0, 0, tzinfo=UTC)
+ADMIN_SECRET = "admin-secret"
+REPORT_PDF_BYTES = b"%PDF-1.4 fake report content for the archive root"
+
+
+# --------------------------------------------------------------------------
+# Settings / app / seam fixtures
+# --------------------------------------------------------------------------
+
+
+def _settings(*, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **overrides: object) -> Settings:
+    monkeypatch.setenv("DAIMON_REPORT__ADMIN_SECRETS", ADMIN_SECRET)
+    monkeypatch.setenv("DAIMON_REPORT__MCP_URL", "http://testserver/mcp")
+    monkeypatch.setenv("DAIMON_REPORT__PUBLIC_URL_BASE", "http://reports.example.com")
+    settings = load_settings(_env_file=None)
+    fields: dict[str, object] = {"data_dir": tmp_path / "data"}
+    fields.update(overrides)
+    return settings.model_copy(update=fields)
+
+
+SeamHandler = Callable[[httpx.Request], httpx.Response]
+
+
+def _seam(handler: SeamHandler | None = None, *, requests: list[httpx.Request]) -> SeamClient:
+    def default_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "bundle": "bundle-handle-1",
+                "sha256": "a" * 64,
+                "size_bytes": 5,
+                "expires_at": "2026-12-01T00:00:00Z",
+            },
+        )
+
+    active_handler = handler if handler is not None else default_handler
+
+    def recording_handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return active_handler(request)
+
+    transport = httpx.MockTransport(recording_handler)
+    return SeamClient(
+        mcp_url="http://testserver/mcp", http_client=httpx.AsyncClient(transport=transport)
+    )
+
+
+def _make_app(*, settings: Settings, conn: sqlite3.Connection, seam: SeamClient) -> FastAPI:
+    app = FastAPI()
+    app.include_router(
+        build_uploads_router(settings=settings, conn_factory=lambda: conn, seam=seam)
+    )
+    return app
+
+
+async def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver")
+
+
+# --------------------------------------------------------------------------
+# Store seeding helpers
+# --------------------------------------------------------------------------
+
+
+def _seed_report(
+    conn: sqlite3.Connection,
+    *,
+    slug: str = "acme",
+    cap_usd: Decimal = Decimal("10"),
+    tenant_id: str = "tenant-1",
+    agent_token: str = "seam-token-secret-1",
+) -> reports_store.ReportRow:
+    return reports_store.save_report(
+        conn,
+        slug=slug,
+        title="Acme Q3",
+        tenant_id=tenant_id,
+        agent_name="analyst",
+        cap_usd=cap_usd,
+        agent_token=agent_token,
+        now=NOW,
+    )
+
+
+def _seed_recipient(conn: sqlite3.Connection, *, slug: str = "acme", name: str = "Jane") -> None:
+    reports_store.add_recipient(
+        conn,
+        slug=slug,
+        name=name,
+        label="reader",
+        token=f"tok-{name}",
+        now=NOW,
+        ttl_days=90,
+    )
+
+
+def _seed_running_thread(
+    conn: sqlite3.Connection, *, slug: str = "acme", recipient_token: str = "rtok"
+) -> threads_store.ThreadRow:
+    thread = threads_store.create_thread(
+        conn, slug=slug, recipient_token=recipient_token, title="a question", now=NOW
+    )
+    began = threads_store.begin_turn(
+        conn,
+        thread_id=thread.id,
+        reserved_usd=Decimal("0.5"),
+        deadline_at=NOW + timedelta(seconds=60),
+        now=NOW,
+    )
+    assert began
+    loaded = threads_store.load_thread(
+        conn, thread_id=thread.id, slug=slug, recipient_token=recipient_token
+    )
+    assert loaded is not None
+    return loaded
+
+
+# --------------------------------------------------------------------------
+# Capability-token minting — inlined, mirrors test_capability.py exactly
+# --------------------------------------------------------------------------
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _mint(secret: str, payload: dict[str, object]) -> str:
+    payload_b64 = _b64(json.dumps(payload, separators=(",", ":")).encode())
+    sig = hmac.new(secret.encode(), payload_b64.encode(), hashlib.sha256).digest()
+    return f"{payload_b64}.{_b64(sig)}"
+
+
+def _capability_payload(**over: object) -> dict[str, object]:
+    # `exp` is computed off the REAL clock, not the fixed `NOW` used for store
+    # timestamps: `uploads.py`'s handlers call `datetime.now(UTC)` directly
+    # (no clock injection, per this plan's own router signature), so a token
+    # must be valid against whatever moment the test actually runs.
+    base: dict[str, object] = {
+        "slug": "acme",
+        "op": "report",
+        "name": None,
+        "max_bytes": 10_000_000,
+        "exp": int(datetime.now(UTC).timestamp()) + 300,
+        "jti": "jti-1",
+    }
+    base.update(over)
+    return base
+
+
+def _capability_token(secret: str = ADMIN_SECRET, **over: object) -> str:
+    return _mint(secret, _capability_payload(**over))
+
+
+# --------------------------------------------------------------------------
+# Archive-building helpers — real tarfile archives, including hostile ones
+# --------------------------------------------------------------------------
+
+
+def _build_archive(members: list[tuple[tarfile.TarInfo, bytes | None]]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for info, data in members:
+            tar.addfile(info, io.BytesIO(data) if data is not None else None)
+    return buf.getvalue()
+
+
+def _pdf_member(
+    data: bytes = REPORT_PDF_BYTES, name: str = "report.pdf"
+) -> tuple[tarfile.TarInfo, bytes]:
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    return info, data
+
+
+def _valid_archive(pdf_bytes: bytes = REPORT_PDF_BYTES) -> bytes:
+    other_data = b"a,b,c\n1,2,3\n"
+    other = tarfile.TarInfo(name="bundle/data.csv")
+    other.size = len(other_data)
+    return _build_archive([_pdf_member(pdf_bytes), (other, other_data)])
+
+
+def _archive_with_absolute_path_member() -> bytes:
+    evil_data = b"evil"
+    evil = tarfile.TarInfo(name="/etc/passwd")
+    evil.size = len(evil_data)
+    return _build_archive([_pdf_member(), (evil, evil_data)])
+
+
+def _archive_with_traversal_member() -> bytes:
+    evil_data = b"evil"
+    evil = tarfile.TarInfo(name="../evil.txt")
+    evil.size = len(evil_data)
+    return _build_archive([_pdf_member(), (evil, evil_data)])
+
+
+def _archive_with_symlink_member() -> bytes:
+    evil = tarfile.TarInfo(name="link")
+    evil.type = tarfile.SYMTYPE
+    evil.linkname = "/etc/passwd"
+    return _build_archive([_pdf_member(), (evil, None)])
+
+
+def _archive_with_no_report_pdf() -> bytes:
+    data = b"not the report"
+    other = tarfile.TarInfo(name="other.pdf")
+    other.size = len(data)
+    return _build_archive([(other, data)])
+
+
+def _bomb_archive(*, declared_size: int) -> bytes:
+    """A member whose declared size exceeds a ceiling but whose real bytes are small.
+
+    Real content is `declared_size` zero bytes — genuinely that large before
+    compression, but gzip compresses a run of zeros to almost nothing, which
+    is exactly the shape of a real compression bomb: a tiny file on the wire
+    that declares (and, if extracted naively, produces) a huge payload.
+    """
+    return _build_archive([_pdf_member(b"\x00" * declared_size)])
+
+
+# --------------------------------------------------------------------------
+# Publish route: invalid / replayed / missing-report capability tokens
+# --------------------------------------------------------------------------
+
+
+async def test_publish_with_garbage_token_returns_404_and_writes_no_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    requests: list[httpx.Request] = []
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=requests))
+    async with await _client(app) as client:
+        resp = await client.put("/publish/not-a-real-token", content=_valid_archive())
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == _PUBLISH_INVALID_MESSAGE
+    assert not (settings.data_dir / "acme" / "bundle.tar.gz").exists()
+    assert requests == []
+
+
+async def test_publish_with_tampered_payload_returns_same_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    good = _capability_token()
+    payload_b64, sig_b64 = good.split(".", 1)
+    tampered = json.loads(base64.urlsafe_b64decode(payload_b64 + "=="))
+    tampered["slug"] = "victim"
+    forged = f"{_b64(json.dumps(tampered, separators=(',', ':')).encode())}.{sig_b64}"
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{forged}", content=_valid_archive())
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == _PUBLISH_INVALID_MESSAGE
+
+
+async def test_publish_with_expired_token_returns_same_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    expired = _capability_token(exp=1)  # 1970-01-01T00:00:01Z — expired regardless of wall clock
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{expired}", content=_valid_archive())
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == _PUBLISH_INVALID_MESSAGE
+
+
+async def test_publish_with_wrong_op_returns_same_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token(op="blog")
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=_valid_archive())
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == _PUBLISH_INVALID_MESSAGE
+
+
+async def test_publish_token_cannot_be_replayed_and_seam_called_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token(jti="replay-me")
+    requests: list[httpx.Request] = []
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=requests))
+    async with await _client(app) as client:
+        first = await client.put(f"/publish/{token}", content=_valid_archive())
+        second = await client.put(f"/publish/{token}", content=_valid_archive())
+    assert first.status_code == 200
+    assert second.status_code == 404
+    assert second.json()["detail"] == _PUBLISH_INVALID_MESSAGE
+    assert len(requests) == 1, "the seam must be called exactly once across both attempts"
+
+
+async def test_publish_burns_token_before_reading_body_even_when_the_body_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Proves burn-before-read, not just burn-before-push.
+
+    The first attempt's body is oversized and never gets past `_spool_body`
+    (413) — under the correct ordering the token is ALREADY burnt by then, so
+    a second, otherwise-valid attempt with the same token is refused before
+    the seam is ever reached. Mutation-sensitive: moving the burn to after
+    `_spool_body` lets the first (rejected) attempt leave the token unburnt,
+    and the second attempt then succeeds — `requests` goes from `[]` to
+    having one entry. Confirmed live: reverting `uploads.py`'s burn call to
+    sit after `_spool_body` turns this test red (`requests == [<PUT /bundles>]`
+    instead of `[]`); reverting the edit turns it green again.
+    """
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    valid_archive = _valid_archive()
+    token = _capability_token(jti="oversized-first", max_bytes=len(valid_archive) + 50)
+    requests: list[httpx.Request] = []
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=requests))
+    async with await _client(app) as client:
+        first = await client.put(f"/publish/{token}", content=b"x" * (len(valid_archive) + 1000))
+        second = await client.put(f"/publish/{token}", content=valid_archive)
+    assert first.status_code == 413
+    assert second.status_code == 404
+    assert second.json()["detail"] == _PUBLISH_INVALID_MESSAGE
+    assert requests == [], (
+        "the oversized first attempt must already have burnt the token, so the "
+        "second attempt (and the seam) is never reached"
+    )
+
+
+async def test_publish_with_capability_for_missing_report_returns_same_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    # No report seeded for "ghost".
+    token = _capability_token(slug="ghost")
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=_valid_archive())
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == _PUBLISH_INVALID_MESSAGE
+
+
+# --------------------------------------------------------------------------
+# Publish route: size cap and content-type checks
+# --------------------------------------------------------------------------
+
+
+async def test_publish_body_over_the_smaller_cap_returns_413_and_writes_no_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token(max_bytes=10)
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=b"x" * 20)
+    assert resp.status_code == 413
+    assert not (settings.data_dir / "acme").exists()
+
+
+async def test_publish_non_gzip_body_returns_415(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token()
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=b"not a gzip archive at all")
+    assert resp.status_code == 415
+
+
+# --------------------------------------------------------------------------
+# Publish route: hostile-archive rejection
+# --------------------------------------------------------------------------
+
+
+async def test_publish_archive_without_report_pdf_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token()
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=_archive_with_no_report_pdf())
+    assert resp.status_code == 422
+    assert "report.pdf" in resp.json()["detail"]
+
+
+async def test_publish_archive_with_absolute_path_member_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token()
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=_archive_with_absolute_path_member())
+    assert resp.status_code == 422
+    assert not (settings.data_dir / "acme").exists(), (
+        "a refused archive must not create the report's own directory at all"
+    )
+    assert not (settings.data_dir / "etc" / "passwd").exists()
+    assert not (settings.data_dir / "passwd").exists()
+
+
+def _snapshot_ignoring_store_infra(data_dir: Path) -> set[str]:
+    """The report directory's parent's contents, minus the host's own SQLite/registry files.
+
+    `reports_store.connect()` and the capability jti burn both write into
+    `data_dir` as ordinary, expected side effects of handling any request at
+    all (the WAL/registry files, not anything the archive controls) — a
+    literal before/after diff would flag those every time, unrelated to
+    whether the traversal member escaped anywhere. Filtered out by name so
+    the comparison is only sensitive to what the archive itself could cause.
+    """
+    if not data_dir.exists():
+        return set()
+    ignored_prefixes = ("host.sqlite", "consumed.json")
+    return {
+        str(p.relative_to(data_dir))
+        for p in data_dir.rglob("*")
+        if not p.name.startswith(ignored_prefixes)
+    }
+
+
+async def test_publish_archive_with_traversal_member_is_refused_and_leaves_parent_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    before = _snapshot_ignoring_store_infra(settings.data_dir)
+    token = _capability_token()
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=_archive_with_traversal_member())
+    assert resp.status_code == 422
+    after = _snapshot_ignoring_store_infra(settings.data_dir)
+    assert before == after, "a refused traversal archive must not change the parent directory"
+    assert not (settings.data_dir / "evil.txt").exists()
+
+
+async def test_publish_archive_with_symlink_member_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token()
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=_archive_with_symlink_member())
+    assert resp.status_code == 422
+
+
+async def test_publish_compression_bomb_is_refused_without_exhausting_memory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A small decompressed ceiling keeps this test's own archive tiny while
+    # still exercising the exact declared-size-over-ceiling refusal path.
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch, max_pdf_bytes=1_000)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token()
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    archive = _bomb_archive(declared_size=2_000)
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=archive)
+    assert resp.status_code == 422
+    assert "ceiling" in resp.json()["detail"]
+
+
+# --------------------------------------------------------------------------
+# Publish route: happy path, re-publish, and seam failure handling
+# --------------------------------------------------------------------------
+
+
+async def test_publish_happy_path_writes_pdf_archive_and_returns_recipient_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn, agent_token="seam-token-secret-1")
+    _seed_recipient(conn, name="Jane")
+    _seed_recipient(conn, name="Bob")
+    token = _capability_token()
+    requests: list[httpx.Request] = []
+    archive = _valid_archive()
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=requests))
+
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=archive)
+
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["slug"] == "acme"
+    links = payload["links"]
+    assert len(links) == 2
+    for link in links:
+        assert link["link"].startswith("http://reports.example.com/r/acme?k=")
+
+    report = reports_store.load_report(conn, slug="acme")
+    assert report is not None
+    assert report.current_pdf == "v1.pdf"
+    assert (settings.data_dir / "acme" / "v1.pdf").read_bytes() == REPORT_PDF_BYTES
+
+    archive_path = settings.data_dir / "acme" / "bundle.tar.gz"
+    assert archive_path.read_bytes() == archive
+    assert report.archive_path == str(archive_path)
+    assert report.bundle_handle == "bundle-handle-1"
+
+    assert len(requests) == 1, "push_bundle must be called exactly once"
+    assert requests[0].headers["authorization"] == "Bearer seam-token-secret-1", (
+        "the archive must be pushed under the report's own seam token, not a shared one"
+    )
+
+
+async def test_second_publish_of_same_slug_replaces_archive_bytes_with_no_leftover_tmp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    first_archive = _valid_archive(b"%PDF first revision bytes")
+    second_archive = _valid_archive(b"%PDF second, different revision bytes")
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+
+    async with await _client(app) as client:
+        first = await client.put(
+            f"/publish/{_capability_token(jti='pub-1')}", content=first_archive
+        )
+        second = await client.put(
+            f"/publish/{_capability_token(jti='pub-2')}", content=second_archive
+        )
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    archive_path = settings.data_dir / "acme" / "bundle.tar.gz"
+    assert archive_path.read_bytes() == second_archive, "the second publish's bytes must win"
+
+    leftovers = [p for p in (settings.data_dir / "acme").iterdir() if p.name.startswith(".")]
+    assert leftovers == [], "no temporary file should survive a completed publish"
+
+
+async def test_publish_archive_survives_a_seam_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token()
+
+    def failing_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "seam is down"})
+
+    requests: list[httpx.Request] = []
+    app = _make_app(settings=settings, conn=conn, seam=_seam(failing_handler, requests=requests))
+    archive = _valid_archive()
+
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=archive)
+
+    assert resp.status_code == 502
+    archive_path = settings.data_dir / "acme" / "bundle.tar.gz"
+    assert archive_path.exists(), "a failed push must not take the only copy of the archive with it"
+    assert archive_path.read_bytes() == archive
+
+
+async def test_publish_seam_unauthorized_marks_report_and_asks_for_republish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    token = _capability_token()
+
+    def unauthorized_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "unauthorized"})
+
+    app = _make_app(settings=settings, conn=conn, seam=_seam(unauthorized_handler, requests=[]))
+
+    async with await _client(app) as client:
+        resp = await client.put(f"/publish/{token}", content=_valid_archive())
+
+    assert resp.status_code == 409
+    assert "re-publish" in resp.json()["detail"]
+    report = reports_store.load_report(conn, slug="acme")
+    assert report is not None
+    assert report.seam_status == "unauthorized"
+
+
+# --------------------------------------------------------------------------
+# Turn upload route
+# --------------------------------------------------------------------------
+
+
+async def test_turn_upload_with_unknown_token_returns_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put("/upload/no-such-token", content=b"%PDF anything")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == _UPLOAD_INVALID_MESSAGE
+
+
+async def test_turn_upload_for_an_ended_turn_returns_404(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    thread = _seed_running_thread(conn)
+    threads_store.end_turn(conn, thread_id=thread.id, now=NOW)
+    reports_store.create_upload_token(
+        conn, token="stale-tok", slug="acme", thread_id=thread.id, now=NOW
+    )
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put("/upload/stale-tok", content=b"%PDF anything")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == _UPLOAD_INVALID_MESSAGE
+
+
+async def test_turn_upload_non_pdf_body_returns_415(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    thread = _seed_running_thread(conn)
+    reports_store.create_upload_token(
+        conn, token="tok-1", slug="acme", thread_id=thread.id, now=NOW
+    )
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put("/upload/tok-1", content=b"not a pdf")
+    assert resp.status_code == 415
+
+
+async def test_turn_upload_over_max_bytes_returns_413_and_writes_no_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch, max_pdf_bytes=10)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    thread = _seed_running_thread(conn)
+    reports_store.create_upload_token(
+        conn, token="tok-1", slug="acme", thread_id=thread.id, now=NOW
+    )
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    async with await _client(app) as client:
+        resp = await client.put("/upload/tok-1", content=b"%PDF" + b"x" * 20)
+    assert resp.status_code == 413
+    assert not (settings.data_dir / "acme").exists()
+
+
+async def test_turn_upload_happy_path_records_revision_and_cannot_be_replayed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    conn = reports_store.connect(settings.data_dir)
+    _seed_report(conn)
+    thread = _seed_running_thread(conn)
+    reports_store.create_upload_token(
+        conn, token="tok-1", slug="acme", thread_id=thread.id, now=NOW
+    )
+    app = _make_app(settings=settings, conn=conn, seam=_seam(requests=[]))
+    pdf_bytes = b"%PDF revised report bytes"
+
+    async with await _client(app) as client:
+        first = await client.put("/upload/tok-1", content=pdf_bytes)
+        replay = await client.put("/upload/tok-1", content=pdf_bytes)
+
+    assert first.status_code == 200
+    assert first.json()["shown_as"] == "v1.pdf"
+    assert (settings.data_dir / "acme" / "v1.pdf").read_bytes() == pdf_bytes
+
+    report = reports_store.load_report(conn, slug="acme")
+    assert report is not None
+    assert report.current_pdf == "v1.pdf"
+    revisions = reports_store.list_revisions(conn, slug="acme")
+    assert len(revisions) == 1
+    assert revisions[0].by_thread == str(thread.id)
+
+    assert replay.status_code == 404, "the same per-turn token must not be usable twice"
+    assert replay.json()["detail"] == _UPLOAD_INVALID_MESSAGE

--- a/packages/core/daimon/core/notebooks/capability.py
+++ b/packages/core/daimon/core/notebooks/capability.py
@@ -7,6 +7,10 @@ signed payload, so a tampered URL path cannot redirect bytes to another slug.
 
 Pure: the caller injects ``now`` (clock) and ``jti`` (nonce) — no I/O, no clock,
 no RNG here, so the token is deterministic given its inputs.
+
+The ``"report"`` operation is verified by ``report_host.capability`` instead —
+a separate standalone app with its own duplicated verify side, kept in lockstep
+by tests on both sides.
 """
 
 from __future__ import annotations
@@ -18,7 +22,7 @@ import json
 from datetime import datetime, timedelta
 from typing import Literal
 
-Op = Literal["blog", "notebook", "data"]
+Op = Literal["blog", "notebook", "data", "report"]
 
 
 def _b64(raw: bytes) -> str:

--- a/packages/core/tests/test_capability_lockstep.py
+++ b/packages/core/tests/test_capability_lockstep.py
@@ -1,0 +1,66 @@
+"""Drift gate between the mint and verify halves of the capability-token pair.
+
+The mint side lives in ``daimon.core.notebooks.capability``; the verify side
+is duplicated (not imported) into each standalone app, including
+``report_host.capability``. This is the one place a test is allowed to
+import both — because a drift between them would originate here, on the
+mint side, and should be caught before it ships.
+
+What breaks this test: any change to the payload key set, or the signing
+input (which bytes get HMAC'd, or with what algorithm). The key-set case is
+only a real drift gate because ``report_host.capability.CapabilityClaims``
+sets ``extra="forbid"`` — an unrecognized field in the signed payload is a
+hard validation failure on the verify side, not a silently-ignored extra.
+Confirmed by mutation: temporarily adding a key to the core mint payload
+turns this test red; reverted after confirming.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from daimon.core.notebooks.capability import mint_token
+from pydantic import SecretStr
+from report_host.capability import verify_token
+
+_SECRET = "shared-report-secret"
+_NOW = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def test_token_minted_by_core_verifies_in_report_host_and_claims_match() -> None:
+    token = mint_token(
+        _SECRET,
+        slug="q3-financials",
+        op="report",
+        max_bytes=25 * 1024 * 1024,
+        now=_NOW,
+        jti="jti-123",
+        ttl_seconds=300,
+        name="bundle.tar.gz",
+    )
+
+    claims = verify_token([SecretStr(_SECRET)], token, now=_NOW)
+
+    assert claims is not None, "a token minted by core must verify in report_host"
+    assert claims.slug == "q3-financials"
+    assert claims.op == "report"
+    assert claims.name == "bundle.tar.gz"
+    assert claims.max_bytes == 25 * 1024 * 1024
+    assert claims.jti == "jti-123"
+    assert claims.exp == int((_NOW + timedelta(seconds=300)).timestamp())
+
+
+def test_token_minted_by_core_is_rejected_after_expiry_in_report_host() -> None:
+    token = mint_token(
+        _SECRET,
+        slug="q3-financials",
+        op="report",
+        max_bytes=1_000,
+        now=_NOW,
+        jti="jti-456",
+        ttl_seconds=1,
+    )
+
+    claims = verify_token([SecretStr(_SECRET)], token, now=_NOW + timedelta(seconds=2))
+
+    assert claims is None, "an expired core-minted token must be refused by report_host"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ billing = ["daimon-adapter-mcp[billing]"]
 Repository = "https://github.com/pymc-labs/daimon"
 
 [tool.uv.workspace]
-members = ["packages/core", "packages/adapters/*", "packages/testing", "apps/notebook-host"]
+members = ["packages/core", "packages/adapters/*", "packages/testing", "apps/notebook-host", "apps/report-host"]
 
 [tool.uv.sources]
 daimon-core = { workspace = true }
@@ -51,14 +51,14 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 "**/tests/**" = ["E501"]
 
 [tool.pyright]
-include = ["packages/core/daimon", "packages/adapters/cli/daimon", "packages/adapters/mcp/daimon", "packages/adapters/discord/daimon", "packages/adapters/scheduler/daimon", "packages/adapters/slack/daimon", "apps/notebook-host/src/notebook_host"]
+include = ["packages/core/daimon", "packages/adapters/cli/daimon", "packages/adapters/mcp/daimon", "packages/adapters/discord/daimon", "packages/adapters/scheduler/daimon", "packages/adapters/slack/daimon", "apps/notebook-host/src/notebook_host", "apps/report-host/src/report_host"]
 stubPath = "typings"
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
 reportMissingImports = "error"
 
 [tool.importlinter]
-root_packages = ["daimon", "notebook_host"]
+root_packages = ["daimon", "notebook_host", "report_host"]
 
 [[tool.importlinter.contracts]]
 name = "Core must not import adapters"
@@ -130,11 +130,17 @@ type = "forbidden"
 source_modules = ["notebook_host"]
 forbidden_modules = ["daimon"]
 
+[[tool.importlinter.contracts]]
+name = "report-host must not import daimon"
+type = "forbidden"
+source_modules = ["report_host"]
+forbidden_modules = ["daimon"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
-testpaths = ["packages/core/tests", "packages/adapters/cli/tests", "packages/adapters/mcp/tests", "packages/adapters/discord/tests", "packages/adapters/scheduler/tests", "packages/adapters/slack/tests", "packages/testing/tests", "tests/integration", "tests/parity", "apps/notebook-host/tests"]
+testpaths = ["packages/core/tests", "packages/adapters/cli/tests", "packages/adapters/mcp/tests", "packages/adapters/discord/tests", "packages/adapters/scheduler/tests", "packages/adapters/slack/tests", "packages/testing/tests", "tests/integration", "tests/parity", "apps/notebook-host/tests", "apps/report-host/tests"]
 addopts = "--import-mode=importlib -m 'not contract and not slow'"
 markers = [
     "contract: live MA API tests -- opt-in only, never gate CI",

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -74,6 +74,7 @@ SECTION_TITLES: dict[str, str] = {
     "credentials": "Credentials",
     "gemini": "Gemini",
     "notebook": "Notebook Host",
+    "report_host": "Report Host",
     "sentry": "Sentry",
     "billing": "Billing Policy",
     "artifacts": "Artifacts",

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ members = [
     "daimon-core",
     "daimon-testing",
     "notebook-host",
+    "report-host",
 ]
 
 [[package]]
@@ -3508,6 +3509,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "report-host"
+version = "0.1.0"
+source = { editable = "apps/report-host" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "mcp", specifier = ">=1.27" },
+    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pydantic-settings", specifier = ">=2.4" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this is

A standalone report host: a second service that serves one published report
as a PDF in a browser viewer, with a chat sidebar backed by daimon. Each
recipient gets their own link and their own conversation with the report's
agent, scoped to a bundle of source files mounted for that report only.

## Isolation

`report_host` cannot import `daimon` — enforced by a forbidden `import-linter`
contract with a mutation test proving it actually fires, not just present in
config. It ships as its own image with no model-provider key and no database
credential; the only secrets it holds at runtime are its own admin bearer and,
per published report, one seam token that lets it call back into daimon over
MCP.

## What it enforces

- Per-recipient link scoping and expiry, with independent revocation
- A cap on concurrently running turns per report and a cap on open
  conversations per recipient
- A budget reserved the moment a turn starts and settled against the seam's
  real reported cost on every terminal outcome (success, cancel, or error) —
  never left at the optimistic reserve
- A turn deadline that cancels the turn rather than abandoning it, so a
  reader always gets a resolution
- Defensive archive extraction on the publish route: path traversal, symlink
  escapes, and oversized archives are all rejected before anything touches
  disk, proven against hand-built hostile archives with confirmed-red
  mutation tests

## How it deploys

A second container on the existing host, behind the same reverse proxy, on
its own hostname, built and refreshed by the same deploy workflow as the
existing notebook host. Its admin bearer comes from the operator's own secret
store, provisioned the same way as every other operational secret in this
project.

## Status

This is the second of three changes that make up the report-reading feature
(the first landed the MCP seam this host calls into). The tools to author and
publish a report from inside daimon itself are the third change and don't
exist yet — until they land, a report is created through this host's admin
API directly, which is enough to prove the service end to end on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJPPkRT2D8mdGA95jKXoNW
