### PR TITLE
fix(report-host): pin the mcp client major and settle the reserve on every turn exit

### DIFF
--- a/apps/report-host/pyproject.toml
+++ b/apps/report-host/pyproject.toml
@@ -10,7 +10,11 @@ dependencies = [
     "httpx>=0.27",
     "pydantic>=2.7",
     "pydantic-settings>=2.4",
-    "mcp>=1.27",
+    # Pinned below 2.0: mcp_client.py unpacks streamable_http_client's
+    # context-manager result, and 2.x changed that from a 3-tuple
+    # (read, write, get_session_id) to a 2-tuple (read, write). Lift the
+    # pin once mcp_client.py is updated for the 2.x shape.
+    "mcp>=1.27,<2",
 ]
 
 [project.urls]

--- a/apps/report-host/src/report_host/mcp_client.py
+++ b/apps/report-host/src/report_host/mcp_client.py
@@ -223,15 +223,17 @@ class SeamClient:
                 httpx.AsyncClient(
                     transport=self._transport, headers=headers, follow_redirects=True
                 ) as call_client,
-                streamable_http_client(self._mcp_url, http_client=call_client) as (
-                    read,
-                    write,
-                    _get_session_id,
-                ),
-                ClientSession(read, write) as session,
+                streamable_http_client(self._mcp_url, http_client=call_client) as streams,
             ):
-                await session.initialize()
-                result = await session.call_tool(tool, arguments)
+                # mcp 1.x yields a 3-tuple (read, write, get_session_id); 2.x
+                # narrowed this to a 2-tuple (read, write). Index rather than
+                # destructure so a resolver drift past the pyproject pin
+                # (mcp>=1.27,<2) fails loudly there, not as a bare
+                # `ValueError: not enough values to unpack` at runtime.
+                read, write = streams[0], streams[1]
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(tool, arguments)
         except* httpx.HTTPStatusError as eg:
             err = _flatten_first(eg)
             if err.response.status_code == 401:

--- a/apps/report-host/src/report_host/turns.py
+++ b/apps/report-host/src/report_host/turns.py
@@ -23,6 +23,7 @@ call funnels through the single ``_settle_reservation`` helper below.
 from __future__ import annotations
 
 import asyncio
