### PR TITLE
feat(report-host): publishing tools + skill — reading rooms from a chat thread

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,12 @@ DAIMON_ANTHROPIC__API_KEY=
 # Per-upload byte budget signed into notebook upload tokens. 1 MiB mirrors the notebook host's own ceiling, which is enforced independently as a second layer of defense.
 # DAIMON_NOTEBOOK__MAX_SOURCE_BYTES=1048576
 
+# === Report Host (optional) ===
+# Base URL of the report-host service (e.g. http://report-host:8002).
+# DAIMON_REPORT_HOST__HOST_URL=
+# Bearer secret used to authenticate admin calls to the report-host service. Must be the same value the report host itself is configured with (its DAIMON_REPORT__ADMIN_SECRETS) — rotating one without the other breaks publishing. (secret)
+# DAIMON_REPORT_HOST__ADMIN_SECRET=
+
 # === Sentry (optional) ===
 # Sentry DSN. When unset, error reporting is disabled entirely. (secret)
 # DAIMON_SENTRY__DSN=

--- a/defaults/skills/report-publish/SKILL.md
+++ b/defaults/skills/report-publish/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: report-publish
+description: Publish a finished report as a page a named set of people can read and ask questions about. Covers gathering recipients and a cap, building the one archive the reading room expects, the size discipline for a large bundle, and the mint-then-upload-then-share procedure. Use when someone wants to hand a finished report to specific people, not for sharing a notebook or a chart in the thread.
+---
+
+# report-publish
+
+You are publishing a finished report as a reading room: a page where the
+people you name can read the report and ask an agent questions about it,
+grounded in the analysis behind it.
+
+## 1. When to use this
+
+Use this when someone has a finished report and wants specific people to be
+able to read it and ask follow-up questions about the numbers in it. This is
+not for sharing an interactive notebook or dashboard — that is a different
+tool. It is not for posting a chart or a table directly in the conversation
+either. It is specifically for a finished, standalone report that a named
+audience should be able to sit with and interrogate on their own time.
+
+## 2. What to gather first
+
+Before you build anything, gather:
+
+- **A short slug.** Lowercase letters, numbers and hyphens only — it becomes
+  part of every recipient's link.
+- **A human title** for the report.
+- **One entry per recipient**, each with a name and a label naming who they
+  are (an email, a role, a handle — whatever tells the two of you apart
+  later).
+- **A dollar cap** for the whole report's questions. This cap covers every
+  recipient's questions together, not one cap each — plan it accordingly.
+- **Which agent should answer questions.** This defaults to the agent already
+  configured for the workspace; you may name a different one. Either way, the
+  reader gets a variant of that agent with the same voice and knowledge, minus
+  every integration it would otherwise have — a reader-facing agent never
+  reaches into the workspace's chat tools or its own extra connections.
+
+## 3. Build the archive
+
+Everything the reading room serves comes from ONE gzip archive. The report
+PDF sits at its root. The analysis directories sit beside it, at the same
+level. Every path inside the archive must be relative — no leading slash, no
+parent-directory reference. An absolute path or a relative path that climbs
+out of the archive root gets the whole upload refused, so build the archive
+from inside the directory you're compressing, not by adding files with their
+full path baked in.
+
+The layout, as a tree:
+
+```
+report.pdf     the report itself, at the archive root
+README.md      how the answering agent should answer, and how to rebuild the report
+manifest.json  links each figure to its render script, its table, its model and its source data
+data/          the source data as it was loaded, before any joins
+prep/          scripts that join and clean data/ into the tables below
+models/        the fitted model(s): scripts, summaries, diagnostics, full trace
+tables/        the per-figure and headline numbers, already computed
+figures/       one render script (and rendered image) per figure
+typst/         the report's source — edit and rebuild from here
+```
+
+Write a real `README.md` and a real `manifest.json`, not placeholders — these
+two files are what make the answers good, because the answering agent reads
+them first, before anything else in the bundle. A `manifest.json` a reader
+never sees but an answering agent needs is the difference between "why is
+this number what it is" getting a sourced answer and getting a guess. Give
+the README the answering persona and any report-specific notes; give the
+manifest a real chain from each figure to its table, its model and its source
+data, plus a run order for the scripts.
+
+## 4. Size discipline
+
+There is a hard cap on the archive's size. If your bundle does not fit under
+it, drop things in this order:
+
+1. **Raw posterior draws and trace files** — the biggest single space cost,
+   and the least likely to be asked for directly.
+2. **Intermediate caches** — anything a script recomputes cheaply and does
+   not need to ship pre-built.
+3. **Anything regenerable from a script that is already in the archive** — if
+   `models/fit.py` produces it and `models/fit.py` is in the bundle, the
+   output doesn't also need to be.
+
+Keep the tables, the manifest and the source data no matter what — those are
+exactly what a "why is this number what it is" question resolves against,
+and dropping them breaks the whole point of the reading room. If the archive
+still does not fit after dropping the three categories above, subset the
+source data (a sample, a recent window, an aggregate) rather than dropping
+the tables or the manifest.
+
+## 5. The procedure
+
+1. Call the publish tool with the slug, title, recipients, cap and agent
+   choice from step 2. It returns a one-time upload URL and one link per
+   recipient.
+2. PUT the archive to the upload URL with a single curl command:
+   ```bash
+   curl -sS -X PUT --data-binary @bundle.tar.gz "<upload_url>"
+   ```
+   Never put the archive's contents through a tool argument — a tool call
+   truncates large content, and a multi-megabyte archive will not survive the
+   round trip. The upload URL is what carries the bytes; the tool call only
+   ever carries small values.
+3. Relay each person their own link. The links are per-recipient and must
+   not be swapped or shared — sending Ada's link to Ben means Ben reads Ada's
+   report under Ada's name, and sending one link to everyone collapses the
+   isolation the reading room is built around entirely.
+
+## 6. Afterwards
+
+Each recipient gets their own conversation with the answering agent, and the
+cap you set covers all of them together, not one each. A recipient can ask
+the answering agent to revise the report; the agent rebuilds it and uploads
+the new version, which replaces the old one in every recipient's viewer.
+Deleting the report revokes every link at once and cannot be undone — a
+recipient who needs access again after that would need a fresh publish and a
+new link.
+
+## 7. What not to do
+
+- Do not put client data in a repository. The archive replaces that path
+  entirely — there is no reason for a client's data to live anywhere else.
+- Do not reuse one link for several people. Every recipient gets their own.
+- Do not publish without a cap. An uncapped report has no limit on what
+  reader questions can spend.
+- Do not paste the archive into a tool argument. Mint the upload URL, then
+  curl the file to it.

--- a/packages/adapters/mcp/daimon/adapters/mcp/server.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/server.py
@@ -53,6 +53,7 @@ from daimon.adapters.mcp.tools.github_app import register_github_app_tools
 from daimon.adapters.mcp.tools.media import register_media_tools, register_upload_tool
 from daimon.adapters.mcp.tools.notebook import register_notebook_tools
 from daimon.adapters.mcp.tools.propagation import register_propagation_tools
+from daimon.adapters.mcp.tools.publish import register_publish_tools
 from daimon.adapters.mcp.tools.wizard import register_wizard_tools
 from daimon.adapters.mcp.uploads import build_upload_route
 from daimon.adapters.mcp.webhooks import build_github_webhook, build_stripe_webhook
