### PR TITLE
fix(core): derive reader variants from the base toolset, not the source's

### DIFF
--- a/packages/core/daimon/core/reader_agent.py
+++ b/packages/core/daimon/core/reader_agent.py
@@ -25,7 +25,6 @@ from typing import cast
 
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsSkillParams
-from anthropic.types.beta.agent_create_params import Tool
 from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
     BetaManagedAgentsURLMCPServerParams,
 )
@@ -156,10 +155,13 @@ async def ensure_reader_variant(
         model=source_ma.model.id,
         description=source_ma.description,
         system=source_ma.system,
-        tools=cast(
-            "list[Tool] | None",
-            [tool.model_dump(mode="json") for tool in source_ma.tools] or None,
-        ),
+        # A reader carries only the base agent toolset, which `dump_agent_spec`
+        # injects (with always-allow) on every create/update. The source's
+        # toolset is deliberately not round-tripped: the live agent response
+        # carries per-tool fields (a `type` on each config entry) that the
+        # create-params shape rejects, and a reader has no use for the
+        # source's toolset overrides anyway.
+        tools=None,
         mcp_servers=cast(
             "list[BetaManagedAgentsURLMCPServerParams] | None",
             [server.model_dump(mode="json") for server in source_ma.mcp_servers] or None,

--- a/packages/core/tests/test_reader_agent.py
+++ b/packages/core/tests/test_reader_agent.py
@@ -424,3 +424,54 @@ async def test_ensure_reader_variant_raises_for_unknown_source() -> None:
         await ensure_reader_variant(
             client, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="ghost"
         )
+
+
+async def test_ensure_reader_variant_ignores_the_source_toolset_shape() -> None:
+    """A live agent's toolset carries per-config fields the create shape rejects.
+
+    Managed Agents returns each toolset config entry with a ``type`` next to
+    its ``name`` (and ``enabled`` / ``permission_policy`` filled in). Feeding
+    that back into an agent spec fails validation, which is exactly what
+    happened on the first live publish. The reader must be created from the
+    base toolset alone, whatever the source carries.
+    """
+    source = _source_agent_dict(id_="ag_src", spec_hash="src-hash-1")
+    source["tools"] = [
+        {
+            "type": "agent_toolset_20260401",
+            "default_config": {"enabled": True, "permission_policy": {"type": "always_allow"}},
+            "configs": [
+                {
+                    "type": name,
+                    "name": name,
+                    "enabled": True,
+                    "permission_policy": {"type": "always_allow"},
+                }
+                for name in ("bash", "read", "edit", "grep", "glob", "write")
+            ],
+        }
+    ]
+    router = _router([source])
+    created: dict[str, Any] = {}
+    _add_create_route(router, created)
+    client = build_fake_anthropic(router.dispatch)
+
+    result = await ensure_reader_variant(
+        client, tenant_id=TENANT_ID, account_id=ACCOUNT_ID, source_name="alpha"
+    )
+
+    assert result.id == "ag_reader"
+    tools = created["tools"]
+    assert [tool["type"] for tool in tools] == ["agent_toolset_20260401"], (
+        "the reader must carry exactly the base agent toolset"
+    )
+    config_names = [config["name"] for config in tools[0]["configs"]]
+    assert config_names == ["bash", "read", "edit", "grep", "glob", "write"], (
+        "the base toolset's six tools, in the spec's own order"
+    )
+    assert all("type" not in config for config in tools[0]["configs"]), (
+        "no per-config type may leak from the live response into the create call"
+    )
+    assert tools[0]["default_config"]["permission_policy"] == {"type": "always_allow"}, (
+        "readers run headless, so the dump step must inject always-allow"
+    )


### PR DESCRIPTION
## What broke

The first real publish of a reading room from a chat thread failed inside `publish_report` with a spec validation error: the reader variant is derived from the live source agent, and the live agent response carries a `type` on every toolset config entry, which the agent create-params shape forbids. Every publish attempt died before the host was ever contacted.

## Fix

A reader only ever needs the base agent toolset, and the spec dump step already injects that toolset with the always-allow policy on every create and update. The derivation now leaves `tools` unset instead of round-tripping the source's toolset, so nothing from the live response shape can leak into the create call.

## Proof

- New test builds the source agent with the exact live response shape (config entries carrying `type`, `enabled`, `permission_policy`) and asserts the created reader carries exactly the base six-tool toolset with always-allow and no per-config `type`.
- The test fails against the previous module and passes with this change.
- Full suite green apart from the two pre-existing CLI failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJPPkRT2D8mdGA95jKXoNW