+import logging
 import sqlite3
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -42,6 +43,8 @@ from report_host.mcp_client import (
 from report_host.reports_store import ReportRow
 from report_host.threads_store import ThreadRow
 
+log = logging.getLogger(__name__)
+
 # One fixed, reader-facing message for a bundle the host cannot re-push —
 # either there is no archive on record, the file is no longer on the volume,
 # or it resolves outside `settings.data_dir`. A single constant (not an
@@ -59,6 +62,16 @@ _REPORT_MISSING_MESSAGE = "This report could not be found; ask the publisher to 
 _DEADLINE_MESSAGE = (
     "This question was not answered within the time limit and has been stopped. "
     "It is still billed for what it consumed."
+)
+# Shown for any failure `run_turn` did not otherwise recognize (see the
+# `except Exception` boundary below). A single constant (not an f-string),
+# same reasoning as BUNDLE_MISSING_MESSAGE above: fixed and generic, never
+# an exception string or a stack frame, so a reader is never shown internals
+# — nor the seam token, which is the one thing about this failure that must
+# not leave the process — and so tests can assert on it by identity.
+TURN_FAILED_MESSAGE = (
+    "daimon could not start on this question; nothing was charged. "
+    "Ask again; if it repeats, tell the report's publisher."
 )
 
 
@@ -195,11 +208,17 @@ async def run_turn(
     so a restart's resume sweep and a real reader question call this
     function identically.
 
-    Exception boundary: this runs as a background task, so it is a
-    legitimate catch site. Only ``SeamError`` is caught, and it is stored as
-    a message the reader can act on; anything else is a bug in the host and
-    propagates.
+    Exception boundary: this runs as a background task with no caller to
+    propagate to, so it is a legitimate catch site for anything, not only
+    ``SeamError``. A ``SeamError`` is stored as a message the reader can act
+    on; anything else is logged (thread id and slug, never the token) and
+    reported as one fixed, generic message. Either way the turn ends idle
+    rather than stuck, and its reservation is settled exactly once:
+    ``reservation_pending`` tracks whether a reservation is currently
+    outstanding for this call, every explicit settle below clears it before
+    returning, and the ``finally`` releases it if none of them ran.
     """
+    reservation_pending = False
     try:
         report = reports_store.load_report(conn, slug=thread.slug)
         if report is None:
@@ -229,6 +248,7 @@ async def run_turn(
                     pdf_revision=report.current_pdf,
                 )
                 return
+            reservation_pending = True
 
             try:
                 if thread.handle is None:
@@ -254,6 +274,7 @@ async def run_turn(
                     _settle_reservation(
                         conn, slug=report.slug, reserved=settings.reserve_usd, actual=Decimal(0)
                     )
+                    reservation_pending = False
                     return
 
                 archive_bytes = archive_path.read_bytes()
@@ -292,6 +313,7 @@ async def run_turn(
                     _settle_reservation(
                         conn, slug=report.slug, reserved=settings.reserve_usd, actual=Decimal(0)
                     )
+                    reservation_pending = False
                     return
             except SeamUnauthorizedError:
                 reports_store.set_seam_status(conn, slug=report.slug, status="unauthorized")
@@ -307,6 +329,7 @@ async def run_turn(
                 _settle_reservation(
                     conn, slug=report.slug, reserved=settings.reserve_usd, actual=Decimal(0)
                 )
+                reservation_pending = False
                 return
 
             handle = started.handle
@@ -326,6 +349,10 @@ async def run_turn(
             handle = thread.handle
             turn_event_id = thread.turn_event_id
             turn_started_at_text = reports_store.dt_to_text(thread.turn_started_at)
+            # A restart-resume re-attach: the reservation was taken by the
+            # call that crashed mid-turn and is still outstanding on the
+            # report right now. This call, not that one, is what settles it.
+            reservation_pending = True
 
         seen_event_ids: frozenset[str] = frozenset()
         cancelled_at_deadline = False
@@ -383,7 +410,12 @@ async def run_turn(
         _settle_reservation(
             conn, slug=report.slug, reserved=settings.reserve_usd, actual=cost.cost_usd
         )
+        reservation_pending = False
     except SeamError as err:
+        # No explicit settle here: a generic SeamError (an unrecognized tool
+        # error, a transport failure) has none of the specific branches
+        # above's cleanup to run, so the `finally` below is what releases
+        # this call's reservation.
         threads_store.add_message(
             conn,
             thread_id=thread.id,
@@ -396,6 +428,22 @@ async def run_turn(
             bundle_sha256=None,
             pdf_revision=None,
         )
+    except Exception:
+        log.exception("run_turn failed unexpectedly thread_id=%s slug=%s", thread.id, thread.slug)
+        threads_store.add_message(
+            conn,
+            thread_id=thread.id,
+            role="system",
+            text=TURN_FAILED_MESSAGE,
+            now=now(),
+            bundle_sha256=None,
+            pdf_revision=None,
+        )
     finally:
+        if reservation_pending:
+            _settle_reservation(
+                conn, slug=thread.slug, reserved=settings.reserve_usd, actual=Decimal(0)
+            )
+            reservation_pending = False
         if not shutting_down():
             threads_store.end_turn(conn, thread_id=thread.id, now=now())

--- a/apps/report-host/tests/test_mcp_client.py
+++ b/apps/report-host/tests/test_mcp_client.py
@@ -12,12 +12,17 @@ fixture from `conftest.py`, not defined here, so plan 21-14's shell tests for
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+import contextlib
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager
 from decimal import Decimal
 
 import httpx
 import pytest
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from mcp.client.streamable_http import streamable_http_client as real_streamable_http_client
+from mcp.shared.message import SessionMessage
+from report_host import mcp_client as mcp_client_module
 from report_host.mcp_client import (
     BundleExpiredError,
     BundlePushed,
@@ -238,6 +243,55 @@ async def test_unauthorized_bearer_raises_seam_unauthorized_error(
     async with fake_seam_lifespan(app):
         with pytest.raises(SeamUnauthorizedError):
             await _seam_client(app).start_turn(token="revoked-token", message="hello")
+
+
+async def test_call_tool_tolerates_a_two_tuple_from_streamable_http_client(
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    """Pins the fix for the 1.x-vs-2.x unpack: `_call_tool` must index into
+    ``streamable_http_client``'s result rather than destructure it, so a
+    2-tuple (mcp 2.x's narrower yield) works exactly like the 3-tuple mcp 1.x
+    yields today.
+
+    No installed mcp release actually produces a 2-tuple (this project pins
+    ``mcp<2``), so the real transport is wrapped and its third element is
+    dropped — a validated fake that speaks the real wire protocol underneath,
+    not a stand-in for the whole client, only for the shape this test needs.
+    """
+
+    @contextlib.asynccontextmanager
+    async def two_tuple_streamable_http_client(
+        url: str,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        terminate_on_close: bool = True,
+    ) -> AsyncIterator[
+        tuple[
+            MemoryObjectReceiveStream[SessionMessage | Exception],
+            MemoryObjectSendStream[SessionMessage],
+        ]
+    ]:
+        async with real_streamable_http_client(
+            url, http_client=http_client, terminate_on_close=terminate_on_close
+        ) as (read, write, _get_session_id):
+            yield read, write
+
+    monkeypatch.setattr(
+        mcp_client_module, "streamable_http_client", two_tuple_streamable_http_client
+    )
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {"handle": "ses_1", "turn_event_id": "evt_1", "turn_started_at": "t0"}
+
+    captured: list[str] = []
+    app = build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=captured)
+    async with fake_seam_lifespan(app):
+        result = await _seam_client(app).start_turn(token="tok", message="hello")
+    assert result == StartedTurn(handle="ses_1", turn_event_id="evt_1", turn_started_at="t0"), (
+        "a 2-tuple from streamable_http_client must not raise an unpack error"
+    )
 
 
 async def test_archive_session_returns_none_and_issues_exactly_one_call(

--- a/apps/report-host/tests/test_turns.py
+++ b/apps/report-host/tests/test_turns.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 from report_host import reports_store, threads_store, turns
 from report_host.config import Settings, load_settings
-from report_host.mcp_client import SeamClient
+from report_host.mcp_client import SeamClient, StartedTurn
 from report_host.turns import read_turn_progress, run_turn
 from starlette.types import Receive, Scope, Send
 
@@ -847,3 +847,169 @@ async def test_run_turn_reattach_sends_nothing_and_polls_straight_to_terminal(
     updated_report = reports_store.load_report(conn, slug="acme")
     assert updated_report is not None
     assert updated_report.spent_usd == Decimal("0.02")
+
+
+# --------------------------------------------------------------------------
+# The exception boundary: an unexpected exception, and the generic SeamError
+# branch, must both release the reservation exactly once — the staging
+# defect this fixes let three failed questions leak $1.80 of a $2.00 cap
+# with no seam call ever billed.
+# --------------------------------------------------------------------------
+
+
+async def test_run_turn_with_unexpected_exception_releases_reservation_and_shows_fixed_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    """The `except Exception` boundary: a bug in the seam client — not a
+    SeamError — must still end the turn, release the reservation, and show
+    the reader the one fixed message, never propagating out of `run_turn`.
+    This reproduces the actual staging defect (an unhandled `ValueError`
+    from the mcp client) with a plain `RuntimeError`, since the point being
+    pinned is the boundary itself, not which library raised."""
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    app = build_fake_seam(behaviors={}, captured_auth=[])
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+    seam_client = _seam_client(app)
+
+    async def raise_runtime_error(
+        *, token: str, message: str, bundle: str | None = None
+    ) -> StartedTurn:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(seam_client, "start_turn", raise_runtime_error)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=seam_client,
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0"), (
+        "an unhandled exception must still release the reservation, not leak it"
+    )
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    system_texts = [m.text for m in messages if m.role == "system"]
+    assert system_texts == [turns.TURN_FAILED_MESSAGE]
+    updated_thread = threads_store.load_thread(
+        conn, thread_id=thread.id, slug="acme", recipient_token="rcpt-1"
+    )
+    assert updated_thread is not None
+    assert updated_thread.status == "idle", "the thread must end idle, not stuck running"
+
+
+async def test_run_turn_with_generic_seam_error_releases_the_reservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    """The plain `except SeamError` branch (a transport failure or an
+    unrecognized tool error — anything that is neither `BundleExpiredError`
+    nor `SeamUnauthorizedError`) has no reservation cleanup of its own; the
+    `finally` release is what stops it leaking the reserve, same as it did
+    on staging when `SeamError`-shaped failures ran out three questions'
+    worth of reserve with no seam call ever billed."""
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        raise Exception("seam is temporarily unavailable")  # noqa: TRY002
+
+    app = build_fake_seam(behaviors={"start_turn": start_turn}, captured_auth=[])
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0"), (
+        "a generic SeamError must still release the reservation"
+    )
+    messages = threads_store.list_messages(conn, thread_id=thread.id)
+    system_texts = [m.text for m in messages if m.role == "system"]
+    assert len(system_texts) == 1
+    assert "could not answer" in system_texts[0].lower()
+
+
+async def test_run_turn_happy_path_settles_the_reservation_exactly_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build_fake_seam: FakeSeamBuilder,
+    fake_seam_lifespan: FakeSeamLifespan,
+) -> None:
+    """Mutation check for the settle funnel: on a clean happy path, the real
+    `reports_store.settle_budget` must land exactly once. Making the
+    `finally` release unconditional (rather than gated on
+    `reservation_pending`) turns this red with a second, spurious call —
+    verified by hand while writing this fix, not asserted here since the
+    codebase does not carry a mutation-testing harness."""
+    conn, _report, thread = _setup(tmp_path)
+    thread = _begin(conn, thread, deadline_at=NOW + timedelta(seconds=1200))
+
+    get_my_session, list_events = _scripted([("idle", [_event("evt-1", "session.status_idle")])])
+
+    def start_turn(_args: dict[str, object]) -> dict[str, object]:
+        return {
+            "handle": "ses-1",
+            "turn_event_id": "evt-0",
+            "turn_started_at": "2026-09-08T12:00:00+00:00",
+        }
+
+    def get_turn_cost(_args: dict[str, object]) -> dict[str, object]:
+        return {"cost_usd": "0.10", "event_count": 1}
+
+    app = build_fake_seam(
+        behaviors={
+            "start_turn": start_turn,
+            "get_my_session": get_my_session,
+            "list_events": list_events,
+            "get_turn_cost": get_turn_cost,
+        },
+        captured_auth=[],
+    )
+    settings = _settings(tmp_path=tmp_path, monkeypatch=monkeypatch)
+
+    settle_calls: list[tuple[Decimal, Decimal | None]] = []
+    real_settle_budget = reports_store.settle_budget
+
+    def counting_settle_budget(
+        conn: sqlite3.Connection, *, slug: str, reserved: Decimal, actual: Decimal | None
+    ) -> None:
+        settle_calls.append((reserved, actual))
+        real_settle_budget(conn, slug=slug, reserved=reserved, actual=actual)
+
+    monkeypatch.setattr(reports_store, "settle_budget", counting_settle_budget)
+
+    async with fake_seam_lifespan(app):
+        await run_turn(
+            conn=conn,
+            seam=_seam_client(app),
+            settings=settings,
+            thread=thread,
+            message="hello",
+            now=lambda: NOW,
+        )
+
+    assert len(settle_calls) == 1, "the happy path must settle the reservation exactly once"
+    updated_report = reports_store.load_report(conn, slug="acme")
+    assert updated_report is not None
+    assert updated_report.spent_usd == Decimal("0.10")

--- a/uv.lock
+++ b/uv.lock
@@ -3528,7 +3528,7 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", specifier = ">=1.27" },
+    { name = "mcp", specifier = ">=1.27,<2" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },


### PR DESCRIPTION
## Summary

A staging walk-through of the report host found two defects, each with its own commit here.

**1. Every reader question failed instantly.** The image resolved `mcp==2.2.0` from an unpinned `mcp>=1.27`, while the workspace's own lock stayed on `1.27.0`. mcp 2.x narrowed what `streamable_http_client`'s context manager yields from a 3-tuple `(read, write, get_session_id)` to a 2-tuple `(read, write)`; the client destructured it positionally, so every call crashed with `ValueError: not enough values to unpack (expected 3, got 2)`. Fixed two ways: `apps/report-host/pyproject.toml` now pins `mcp>=1.27,<2`, and `mcp_client.py` indexes into the yielded tuple instead of destructuring it, so a future major bump fails at the pin rather than as a bare runtime `ValueError`. A new test patches the transport with a fake yielding a 2-tuple and proves a call still completes.

**2. Failed questions leaked the spending reserve.** `run_turn`'s outer catch only handled `SeamError`; the `ValueError` above escaped that catch entirely, and — for `SeamError` shapes that hit the generic branch too — the reservation taken at the start of the turn was never settled. Three failed questions on staging consumed $1.80 of a $2.00 cap with no seam call ever billed, and the reader saw nothing until the cap notice on the third question. Fixed by tracking whether a reservation is currently outstanding and releasing it from a single `finally` that runs on every exit path, plus a new `except Exception` boundary — this is a background task with no caller to propagate to, so catching broadly here is the documented exception to "catch narrowly." An unexpected failure now logs (thread id and slug, never the token) and shows the reader one fixed message instead of leaving the turn stuck. New tests cover an unhandled exception from the seam client, a generic `SeamError`, and a settle-count check on the happy path.

## Test plan

- [x] `apps/report-host` test suite: 154 passed
- [x] Full workspace suite: 5199 passed, 2 pre-existing unrelated CLI failures (logged separately, not touched by this change), 4 skipped
- [x] `uv run pyright` — clean, project-wide
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run lint-imports` — all 7 contracts kept
- [x] `docker build -f apps/report-host/Dockerfile` then checked the installed `mcp` version inside the image — resolves to a 1.x release, not 2.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJPPkRT2D8mdGA95jKXoNW