@@ -289,6 +290,7 @@ def create_mcp_app(
         log.info("channel tools disabled", reason="no discord or slack settings")
     self_edit.register_self_edit_tools(mcp, runtime)  # agent self-edit tools
     register_notebook_tools(mcp, runtime)  # notebook publish (raises when unconfigured)
+    register_publish_tools(mcp, runtime)  # report publish/delete (raises when unconfigured)
     register_propagation_tools(mcp, runtime)  # set/clear agent default
 
     register_upload_tool(mcp, runtime=runtime)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/publish.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/publish.py
@@ -1,0 +1,181 @@
+"""Report publishing MCP tools. Thin wrappers around daimon.core.reports.publish.
+
+Registered with the plain tool decorator, no visibility tag of any kind.
+This is the security control the whole module exists to carry: a report's
+own token is agent-scoped (it carries an ``agent_id`` claim), and
+``IdentityMiddleware`` narrows any agent-scoped session down to exactly one
+tagged group of tools reserved for chat turns — neither tool here is a
+member of that group. Tagging either tool with it would hand every report
+reader the ability to publish or delete reports in the publishing tenant.
+Untagged keeps both on the default operator surface, reachable by any
+ordinary platform-user token in its own tenant, and invisible to a report's
+own token.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import httpx
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools._ctx import _auth  # pyright: ignore[reportPrivateUsage]
+from daimon.core.errors import DaimonError
+from daimon.core.reports.host_client import Recipient, ReportHostError
+from daimon.core.reports.publish import (
+    HostNotConfiguredError,
+    InvalidSlugError,
+    delete_report,
+    publish_report,
+)
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+
+
+def _report_host_error_message(err: ReportHostError) -> str:
+    """Recover the timeout/unreachable distinction from the wrapped cause.
+
+    ``daimon.core.reports.host_client``'s ``_send`` wraps every
+    ``httpx.HTTPError`` — timeouts and transport failures included — into a
+    single ``ReportHostError`` via ``raise ReportHostError(...) from exc``,
+    so a raw ``httpx.TimeoutException``/``TransportError`` never reaches this
+    module directly. The chained ``__cause__`` still carries the original
+    exception, which is what lets a timed-out host and one that returned a
+    non-2xx status read differently to the person in the chat thread, the
+    same distinction the notebook tools draw at their own boundary.
+    """
+    cause = err.__cause__
+    if isinstance(cause, httpx.TimeoutException):
+        return "report host timed out"
+    if isinstance(cause, httpx.TransportError):
+        return f"report host unreachable: {cause}"
+    return str(err)
+
+
+async def _publish_report_impl(
+    runtime: McpRuntime,
+    *,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID,
+    slug: str,
+    title: str,
+    recipients: list[Recipient],
+    cap_usd: Decimal,
+    agent: str | None,
+    client_factory: type[httpx.AsyncClient] = httpx.AsyncClient,
+) -> dict[str, object]:
+    if runtime.settings.mcp.jwt_secret is None:
+        raise ToolError("report host not configured: DAIMON_MCP__JWT_SECRET is unset")
+    jwt_secret = runtime.settings.mcp.jwt_secret.get_secret_value().encode()
+    try:
+        async with client_factory() as client:
+            result = await publish_report(
+                anthropic=runtime.client,
+                session_factory=runtime.session_factory,
+                http_client=client,
+                report_host_settings=runtime.settings.report_host,
+                jwt_secret=jwt_secret,
+                max_bundle_bytes=runtime.settings.mcp.bundle_max_bytes,
+                default=runtime.deployment_default,
+                tenant_id=tenant_id,
+                account_id=account_id,
+                slug=slug,
+                title=title,
+                recipients=recipients,
+                cap_usd=cap_usd,
+                agent=agent,
+                now=datetime.now(UTC),
+            )
+    except HostNotConfiguredError as err:
+        raise ToolError("report host not configured") from err
+    except InvalidSlugError as err:
+        raise ToolError(str(err)) from err
+    except ReportHostError as err:
+        raise ToolError(_report_host_error_message(err)) from err
+    except DaimonError as err:
+        raise ToolError(str(err)) from err
+    return {"upload_url": result.upload_url, "links": result.links}
+
+
+async def _delete_report_impl(
+    runtime: McpRuntime,
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    client_factory: type[httpx.AsyncClient] = httpx.AsyncClient,
+) -> dict[str, object]:
+    try:
+        async with client_factory() as client:
+            result = await delete_report(
+                session_factory=runtime.session_factory,
+                http_client=client,
+                report_host_settings=runtime.settings.report_host,
+                tenant_id=tenant_id,
+                slug=slug,
+                now=datetime.now(UTC),
+            )
+    except HostNotConfiguredError as err:
+        raise ToolError("report host not configured") from err
+    except ReportHostError as err:
+        raise ToolError(_report_host_error_message(err)) from err
+    return {"tokens_revoked": result.tokens_revoked, "host_removed": result.host_removed}
+
+
+def register_publish_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
+    @mcp.tool
+    async def publish_report(  # pyright: ignore[reportUnusedFunction]
+        ctx: Context,
+        slug: str,
+        title: str,
+        recipients: list[Recipient],
+        cap_usd: float | str,
+        agent: str | None = None,
+    ) -> dict[str, object]:
+        """Publish a report: a page where the named people can read it and
+        ask it questions.
+
+        Pass a short slug (goes in the URL), a title, one entry per
+        recipient (``name`` and ``label`` — a short identifier for their
+        link, e.g. an email or handle), a dollar cap on how much reader Q&A
+        may spend against your tenant's balance, and optionally which agent
+        should answer questions (defaults to this tenant's configured
+        agent).
+
+        Returns ``{upload_url, links}``: ``upload_url`` is a one-time
+        capability URL: ``links`` maps each recipient's name to their own
+        personal link.
+
+        What to do next: build ONE gzip archive (``tar -czf bundle.tar.gz
+        report.pdf analysis/``) with the report PDF at its root and the
+        analysis files beside it, using relative paths only — no absolute
+        paths, no leading slash — then PUT it to ``upload_url``:
+        ``curl -sS -X PUT --data-binary @bundle.tar.gz "<upload_url>"``.
+        Keep the archive under the size cap; if it's too large, raw model
+        output files (posterior draws, large .nc/.csv dumps) are the first
+        thing to drop — never the PDF or the code that produced it. Relay
+        each recipient their own link; the links are not interchangeable.
+        """
+        auth = await _auth(ctx)
+        return await _publish_report_impl(
+            runtime,
+            tenant_id=auth.tenant_id,
+            account_id=auth.account_id,
+            slug=slug,
+            title=title,
+            recipients=recipients,
+            cap_usd=Decimal(str(cap_usd)),
+            agent=agent,
+        )
+
+    @mcp.tool
+    async def delete_report(ctx: Context, slug: str) -> dict[str, object]:  # pyright: ignore[reportUnusedFunction]
+        """Un-publish a report you published.
+
+        Revokes the report's credential and removes it from the host —
+        every link you handed out stops working. This cannot be undone;
+        re-publishing the same slug mints a new credential and new links,
+        so anyone who needs access again must be sent their new link.
+        """
+        auth = await _auth(ctx)
+        return await _delete_report_impl(runtime, tenant_id=auth.tenant_id, slug=slug)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/publish.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/publish.py
@@ -61,10 +61,14 @@ async def _publish_report_impl(
     slug: str,
     title: str,
     recipients: list[Recipient],
-    cap_usd: Decimal,
+    cap_usd: float | str,
     agent: str | None,
     client_factory: type[httpx.AsyncClient] = httpx.AsyncClient,
 ) -> dict[str, object]:
+    # FastMCP has no Decimal-shaped tool argument, so cap_usd arrives as a
+    # float or a string; a string round trip is what keeps a float's binary
+    # imprecision from ever reaching the core function as a signed cap.
+    cap = Decimal(str(cap_usd))
     if runtime.settings.mcp.jwt_secret is None:
         raise ToolError("report host not configured: DAIMON_MCP__JWT_SECRET is unset")
     jwt_secret = runtime.settings.mcp.jwt_secret.get_secret_value().encode()
@@ -83,7 +87,7 @@ async def _publish_report_impl(
                 slug=slug,
                 title=title,
                 recipients=recipients,
-                cap_usd=cap_usd,
+                cap_usd=cap,
                 agent=agent,
                 now=datetime.now(UTC),
             )
@@ -164,7 +168,7 @@ def register_publish_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
             slug=slug,
             title=title,
             recipients=recipients,
-            cap_usd=Decimal(str(cap_usd)),
+            cap_usd=cap_usd,
             agent=agent,
         )
 

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -1264,6 +1264,28 @@
         'type': 'object',
       }),
     }),
+    'delete_report': dict({
+      'description': '''
+        Un-publish a report you published.
+        
+        Revokes the report's credential and removes it from the host —
+        every link you handed out stops working. This cannot be undone;
+        re-publishing the same slug mints a new credential and new links,
+        so anyone who needs access again must be sent their new link.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'slug': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'slug',
+        ]),
+        'type': 'object',
+      }),
+    }),
     'delete_routine': dict({
       'description': 'Delete a routine (hard delete, tenant-scoped).',
       'parameters': dict({
@@ -2222,6 +2244,96 @@
           'prompt',
           'steps',
           'channel_id',
+        ]),
+        'type': 'object',
+      }),
+    }),
+    'publish_report': dict({
+      'description': '''
+        Publish a report: a page where the named people can read it and
+        ask it questions.
+        
+        Pass a short slug (goes in the URL), a title, one entry per
+        recipient (``name`` and ``label`` — a short identifier for their
+        link, e.g. an email or handle), a dollar cap on how much reader Q&A
+        may spend against your tenant's balance, and optionally which agent
+        should answer questions (defaults to this tenant's configured
+        agent).
+        
+        Returns ``{upload_url, links}``: ``upload_url`` is a one-time
+        capability URL: ``links`` maps each recipient's name to their own
+        personal link.
+        
+        What to do next: build ONE gzip archive (``tar -czf bundle.tar.gz
+        report.pdf analysis/``) with the report PDF at its root and the
+        analysis files beside it, using relative paths only — no absolute
+        paths, no leading slash — then PUT it to ``upload_url``:
+        ``curl -sS -X PUT --data-binary @bundle.tar.gz "<upload_url>"``.
+        Keep the archive under the size cap; if it's too large, raw model
+        output files (posterior draws, large .nc/.csv dumps) are the first
+        thing to drop — never the PDF or the code that produced it. Relay
+        each recipient their own link; the links are not interchangeable.
+      ''',
+      'parameters': dict({
+        '$defs': dict({
+          'Recipient': dict({
+            'description': 'One named recipient of a published report; the host mints one link each.',
+            'properties': dict({
+              'label': dict({
+                'type': 'string',
+              }),
+              'name': dict({
+                'type': 'string',
+              }),
+            }),
+            'required': list([
+              'name',
+              'label',
+            ]),
+            'type': 'object',
+          }),
+        }),
+        'additionalProperties': False,
+        'properties': dict({
+          'agent': dict({
+            'anyOf': list([
+              dict({
+                'type': 'string',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+          }),
+          'cap_usd': dict({
+            'anyOf': list([
+              dict({
+                'type': 'number',
+              }),
+              dict({
+                'type': 'string',
+              }),
+            ]),
+          }),
+          'recipients': dict({
+            'items': dict({
+              '$ref': '#/$defs/Recipient',
+            }),
+            'type': 'array',
+          }),
+          'slug': dict({
+            'type': 'string',
+          }),
+          'title': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'slug',
+          'title',
+          'recipients',
+          'cap_usd',
         ]),
         'type': 'object',
       }),

--- a/packages/adapters/mcp/tests/tools/test_publish.py
+++ b/packages/adapters/mcp/tests/tools/test_publish.py
@@ -1,0 +1,497 @@
+"""Tests for the report publishing MCP tools: the impl error mapping, the cap's
+Decimal boundary, and the reachability property that makes these two tools
+invisible to a report's own agent-scoped token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import create_autospec
+
+import httpx
+import pytest
+from anthropic import AsyncAnthropic
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.server import create_mcp_app
+from daimon.adapters.mcp.tools.publish import (
+    _delete_report_impl,  # pyright: ignore[reportPrivateUsage]
+    _publish_report_impl,  # pyright: ignore[reportPrivateUsage]
+)
+from daimon.core.config import (
+    AnthropicSettings,
+    DatabaseSettings,
+    McpSettings,
+    ReportHostSettings,
+    Settings,
+)
+from daimon.core.errors import DaimonError
+from daimon.core.mcp_auth import mint_jwt
+from daimon.core.reports.host_client import Recipient, ReportHostError
+from daimon.core.reports.publish import (
+    DeleteResult,
+    HostNotConfiguredError,
+    InvalidSlugError,
+    PublishResult,
+)
+from daimon.core.scope import DeploymentDefault
+from daimon.testing.factories import make_account, make_tenant
+from factories import make_jwt
+from fastmcp.exceptions import ToolError
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.types import ASGIApp, Message
+
+pytestmark = pytest.mark.asyncio
+
+SECRET = "a" * 32
+
+
+def _make_settings(
+    *,
+    host_url: str | None = "http://report-host:8002",
+    admin_secret: str | None = "admin-secret",
+    jwt_secret: str | None = SECRET,
+) -> Settings:
+    return Settings(
+        database=DatabaseSettings(
+            url=PostgresDsn("postgresql+asyncpg://daimon:daimon@localhost:5432/daimon")
+        ),
+        anthropic=AnthropicSettings(api_key=SecretStr("test-key")),
+        report_host=ReportHostSettings(
+            host_url=HttpUrl(host_url) if host_url else None,
+            admin_secret=SecretStr(admin_secret) if admin_secret else None,
+        ),
+        mcp=McpSettings(jwt_secret=SecretStr(jwt_secret) if jwt_secret else None),
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+def _make_runtime(settings: Settings) -> McpRuntime:
+    fake_sessionmaker: async_sessionmaker[AsyncSession] = create_autospec(
+        async_sessionmaker, instance=True
+    )
+    return McpRuntime(
+        session_factory=fake_sessionmaker,
+        client=AsyncAnthropic(api_key="test-key"),
+        settings=settings,
+        deployment_default=DeploymentDefault(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _publish_report_impl / _delete_report_impl — error mapping, faking the core
+# orchestration at the boundary of the impl (it's exhaustively tested at the
+# host-client/publish-orchestration layer already, in plan 21-22).
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_report_impl_raises_when_jwt_secret_unset() -> None:
+    runtime = _make_runtime(_make_settings(jwt_secret=None))
+    with pytest.raises(ToolError, match="not configured"):
+        await _publish_report_impl(
+            runtime,
+            tenant_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            slug="q1-results",
+            title="Q1 results",
+            recipients=[Recipient(name="Ada", label="ada")],
+            cap_usd="2.50",
+            agent=None,
+        )
+
+
+async def test_publish_report_impl_maps_host_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake(**_kwargs: object) -> PublishResult:
+        raise HostNotConfiguredError("report host not configured: host_url is unset")
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.publish_report", fake)
+    runtime = _make_runtime(_make_settings())
+    with pytest.raises(ToolError, match="report host not configured") as exc_info:
+        await _publish_report_impl(
+            runtime,
+            tenant_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            slug="q1-results",
+            title="Q1 results",
+            recipients=[Recipient(name="Ada", label="ada")],
+            cap_usd="2.50",
+            agent=None,
+        )
+    assert isinstance(exc_info.value.__cause__, HostNotConfiguredError), (
+        "the domain error must be preserved as the tool error's cause"
+    )
+
+
+async def test_publish_report_impl_maps_invalid_slug_to_domain_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake(**_kwargs: object) -> PublishResult:
+        raise InvalidSlugError("invalid report slug: 'Q1 Results'")
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.publish_report", fake)
+    runtime = _make_runtime(_make_settings())
+    with pytest.raises(ToolError, match="invalid report slug: 'Q1 Results'") as exc_info:
+        await _publish_report_impl(
+            runtime,
+            tenant_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            slug="Q1 Results",
+            title="Q1 results",
+            recipients=[Recipient(name="Ada", label="ada")],
+            cap_usd="2.50",
+            agent=None,
+        )
+    assert isinstance(exc_info.value.__cause__, InvalidSlugError)
+
+
+async def test_publish_report_impl_maps_unknown_agent_to_domain_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake(**_kwargs: object) -> PublishResult:
+        raise DaimonError("agent 'ghost' not found")
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.publish_report", fake)
+    runtime = _make_runtime(_make_settings())
+    with pytest.raises(ToolError, match="agent 'ghost' not found") as exc_info:
+        await _publish_report_impl(
+            runtime,
+            tenant_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            slug="q1-results",
+            title="Q1 results",
+            recipients=[Recipient(name="Ada", label="ada")],
+            cap_usd="2.50",
+            agent="ghost",
+        )
+    assert isinstance(exc_info.value.__cause__, DaimonError)
+
+
+async def test_publish_report_impl_maps_host_error_carrying_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake(**_kwargs: object) -> PublishResult:
+        raise ReportHostError("report host returned 500: internal error")
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.publish_report", fake)
+    runtime = _make_runtime(_make_settings())
+    with pytest.raises(ToolError, match="report host returned 500: internal error") as exc_info:
+        await _publish_report_impl(
+            runtime,
+            tenant_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            slug="q1-results",
+            title="Q1 results",
+            recipients=[Recipient(name="Ada", label="ada")],
+            cap_usd="2.50",
+            agent=None,
+        )
+    assert isinstance(exc_info.value.__cause__, ReportHostError)
+
+
+async def test_publish_report_impl_maps_timeout_distinctly(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake(**_kwargs: object) -> PublishResult:
+        raise ReportHostError("report host request failed: timed out") from httpx.TimeoutException(
+            "timed out"
+        )
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.publish_report", fake)
+    runtime = _make_runtime(_make_settings())
+    with pytest.raises(ToolError, match="report host timed out"):
+        await _publish_report_impl(
+            runtime,
+            tenant_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            slug="q1-results",
+            title="Q1 results",
+            recipients=[Recipient(name="Ada", label="ada")],
+            cap_usd="2.50",
+            agent=None,
+        )
+
+
+async def test_publish_report_impl_maps_transport_failure_distinctly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake(**_kwargs: object) -> PublishResult:
+        raise ReportHostError(
+            "report host request failed: connection refused"
+        ) from httpx.TransportError("connection refused")
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.publish_report", fake)
+    runtime = _make_runtime(_make_settings())
+    with pytest.raises(ToolError, match="report host unreachable: connection refused"):
+        await _publish_report_impl(
+            runtime,
+            tenant_id=uuid.uuid4(),
+            account_id=uuid.uuid4(),
+            slug="q1-results",
+            title="Q1 results",
+            recipients=[Recipient(name="Ada", label="ada")],
+            cap_usd="2.50",
+            agent=None,
+        )
+
+
+async def test_publish_report_impl_happy_path_returns_upload_url_and_links_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake(**_kwargs: object) -> PublishResult:
+        return PublishResult(
+            upload_url="http://report-host:8002/publish/tok",
+            links={"Ada": "http://report-host:8002/r/q1-results?t=abc"},
+        )
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.publish_report", fake)
+    runtime = _make_runtime(_make_settings())
+    out = await _publish_report_impl(
+        runtime,
+        tenant_id=uuid.uuid4(),
+        account_id=uuid.uuid4(),
+        slug="q1-results",
+        title="Q1 results",
+        recipients=[Recipient(name="Ada", label="ada")],
+        cap_usd="2.50",
+        agent=None,
+    )
+    assert out == {
+        "upload_url": "http://report-host:8002/publish/tok",
+        "links": {"Ada": "http://report-host:8002/r/q1-results?t=abc"},
+    }, "the happy path must return the core result unchanged"
+
+
+@pytest.mark.parametrize("raw_cap", ["2.50", 2.5])
+async def test_publish_report_impl_cap_reaches_core_as_exact_decimal(
+    monkeypatch: pytest.MonkeyPatch, raw_cap: str | float
+) -> None:
+    """A string ("2.50") and a number (2.5, the JSON shape of the same value)
+    both reach the core function as a Decimal, never a bare float."""
+    captured: dict[str, object] = {}
+
+    async def fake(**kwargs: object) -> PublishResult:
+        captured.update(kwargs)
+        return PublishResult(upload_url="http://h/publish/tok", links={})
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.publish_report", fake)
+    runtime = _make_runtime(_make_settings())
+    await _publish_report_impl(
+        runtime,
+        tenant_id=uuid.uuid4(),
+        account_id=uuid.uuid4(),
+        slug="q1-results",
+        title="Q1 results",
+        recipients=[Recipient(name="Ada", label="ada")],
+        cap_usd=raw_cap,
+        agent=None,
+    )
+    cap = captured["cap_usd"]
+    assert isinstance(cap, Decimal), f"cap_usd must reach core as a Decimal, got {type(cap)}"
+    assert cap == Decimal("2.50"), f"expected Decimal('2.50'), got {cap!r}"
+
+
+async def test_delete_report_impl_raises_host_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake(**_kwargs: object) -> DeleteResult:
+        raise HostNotConfiguredError("report host not configured: host_url is unset")
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.delete_report", fake)
+    runtime = _make_runtime(_make_settings())
+    with pytest.raises(ToolError, match="report host not configured") as exc_info:
+        await _delete_report_impl(runtime, tenant_id=uuid.uuid4(), slug="q1-results")
+    assert isinstance(exc_info.value.__cause__, HostNotConfiguredError)
+
+
+async def test_delete_report_impl_maps_host_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake(**_kwargs: object) -> DeleteResult:
+        raise ReportHostError("report host returned 404: not found")
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.delete_report", fake)
+    runtime = _make_runtime(_make_settings())
+    with pytest.raises(ToolError, match="report host returned 404: not found") as exc_info:
+        await _delete_report_impl(runtime, tenant_id=uuid.uuid4(), slug="q1-results")
+    assert isinstance(exc_info.value.__cause__, ReportHostError)
+
+
+async def test_delete_report_impl_passes_caller_tenant_and_returns_core_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake(**kwargs: object) -> DeleteResult:
+        captured.update(kwargs)
+        return DeleteResult(tokens_revoked=2, host_removed=True)
+
+    monkeypatch.setattr("daimon.adapters.mcp.tools.publish.delete_report", fake)
+    runtime = _make_runtime(_make_settings())
+    tenant_id = uuid.uuid4()
+    out = await _delete_report_impl(runtime, tenant_id=tenant_id, slug="q1-results")
+
+    assert captured["tenant_id"] == tenant_id, "the caller's own tenant must be passed through"
+    assert captured["slug"] == "q1-results"
+    assert out == {"tokens_revoked": 2, "host_removed": True}, (
+        "delete_report must return what the core reported, unchanged"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reachability — the point of this file. A report's own token carries an
+# agent_id claim; IdentityMiddleware narrows that session to exactly the
+# agent-chat-tagged tools. publish_report/delete_report are untagged, so
+# they must never appear for such a session, while an ordinary operator
+# token (no agent_id claim) must see both.
+# ---------------------------------------------------------------------------
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
+    send_queue: asyncio.Queue[Message] = asyncio.Queue()
+    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await receive_queue.get()
+
+    async def send(message: Message) -> None:
+        await send_queue.put(message)
+
+    async def run_lifespan() -> None:
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+
+    task = asyncio.create_task(run_lifespan())
+
+    await receive_queue.put({"type": "lifespan.startup"})
+    msg = await send_queue.get()
+    assert msg["type"] == "lifespan.startup.complete", msg
+    try:
+        yield
+    finally:
+        await receive_queue.put({"type": "lifespan.shutdown"})
+        msg = await send_queue.get()
+        assert msg["type"] == "lifespan.shutdown.complete", msg
+        await task
+
+
+def _parse_jsonrpc_response(resp: httpx.Response) -> dict[str, object]:
+    content_type = resp.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        for line in resp.text.splitlines():
+            if line.startswith("data: "):
+                return json.loads(line[6:])  # type: ignore[return-value]
+        raise AssertionError(f"No data line in SSE response: {resp.text!r}")
+    return resp.json()  # type: ignore[return-value]
+
+
+async def _mcp_session(
+    app: ASGIApp,
+    *,
+    token: str,
+    method: str,
+    params: dict[str, object] | None = None,
+) -> dict[str, object]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        init_resp = await c.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0"},
+                },
+            },
+            headers=headers,
+        )
+        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
+        session_id = init_resp.headers.get("mcp-session-id")
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+
+        body = {"jsonrpc": "2.0", "id": 2, "method": method, "params": params or {}}
+        resp = await c.post("/mcp", json=body, headers=headers)
+        assert resp.status_code == 200, f"{method} failed ({resp.status_code}): {resp.text}"
+        return _parse_jsonrpc_response(resp)
+
+
+def _make_app(sessionmaker: async_sessionmaker[AsyncSession]) -> ASGIApp:
+    return create_mcp_app(
+        settings=Settings(
+            database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+            anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+            mcp=McpSettings(jwt_secret=SecretStr(SECRET), public_url=HttpUrl("https://x/mcp")),
+        ),
+        sessionmaker=sessionmaker,
+    )
+
+
+@pytest.mark.parametrize("tool_name", ["publish_report", "delete_report"])
+async def test_operator_token_discovers_publish_and_delete_report_tools(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    tool_name: str,
+) -> None:
+    """An ordinary platform-user token (no agent_id claim) discovers both
+    tools via search_tools — the meta-tool discovery surface every
+    non-narrowed session uses (tools/list only returns the meta-tools
+    themselves for such a session, per the BM25 collapse). This is the
+    positive control that keeps the reachability test below from passing
+    vacuously by the tools simply not existing."""
+    async with sessionmaker() as s, s.begin():
+        tenant = await make_tenant(s, platform="discord", workspace_id="publish-reachability")
+        account = await make_account(s, tenant=tenant)
+    token = make_jwt(account_id=account.id)
+    app = _make_app(sessionmaker)
+
+    result = await _mcp_session(
+        app,
+        token=token,
+        method="tools/call",
+        params={"name": "search_tools", "arguments": {"query": tool_name.replace("_", " ")}},
+    )
+    call_result = result.get("result", result)
+    content = call_result.get("content", [])  # type: ignore[union-attr]
+    output_text = " ".join(item.get("text", "") for item in content if isinstance(item, dict))
+    assert tool_name in output_text, (
+        f"{tool_name} must be discoverable by an operator token; got: {output_text!r}"
+    )
+
+
+async def test_agent_scoped_token_does_not_discover_publish_or_delete_report_tools(
+    sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A report's own token carries an agent_id claim, which narrows the
+    session to exactly the agent-chat-tagged tool set. Neither publish tool
+    is a member of that set, so neither may appear here — the property that
+    stops a reader session from ever publishing or deleting a report."""
+    async with sessionmaker() as s, s.begin():
+        tenant = await make_tenant(s, platform="discord", workspace_id="publish-reachability-agent")
+        account = await make_account(s, tenant=tenant)
+    token = mint_jwt(
+        account_id=account.id, secret=SECRET.encode(), now=datetime.now(UTC), agent_id=uuid.uuid4()
+    )
+    app = _make_app(sessionmaker)
+
+    result = await _mcp_session(app, token=token, method="tools/list")
+    payload = result.get("result", result)
+    tool_names = {t["name"] for t in payload.get("tools", [])}  # type: ignore[union-attr]
+
+    assert not ({"publish_report", "delete_report"} & tool_names), (
+        f"an agent-scoped token must never discover either publish tool; got: {sorted(tool_names)}"
+    )
+    assert "ask" in tool_names, (
+        "the agent-chat tool set must still be visible — otherwise this test "
+        "would pass vacuously by narrowing to nothing at all"
+    )

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -484,6 +484,28 @@ class NotebookSettings(BaseModel):
     )
 
 
+class ReportHostSettings(BaseModel):
+    """Optional report-host client config.
+
+    Both fields optional so deployments without a report host keep working.
+    The publishing MCP tool raises ToolError when host_url is unset.
+    """
+
+    host_url: HttpUrl | None = Field(
+        default=None,
+        description="Base URL of the report-host service (e.g. http://report-host:8002).",
+    )
+    admin_secret: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Bearer secret used to authenticate admin calls to the report-host "
+            "service. Must be the same value the report host itself is "
+            "configured with (its DAIMON_REPORT__ADMIN_SECRETS) — rotating one "
+            "without the other breaks publishing."
+        ),
+    )
+
+
 class SentrySettings(BaseModel):
     """Sentry observability config.
 
@@ -585,6 +607,7 @@ class Settings(BaseSettings):
     credentials: CredentialsSettings = Field(default_factory=CredentialsSettings)
     gemini: GeminiSettings = Field(default_factory=GeminiSettings)
     notebook: NotebookSettings = Field(default_factory=NotebookSettings)
+    report_host: ReportHostSettings = Field(default_factory=ReportHostSettings)
     sentry: SentrySettings = Field(default_factory=SentrySettings)
     billing: BillingSettings = Field(default_factory=BillingSettings)
     artifacts: ArtifactsSettings | None = Field(

--- a/packages/core/daimon/core/reports/__init__.py
+++ b/packages/core/daimon/core/reports/__init__.py
@@ -1,0 +1,1 @@
+"""Report-host client and publish orchestration."""

--- a/packages/core/daimon/core/reports/host_client.py
+++ b/packages/core/daimon/core/reports/host_client.py
@@ -1,0 +1,222 @@
+"""Thin httpx client to the report host's admin API.
+
+Direct analog of ``daimon.core.notebooks.host_client``: a domain-error
+subclass for any non-2xx or transport failure, free async functions taking
+an injected ``httpx.AsyncClient`` (no client construction here), and a
+uniform non-2xx message carrying the status and a truncated body. The one
+deliberate difference from the notebook sibling is that the bearer + host
+URL are threaded through as a single ``ReportHostSettings`` block rather
+than two loose parameters — this module's three functions all need exactly
+that pair, and checking both together is what lets ``_require_configured``
+refuse to speak before any request is issued.
+
+Every request body and response is a typed Pydantic model, never a bare
+untyped mapping — a response missing an expected field raises a
+``ValidationError`` (wrapped as ``ReportHostError``) instead of silently
+returning a half-populated result.
+
+Never logs the seam token or the admin bearer — the uniform error message
+carries only the response status and a truncated body, never the request
+headers or the request body.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import httpx
+from daimon.core.config import ReportHostSettings
+from daimon.core.errors import DaimonError
+from pydantic import BaseModel, ConfigDict, HttpUrl, SecretStr, ValidationError
+
+__all__ = [
+    "ReportHostError",
+    "Recipient",
+    "ReportRegistered",
+    "put_admin_report",
+    "delete_admin_report",
+    "revoke_admin_recipient",
+]
+
+# Conservative per-call timeout, matching the notebook host client's sibling
+# calls (host_client.attach_to_host and friends all use 30.0).
+_TIMEOUT_SECONDS = 30.0
+
+
+class ReportHostError(DaimonError):
+    """Raised when the report host rejects a call, fails a call, or is unconfigured."""
+
+
+class Recipient(BaseModel):
+    """One named recipient of a published report; the host mints one link each."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    label: str
+
+
+class ReportRegistered(BaseModel):
+    """The host's answer to a publish (create-or-replace) call.
+
+    ``links`` maps each recipient's ``name`` to the link the host minted for
+    them — a dict, not the host's own list-of-objects wire shape, because
+    every caller of this function wants "the link for Ada", not a list to
+    scan.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    links: dict[str, str]
+
+
+class _RecipientBody(BaseModel):
+    """Request-body shape for one recipient, matching the host's ``RecipientIn``."""
+
+    name: str
+    label: str
+
+
+class _PublishBody(BaseModel):
+    """Request-body shape for ``PUT /admin/reports/{slug}``.
+
+    Field names and types must match the host's ``PublishRequest`` exactly —
+    that model is what decides them. ``cap_usd`` is serialised as a string
+    (never a bare float) so the host's ``Decimal`` field parses it precisely.
+    """
+
+    title: str
+    tenant_id: str
+    agent_name: str
+    cap_usd: str
+    seam_token: str
+    recipients: list[_RecipientBody]
+
+
+class _RecipientLinkWire(BaseModel):
+    name: str
+    link: str
+
+
+class _ReportRegisteredWire(BaseModel):
+    """Response-body shape from ``PUT /admin/reports/{slug}``."""
+
+    slug: str
+    links: list[_RecipientLinkWire]
+
+
+class _DeletedWire(BaseModel):
+    """Response-body shape shared by both delete/revoke routes."""
+
+    deleted: bool
+
+
+def _require_configured(settings: ReportHostSettings) -> tuple[HttpUrl, SecretStr]:
+    """Return (host_url, admin_secret), or raise before any request is sent.
+
+    Refusing here — rather than letting an unauthenticated request go out
+    and fail on the wire — is the point: a deployment with no report host
+    configured must never emit a bearer-less call.
+    """
+    if settings.host_url is None:
+        raise ReportHostError("report host not configured: host_url is unset")
+    if settings.admin_secret is None:
+        raise ReportHostError("report host not configured: admin_secret is unset")
+    return settings.host_url, settings.admin_secret
+
+
+def _bearer_headers(admin_secret: SecretStr) -> dict[str, str]:
+    return {"Authorization": f"Bearer {admin_secret.get_secret_value()}"}
+
+
+async def _send(client: httpx.AsyncClient, method: str, url: str, **kwargs: Any) -> httpx.Response:
+    try:
+        return await client.request(method, url, timeout=_TIMEOUT_SECONDS, **kwargs)
+    except httpx.HTTPError as exc:
+        raise ReportHostError(f"report host request failed: {exc}") from exc
+
+
+async def put_admin_report(
+    *,
+    client: httpx.AsyncClient,
+    settings: ReportHostSettings,
+    slug: str,
+    title: str,
+    tenant_id: uuid.UUID,
+    agent_name: str,
+    cap_usd: Decimal,
+    seam_token: str,
+    recipients: list[Recipient],
+) -> ReportRegistered:
+    """``PUT /admin/reports/{slug}`` — create or replace a report and its recipients."""
+    host_url, admin_secret = _require_configured(settings)
+    url = f"{str(host_url).rstrip('/')}/admin/reports/{slug}"
+    body = _PublishBody(
+        title=title,
+        tenant_id=str(tenant_id),
+        agent_name=agent_name,
+        cap_usd=str(cap_usd),
+        seam_token=seam_token,
+        recipients=[_RecipientBody(name=r.name, label=r.label) for r in recipients],
+    )
+    r = await _send(
+        client,
+        "PUT",
+        url,
+        json=body.model_dump(mode="json"),
+        headers=_bearer_headers(admin_secret),
+    )
+    if not r.is_success:
+        raise ReportHostError(f"report host returned {r.status_code}: {r.text[:200]}")
+    try:
+        wire = _ReportRegisteredWire.model_validate(r.json())
+    except ValidationError as exc:
+        raise ReportHostError(f"report host response missing expected field: {exc}") from exc
+    return ReportRegistered(slug=wire.slug, links={link.name: link.link for link in wire.links})
+
+
+async def delete_admin_report(
+    *,
+    client: httpx.AsyncClient,
+    settings: ReportHostSettings,
+    slug: str,
+    tenant_id: uuid.UUID,
+) -> bool:
+    """``DELETE /admin/reports/{slug}?tenant_id=``; True if something was actually removed."""
+    host_url, admin_secret = _require_configured(settings)
+    url = f"{str(host_url).rstrip('/')}/admin/reports/{slug}"
+    r = await _send(
+        client,
+        "DELETE",
+        url,
+        params={"tenant_id": str(tenant_id)},
+        headers=_bearer_headers(admin_secret),
+    )
+    if not r.is_success:
+        raise ReportHostError(f"report host returned {r.status_code}: {r.text[:200]}")
+    try:
+        return _DeletedWire.model_validate(r.json()).deleted
+    except ValidationError as exc:
+        raise ReportHostError(f"report host response missing expected field: {exc}") from exc
+
+
+async def revoke_admin_recipient(
+    *,
+    client: httpx.AsyncClient,
+    settings: ReportHostSettings,
+    slug: str,
+    token: str,
+) -> bool:
+    """``DELETE /admin/reports/{slug}/recipients/{token}``; True if a link was revoked."""
+    host_url, admin_secret = _require_configured(settings)
+    url = f"{str(host_url).rstrip('/')}/admin/reports/{slug}/recipients/{token}"
+    r = await _send(client, "DELETE", url, headers=_bearer_headers(admin_secret))
+    if not r.is_success:
+        raise ReportHostError(f"report host returned {r.status_code}: {r.text[:200]}")
+    try:
+        return _DeletedWire.model_validate(r.json()).deleted
+    except ValidationError as exc:
+        raise ReportHostError(f"report host response missing expected field: {exc}") from exc

--- a/packages/core/daimon/core/reports/publish.py
+++ b/packages/core/daimon/core/reports/publish.py
@@ -1,0 +1,275 @@
+"""Publishing orchestration: resolve, derive, mint, register, hand back an upload URL.
+
+Direct analog of ``daimon.core.notebooks.publish``: a not-configured error, a
+slug error, and free functions taking explicit settings plus a tenant/account
+pair — no adapter imports, no FastMCP, no tool-error type, so this can be
+unit-tested without an MCP ``Context``. The wrapper that maps these errors
+into ``ToolError`` lives in the MCP adapter, a separate plan.
+
+Order matters in ``publish_report`` and is the substance of that function:
+validate the slug and the host configuration before anything is created,
+derive the reader variant before any token is minted, mint the token before
+registering with the host, and revoke that token if registration fails. Get
+the order wrong and a report exists on the host with no token, or a token
+exists with no report — both are states nobody will ever clean up.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+import httpx
+from anthropic import AsyncAnthropic
+from daimon.core import ma_identity
+from daimon.core.config import ReportHostSettings
+from daimon.core.errors import DaimonError
+from daimon.core.mcp_auth import mint_agent_mcp_token
+from daimon.core.notebooks.capability import mint_token
+from daimon.core.reader_agent import ensure_reader_variant
+from daimon.core.reports.host_client import (
+    Recipient,
+    ReportHostError,
+    delete_admin_report,
+    put_admin_report,
+)
+from daimon.core.scope import DeploymentDefault, ScopeContext
+from daimon.core.stores.mcp_tokens import list_live_tokens_by_label, revoke_mcp_token
+from daimon.core.stores.scoped_config_read import resolve
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+__all__ = [
+    "HostNotConfiguredError",
+    "InvalidSlugError",
+    "PublishResult",
+    "DeleteResult",
+    "publish_report",
+    "delete_report",
+]
+
+
+class HostNotConfiguredError(DaimonError):
+    """``ReportHostSettings.host_url`` / ``admin_secret`` unset."""
+
+
+class InvalidSlugError(DaimonError):
+    """Caller-provided slug failed the host's own validation pattern."""
+
+
+# Mirrors the report host's own slug pattern exactly
+# (report_host.admin._SLUG_PATTERN) — a slug the host will reject must not
+# first cause an agent to be derived and a token to be minted.
+_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SLUG_MAX_LEN = 64
+
+# The one place the mcp_tokens.label format is defined. publish_report mints
+# under this label; delete_report looks tokens back up by it. Never format
+# this string a second time anywhere else in this module.
+_REPORT_TOKEN_LABEL_PREFIX = "report:"
+
+# 5 minutes: long enough for the publishing agent to curl its bundle to the
+# host, short enough to bound the replay window on the single-use
+# capability. Mirrors daimon.core.notebooks.upload's _UPLOAD_TTL_SECONDS.
+_UPLOAD_TTL_SECONDS = 300
+# 72-bit url-safe nonce for single-use jti dedup, matching
+# daimon.core.notebooks.upload's _JTI_BYTES.
+_JTI_BYTES = 9
+
+
+def _report_token_label(slug: str) -> str:
+    """The mcp_tokens.label format shared by minting (publish) and lookup (delete)."""
+    return f"{_REPORT_TOKEN_LABEL_PREFIX}{slug}"
+
+
+def _validate_slug(slug: str) -> None:
+    if not slug or len(slug) > _SLUG_MAX_LEN or not _SLUG_PATTERN.fullmatch(slug):
+        raise InvalidSlugError(f"invalid report slug: {slug!r}")
+
+
+class PublishResult(BaseModel):
+    """What a caller of ``publish_report`` gets back."""
+
+    model_config = ConfigDict(frozen=True)
+
+    upload_url: str
+    links: dict[str, str]
+
+
+class DeleteResult(BaseModel):
+    """What a caller of ``delete_report`` gets back.
+
+    Carries both counts so the caller can tell "deleted" from "there was
+    nothing there" — a report deleted twice, or a report that never
+    existed, must not look like a successful first deletion.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tokens_revoked: int
+    host_removed: bool
+
+
+async def publish_report(
+    *,
+    anthropic: AsyncAnthropic,
+    session_factory: async_sessionmaker[AsyncSession],
+    http_client: httpx.AsyncClient,
+    report_host_settings: ReportHostSettings,
+    jwt_secret: bytes,
+    max_bundle_bytes: int,
+    default: DeploymentDefault,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID,
+    slug: str,
+    title: str,
+    recipients: list[Recipient],
+    cap_usd: Decimal,
+    agent: str | None,
+    now: datetime,
+) -> PublishResult:
+    """Resolve the source agent, derive its reader variant, mint the report its
+    own token, register it with the host, and return a one-time upload URL.
+
+    ``jwt_secret`` and ``max_bundle_bytes`` are taken as plain values rather
+    than a settings block: the only two things this function needs off
+    ``McpSettings``, injected explicitly per guideline:architecture rather
+    than handing the whole settings block to a function that uses two of
+    its six fields. The caller (the MCP tool wrapper) is responsible for
+    checking ``settings.mcp.jwt_secret`` is configured before calling —
+    the same responsibility the CLI's ``mint-agent-token`` command already
+    carries for the same primitive.
+
+    ``agent`` is the publisher's explicit choice of source agent. When
+    omitted, the tenant's configured agent is resolved through the shared
+    channel/tenant/deployment cascade (``default`` is that cascade's bottom
+    tier, ``daimon.core.defaults.loader.parse_deployment_default``'s
+    output) — nothing about the in-session MCP credential identifies which
+    agent is calling, so there is no inference to attempt here; do not add
+    one later.
+
+    The freshly minted report token is minted under ``account_id`` /
+    ``tenant_id`` — the publisher's own account, which carries a platform
+    principal. This is the billing decision the whole phase turns on: every
+    reader question against this report runs through the normal balance and
+    cap admission checks and lands in the publishing tenant's usage, exactly
+    as if the publisher had asked the question themselves. Minting under
+    any other account would make reader Q&A unbilled and un-admission-gated.
+
+    Order (see module docstring): slug validation and the not-configured
+    check both happen before the reader variant is derived; the variant is
+    derived before any token is minted; the token is minted before the host
+    registration; a failed host registration revokes the token it just
+    minted before propagating, so a report that never made it onto the host
+    never leaves a live, billable credential behind.
+    """
+    _validate_slug(slug)
+    if report_host_settings.host_url is None or report_host_settings.admin_secret is None:
+        raise HostNotConfiguredError(
+            "report host not configured: host_url and admin_secret are required"
+        )
+
+    resolved_agent = agent
+    if resolved_agent is None:
+        async with session_factory() as session:
+            resolved_config = await resolve(
+                session,
+                context=ScopeContext(tenant_id=tenant_id, account_id=account_id),
+                default=default,
+            )
+        if resolved_config.agent_name is None:
+            raise DaimonError(
+                f"no agent configured for tenant {tenant_id} and no --agent was given"
+            )
+        resolved_agent = resolved_config.agent_name
+
+    variant = await ensure_reader_variant(
+        anthropic, tenant_id=tenant_id, account_id=account_id, source_name=resolved_agent
+    )
+
+    label = _report_token_label(slug)
+    agent_uuid = ma_identity.derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=variant.id)
+    async with session_factory() as session, session.begin():
+        seam_token = await mint_agent_mcp_token(
+            session,
+            account_id=account_id,
+            tenant_id=tenant_id,
+            agent_id=agent_uuid,
+            label=label,
+            secret=jwt_secret,
+            now=now,
+        )
+
+    try:
+        registered = await put_admin_report(
+            client=http_client,
+            settings=report_host_settings,
+            slug=slug,
+            title=title,
+            tenant_id=tenant_id,
+            agent_name=resolved_agent,
+            cap_usd=cap_usd,
+            seam_token=seam_token,
+            recipients=recipients,
+        )
+    except ReportHostError:
+        # An orphaned live credential for a report that never registered is
+        # a secret nobody will ever clean up — revoke it before propagating.
+        async with session_factory() as session, session.begin():
+            live = await list_live_tokens_by_label(session, tenant_id=tenant_id, label=label)
+            for row in live:
+                await revoke_mcp_token(session, jti=row.jti, now=now)
+        raise
+
+    capability = mint_token(
+        report_host_settings.admin_secret.get_secret_value(),
+        slug=slug,
+        op="report",
+        max_bytes=max_bundle_bytes,
+        now=now,
+        jti=secrets.token_urlsafe(_JTI_BYTES),
+        ttl_seconds=_UPLOAD_TTL_SECONDS,
+    )
+    upload_url = f"{str(report_host_settings.host_url).rstrip('/')}/publish/{capability}"
+
+    return PublishResult(upload_url=upload_url, links=registered.links)
+
+
+async def delete_report(
+    *,
+    session_factory: async_sessionmaker[AsyncSession],
+    http_client: httpx.AsyncClient,
+    report_host_settings: ReportHostSettings,
+    tenant_id: uuid.UUID,
+    slug: str,
+    now: datetime,
+) -> DeleteResult:
+    """Revoke a report's token(s), then remove it from the host, in that order.
+
+    Revoking first means the failure window (a host call that fails after a
+    successful revoke) leaves a report that is unreachable with a dead
+    credential — a safe end state. The reverse order would leave a live,
+    billable credential for a report nobody can see, which is not.
+
+    Deleting a report with no live tokens and no host row is not an error:
+    a report deleted twice, or one that never existed, answers with a
+    ``DeleteResult`` reporting zero/False rather than raising.
+    """
+    if report_host_settings.host_url is None or report_host_settings.admin_secret is None:
+        raise HostNotConfiguredError(
+            "report host not configured: host_url and admin_secret are required"
+        )
+
+    label = _report_token_label(slug)
+    async with session_factory() as session, session.begin():
+        live = await list_live_tokens_by_label(session, tenant_id=tenant_id, label=label)
+        for row in live:
+            await revoke_mcp_token(session, jti=row.jti, now=now)
+
+    host_removed = await delete_admin_report(
+        client=http_client, settings=report_host_settings, slug=slug, tenant_id=tenant_id
+    )
+    return DeleteResult(tokens_revoked=len(live), host_removed=host_removed)

--- a/packages/core/daimon/core/stores/mcp_tokens.py
+++ b/packages/core/daimon/core/stores/mcp_tokens.py
@@ -96,6 +96,39 @@ async def revoke_mcp_token(
     return McpTokenRow.model_validate(orm)
 
 
+async def list_live_tokens_by_label(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    label: str,
+) -> list[McpTokenRow]:
+    """Return every live (non-revoked) token row matching `label` in `tenant_id`.
+
+    `tenant_id` is a required, undefaulted filter — not an optional narrowing.
+    Two tenants can each publish a report under the same slug on the same
+    deployment, so `label` alone is not unique across tenants; a label-only
+    lookup would let one tenant's `delete_report` revoke another tenant's
+    live token. This is the whole reason the function takes this shape:
+    do not remove the tenant filter to "simplify" a caller.
+
+    Returns an empty list rather than raising when nothing matches — "no
+    live token with that label" is a legitimate state (a report deleted
+    twice, or a report whose token already expired and was cleaned), not
+    an error.
+
+    Returns every live match, not just one: nothing constrains labels to be
+    unique within a tenant, and a caller revoking "the token for this
+    report" should revoke every live one rather than silently picking one.
+    """
+    stmt = select(McpToken).where(
+        McpToken.tenant_id == tenant_id,
+        McpToken.label == label,
+        McpToken.revoked_at.is_(None),
+    )
+    result = await session.execute(stmt)
+    return [McpTokenRow.model_validate(orm) for orm in result.scalars()]
+
+
 async def delete_tokens_for_account(
     session: AsyncSession,
     *,

--- a/packages/core/tests/reports/test_host_client.py
+++ b/packages/core/tests/reports/test_host_client.py
@@ -1,0 +1,325 @@
+"""Tests for daimon.core.reports.host_client.
+
+Transport-level mocking via httpx.MockTransport — no AsyncMock on httpx methods.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Callable
+from decimal import Decimal
+
+import httpx
+import pytest
+from daimon.core.config import ReportHostSettings
+from daimon.core.reports.host_client import (
+    Recipient,
+    ReportHostError,
+    ReportRegistered,
+    delete_admin_report,
+    put_admin_report,
+    revoke_admin_recipient,
+)
+from pydantic import HttpUrl, SecretStr
+
+pytestmark = pytest.mark.asyncio
+
+_HOST_URL = HttpUrl("http://report-host:8002")
+_ADMIN_SECRET = SecretStr("supersecret")
+_SLUG = "q3-financials"
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000a1")
+
+
+def _make_client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _settings(
+    *, host_url: HttpUrl | None = _HOST_URL, admin_secret: SecretStr | None = _ADMIN_SECRET
+) -> ReportHostSettings:
+    return ReportHostSettings(host_url=host_url, admin_secret=admin_secret)
+
+
+async def test_put_admin_report_sends_correct_path_method_and_bearer() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["method"] = req.method
+        captured["auth"] = req.headers.get("Authorization", "")
+        captured["body"] = json.loads(req.content)
+        return httpx.Response(200, json={"slug": _SLUG, "links": []})
+
+    async with _make_client(handler) as client:
+        await put_admin_report(
+            client=client,
+            settings=_settings(),
+            slug=_SLUG,
+            title="Q3 financials",
+            tenant_id=_TENANT_ID,
+            agent_name="analyst",
+            cap_usd=Decimal("2.00"),
+            seam_token="seam-tok",
+            recipients=[],
+        )
+
+    assert captured["url"] == f"http://report-host:8002/admin/reports/{_SLUG}"
+    assert captured["method"] == "PUT"
+    assert captured["auth"] == "Bearer supersecret"
+
+
+async def test_put_admin_report_body_carries_expected_fields_with_string_cap() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.content)
+        return httpx.Response(200, json={"slug": _SLUG, "links": []})
+
+    async with _make_client(handler) as client:
+        await put_admin_report(
+            client=client,
+            settings=_settings(),
+            slug=_SLUG,
+            title="Q3 financials",
+            tenant_id=_TENANT_ID,
+            agent_name="analyst",
+            cap_usd=Decimal("2.00"),
+            seam_token="seam-tok",
+            recipients=[
+                Recipient(name="Ada", label="ada-link"),
+                Recipient(name="Ben", label="ben-link"),
+            ],
+        )
+
+    body = captured["body"]
+    assert isinstance(body, dict)
+    assert body["title"] == "Q3 financials"
+    assert body["tenant_id"] == str(_TENANT_ID)
+    assert body["agent_name"] == "analyst"
+    assert body["seam_token"] == "seam-tok"
+    assert body["cap_usd"] == "2.00", "cap_usd must be serialised as a string, never a float"
+    assert isinstance(body["cap_usd"], str)
+    assert body["recipients"] == [
+        {"name": "Ada", "label": "ada-link"},
+        {"name": "Ben", "label": "ben-link"},
+    ]
+
+
+async def test_put_admin_report_parses_2xx_into_report_registered() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "slug": _SLUG,
+                "links": [
+                    {"name": "Ada", "link": "https://r.example/ada"},
+                    {"name": "Ben", "link": "https://r.example/ben"},
+                ],
+            },
+        )
+
+    async with _make_client(handler) as client:
+        result = await put_admin_report(
+            client=client,
+            settings=_settings(),
+            slug=_SLUG,
+            title="Q3 financials",
+            tenant_id=_TENANT_ID,
+            agent_name="analyst",
+            cap_usd=Decimal("2.00"),
+            seam_token="seam-tok",
+            recipients=[Recipient(name="Ada", label="a"), Recipient(name="Ben", label="b")],
+        )
+
+    assert result == ReportRegistered(
+        slug=_SLUG,
+        links={"Ada": "https://r.example/ada", "Ben": "https://r.example/ben"},
+    )
+
+
+async def test_put_admin_report_raises_on_non_2xx_with_status_in_message() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="this slug belongs to a different tenant")
+
+    async with _make_client(handler) as client:
+        with pytest.raises(ReportHostError, match="403"):
+            await put_admin_report(
+                client=client,
+                settings=_settings(),
+                slug=_SLUG,
+                title="t",
+                tenant_id=_TENANT_ID,
+                agent_name="analyst",
+                cap_usd=Decimal("2.00"),
+                seam_token="seam-tok",
+                recipients=[],
+            )
+
+
+async def test_put_admin_report_transport_error_raises_with_cause_preserved() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    async with _make_client(handler) as client:
+        with pytest.raises(ReportHostError) as excinfo:
+            await put_admin_report(
+                client=client,
+                settings=_settings(),
+                slug=_SLUG,
+                title="t",
+                tenant_id=_TENANT_ID,
+                agent_name="analyst",
+                cap_usd=Decimal("2.00"),
+                seam_token="seam-tok",
+                recipients=[],
+            )
+    assert isinstance(excinfo.value.__cause__, httpx.ConnectError), (
+        "the transport failure must be preserved as the exception cause"
+    )
+
+
+async def test_put_admin_report_unset_host_url_raises_before_any_request() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen.append(req)
+        return httpx.Response(200, json={"slug": _SLUG, "links": []})
+
+    async with _make_client(handler) as client:
+        with pytest.raises(ReportHostError, match="host_url"):
+            await put_admin_report(
+                client=client,
+                settings=_settings(host_url=None),
+                slug=_SLUG,
+                title="t",
+                tenant_id=_TENANT_ID,
+                agent_name="analyst",
+                cap_usd=Decimal("2.00"),
+                seam_token="seam-tok",
+                recipients=[],
+            )
+    assert seen == [], "an unconfigured host_url must never issue a request"
+
+
+async def test_put_admin_report_unset_admin_secret_raises_before_any_request() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen.append(req)
+        return httpx.Response(200, json={"slug": _SLUG, "links": []})
+
+    async with _make_client(handler) as client:
+        with pytest.raises(ReportHostError, match="admin_secret"):
+            await put_admin_report(
+                client=client,
+                settings=_settings(admin_secret=None),
+                slug=_SLUG,
+                title="t",
+                tenant_id=_TENANT_ID,
+                agent_name="analyst",
+                cap_usd=Decimal("2.00"),
+                seam_token="seam-tok",
+                recipients=[],
+            )
+    assert seen == [], "an unconfigured admin_secret must never issue a request"
+
+
+async def test_put_admin_report_response_missing_field_raises() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        # Missing "links" entirely — a shape mismatch, not a partial result.
+        return httpx.Response(200, json={"slug": _SLUG})
+
+    async with _make_client(handler) as client:
+        with pytest.raises(ReportHostError):
+            await put_admin_report(
+                client=client,
+                settings=_settings(),
+                slug=_SLUG,
+                title="t",
+                tenant_id=_TENANT_ID,
+                agent_name="analyst",
+                cap_usd=Decimal("2.00"),
+                seam_token="seam-tok",
+                recipients=[],
+            )
+
+
+async def test_delete_admin_report_sends_tenant_id_query_param_and_bearer() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["method"] = req.method
+        captured["auth"] = req.headers.get("Authorization", "")
+        return httpx.Response(200, json={"deleted": True})
+
+    async with _make_client(handler) as client:
+        deleted = await delete_admin_report(
+            client=client, settings=_settings(), slug=_SLUG, tenant_id=_TENANT_ID
+        )
+
+    assert captured["method"] == "DELETE"
+    assert (
+        captured["url"] == f"http://report-host:8002/admin/reports/{_SLUG}?tenant_id={_TENANT_ID}"
+    )
+    assert captured["auth"] == "Bearer supersecret"
+    assert deleted is True
+
+
+async def test_delete_admin_report_returns_false_when_host_removed_nothing() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"deleted": False})
+
+    async with _make_client(handler) as client:
+        deleted = await delete_admin_report(
+            client=client, settings=_settings(), slug=_SLUG, tenant_id=_TENANT_ID
+        )
+    assert deleted is False
+
+
+async def test_delete_admin_report_raises_on_non_2xx() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    async with _make_client(handler) as client:
+        with pytest.raises(ReportHostError, match="500"):
+            await delete_admin_report(
+                client=client, settings=_settings(), slug=_SLUG, tenant_id=_TENANT_ID
+            )
+
+
+async def test_delete_admin_report_unset_settings_raises_before_any_request() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen.append(req)
+        return httpx.Response(200, json={"deleted": True})
+
+    async with _make_client(handler) as client:
+        with pytest.raises(ReportHostError):
+            await delete_admin_report(
+                client=client,
+                settings=_settings(host_url=None, admin_secret=None),
+                slug=_SLUG,
+                tenant_id=_TENANT_ID,
+            )
+    assert seen == []
+
+
+async def test_revoke_admin_recipient_deletes_by_token() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["method"] = req.method
+        return httpx.Response(200, json={"deleted": True})
+
+    async with _make_client(handler) as client:
+        revoked = await revoke_admin_recipient(
+            client=client, settings=_settings(), slug=_SLUG, token="tok-1"
+        )
+
+    assert captured["method"] == "DELETE"
+    assert captured["url"] == f"http://report-host:8002/admin/reports/{_SLUG}/recipients/tok-1"
+    assert revoked is True

--- a/packages/core/tests/reports/test_publish.py
+++ b/packages/core/tests/reports/test_publish.py
@@ -1,0 +1,701 @@
+"""Tests for daimon.core.reports.publish.
+
+Transport-level MA fakes (MARouter/build_fake_anthropic), a mock HTTP
+transport for the report host, and a real Postgres session (via
+db_session_factory) for the token rows — per guideline:testing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import httpx
+import pytest
+from anthropic.types.beta import BetaManagedAgentsAgent
+from daimon.core.config import ReportHostSettings
+from daimon.core.defaults.metadata import (
+    MA_METADATA_KEY_NAME,
+    MA_METADATA_KEY_SPEC_HASH,
+    MA_METADATA_KEY_TENANT,
+    tenant_scoped_display_title,
+)
+from daimon.core.errors import DaimonError
+from daimon.core.reader_agent import READER_SKILL_NAME
+from daimon.core.reports.host_client import Recipient, ReportHostError
+from daimon.core.reports.publish import (
+    DeleteResult,
+    HostNotConfiguredError,
+    InvalidSlugError,
+    delete_report,
+    publish_report,
+)
+from daimon.core.scope import DeploymentDefault
+from daimon.core.stores.mcp_tokens import get_mcp_token, list_live_tokens_by_label
+from daimon.testing.factories import make_account, make_mcp_token, make_tenant
+from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
+from pydantic import HttpUrl, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+NOW = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_JWT_SECRET = b"jwt-shared-secret-well-over-the-32-byte-minimum"
+_MAX_BUNDLE_BYTES = 25 * 1024 * 1024
+
+
+def _settings() -> ReportHostSettings:
+    return ReportHostSettings(
+        host_url=HttpUrl("http://report-host:8002"), admin_secret=SecretStr("shared-secret")
+    )
+
+
+def _host_client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _source_agent_dict(
+    *, id_: str, name: str, tenant_id: uuid.UUID, spec_hash: str = "src-hash-1", version: int = 1
+) -> dict[str, Any]:
+    metadata: dict[str, str] = {
+        MA_METADATA_KEY_TENANT: str(tenant_id),
+        MA_METADATA_KEY_NAME: name,
+        MA_METADATA_KEY_SPEC_HASH: spec_hash,
+    }
+    return BetaManagedAgentsAgent.model_validate(
+        {
+            "id": id_,
+            "type": "agent",
+            "name": name,
+            "model": {"id": "claude-sonnet-4-6"},
+            "metadata": metadata,
+            "description": None,
+            "archived_at": None,
+            "created_at": "2026-06-01T00:00:00Z",
+            "updated_at": "2026-06-01T00:00:00Z",
+            "version": version,
+            "mcp_servers": [],
+            "skills": [],
+            "tools": [],
+            "system": "You are alpha, a data analyst.",
+        }
+    ).model_dump(mode="json")
+
+
+def _ma_router(agents: list[dict[str, Any]], *, tenant_id: uuid.UUID) -> MARouter:
+    """List + per-id retrieve + a skills list resolving the report-reader ref."""
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, _m: list_response(agents))
+
+    def _retrieve(_req: httpx.Request, match: re.Match[str]) -> httpx.Response:
+        agent_id = match.group(1)
+        for agent in agents:
+            if agent["id"] == agent_id:
+                return httpx.Response(200, json=agent)
+        return httpx.Response(
+            404,
+            json={"type": "error", "error": {"type": "not_found_error", "message": "not found"}},
+        )
+
+    router.add("GET", r"/v1/agents/([^/]+)", _retrieve)
+    canonical_title = tenant_scoped_display_title(tenant_id=tenant_id, name=READER_SKILL_NAME)
+    router.add(
+        "GET",
+        r"/v1/skills",
+        lambda req, _m: list_response(
+            [
+                {
+                    "id": "sk_reader_resolved",
+                    "type": "custom",
+                    "display_title": canonical_title,
+                    "latest_version": "1",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "updated_at": "2026-06-01T00:00:00Z",
+                    "source": "custom",
+                }
+            ]
+        ),
+    )
+    return router
+
+
+def _add_create_route(router: MARouter, captured: dict[str, Any], *, reader_id: str) -> None:
+    def on_create(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        captured.update(json.loads(req.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": reader_id,
+                "type": "agent",
+                "name": captured["name"],
+                "model": {"id": "claude-sonnet-4-6"},
+                "metadata": captured["metadata"],
+                "description": None,
+                "archived_at": None,
+                "created_at": "2026-06-01T00:00:00Z",
+                "updated_at": "2026-06-01T00:00:00Z",
+                "version": 1,
+                "mcp_servers": [],
+                "skills": [{"type": "custom", "skill_id": "sk_reader_resolved", "version": "1"}],
+                "tools": [],
+                "system": captured.get("system", ""),
+            },
+        )
+
+    router.add("POST", r"/v1/agents", on_create)
+
+
+def _reader_agent_dict(
+    *, id_: str, name: str, tenant_id: uuid.UUID, metadata: dict[str, str], version: int = 1
+) -> dict[str, Any]:
+    return BetaManagedAgentsAgent.model_validate(
+        {
+            "id": id_,
+            "type": "agent",
+            "name": name,
+            "model": {"id": "claude-sonnet-4-6"},
+            "metadata": {
+                MA_METADATA_KEY_TENANT: str(tenant_id),
+                MA_METADATA_KEY_NAME: name,
+                **metadata,
+            },
+            "description": None,
+            "archived_at": None,
+            "created_at": "2026-06-01T00:00:00Z",
+            "updated_at": "2026-06-01T00:00:00Z",
+            "version": version,
+            "mcp_servers": [],
+            "skills": [{"type": "custom", "skill_id": "sk_reader_resolved", "version": "1"}],
+            "tools": [],
+            "system": "",
+        }
+    ).model_dump(mode="json")
+
+
+async def _seed_tenant(
+    session_factory: async_sessionmaker[AsyncSession], *, workspace_id: str | None = None
+) -> tuple[uuid.UUID, uuid.UUID]:
+    async with session_factory() as session:
+        tenant = await make_tenant(session, workspace_id=workspace_id)
+        account = await make_account(session, tenant=tenant)
+        await session.commit()
+    return tenant.id, account.id
+
+
+# ---------------------------------------------------------------------------
+# publish_report
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_report_registers_with_host_and_returns_upload_url_and_links(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id, account_id = await _seed_tenant(db_session_factory)
+    source = _source_agent_dict(id_="ag_src", name="alpha", tenant_id=tenant_id)
+    ma_router = _ma_router([source], tenant_id=tenant_id)
+    created: dict[str, Any] = {}
+    _add_create_route(ma_router, created, reader_id="ag_reader")
+    anthropic = build_fake_anthropic(ma_router.dispatch)
+
+    host_calls: list[httpx.Request] = []
+
+    def host_handler(req: httpx.Request) -> httpx.Response:
+        host_calls.append(req)
+        return httpx.Response(
+            200, json={"slug": "q3", "links": [{"name": "Ada", "link": "https://r.example/ada"}]}
+        )
+
+    result = await publish_report(
+        anthropic=anthropic,
+        session_factory=db_session_factory,
+        http_client=_host_client(host_handler),
+        report_host_settings=_settings(),
+        jwt_secret=_JWT_SECRET,
+        max_bundle_bytes=_MAX_BUNDLE_BYTES,
+        default=DeploymentDefault(),
+        tenant_id=tenant_id,
+        account_id=account_id,
+        slug="q3",
+        title="Q3 financials",
+        recipients=[Recipient(name="Ada", label="ada-1")],
+        cap_usd=Decimal("2.00"),
+        agent="alpha",
+        now=NOW,
+    )
+
+    assert len(host_calls) == 1, "exactly one host registration must be issued"
+    body = json.loads(host_calls[0].content)
+    assert body["agent_name"] == "alpha"
+    assert body["seam_token"], "the freshly minted token must be in the request body"
+    assert body["cap_usd"] == "2.00"
+    assert result.links == {"Ada": "https://r.example/ada"}
+    assert result.upload_url.startswith("http://report-host:8002/publish/")
+
+
+async def test_publish_report_leaves_a_live_token_row_findable_by_label(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id, account_id = await _seed_tenant(db_session_factory)
+    source = _source_agent_dict(id_="ag_src", name="alpha", tenant_id=tenant_id)
+    ma_router = _ma_router([source], tenant_id=tenant_id)
+    _add_create_route(ma_router, {}, reader_id="ag_reader")
+    anthropic = build_fake_anthropic(ma_router.dispatch)
+
+    def host_handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"slug": "q3", "links": []})
+
+    await publish_report(
+        anthropic=anthropic,
+        session_factory=db_session_factory,
+        http_client=_host_client(host_handler),
+        report_host_settings=_settings(),
+        jwt_secret=_JWT_SECRET,
+        max_bundle_bytes=_MAX_BUNDLE_BYTES,
+        default=DeploymentDefault(),
+        tenant_id=tenant_id,
+        account_id=account_id,
+        slug="q3",
+        title="Q3 financials",
+        recipients=[],
+        cap_usd=Decimal("2.00"),
+        agent="alpha",
+        now=NOW,
+    )
+
+    async with db_session_factory() as session:
+        rows = await list_live_tokens_by_label(session, tenant_id=tenant_id, label="report:q3")
+    assert len(rows) == 1, (
+        "delete_report finds a report's token by this exact label — it must exist"
+    )
+    assert rows[0].account_id == account_id, (
+        "the token must be minted under the publisher's account"
+    )
+
+
+async def test_publish_report_omitting_agent_resolves_the_tenants_configured_agent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id, account_id = await _seed_tenant(db_session_factory)
+    source = _source_agent_dict(id_="ag_src", name="alpha", tenant_id=tenant_id)
+    ma_router = _ma_router([source], tenant_id=tenant_id)
+    _add_create_route(ma_router, {}, reader_id="ag_reader")
+    anthropic = build_fake_anthropic(ma_router.dispatch)
+
+    host_calls: list[httpx.Request] = []
+
+    def host_handler(req: httpx.Request) -> httpx.Response:
+        host_calls.append(req)
+        return httpx.Response(200, json={"slug": "q3", "links": []})
+
+    await publish_report(
+        anthropic=anthropic,
+        session_factory=db_session_factory,
+        http_client=_host_client(host_handler),
+        report_host_settings=_settings(),
+        jwt_secret=_JWT_SECRET,
+        max_bundle_bytes=_MAX_BUNDLE_BYTES,
+        default=DeploymentDefault(agent_name="alpha"),
+        tenant_id=tenant_id,
+        account_id=account_id,
+        slug="q3",
+        title="Q3 financials",
+        recipients=[],
+        cap_usd=Decimal("2.00"),
+        agent=None,
+        now=NOW,
+    )
+
+    body = json.loads(host_calls[0].content)
+    assert body["agent_name"] == "alpha", (
+        "an omitted agent must resolve through the deployment-default cascade"
+    )
+
+
+async def test_publish_report_unknown_agent_raises_before_any_token_or_host_call(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id, account_id = await _seed_tenant(db_session_factory)
+    source = _source_agent_dict(id_="ag_src", name="alpha", tenant_id=tenant_id)
+    ma_router = _ma_router([source], tenant_id=tenant_id)
+    anthropic = build_fake_anthropic(ma_router.dispatch)
+
+    host_calls: list[httpx.Request] = []
+
+    def host_handler(req: httpx.Request) -> httpx.Response:
+        host_calls.append(req)
+        return httpx.Response(200, json={"slug": "q3", "links": []})
+
+    with pytest.raises(DaimonError):
+        await publish_report(
+            anthropic=anthropic,
+            session_factory=db_session_factory,
+            http_client=_host_client(host_handler),
+            report_host_settings=_settings(),
+            jwt_secret=_JWT_SECRET,
+            max_bundle_bytes=_MAX_BUNDLE_BYTES,
+            default=DeploymentDefault(),
+            tenant_id=tenant_id,
+            account_id=account_id,
+            slug="q3",
+            title="Q3",
+            recipients=[],
+            cap_usd=Decimal("2.00"),
+            agent="ghost",
+            now=NOW,
+        )
+
+    assert host_calls == [], "an unknown source agent must never reach the host"
+    async with db_session_factory() as session:
+        rows = await list_live_tokens_by_label(session, tenant_id=tenant_id, label="report:q3")
+    assert rows == [], "an unknown source agent must never mint a token"
+
+
+async def test_publish_report_invalid_slug_raises_before_any_ma_call(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id, account_id = await _seed_tenant(db_session_factory)
+    call_count = 0
+
+    def counting_handler(_req: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(200, json={"data": [], "next_page": None})
+
+    anthropic = build_fake_anthropic(counting_handler)
+
+    with pytest.raises(InvalidSlugError):
+        await publish_report(
+            anthropic=anthropic,
+            session_factory=db_session_factory,
+            http_client=_host_client(lambda _req: httpx.Response(200, json={})),
+            report_host_settings=_settings(),
+            jwt_secret=_JWT_SECRET,
+            max_bundle_bytes=_MAX_BUNDLE_BYTES,
+            default=DeploymentDefault(),
+            tenant_id=tenant_id,
+            account_id=account_id,
+            slug="Not A Valid Slug!",
+            title="t",
+            recipients=[],
+            cap_usd=Decimal("2.00"),
+            agent="alpha",
+            now=NOW,
+        )
+
+    assert call_count == 0, "an invalid slug must fail before any MA call is issued"
+
+
+async def test_publish_report_unconfigured_host_settings_raises_before_any_ma_call(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id, account_id = await _seed_tenant(db_session_factory)
+    call_count = 0
+
+    def counting_handler(_req: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(200, json={"data": [], "next_page": None})
+
+    anthropic = build_fake_anthropic(counting_handler)
+
+    with pytest.raises(HostNotConfiguredError):
+        await publish_report(
+            anthropic=anthropic,
+            session_factory=db_session_factory,
+            http_client=_host_client(lambda _req: httpx.Response(200, json={})),
+            report_host_settings=ReportHostSettings(host_url=None, admin_secret=None),
+            jwt_secret=_JWT_SECRET,
+            max_bundle_bytes=_MAX_BUNDLE_BYTES,
+            default=DeploymentDefault(),
+            tenant_id=tenant_id,
+            account_id=account_id,
+            slug="q3",
+            title="t",
+            recipients=[],
+            cap_usd=Decimal("2.00"),
+            agent="alpha",
+            now=NOW,
+        )
+
+    assert call_count == 0, "unconfigured report-host settings must fail before any MA call"
+
+
+async def test_publish_report_failed_host_registration_leaves_zero_live_tokens(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The load-bearing unwind test: a failed PUT must revoke the token it just minted."""
+    tenant_id, account_id = await _seed_tenant(db_session_factory)
+    source = _source_agent_dict(id_="ag_src", name="alpha", tenant_id=tenant_id)
+    ma_router = _ma_router([source], tenant_id=tenant_id)
+    _add_create_route(ma_router, {}, reader_id="ag_reader")
+    anthropic = build_fake_anthropic(ma_router.dispatch)
+
+    def failing_host_handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    with pytest.raises(ReportHostError):
+        await publish_report(
+            anthropic=anthropic,
+            session_factory=db_session_factory,
+            http_client=_host_client(failing_host_handler),
+            report_host_settings=_settings(),
+            jwt_secret=_JWT_SECRET,
+            max_bundle_bytes=_MAX_BUNDLE_BYTES,
+            default=DeploymentDefault(),
+            tenant_id=tenant_id,
+            account_id=account_id,
+            slug="q3",
+            title="t",
+            recipients=[],
+            cap_usd=Decimal("2.00"),
+            agent="alpha",
+            now=NOW,
+        )
+
+    async with db_session_factory() as session:
+        rows = await list_live_tokens_by_label(session, tenant_id=tenant_id, label="report:q3")
+    assert rows == [], "a failed host registration must leave zero live tokens for this report"
+
+
+async def test_republish_reuses_reader_variant_and_mints_a_second_token(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Re-publishing the same slug reuses the derived variant (no second agents.create)
+    and mints a second token — this implementation does not revoke the first
+    (only a *failed* registration triggers revocation)."""
+    tenant_id, account_id = await _seed_tenant(db_session_factory)
+    source = _source_agent_dict(id_="ag_src", name="alpha", tenant_id=tenant_id)
+    ma_router = _ma_router([source], tenant_id=tenant_id)
+    created: dict[str, Any] = {}
+    _add_create_route(ma_router, created, reader_id="ag_reader")
+    anthropic = build_fake_anthropic(ma_router.dispatch)
+
+    def host_handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"slug": "q3", "links": []})
+
+    await publish_report(
+        anthropic=anthropic,
+        session_factory=db_session_factory,
+        http_client=_host_client(host_handler),
+        report_host_settings=_settings(),
+        jwt_secret=_JWT_SECRET,
+        max_bundle_bytes=_MAX_BUNDLE_BYTES,
+        default=DeploymentDefault(),
+        tenant_id=tenant_id,
+        account_id=account_id,
+        slug="q3",
+        title="t",
+        recipients=[],
+        cap_usd=Decimal("2.00"),
+        agent="alpha",
+        now=NOW,
+    )
+
+    reader_variant = _reader_agent_dict(
+        id_="ag_reader", name="alpha-reader", tenant_id=tenant_id, metadata=created["metadata"]
+    )
+    # No POST /v1/agents route registered on this second router — a stray
+    # second agents.create call raises AssertionError from MARouter.
+    router2 = _ma_router([source, reader_variant], tenant_id=tenant_id)
+    anthropic2 = build_fake_anthropic(router2.dispatch)
+
+    await publish_report(
+        anthropic=anthropic2,
+        session_factory=db_session_factory,
+        http_client=_host_client(host_handler),
+        report_host_settings=_settings(),
+        jwt_secret=_JWT_SECRET,
+        max_bundle_bytes=_MAX_BUNDLE_BYTES,
+        default=DeploymentDefault(),
+        tenant_id=tenant_id,
+        account_id=account_id,
+        slug="q3",
+        title="t",
+        recipients=[],
+        cap_usd=Decimal("2.00"),
+        agent="alpha",
+        now=NOW,
+    )
+
+    async with db_session_factory() as session:
+        rows = await list_live_tokens_by_label(session, tenant_id=tenant_id, label="report:q3")
+    assert len(rows) == 2, "re-publish mints a second live token; the first is left live"
+
+
+# ---------------------------------------------------------------------------
+# delete_report
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_report_revokes_two_live_tokens_and_calls_host_delete_once(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session)
+        account = await make_account(session, tenant=tenant)
+        row1 = await make_mcp_token(
+            session, tenant=tenant, account=account, label="report:q3", jti=uuid.uuid4()
+        )
+        row2 = await make_mcp_token(
+            session, tenant=tenant, account=account, label="report:q3", jti=uuid.uuid4()
+        )
+        await session.commit()
+
+    calls: list[httpx.Request] = []
+
+    def host_handler(req: httpx.Request) -> httpx.Response:
+        calls.append(req)
+        return httpx.Response(200, json={"deleted": True})
+
+    result = await delete_report(
+        session_factory=db_session_factory,
+        http_client=_host_client(host_handler),
+        report_host_settings=_settings(),
+        tenant_id=tenant.id,
+        slug="q3",
+        now=NOW,
+    )
+
+    assert result.tokens_revoked == 2
+    assert result.host_removed is True
+    assert len(calls) == 1
+    async with db_session_factory() as session:
+        r1 = await get_mcp_token(session, jti=row1.jti)
+        r2 = await get_mcp_token(session, jti=row2.jti)
+    assert r1 is not None and r1.revoked_at is not None
+    assert r2 is not None and r2.revoked_at is not None
+
+
+async def test_delete_report_revoke_happens_before_the_host_call(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A failed host call must still leave the token revoked — proves revoke
+    runs first (not merely that both eventually happen)."""
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session)
+        account = await make_account(session, tenant=tenant)
+        row = await make_mcp_token(
+            session, tenant=tenant, account=account, label="report:q3", jti=uuid.uuid4()
+        )
+        await session.commit()
+
+    def failing_host_handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    with pytest.raises(ReportHostError):
+        await delete_report(
+            session_factory=db_session_factory,
+            http_client=_host_client(failing_host_handler),
+            report_host_settings=_settings(),
+            tenant_id=tenant.id,
+            slug="q3",
+            now=NOW,
+        )
+
+    async with db_session_factory() as session:
+        refreshed = await get_mcp_token(session, jti=row.jti)
+    assert refreshed is not None and refreshed.revoked_at is not None, (
+        "revoke must happen before the host call, not after — a failed host call "
+        "must still leave the token revoked"
+    )
+
+
+async def test_delete_report_does_not_touch_a_same_label_token_in_another_tenant(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session:
+        tenant_a = await make_tenant(session, workspace_id="guild-a")
+        tenant_b = await make_tenant(session, workspace_id="guild-b")
+        account_a = await make_account(session, tenant=tenant_a)
+        account_b = await make_account(session, tenant=tenant_b)
+        row_a = await make_mcp_token(
+            session, tenant=tenant_a, account=account_a, label="report:q3", jti=uuid.uuid4()
+        )
+        row_b = await make_mcp_token(
+            session, tenant=tenant_b, account=account_b, label="report:q3", jti=uuid.uuid4()
+        )
+        await session.commit()
+
+    result = await delete_report(
+        session_factory=db_session_factory,
+        http_client=_host_client(lambda _req: httpx.Response(200, json={"deleted": True})),
+        report_host_settings=_settings(),
+        tenant_id=tenant_a.id,
+        slug="q3",
+        now=NOW,
+    )
+
+    assert result.tokens_revoked == 1
+    async with db_session_factory() as session:
+        ra = await get_mcp_token(session, jti=row_a.jti)
+        rb = await get_mcp_token(session, jti=row_b.jti)
+    assert ra is not None and ra.revoked_at is not None
+    assert rb is not None and rb.revoked_at is None, (
+        "a token sharing this label in another tenant must be untouched"
+    )
+
+
+async def test_delete_report_with_no_tokens_and_no_host_row_reports_nothing_happened(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    tenant_id, _account_id = await _seed_tenant(db_session_factory)
+
+    result = await delete_report(
+        session_factory=db_session_factory,
+        http_client=_host_client(lambda _req: httpx.Response(200, json={"deleted": False})),
+        report_host_settings=_settings(),
+        tenant_id=tenant_id,
+        slug="ghost",
+        now=NOW,
+    )
+
+    assert result == DeleteResult(tokens_revoked=0, host_removed=False)
+
+
+async def test_delete_report_twice_is_idempotent(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as session:
+        tenant = await make_tenant(session)
+        account = await make_account(session, tenant=tenant)
+        await make_mcp_token(
+            session, tenant=tenant, account=account, label="report:q3", jti=uuid.uuid4()
+        )
+        await session.commit()
+
+    calls: list[httpx.Request] = []
+
+    def host_handler(req: httpx.Request) -> httpx.Response:
+        calls.append(req)
+        if len(calls) == 1:
+            return httpx.Response(200, json={"deleted": True})
+        return httpx.Response(200, json={"deleted": False})
+
+    first = await delete_report(
+        session_factory=db_session_factory,
+        http_client=_host_client(host_handler),
+        report_host_settings=_settings(),
+        tenant_id=tenant.id,
+        slug="q3",
+        now=NOW,
+    )
+    second = await delete_report(
+        session_factory=db_session_factory,
+        http_client=_host_client(host_handler),
+        report_host_settings=_settings(),
+        tenant_id=tenant.id,
+        slug="q3",
+        now=NOW,
+    )
+
+    assert first.tokens_revoked == 1
+    assert first.host_removed is True
+    assert second.tokens_revoked == 0
+    assert second.host_removed is False, (
+        "deleting a slug already deleted must not raise or over-report"
+    )

--- a/packages/core/tests/stores/test_mcp_tokens.py
+++ b/packages/core/tests/stores/test_mcp_tokens.py
@@ -173,3 +173,172 @@ async def test_get_mcp_token_returns_none_for_unknown_jti(
     unknown_jti = uuid.uuid4()
     row = await store.get_mcp_token(db_session, jti=unknown_jti)
     assert row is None, "get_mcp_token must return None for an unknown jti"
+
+
+async def test_list_live_tokens_by_label_returns_matching_live_token_in_tenant(
+    db_session: AsyncSession,
+) -> None:
+    """A live token with a matching label in the right tenant is returned."""
+    tenant_id, account_id = await _seed_tenant_and_account(db_session)
+    jti = uuid.uuid4()
+    now = datetime.now(tz=UTC)
+
+    await store.create_mcp_token_row(
+        db_session,
+        jti=jti,
+        account_id=account_id,
+        tenant_id=tenant_id,
+        agent_id=str(uuid.uuid4()),
+        label="walkthrough-slug",
+        created_at=now,
+    )
+
+    rows = await store.list_live_tokens_by_label(
+        db_session, tenant_id=tenant_id, label="walkthrough-slug"
+    )
+
+    assert [row.jti for row in rows] == [jti], (
+        "the live token with a matching label in the right tenant must be returned"
+    )
+
+
+async def test_list_live_tokens_by_label_excludes_token_from_other_tenant(
+    db_session: AsyncSession,
+) -> None:
+    """A token with the same label in a DIFFERENT tenant is not returned.
+
+    This is the load-bearing case: two tenants can publish a report under
+    the same slug, and one tenant's lookup must never see the other's token.
+    """
+    tenant_id, account_id = await _seed_tenant_and_account(db_session)
+    other_tenant_id, other_account_id = await _seed_tenant_and_account(db_session)
+
+    await store.create_mcp_token_row(
+        db_session,
+        jti=uuid.uuid4(),
+        account_id=other_account_id,
+        tenant_id=other_tenant_id,
+        agent_id=str(uuid.uuid4()),
+        label="shared-slug",
+        created_at=datetime.now(tz=UTC),
+    )
+
+    rows = await store.list_live_tokens_by_label(
+        db_session, tenant_id=tenant_id, label="shared-slug"
+    )
+
+    assert rows == [], (
+        "a token minted for a different tenant must never be returned, even with a matching label"
+    )
+
+
+async def test_list_live_tokens_by_label_excludes_revoked_token(
+    db_session: AsyncSession,
+) -> None:
+    """A revoked token with a matching label is not returned."""
+    tenant_id, account_id = await _seed_tenant_and_account(db_session)
+    jti = uuid.uuid4()
+    now = datetime.now(tz=UTC)
+
+    await store.create_mcp_token_row(
+        db_session,
+        jti=jti,
+        account_id=account_id,
+        tenant_id=tenant_id,
+        agent_id=str(uuid.uuid4()),
+        label="revoked-slug",
+        created_at=now,
+    )
+    await store.revoke_mcp_token(db_session, jti=jti, now=now)
+
+    rows = await store.list_live_tokens_by_label(
+        db_session, tenant_id=tenant_id, label="revoked-slug"
+    )
+
+    assert rows == [], "a revoked token must not be returned by the live-token lookup"
+
+
+async def test_list_live_tokens_by_label_excludes_different_label(
+    db_session: AsyncSession,
+) -> None:
+    """A token with a different label is not returned."""
+    tenant_id, account_id = await _seed_tenant_and_account(db_session)
+
+    await store.create_mcp_token_row(
+        db_session,
+        jti=uuid.uuid4(),
+        account_id=account_id,
+        tenant_id=tenant_id,
+        agent_id=str(uuid.uuid4()),
+        label="some-other-slug",
+        created_at=datetime.now(tz=UTC),
+    )
+
+    rows = await store.list_live_tokens_by_label(
+        db_session, tenant_id=tenant_id, label="requested-slug"
+    )
+
+    assert rows == [], "a token with a non-matching label must not be returned"
+
+
+async def test_list_live_tokens_by_label_excludes_null_label(
+    db_session: AsyncSession,
+) -> None:
+    """A token whose label is None is not returned by any label query."""
+    tenant_id, account_id = await _seed_tenant_and_account(db_session)
+
+    await store.create_mcp_token_row(
+        db_session,
+        jti=uuid.uuid4(),
+        account_id=account_id,
+        tenant_id=tenant_id,
+        agent_id=str(uuid.uuid4()),
+        label=None,
+        created_at=datetime.now(tz=UTC),
+    )
+
+    rows = await store.list_live_tokens_by_label(db_session, tenant_id=tenant_id, label="")
+
+    assert rows == [], "a token with a None label must never surface from a label query"
+
+
+async def test_list_live_tokens_by_label_returns_all_matches_sharing_one_label(
+    db_session: AsyncSession,
+) -> None:
+    """Two live tokens sharing one label in one tenant are both returned."""
+    tenant_id, account_id = await _seed_tenant_and_account(db_session)
+    now = datetime.now(tz=UTC)
+    jti_a = uuid.uuid4()
+    jti_b = uuid.uuid4()
+
+    for jti in (jti_a, jti_b):
+        await store.create_mcp_token_row(
+            db_session,
+            jti=jti,
+            account_id=account_id,
+            tenant_id=tenant_id,
+            agent_id=str(uuid.uuid4()),
+            label="shared-among-two",
+            created_at=now,
+        )
+
+    rows = await store.list_live_tokens_by_label(
+        db_session, tenant_id=tenant_id, label="shared-among-two"
+    )
+
+    assert {row.jti for row in rows} == {jti_a, jti_b}, (
+        "both live tokens sharing the label must be returned, not just one"
+    )
+
+
+async def test_list_live_tokens_by_label_returns_empty_list_on_no_match(
+    db_session: AsyncSession,
+) -> None:
+    """An unmatched query returns an empty list and does not raise."""
+    tenant_id, _account_id = await _seed_tenant_and_account(db_session)
+
+    rows = await store.list_live_tokens_by_label(
+        db_session, tenant_id=tenant_id, label="nonexistent-slug"
+    )
+
+    assert rows == [], "an unmatched label query must return an empty list, not raise"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ source_modules = [
     "daimon.core.output_delivery",
     "daimon.core.privacy",
     "daimon.core.purge",
+    "daimon.core.reports",
     "daimon.core.scope",
     "daimon.core.skill_sync",
     "daimon.core.skill_zip",

--- a/tests/integration/test_report_flow.py
+++ b/tests/integration/test_report_flow.py
@@ -1,0 +1,384 @@
+"""End-to-end walk of publishing a report and reading it, against a real
+deployment.
+
+Opt-in only (``-m contract``), never a CI gate. Requires four environment
+variables naming a real running stack:
+
+- ``DAIMON_TEST_REPORT_MCP_URL`` — the seam's MCP endpoint (the daimon-mcp
+  server that exposes the ``publish_report``/``delete_report`` tools), e.g.
+  ``https://<host>/mcp``.
+- ``DAIMON_TEST_REPORT_MCP_BEARER`` — a platform-user MCP bearer token,
+  scoped to one tenant, authorized to call those two tools in that tenant.
+- ``DAIMON_TEST_REPORT_HOST_URL`` — the report host's own base URL (the
+  reader-facing app the tool's ``upload_url`` and recipient links point
+  into), e.g. ``https://<host>``.
+- ``DAIMON_TEST_REPORT_TENANT_ID`` — the tenant the bearer above is scoped
+  to. Used only to build a readable, unique slug for this run; never sent
+  to the tool (the tool resolves the caller's tenant from the bearer).
+
+Run it explicitly: ``uv run pytest -m contract tests/integration/test_report_flow.py``.
+With any of the four unset, it skips (never errors) naming what's missing.
+
+Walks: publish through the tool, upload a small real archive, read the
+viewer state, ask a grounded question, ask a follow-up in the same thread,
+ask something the bundle cannot answer, confirm the second recipient sees
+none of the first's threads, then delete the report and confirm both links
+stop working. Cleanup (``delete_report``) runs on the failure path as well
+as the success path via a ``try``/``finally``, and the slug carries a random
+suffix so two concurrent runs never collide.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import secrets
+import tarfile
+import time
+from dataclasses import dataclass
+from typing import cast
+
+import httpx
+import pytest
+from fastmcp import Client
+
+pytestmark = pytest.mark.contract
+
+_ENV_MCP_URL = "DAIMON_TEST_REPORT_MCP_URL"
+_ENV_MCP_BEARER = "DAIMON_TEST_REPORT_MCP_BEARER"
+_ENV_REPORT_HOST_URL = "DAIMON_TEST_REPORT_HOST_URL"
+_ENV_TENANT_ID = "DAIMON_TEST_REPORT_TENANT_ID"
+_REQUIRED_ENV_VARS = (_ENV_MCP_URL, _ENV_MCP_BEARER, _ENV_REPORT_HOST_URL, _ENV_TENANT_ID)
+
+# The one number this walk's grounded question resolves against, planted in
+# the tiny bundle's own table — not sourced from any real report.
+_KNOWN_TOTAL_VISITS = 28155
+
+_POLL_INTERVAL_SECONDS = 3.0
+_TURN_TIMEOUT_SECONDS = 600.0
+
+_REFUSAL_MARKERS = (
+    "not in",
+    "isn't in",
+    "don't have",
+    "does not cover",
+    "doesn't cover",
+    "no information",
+    "not covered",
+    "can't answer",
+    "cannot answer",
+    "not able to find",
+    "not something",
+    "outside",
+)
+
+
+@dataclass(frozen=True)
+class _FlowEnv:
+    mcp_url: str
+    mcp_bearer: str
+    report_host_url: str
+    tenant_id: str
+
+
+def _flow_env() -> _FlowEnv:
+    """Read the four required env vars, or skip cleanly naming what's missing."""
+    missing = [name for name in _REQUIRED_ENV_VARS if not os.environ.get(name)]
+    if missing:
+        pytest.skip(f"missing env vars for the report flow test: {', '.join(missing)}")
+    return _FlowEnv(
+        mcp_url=os.environ[_ENV_MCP_URL],
+        mcp_bearer=os.environ[_ENV_MCP_BEARER],
+        report_host_url=os.environ[_ENV_REPORT_HOST_URL].rstrip("/"),
+        tenant_id=os.environ[_ENV_TENANT_ID],
+    )
+
+
+def _build_bundle_archive() -> bytes:
+    """One gzip archive: a minimal PDF at the root, a readme, a manifest, and
+    one table carrying a single known number the grounded question resolves
+    against."""
+    manifest = {
+        "report": "report-flow contract test bundle (synthetic)",
+        "tables": {"headline": "tables/headline.json"},
+    }
+    headline = {"total_visits": _KNOWN_TOTAL_VISITS}
+    readme = (
+        "# report-flow contract test bundle\n\n"
+        "Answer only from tables/headline.json. It holds one number: "
+        "total_visits. Quote the file and the key when you state it.\n"
+    )
+    members: list[tuple[str, bytes]] = [
+        ("report.pdf", b"%PDF-1.4 minimal contract-test report\n%%EOF"),
+        ("README.md", readme.encode()),
+        ("manifest.json", json.dumps(manifest).encode()),
+        ("tables/headline.json", json.dumps(headline).encode()),
+    ]
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, data in members:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+async def _get_state(
+    http: httpx.AsyncClient, report_host_url: str, slug: str, token: str
+) -> dict[str, object]:
+    resp = await http.get(f"{report_host_url}/api/{slug}/state", params={"k": token})
+    resp.raise_for_status()
+    return _as_mapping(resp.json())
+
+
+async def _ask(
+    http: httpx.AsyncClient,
+    report_host_url: str,
+    slug: str,
+    token: str,
+    message: str,
+    thread_id: int | None,
+) -> int:
+    resp = await http.post(
+        f"{report_host_url}/api/{slug}/ask",
+        params={"k": token},
+        json={"message": message, "thread": thread_id},
+    )
+    resp.raise_for_status()
+    return _as_int(_as_mapping(resp.json())["thread"])
+
+
+async def _poll_thread_until_settled(
+    http: httpx.AsyncClient,
+    report_host_url: str,
+    slug: str,
+    token: str,
+    thread_id: int,
+    after: int,
+) -> list[dict[str, object]]:
+    """Poll the thread until it stops running, returning every message seen."""
+    deadline = time.monotonic() + _TURN_TIMEOUT_SECONDS
+    seen: list[dict[str, object]] = []
+    last_id = after
+    while True:
+        resp = await http.get(
+            f"{report_host_url}/api/{slug}/threads/{thread_id}",
+            params={"k": token, "after": last_id},
+        )
+        resp.raise_for_status()
+        body = _as_mapping(resp.json())
+        messages = _as_list(body["messages"])
+        for raw_message in messages:
+            message = _as_mapping(raw_message)
+            seen.append(message)
+            last_id = _as_int(message["id"])
+        if body["status"] != "running":
+            return seen
+        assert time.monotonic() < deadline, (
+            f"thread {thread_id} did not settle within {_TURN_TIMEOUT_SECONDS}s"
+        )
+        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+
+
+def _last_assistant_text(messages: list[dict[str, object]]) -> str:
+    assistant_messages = [m for m in messages if m["role"] != "user"]
+    assert assistant_messages, "expected at least one non-user message after asking"
+    return _as_str(assistant_messages[-1]["text"])
+
+
+def _as_mapping(value: object) -> dict[str, object]:
+    """Narrow an ``object`` known (by the wire contract) to be a JSON object.
+
+    A plain ``isinstance(value, dict)`` leaves pyright with ``dict[Unknown,
+    Unknown]`` because the source is a decoded JSON value (``Any``) — every
+    JSON object this test reads is host-defined and dynamically shaped, so a
+    single narrowing cast here, verified by the isinstance check on the line
+    above it, is what lets every caller work with a precisely typed
+    ``dict[str, object]`` instead of re-deriving this cast at every call site.
+    """
+    assert isinstance(value, dict), f"expected a JSON object, got {value!r}"
+    return cast(dict[str, object], value)
+
+
+def _as_list(value: object) -> list[object]:
+    """Narrow an ``object`` known to be a JSON array. See ``_as_mapping``."""
+    assert isinstance(value, list), f"expected a JSON array, got {value!r}"
+    return cast(list[object], value)
+
+
+def _as_str(value: object) -> str:
+    assert isinstance(value, str), f"expected a string, got {value!r}"
+    return value
+
+
+def _as_float(value: object) -> float:
+    assert isinstance(value, int | float | str), f"expected a number, got {value!r}"
+    return float(value)
+
+
+def _as_int(value: object) -> int:
+    assert isinstance(value, int | str), f"expected an integer, got {value!r}"
+    return int(value)
+
+
+async def test_report_flow_publish_upload_ask_isolate_delete() -> None:
+    env = _flow_env()
+    slug = f"flow-test-{secrets.token_hex(4)}"
+
+    async with (
+        Client(env.mcp_url, auth=env.mcp_bearer) as mcp_client,
+        httpx.AsyncClient(timeout=30.0) as http,
+    ):
+        # Step 1: publish through the tool.
+        publish_result = await mcp_client.call_tool(
+            "publish_report",
+            {
+                "slug": slug,
+                "title": "Report flow contract test",
+                "recipients": [
+                    {"name": "Ada", "label": "ada@example.com"},
+                    {"name": "Ben", "label": "ben@example.com"},
+                ],
+                "cap_usd": "1.00",
+            },
+        )
+        publish_data = _as_mapping(publish_result.data)
+
+        try:
+            # Step 2: the response carries an upload URL and one per-recipient
+            # link, and the two links differ.
+            upload_url = _as_str(publish_data["upload_url"])
+            links = _as_mapping(publish_data["links"])
+            assert upload_url, "publish must return an upload URL"
+            assert set(links) == {"Ada", "Ben"}, "publish must return one link per recipient"
+            assert links["Ada"] != links["Ben"], "recipient links must not be interchangeable"
+            ada_link = _as_str(links["Ada"])
+            ben_link = _as_str(links["Ben"])
+            ada_token = _as_str(httpx.URL(ada_link).params["k"])
+            ben_token = _as_str(httpx.URL(ben_link).params["k"])
+
+            # Step 3: build a small archive and PUT it to the upload URL.
+            archive_bytes = _build_bundle_archive()
+            upload_resp = await http.put(upload_url, content=archive_bytes)
+            upload_resp.raise_for_status()
+
+            # Step 4: the upload response carries the per-recipient links.
+            upload_body = _as_mapping(upload_resp.json())
+            upload_links = _as_mapping(upload_body["links"])
+            assert set(upload_links) >= {"Ada", "Ben"}, (
+                "the publish upload response must carry a link for every recipient"
+            )
+
+            # Step 5: read the first recipient's state — report present, PDF
+            # served, budget shows the cap and no spend yet.
+            state = await _get_state(http, env.report_host_url, slug, ada_token)
+            current_pdf = _as_str(state["current_pdf"])
+            assert current_pdf, "state must name a current PDF after upload"
+            pdf_resp = await http.get(
+                f"{env.report_host_url}/files/{slug}/{current_pdf}",
+                params={"k": ada_token},
+            )
+            pdf_resp.raise_for_status()
+            assert pdf_resp.content.startswith(b"%PDF"), "the served file must be the uploaded PDF"
+            budget = _as_mapping(state["budget"])
+            assert _as_float(budget["spent_usd"]) == 0.0, "no spend before any question is asked"
+            assert _as_float(budget["cap_usd"]) == 1.0, "the cap must be the one published"
+
+            # Step 6: ask a grounded question; poll until settled; the answer
+            # names the known number and the file it came from.
+            thread_id = await _ask(
+                http,
+                env.report_host_url,
+                slug,
+                ada_token,
+                "What is total_visits, and which file does it come from?",
+                None,
+            )
+            first_messages = await _poll_thread_until_settled(
+                http, env.report_host_url, slug, ada_token, thread_id, after=0
+            )
+            first_answer = _last_assistant_text(first_messages)
+            assert str(_KNOWN_TOTAL_VISITS) in first_answer, (
+                f"grounded answer must cite {_KNOWN_TOTAL_VISITS}, got: {first_answer!r}"
+            )
+            assert "headline" in first_answer.lower(), (
+                f"grounded answer must name the file it came from, got: {first_answer!r}"
+            )
+            last_seen_id = _as_int(first_messages[-1]["id"])
+
+            # Step 7: a follow-up in the same thread does not settle
+            # instantly with nothing, and its answer belongs to the second
+            # question (the prototype's bug: a stale terminal line reread
+            # from the previous turn).
+            await _ask(
+                http,
+                env.report_host_url,
+                slug,
+                ada_token,
+                "Say that number again, spelled out in words.",
+                thread_id,
+            )
+            follow_up_messages = await _poll_thread_until_settled(
+                http, env.report_host_url, slug, ada_token, thread_id, after=last_seen_id
+            )
+            assert follow_up_messages, "a follow-up must produce at least one new message"
+            follow_up_answer = _last_assistant_text(follow_up_messages)
+            assert follow_up_answer != first_answer, (
+                "the follow-up's answer must not be the first question's stale answer"
+            )
+            last_seen_id = _as_int(follow_up_messages[-1]["id"])
+
+            # Step 8: a question the bundle cannot answer gets a refusal, not
+            # an invented figure.
+            await _ask(
+                http,
+                env.report_host_url,
+                slug,
+                ada_token,
+                "What was the customer satisfaction score for the sales team?",
+                thread_id,
+            )
+            refusal_messages = await _poll_thread_until_settled(
+                http, env.report_host_url, slug, ada_token, thread_id, after=last_seen_id
+            )
+            refusal_answer = _last_assistant_text(refusal_messages).lower()
+            assert any(marker in refusal_answer for marker in _REFUSAL_MARKERS), (
+                f"out-of-bundle question must be refused, not answered with an invented "
+                f"figure, got: {refusal_answer!r}"
+            )
+
+            # Step 9: spend is now real, positive, and under the cap.
+            state_after = await _get_state(http, env.report_host_url, slug, ada_token)
+            budget_after = _as_mapping(state_after["budget"])
+            spent = _as_float(budget_after["spent_usd"])
+            cap = _as_float(budget_after["cap_usd"])
+            assert 0.0 < spent < cap, f"spend must be positive and under cap, got {spent} of {cap}"
+
+            # Step 10: the second recipient sees the report but none of the
+            # first recipient's threads.
+            ben_state = await _get_state(http, env.report_host_url, slug, ben_token)
+            assert _as_str(ben_state["current_pdf"]) == current_pdf, (
+                "both recipients must see the same published report"
+            )
+            assert ben_state["threads"] == [], (
+                "a recipient must never see another recipient's threads"
+            )
+        finally:
+            # Step 11: delete through the tool; both links stop working.
+            # Runs on the failure path as well as the success path.
+            await mcp_client.call_tool("delete_report", {"slug": slug})
+
+        ada_state_resp = await http.get(
+            f"{env.report_host_url}/api/{slug}/state", params={"k": ada_token}
+        )
+        assert ada_state_resp.status_code == httpx.codes.FORBIDDEN, (
+            "the first recipient's link must stop working after delete"
+        )
+        ben_state_resp = await http.get(
+            f"{env.report_host_url}/api/{slug}/state", params={"k": ben_token}
+        )
+        assert ben_state_resp.status_code == httpx.codes.FORBIDDEN, (
+            "the second recipient's link must stop working after delete"
+        )


### PR DESCRIPTION
## Summary

This is the third and final change in the report-host flow. It adds the piece that makes reading rooms reachable the way a user will actually meet them: from a chat thread, by asking their agent.

- A user can ask their agent to make a **reading room** for a finished report: name a title, list the recipients, set a spending cap. The agent (a `publish_report` tool call) mints the archive upload, registers the report with the host, and hands back one link per recipient.
- The agent that answers reader questions is a **derived variant of the agent the user already works with** — same voice, same skills — with every integration removed and nothing mounted but the report's own files. It cannot reach anything outside the report.
- **Billing follows the publisher, not the reader**: each report mints its own credential under the publishing account, so every reader question runs the normal balance and cap checks against that tenant, with the host's own cap as a second, independent bound.
- **Deleting is final**: a `delete_report` tool revokes the report's credential and removes it from the host. Both recipient links stop working immediately, and the action cannot be undone.

Together with the two prior changes (the seam and the standalone host), this completes the reading-room flow end to end.

## What's included

- `publish_report` / `delete_report` MCP tools on the operator surface, with full unit and snapshot-schema test coverage
- `daimon.core.reports`: orchestration for minting a per-report credential, calling the host's admin API, and reversing both on deletion
- A settings block (`DAIMON_REPORT_HOST__*`) so daimon knows where the report host lives and how to authenticate to it
- `defaults/skills/report-publish/SKILL.md`: the authoring-side procedure an agent follows — what to gather, how to build one archive with the report at its root, a concrete size-discipline drop order, and the mint → upload → share sequence
- An opt-in, contract-marked end-to-end test (`tests/integration/test_report_flow.py`) that walks publish → upload → read → ask → follow-up → refuse → isolate → delete against a real deployment, for anyone who has one available to run it against

## Test plan

- [x] Full project gate green: `pytest` (5248 passed, 2 pre-existing unrelated CLI failures, 4 skipped), `pyright` (strict, 0 errors), `ruff check`/`format --check`, `lint-imports` (7/7 contracts kept), `.env.example` up to date, anti-pattern lint, migration lint
- [x] Diff and commit-subject hygiene sweep clean of any companion infra repo material
- [ ] Staging walk-through: publish a report from a real chat thread, verify grounded answers, follow-up handling, billing visibility in the publishing tenant, reader isolation, revision, and revocation (to run after merge + staging deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJPPkRT2D8mdGA95jKXoNW