### PR TITLE
feat(discord): human-support escalation metered by per-user credits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,8 +131,8 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_BILLING__SIGNUP_CREDIT=10.00
 
 # === Support (optional) ===
-# Platform user ids DM'd when someone escalates to human support. Empty (the default) disables the escalate affordance entirely — a request that reaches nobody is worse than no button at all.
-# DAIMON_SUPPORT__OPERATOR_USER_IDS=[]
+# Channel id where human-support requests are posted. Unset (the default) disables the escalate affordance entirely — a request that reaches nobody is worse than no button at all. A channel rather than operator DMs: it survives one person's DMs being closed, and it leaves a shared record anyone on the rota can pick up. The bot must be able to post there.
+# DAIMON_SUPPORT__ESCALATION_CHANNEL_ID=
 # How many human-support requests each user gets within a tenant. A COUNT of interactions, NOT the USD in DAIMON_BILLING__SIGNUP_CREDIT — the two are deliberately separate ledgers. 0 disables escalation.
 # DAIMON_SUPPORT__CREDITS_PER_USER=3
 

--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,12 @@ DAIMON_ANTHROPIC__API_KEY=
 # USD credit automatically seeded when a guild/workspace is provisioned, so a freshly-installed tenant can chat immediately on trial credit before paying. Set to 0 to require payment before use.
 # DAIMON_BILLING__SIGNUP_CREDIT=10.00
 
+# === Support (optional) ===
+# Platform user ids DM'd when someone escalates to human support. Empty (the default) disables the escalate affordance entirely — a request that reaches nobody is worse than no button at all.
+# DAIMON_SUPPORT__OPERATOR_USER_IDS=[]
+# How many human-support requests each user gets within a tenant. A COUNT of interactions, NOT the USD in DAIMON_BILLING__SIGNUP_CREDIT — the two are deliberately separate ledgers. 0 disables escalation.
+# DAIMON_SUPPORT__CREDITS_PER_USER=3
+
 # === Artifacts (optional) ===
 # S3-compatible bucket endpoint; used for uploads and presigned GET URLs.
 # DAIMON_ARTIFACTS__ENDPOINT_URL=

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -290,8 +290,10 @@ class DaimonBot(commands.Bot):
         # class-level registration rather than a live view. Local import for
         # the same cycle reason as above.
         from daimon.adapters.discord.feedback_button import FeedbackButton
+        from daimon.adapters.discord.support_escalation import SupportEscalateButton
 
         self.add_dynamic_items(FeedbackButton)
+        self.add_dynamic_items(SupportEscalateButton)
 
     async def _post_to_guild(self, guild: discord.Guild, embed: discord.Embed) -> None:
         """Post an embed via the fallback chain: text channel → DM owner → skip."""

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_reactions.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_reactions.py
@@ -250,13 +250,14 @@ class FeedbackReactionCog(commands.Cog):
         modal is submitted -- someone can react, wait, and submit after
         spending their last credit elsewhere, and only the write decides.
 
-        An empty operator list disables the affordance rather than recording
-        requests nobody will read: an escalate path that reaches no one is
-        worse than none, because the person believes they have asked for help.
+        An unset escalation channel disables the affordance rather than
+        recording requests nobody will read: an escalate path that reaches no
+        one is worse than none, because the person believes they have asked
+        for help.
         """
         settings = self._bot.runtime.settings
         allowance = settings.support.credits_per_user
-        if not settings.support.operator_user_ids or allowance <= 0:
+        if settings.support.escalation_channel_id is None or allowance <= 0:
             log.info("support.disabled", message_id=str(payload.message_id))
             return
 

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_reactions.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_reactions.py
@@ -39,6 +39,7 @@ from typing import cast
 import structlog
 from daimon.adapters.discord.bot import DaimonBot
 from daimon.adapters.discord.feedback_button import FeedbackButton
+from daimon.adapters.discord.support_escalation import SupportEscalateButton
 from daimon.core.ma_identity import derive_tenant_uuid
 from daimon.core.message_feedback import (
     Vote,
@@ -48,8 +49,10 @@ from daimon.core.message_feedback import (
 )
 from daimon.core.stores.identity import find_platform_principal
 from daimon.core.stores.message_feedback import record_vote
+from daimon.core.stores.support_escalation import count_escalations_for_user
 from daimon.core.stores.tenants import get_tenant
 from daimon.core.stores.thread_sessions import get_latest_thread_session
+from daimon.core.support_escalation import has_credit, is_escalation_reaction, remaining_credits
 
 import discord
 from discord.ext import commands
@@ -93,6 +96,27 @@ class FeedbackReactionCog(commands.Cog):
         if self._bot.user is None:
             return  # not connected yet
         bot_user_id = self._bot.user.id
+
+        if is_escalation_reaction(
+            emoji_name=payload.emoji.name,
+            emoji_is_custom=payload.emoji.id is not None,
+            reactor_id=payload.user_id,
+            bot_user_id=bot_user_id,
+            guild_id=payload.guild_id,
+        ):
+            # Escalation shares this listener because it shares the seeded
+            # reactions, and nothing else. It never touches message_feedback.
+            verdict = is_bot_authored(
+                message_author_id=payload.message_author_id, bot_user_id=bot_user_id
+            )
+            if verdict is False:
+                return
+            if verdict is None and not await self._is_bot_message_via_fetch(
+                payload, bot_user_id=bot_user_id
+            ):
+                return
+            await self._offer_support(payload)
+            return
 
         candidate_vote = vote_for_reaction(
             emoji_name=payload.emoji.name,
@@ -216,6 +240,70 @@ class FeedbackReactionCog(commands.Cog):
         if len(self._author_is_bot) >= _AUTHOR_CACHE_MAX_ENTRIES:
             del self._author_is_bot[next(iter(self._author_is_bot))]
         self._author_is_bot[message_id] = is_bot_message
+
+    async def _offer_support(self, payload: discord.RawReactionActionEvent) -> None:
+        """Bridge an escalate reaction into the private note form.
+
+        Reacting spends NOTHING. This only reads the person's remaining
+        credits to decide which of two direct messages to send, and the
+        authoritative gate runs again inside the write transaction when the
+        modal is submitted -- someone can react, wait, and submit after
+        spending their last credit elsewhere, and only the write decides.
+
+        An empty operator list disables the affordance rather than recording
+        requests nobody will read: an escalate path that reaches no one is
+        worse than none, because the person believes they have asked for help.
+        """
+        settings = self._bot.runtime.settings
+        allowance = settings.support.credits_per_user
+        if not settings.support.operator_user_ids or allowance <= 0:
+            log.info("support.disabled", message_id=str(payload.message_id))
+            return
+
+        # guild_id is guaranteed non-None: is_escalation_reaction already
+        # returned False for any reaction lacking a guild.
+        tenant_id = derive_tenant_uuid(platform="discord", workspace_id=str(payload.guild_id))
+        async with self._bot.runtime.sessionmaker() as session:
+            used = await count_escalations_for_user(
+                session, tenant_id=tenant_id, platform_user_id=str(payload.user_id)
+            )
+
+        try:
+            user = self._bot.get_user(payload.user_id)
+            if user is None:
+                user = await self._bot.fetch_user(payload.user_id)
+            if not has_credit(allowance=allowance, used=used):
+                await user.send(
+                    "You've used all your human-support requests. "
+                    "Contact us if you'd like more added to your account."
+                )
+                return
+            left = remaining_credits(allowance=allowance, used=used)
+            view: discord.ui.View = discord.ui.View(timeout=None)
+            view.add_item(
+                SupportEscalateButton(
+                    guild_id=str(payload.guild_id),
+                    channel_id=str(payload.channel_id),
+                    message_id=str(payload.message_id),
+                )
+            )
+            await user.send(
+                content=(
+                    f"You asked for a human on that answer. "
+                    f"You have {left} support request(s) left -- "
+                    "tell us what you need and we'll pick it up."
+                ),
+                view=view,
+            )
+        except discord.HTTPException as exc:
+            # Closed DMs are the common case and there is no other channel to
+            # reach this person on. Nothing has been spent, so this costs them
+            # only the prompt.
+            log.info(
+                "support.prompt_undeliverable",
+                message_id=str(payload.message_id),
+                error=str(exc),
+            )
 
     async def _send_feedback_prompt(
         self, payload: discord.RawReactionActionEvent, *, feedback_id: uuid.UUID

--- a/packages/adapters/discord/daimon/adapters/discord/feedback_seed.py
+++ b/packages/adapters/discord/daimon/adapters/discord/feedback_seed.py
@@ -31,6 +31,7 @@ from collections.abc import Callable
 
 import structlog
 from daimon.core.message_feedback import THUMBS_DOWN, THUMBS_UP
+from daimon.core.support_escalation import ESCALATE
 
 import discord
 
@@ -38,7 +39,7 @@ log = structlog.get_logger()
 
 
 async def seed_feedback_reactions(channel: discord.abc.Messageable, *, message_id: str) -> None:
-    """Add the positive emoji then the negative one to `message_id`'s message.
+    """Add the two vote emoji, then the escalate emoji, to `message_id`'s message.
 
     The positive emoji is added first so the two always render in the same
     order. Best-effort: never raises. `discord.abc.Messageable` itself does
@@ -56,6 +57,10 @@ async def seed_feedback_reactions(channel: discord.abc.Messageable, *, message_i
         partial = get_partial_message(int(message_id))
         await partial.add_reaction(THUMBS_UP)
         await partial.add_reaction(THUMBS_DOWN)
+        # The escalate emoji is seeded LAST so the two vote emoji keep the
+        # order they have always rendered in. It is not a vote and never
+        # reaches message_feedback -- `vote_for_reaction` does not match it.
+        await partial.add_reaction(ESCALATE)
     except Exception as exc:  # noqa: BLE001 -- best-effort affordance running after the answer was delivered; a seed failure must never surface as a turn failure (see module docstring)
         log.warning(
             "feedback.seed_failed",

--- a/packages/adapters/discord/daimon/adapters/discord/support_escalation.py
+++ b/packages/adapters/discord/daimon/adapters/discord/support_escalation.py
@@ -1,0 +1,278 @@
+"""SupportEscalateButton + SupportModal -- the human-support path.
+
+A third seeded reaction (`ESCALATE`) sits beside the two vote emoji on every
+final answer. It is deliberately a REACTION rather than a button on the answer
+itself: `feedback_seed.py` already seeds emoji on that message and
+`feedback_reactions.py` already listens, so this reuses a path that exists and
+is tested, and the turn's render path is untouched. A real button would mean
+every final message carries a persistent View -- a much larger change for the
+same affordance. If one-click ever matters more than that, the upgrade is to
+add a View here, not to redesign this.
+
+Because a reaction carries no interaction handle, the same bridge
+`feedback_button.py` documents applies: react -> direct message carrying a
+button -> modal. The custom_id carries `(channel_id, message_id)` rather than a
+row id because NO ROW EXISTS YET. Reacting must not spend a credit; only
+sending the note does. That is also why the credit gate is evaluated twice --
+once here for a cheap early "you're out", and authoritatively inside the write
+transaction, which is the one that counts.
+
+Template-disjointness: the `sup:` prefix must never overlap `mfb:` (feedback),
+`ztc:` (credential requests) or the wizard's prefixes. discord.py fullmatches
+an incoming custom_id against EVERY registered template with no early break,
+so an overlap fires two handlers on one click.
+
+Delivery ordering is the load-bearing part of this module. The row is
+committed BEFORE any operator DM is attempted, and `delivered_at` is stamped
+only once a DM actually lands. A closed-DM operator is the ordinary failure
+mode -- `_send_feedback_prompt` already documents that Discord gives no way
+around it -- and a support request from a paying trial client that vanishes
+because nobody's DMs were open is the one outcome here worth engineering
+against. An undelivered row can be swept later; a dropped one cannot.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Self, cast
+
+import structlog
+from daimon.adapters.discord.bot import DaimonBot
+from daimon.adapters.discord.runtime import DiscordRuntime
+from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.stores.identity import find_platform_principal
+from daimon.core.stores.support_escalation import (
+    mark_delivered,
+    record_escalation,
+)
+from daimon.core.stores.thread_sessions import get_latest_thread_session
+from daimon.core.support_escalation import CUSTOM_ID_TEMPLATE, build_custom_id
+
+import discord
+from discord.ext import commands
+
+_log = structlog.get_logger()
+
+_CALLBACK_FAILED = "Something went wrong opening the form -- please try again."
+_SUBMIT_FAILED = "Something went wrong sending your request -- please try again."
+_EMPTY_NOTE = "Please describe what you need help with."
+_MALFORMED = "This support request is no longer available."
+_OUT_OF_CREDITS = (
+    "You've used all your human-support requests. "
+    "Contact us if you'd like more added to your account."
+)
+_RECEIVED = (
+    "Thanks -- your request has been recorded and someone will follow up. "
+    "You have {remaining} left."
+)
+_RECORDED_UNDELIVERED = "Thanks -- your request has been recorded and someone will follow up."
+
+
+class SupportModal(discord.ui.Modal, title="Ask a human"):
+    """Free-text form; writing it is what spends the credit.
+
+    `on_submit` commits the row, closes the transaction, and only then tries
+    to reach an operator. Holding the transaction open across the DM round
+    trips would pin a connection for the duration of an unbounded number of
+    HTTP calls, and a failure part-way would roll back a request the person
+    has already been told about.
+    """
+
+    def __init__(
+        self, *, runtime: DiscordRuntime, guild_id: str, channel_id: str, message_id: str
+    ) -> None:
+        super().__init__()
+        self._runtime = runtime
+        self._guild_id = guild_id
+        self._channel_id = channel_id
+        self._message_id = message_id
+        self.note_input: discord.ui.TextInput[SupportModal] = discord.ui.TextInput(
+            label="What do you need help with?",
+            style=discord.TextStyle.paragraph,
+            required=True,
+            max_length=4000,
+        )
+        self.add_item(self.note_input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        note = str(self.note_input.value or "")
+        if not note.strip():
+            await interaction.followup.send(_EMPTY_NOTE, ephemeral=True)
+            return
+
+        settings = self._runtime.settings
+        # The button arrives by direct message, so `interaction.guild_id` is
+        # None and the originating guild comes from the custom_id instead.
+        guild_id = self._guild_id
+        tenant_id = derive_tenant_uuid(platform="discord", workspace_id=guild_id)
+        user_id = str(interaction.user.id)
+
+        async with self._runtime.sessionmaker() as session, session.begin():
+            thread_row = await get_latest_thread_session(
+                session,
+                tenant_id=tenant_id,
+                platform="discord",
+                thread_id=self._channel_id,
+            )
+            principal = await find_platform_principal(
+                session,
+                tenant_id=tenant_id,
+                platform="discord",
+                external_id=user_id,
+            )
+            row = await record_escalation(
+                session,
+                tenant_id=tenant_id,
+                account_id=principal.account_id if principal is not None else None,
+                platform="discord",
+                platform_user_id=user_id,
+                channel_id=self._channel_id,
+                message_id=self._message_id,
+                ma_session_id=thread_row.ma_session_id if thread_row is not None else None,
+                note=note,
+                allowance=settings.support.credits_per_user,
+            )
+
+        if row is None:
+            _log.info("support.out_of_credits", tenant_id=str(tenant_id))
+            await interaction.followup.send(_OUT_OF_CREDITS, ephemeral=True)
+            return
+
+        # The row is committed. Everything below is best-effort delivery, and
+        # a total failure downgrades the confirmation wording rather than the
+        # outcome -- the request is already durable.
+        delivered = await self._notify_operators(
+            interaction=interaction,
+            note=note,
+            guild_id=guild_id,
+            operator_ids=settings.support.operator_user_ids,
+        )
+        if delivered:
+            async with self._runtime.sessionmaker() as session, session.begin():
+                await mark_delivered(session, escalation_id=row.id)
+
+        _log.info(
+            "support.escalation_recorded",
+            escalation_id=str(row.id),
+            tenant_id=str(tenant_id),
+            delivered=delivered,
+        )
+        if not delivered:
+            await interaction.followup.send(_RECORDED_UNDELIVERED, ephemeral=True)
+            return
+        remaining = max(
+            settings.support.credits_per_user - (await self._used(tenant_id, user_id)), 0
+        )
+        await interaction.followup.send(_RECEIVED.format(remaining=remaining), ephemeral=True)
+
+    async def _used(self, tenant_id: Any, user_id: str) -> int:
+        from daimon.core.stores.support_escalation import count_escalations_for_user
+
+        async with self._runtime.sessionmaker() as session:
+            return await count_escalations_for_user(
+                session, tenant_id=tenant_id, platform_user_id=user_id
+            )
+
+    async def _notify_operators(
+        self,
+        *,
+        interaction: discord.Interaction,
+        note: str,
+        guild_id: str,
+        operator_ids: list[str],
+    ) -> bool:
+        """DM every configured operator. True if at least ONE landed.
+
+        Every operator is tried even after one succeeds: they are a rota, not
+        a fallback chain, and stopping at the first success would silently
+        make the first id in the list the only one who ever hears anything.
+        """
+        link = f"https://discord.com/channels/{guild_id}/{self._channel_id}/{self._message_id}"
+        body = f"**Human support requested** by {interaction.user.mention}\n{link}\n\n{note}"
+        bot = cast(commands.Bot, interaction.client)
+        delivered = False
+        for raw_id in operator_ids:
+            try:
+                operator = bot.get_user(int(raw_id)) or await bot.fetch_user(int(raw_id))
+                await operator.send(body)
+                delivered = True
+            except (discord.HTTPException, ValueError) as exc:
+                # Closed DMs (Forbidden) and a malformed configured id are both
+                # operator-side misconfiguration, not the requester's problem.
+                _log.warning(
+                    "support.operator_undeliverable",
+                    operator_id=raw_id,
+                    err_type=type(exc).__name__,
+                )
+        return delivered
+
+    async def on_error(self, interaction: discord.Interaction, error: Exception) -> None:
+        """Adapter boundary: discord.py routes on_submit failures here, not to a dispatcher."""
+        _log.exception("support_modal.on_error", err_type=type(error).__name__)
+        if interaction.response.is_done():
+            await interaction.followup.send(_SUBMIT_FAILED, ephemeral=True)
+        else:
+            await interaction.response.send_message(_SUBMIT_FAILED, ephemeral=True)
+
+
+class SupportEscalateButton(
+    discord.ui.DynamicItem[discord.ui.Button[discord.ui.View]], template=CUSTOM_ID_TEMPLATE
+):
+    """Persistent button delivered by DM; its only job is to open the modal.
+
+    Defines no `interaction_check`, for the reason `feedback_button.py`
+    documents: the button arrives in a one-to-one direct message, so Discord's
+    own channel membership is the outer boundary, and the custom_id carries no
+    user identity to compare a clicker against. The authoritative gate is the
+    write path -- the escalation is recorded against the CLICKING user's id and
+    counted against their own allowance, so a forwarded custom_id spends the
+    forwarder's credit, not the original recipient's.
+    """
+
+    def __init__(self, *, guild_id: str, channel_id: str, message_id: str) -> None:
+        button: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            style=discord.ButtonStyle.primary,
+            label="Ask a human",
+            custom_id=build_custom_id(
+                guild_id=guild_id, channel_id=channel_id, message_id=message_id
+            ),
+        )
+        super().__init__(button)
+        self.guild_id = guild_id
+        self.channel_id = channel_id
+        self.message_id = message_id
+
+    @classmethod
+    async def from_custom_id(  # type: ignore[override]  # discord.py's ClientT is a free TypeVar; this adapter only ever runs DaimonBot
+        cls,
+        interaction: discord.Interaction[commands.Bot],
+        item: discord.ui.Item[Any],
+        match: re.Match[str],
+        /,
+    ) -> Self:
+        return cls(
+            guild_id=match["guild_id"],
+            channel_id=match["channel_id"],
+            message_id=match["message_id"],
+        )
+
+    async def callback(  # type: ignore[override]  # see from_custom_id
+        self, interaction: discord.Interaction[commands.Bot]
+    ) -> None:
+        try:
+            bot = cast(DaimonBot, interaction.client)
+            await interaction.response.send_modal(
+                SupportModal(
+                    runtime=bot.runtime,
+                    guild_id=self.guild_id,
+                    channel_id=self.channel_id,
+                    message_id=self.message_id,
+                )
+            )
+        except Exception as err:  # noqa: BLE001 -- dynamic-item dispatch is an adapter boundary; discord.py's dispatcher swallows anything raised here
+            _log.exception("support_button.callback_failed", err_type=type(err).__name__)
+            if interaction.response.is_done():
+                await interaction.followup.send(_CALLBACK_FAILED, ephemeral=True)
+            else:
+                await interaction.response.send_message(_CALLBACK_FAILED, ephemeral=True)

--- a/packages/adapters/discord/daimon/adapters/discord/support_escalation.py
+++ b/packages/adapters/discord/daimon/adapters/discord/support_escalation.py
@@ -22,13 +22,17 @@ Template-disjointness: the `sup:` prefix must never overlap `mfb:` (feedback),
 an incoming custom_id against EVERY registered template with no early break,
 so an overlap fires two handlers on one click.
 
+Requests land in a CHANNEL, not in operator direct messages. A channel
+survives one person's DMs being closed, leaves a shared record anyone on the
+rota can pick up, and does not silently make whoever is first in a config list
+the only person who ever hears anything.
+
 Delivery ordering is the load-bearing part of this module. The row is
-committed BEFORE any operator DM is attempted, and `delivered_at` is stamped
-only once a DM actually lands. A closed-DM operator is the ordinary failure
-mode -- `_send_feedback_prompt` already documents that Discord gives no way
-around it -- and a support request from a paying trial client that vanishes
-because nobody's DMs were open is the one outcome here worth engineering
-against. An undelivered row can be swept later; a dropped one cannot.
+committed BEFORE the post is attempted, and `delivered_at` is stamped only
+once it actually lands. A support request from a paying trial client that
+vanishes because the channel was misconfigured or the bot lost access is the
+one outcome here worth engineering against. An undelivered row can be swept
+later; a dropped one cannot.
 """
 
 from __future__ import annotations
@@ -102,6 +106,11 @@ class SupportModal(discord.ui.Modal, title="Ask a human"):
             return
 
         settings = self._runtime.settings
+        channel_id = settings.support.escalation_channel_id
+        if channel_id is None:
+            # Disabled between the reaction and the submit. Nothing is spent.
+            await interaction.followup.send(_MALFORMED, ephemeral=True)
+            return
         # The button arrives by direct message, so `interaction.guild_id` is
         # None and the originating guild comes from the custom_id instead.
         guild_id = self._guild_id
@@ -142,11 +151,11 @@ class SupportModal(discord.ui.Modal, title="Ask a human"):
         # The row is committed. Everything below is best-effort delivery, and
         # a total failure downgrades the confirmation wording rather than the
         # outcome -- the request is already durable.
-        delivered = await self._notify_operators(
+        delivered = await self._post_to_channel(
             interaction=interaction,
             note=note,
             guild_id=guild_id,
-            operator_ids=settings.support.operator_user_ids,
+            channel_id=channel_id,
         )
         if delivered:
             async with self._runtime.sessionmaker() as session, session.begin():
@@ -174,38 +183,49 @@ class SupportModal(discord.ui.Modal, title="Ask a human"):
                 session, tenant_id=tenant_id, platform_user_id=user_id
             )
 
-    async def _notify_operators(
+    async def _post_to_channel(
         self,
         *,
         interaction: discord.Interaction,
         note: str,
         guild_id: str,
-        operator_ids: list[str],
+        channel_id: str,
     ) -> bool:
-        """DM every configured operator. True if at least ONE landed.
+        """Post the request into the escalation channel. True if it landed.
 
-        Every operator is tried even after one succeeds: they are a rota, not
-        a fallback chain, and stopping at the first success would silently
-        make the first id in the list the only one who ever hears anything.
+        Resolves through the cache first and falls back to one fetch, because
+        the escalation channel lives in the operators' own guild and may not be
+        in a freshly-started bot's cache. Returns False on anything that means
+        the message did not arrive -- a channel that cannot be resolved, one
+        the bot cannot post in, or an id that is not a channel it can message
+        -- so the caller leaves `delivered_at` NULL and tells the requester the
+        honest thing.
         """
         link = f"https://discord.com/channels/{guild_id}/{self._channel_id}/{self._message_id}"
-        body = f"**Human support requested** by {interaction.user.mention}\n{link}\n\n{note}"
+        body = (
+            f"**Human support requested** by {interaction.user.mention} "
+            f"({interaction.user})\n{link}\n\n{note}"
+        )
         bot = cast(commands.Bot, interaction.client)
-        delivered = False
-        for raw_id in operator_ids:
-            try:
-                operator = bot.get_user(int(raw_id)) or await bot.fetch_user(int(raw_id))
-                await operator.send(body)
-                delivered = True
-            except (discord.HTTPException, ValueError) as exc:
-                # Closed DMs (Forbidden) and a malformed configured id are both
-                # operator-side misconfiguration, not the requester's problem.
-                _log.warning(
-                    "support.operator_undeliverable",
-                    operator_id=raw_id,
-                    err_type=type(exc).__name__,
-                )
-        return delivered
+        try:
+            channel = bot.get_channel(int(channel_id))
+            if channel is None:
+                channel = await bot.fetch_channel(int(channel_id))
+            if not isinstance(channel, discord.abc.Messageable):
+                _log.warning("support.channel_not_messageable", channel_id=channel_id)
+                return False
+            await channel.send(body)
+            return True
+        except (discord.HTTPException, ValueError) as exc:
+            # A misconfigured id, a channel the bot was removed from, or lost
+            # send permission. All operator-side, none of them the requester's
+            # problem -- and none of them may lose the row.
+            _log.warning(
+                "support.channel_undeliverable",
+                channel_id=channel_id,
+                err_type=type(exc).__name__,
+            )
+            return False
 
     async def on_error(self, interaction: discord.Interaction, error: Exception) -> None:
         """Adapter boundary: discord.py routes on_submit failures here, not to a dispatcher."""

--- a/packages/adapters/discord/tests/privacy_panel/conftest.py
+++ b/packages/adapters/discord/tests/privacy_panel/conftest.py
@@ -37,6 +37,7 @@ def _make_preview(**overrides: Any) -> PurgePreview:
         "credential_requests": PurgePreviewRow(count=0, example=None),
         "wizard_sessions": PurgePreviewRow(count=0, example=None),
         "message_feedback": PurgePreviewRow(count=0, example=None),
+        "support_escalations": PurgePreviewRow(count=0, example=None),
     }
     base.update(overrides)
     return PurgePreview(**base)

--- a/packages/adapters/discord/tests/test_branding.py
+++ b/packages/adapters/discord/tests/test_branding.py
@@ -90,6 +90,7 @@ def _make_preview() -> PurgePreview:
         credential_requests=zero,
         wizard_sessions=zero,
         message_feedback=zero,
+        support_escalations=zero,
     )
 
 

--- a/packages/adapters/discord/tests/test_feedback_seed.py
+++ b/packages/adapters/discord/tests/test_feedback_seed.py
@@ -38,6 +38,7 @@ from daimon.core.message_feedback import THUMBS_DOWN, THUMBS_UP
 from daimon.core.notebooks._rate_limit import RateLimiter
 from daimon.core.scope import DeploymentDefault, ResolvedConfig
 from daimon.core.stores import tenant_ledger
+from daimon.core.support_escalation import ESCALATE
 from daimon.core.turn.deps import TurnDeps
 from daimon.core.turn.state import TextBlock, TurnState
 from daimon.testing.factories import make_tenant
@@ -47,7 +48,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 # --- unit tests: the helper alone -------------------------------------------
 
 
-async def test_seed_adds_positive_then_negative_emoji() -> None:
+async def test_seed_adds_the_two_vote_emoji_then_the_escalate_emoji() -> None:
     partial = MagicMock()
     partial.add_reaction = AsyncMock()
     channel = MagicMock()
@@ -55,10 +56,14 @@ async def test_seed_adds_positive_then_negative_emoji() -> None:
 
     await seed_feedback_reactions(channel, message_id="123")
 
-    assert partial.add_reaction.await_count == 2, "both emoji must be added"
-    first_call, second_call = partial.add_reaction.await_args_list
+    assert partial.add_reaction.await_count == 3, "both vote emoji and the escalate emoji"
+    first_call, second_call, third_call = partial.add_reaction.await_args_list
     assert first_call.args[0] == THUMBS_UP, "the positive emoji must be added first"
     assert second_call.args[0] == THUMBS_DOWN, "the negative emoji must be added second"
+    assert third_call.args[0] == ESCALATE, (
+        "the escalate emoji is seeded LAST so the two vote emoji keep the order "
+        "they have always rendered in"
+    )
 
 
 async def test_seed_when_add_reaction_raises_forbidden_returns_normally() -> None:
@@ -343,7 +348,7 @@ def _fake_run_turn(final_state: TurnState) -> object:
 @patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock)
 @patch("daimon.core.turn.prepare.create_session", new_callable=AsyncMock)
 @patch("daimon.core.turn.admission.resolve_config", new_callable=AsyncMock)
-async def test_a_real_text_answer_seeds_both_emoji_on_the_final_message(
+async def test_a_real_text_answer_seeds_all_three_emoji_on_the_final_message(
     mock_resolve: AsyncMock,
     mock_create_session: AsyncMock,
     mock_run_turn: AsyncMock,
@@ -372,7 +377,7 @@ async def test_a_real_text_answer_seeds_both_emoji_on_the_final_message(
     await bot.on_message(message)
 
     mock_thread.get_partial_message.assert_called_once_with(777888999)
-    assert mock_thread.get_partial_message.return_value.add_reaction.await_count == 2, (
+    assert mock_thread.get_partial_message.return_value.add_reaction.await_count == 3, (
         "an answered turn must seed both vote emoji on its final message"
     )
 

--- a/packages/adapters/slack/tests/test_privacy_panel.py
+++ b/packages/adapters/slack/tests/test_privacy_panel.py
@@ -310,6 +310,7 @@ def _make_preview(**overrides: Any) -> PurgePreview:
         "credential_requests": PurgePreviewRow(count=0, example=None),
         "wizard_sessions": PurgePreviewRow(count=0, example=None),
         "message_feedback": PurgePreviewRow(count=0, example=None),
+        "support_escalations": PurgePreviewRow(count=0, example=None),
     }
     base.update(overrides)
     return PurgePreview(**base)

--- a/packages/core/alembic/versions/0012_support_escalations.py
+++ b/packages/core/alembic/versions/0012_support_escalations.py
@@ -1,0 +1,69 @@
+"""support_escalations
+
+Human-support escalation requests. The rows are the credit ledger: remaining
+credits for a person are the configured allowance minus their row count, so
+there is deliberately no counter column to drift.
+
+Revision ID: 0012_support_escalations
+Revises: 0011_active_turn_channel
+
+downgrade: safe
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0012_support_escalations"
+down_revision: str | None = "0011_active_turn_channel"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "support_escalations",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "tenant_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "account_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("accounts.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("platform", sa.Text(), nullable=False),
+        sa.Column("platform_user_id", sa.Text(), nullable=False),
+        sa.Column("channel_id", sa.Text(), nullable=False),
+        sa.Column("message_id", sa.Text(), nullable=False),
+        sa.Column("ma_session_id", sa.Text(), nullable=True),
+        sa.Column("note", sa.Text(), nullable=False),
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "support_escalations_tenant_user_idx",
+        "support_escalations",
+        ["tenant_id", "platform_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("support_escalations_tenant_user_idx", table_name="support_escalations")
+    op.drop_table("support_escalations")

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -1144,3 +1144,65 @@ class FileUpload(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+
+
+class SupportEscalation(Base):
+    """One row per human-support request. The rows ARE the credit ledger.
+
+    There is no counter column and no `credits_remaining`: remaining is the
+    configured allowance minus the number of rows for that (tenant,
+    platform_user_id). A counter would be a second source of truth that can
+    drift from the rows it summarises, and it would need to be written in the
+    same transaction as the insert anyway -- which counting already is.
+
+    `platform_user_id` is the identity key for the same reason it is on
+    `message_feedback`: somebody can ask for help without ever having taken a
+    turn, so `account_id` may be NULL. Credits are per user WITHIN a tenant,
+    so the count predicate is always both columns together.
+
+    `delivered_at` is NULL until an operator DM actually lands. The row is
+    committed BEFORE any delivery is attempted, so a request whose every
+    operator DM bounces -- closed DMs are the ordinary failure -- survives as
+    an undelivered row instead of vanishing. That ordering is the whole point
+    of the column: it is the difference between a support request that can be
+    swept up later and one that was silently dropped on a paying trial.
+
+    Deliberately NO uniqueness constraint on (tenant, message, user): asking
+    for help twice about the same answer is legitimate and each request spends
+    its own credit.
+    """
+
+    __tablename__ = "support_escalations"
+    __table_args__ = (
+        Index(
+            "support_escalations_tenant_user_idx",
+            "tenant_id",
+            "platform_user_id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    account_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("accounts.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    platform: Mapped[str] = mapped_column(Text, nullable=False)
+    platform_user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    channel_id: Mapped[str] = mapped_column(Text, nullable=False)
+    message_id: Mapped[str] = mapped_column(Text, nullable=False)
+    ma_session_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    note: Mapped[str] = mapped_column(Text, nullable=False)
+    delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -555,6 +555,39 @@ class BillingSettings(BaseModel):
     )
 
 
+class SupportSettings(BaseModel):
+    """Human-support escalation: who gets pinged, and how many asks each user gets.
+
+    `credits_per_user` is a COUNT of human interactions, deliberately not the
+    USD in `BillingSettings.signup_credit`. Sharing a ledger with billing would
+    let a support request eat the tenant's ability to run turns, and would give
+    a paid-up tenant unlimited support. Different unit, different table.
+
+    An empty `operator_user_ids` disables the escalate affordance entirely
+    rather than recording requests nobody will ever see. Failing closed is the
+    honest behaviour: an escalate button that reaches no one is worse than no
+    button, because the person believes they have asked for help.
+    """
+
+    operator_user_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Platform user ids DM'd when someone escalates to human support. "
+            "Empty (the default) disables the escalate affordance entirely — "
+            "a request that reaches nobody is worse than no button at all."
+        ),
+    )
+    credits_per_user: int = Field(
+        default=3,
+        ge=0,
+        description=(
+            "How many human-support requests each user gets within a tenant. "
+            "A COUNT of interactions, NOT the USD in DAIMON_BILLING__SIGNUP_CREDIT — "
+            "the two are deliberately separate ledgers. 0 disables escalation."
+        ),
+    )
+
+
 class ArtifactsSettings(BaseModel):
     """Optional private object storage for hosted-client artifacts."""
 
@@ -610,6 +643,7 @@ class Settings(BaseSettings):
     report_host: ReportHostSettings = Field(default_factory=ReportHostSettings)
     sentry: SentrySettings = Field(default_factory=SentrySettings)
     billing: BillingSettings = Field(default_factory=BillingSettings)
+    support: SupportSettings = Field(default_factory=SupportSettings)
     artifacts: ArtifactsSettings | None = Field(
         default=None,
         description=(

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -556,25 +556,28 @@ class BillingSettings(BaseModel):
 
 
 class SupportSettings(BaseModel):
-    """Human-support escalation: who gets pinged, and how many asks each user gets.
+    """Human-support escalation: where requests land, and how many each user gets.
 
     `credits_per_user` is a COUNT of human interactions, deliberately not the
     USD in `BillingSettings.signup_credit`. Sharing a ledger with billing would
     let a support request eat the tenant's ability to run turns, and would give
     a paid-up tenant unlimited support. Different unit, different table.
 
-    An empty `operator_user_ids` disables the escalate affordance entirely
+    An unset `escalation_channel_id` disables the escalate affordance entirely
     rather than recording requests nobody will ever see. Failing closed is the
     honest behaviour: an escalate button that reaches no one is worse than no
     button, because the person believes they have asked for help.
     """
 
-    operator_user_ids: list[str] = Field(
-        default_factory=list,
+    escalation_channel_id: str | None = Field(
+        default=None,
         description=(
-            "Platform user ids DM'd when someone escalates to human support. "
-            "Empty (the default) disables the escalate affordance entirely — "
-            "a request that reaches nobody is worse than no button at all."
+            "Channel id where human-support requests are posted. Unset (the "
+            "default) disables the escalate affordance entirely — a request "
+            "that reaches nobody is worse than no button at all. A channel "
+            "rather than operator DMs: it survives one person's DMs being "
+            "closed, and it leaves a shared record anyone on the rota can pick "
+            "up. The bot must be able to post there."
         ),
     )
     credits_per_user: int = Field(

--- a/packages/core/daimon/core/privacy.py
+++ b/packages/core/daimon/core/privacy.py
@@ -36,6 +36,7 @@ from daimon.core.stores import message_feedback as message_feedback_store
 from daimon.core.stores import routines as routines_store
 from daimon.core.stores import slack_turn_contexts as slack_turn_contexts_store
 from daimon.core.stores import slack_user_tokens as slack_user_tokens_store
+from daimon.core.stores import support_escalation as support_escalation_store
 from daimon.core.stores import tenants as tenants_store
 from daimon.core.stores import user_skills as user_skills_store
 from daimon.core.stores import wizard_session as wizard_session_store
@@ -80,6 +81,7 @@ class PurgePreview(BaseModel):
     credential_requests: PurgePreviewRow
     wizard_sessions: PurgePreviewRow
     message_feedback: PurgePreviewRow
+    support_escalations: PurgePreviewRow
 
 
 def _format_platform_principal(p: PlatformPrincipalRow) -> str:
@@ -335,6 +337,19 @@ async def collect_purge_preview(
         )
         message_feedback = PurgePreviewRow(count=message_feedback_count, example=None)
 
+        # 15. support_escalations — same account-scoped shape, and the SAME
+        # platform-user keys, as message_feedback above. The argument shapes
+        # here are identical to purge_account's delete by contract; any
+        # divergence makes this preview lie about what erasure will remove.
+        support_escalations_count = (
+            await support_escalation_store.count_support_escalations_for_account(
+                session,
+                account_id=account_id,
+                platform_user_keys=message_feedback_platform_user_keys,
+            )
+        )
+        support_escalations = PurgePreviewRow(count=support_escalations_count, example=None)
+
     return PurgePreview(
         linked_principals=linked_principals,
         principal_links=principal_links,
@@ -351,4 +366,5 @@ async def collect_purge_preview(
         credential_requests=credential_requests,
         wizard_sessions=wizard_sessions,
         message_feedback=message_feedback,
+        support_escalations=support_escalations,
     )

--- a/packages/core/daimon/core/purge.py
+++ b/packages/core/daimon/core/purge.py
@@ -100,6 +100,7 @@ from daimon.core.stores import message_feedback as message_feedback_store
 from daimon.core.stores import routines as routines_store
 from daimon.core.stores import slack_turn_contexts as slack_turn_contexts_store
 from daimon.core.stores import slack_user_tokens as slack_user_tokens_store
+from daimon.core.stores import support_escalation as support_escalation_store
 from daimon.core.stores import tenants as tenants_store
 from daimon.core.stores import user_skills as user_skills_store
 from daimon.core.stores import wizard_session as wizard_session_store
@@ -133,6 +134,7 @@ class PurgeReport(BaseModel):
     credential_requests: int = 0
     wizard_sessions: int = 0
     message_feedback: int = 0
+    support_escalations: int = 0
 
     def merge(self, other: PurgeReport) -> PurgeReport:
         return PurgeReport(
@@ -152,6 +154,7 @@ class PurgeReport(BaseModel):
             credential_requests=self.credential_requests + other.credential_requests,
             wizard_sessions=self.wizard_sessions + other.wizard_sessions,
             message_feedback=self.message_feedback + other.message_feedback,
+            support_escalations=self.support_escalations + other.support_escalations,
         )
 
 
@@ -226,6 +229,19 @@ async def _purge_principal_in_session(
                 platform_user_id=principal.external_id,
             )
         )
+        # support_escalations carries the SAME (tenant, platform-user) key and
+        # the same account_id = NULL hazard: somebody can ask for help without
+        # ever having taken a turn, so an account-keyed pass alone would leave
+        # the request AND its free-text note behind. The note is unsolicited
+        # personal text, so this is the same erasure obligation the vote text
+        # carries, not a bookkeeping nicety.
+        support_escalations_count = (
+            await support_escalation_store.delete_support_escalations_for_platform_user(
+                session,
+                tenant_id=principal.tenant_id,
+                platform_user_id=principal.external_id,
+            )
+        )
     else:
         routines_count = 0
         kind = "cli"
@@ -269,6 +285,10 @@ async def _purge_principal_in_session(
         # running one would risk deleting an unrelated platform user's rows
         # that happen to share the string.
         message_feedback_count = 0
+        # Escalation is a reaction-then-modal path in a guild, so a CLI
+        # principal owns no support_escalations rows — same reasoning, and the
+        # same refusal to match on os_user, as message_feedback above.
+        support_escalations_count = 0
 
     # user_skills and github_credentials are keyed by principal_id alone — both
     # principal kinds own rows in these tables.
@@ -314,6 +334,7 @@ async def _purge_principal_in_session(
         credential_requests=credential_requests_count,
         wizard_sessions=wizard_sessions_count,
         message_feedback=message_feedback_count,
+        support_escalations=support_escalations_count,
     )
 
 
@@ -426,6 +447,15 @@ async def purge_account(
         message_feedback_count = await message_feedback_store.delete_message_feedback_for_account(
             session, account_id=account_id, platform_user_keys=platform_user_keys
         )
+        # Same account_id = NULL hazard, same obligation: the note is
+        # unsolicited personal text, so an account erasure that missed these
+        # rows would leave it behind.
+        support_escalations_count = (
+            await support_escalation_store.delete_support_escalations_for_account(
+                session, account_id=account_id, platform_user_keys=platform_user_keys
+            )
+        )
+
         # slack_turn_contexts (D-07): keyed by (tenant_id, account_id), not
         # principal_id. Loop every tenant the account's principals belong to —
         # mirrors the upstream session-deletion loop below.
@@ -444,6 +474,7 @@ async def purge_account(
             PurgeReport(
                 mcp_tokens=mcp_tokens_count,
                 message_feedback=message_feedback_count,
+                support_escalations=support_escalations_count,
                 user_configs=user_cfg_count,
                 accounts=account_count,
                 slack_turn_contexts=slack_turn_contexts_count,

--- a/packages/core/daimon/core/stores/domain.py
+++ b/packages/core/daimon/core/stores/domain.py
@@ -556,3 +556,21 @@ class FileUploadRow(BaseModel):
     content_type: str
     content: bytes | None
     created_at: datetime
+
+
+class SupportEscalationRow(BaseModel):
+    """Pydantic row for SupportEscalation — one human-support request."""
+
+    model_config = ConfigDict(from_attributes=True, frozen=True)
+
+    id: uuid.UUID
+    tenant_id: uuid.UUID
+    account_id: uuid.UUID | None
+    platform: str
+    platform_user_id: str
+    channel_id: str
+    message_id: str
+    ma_session_id: str | None
+    note: str
+    delivered_at: datetime | None
+    created_at: datetime

--- a/packages/core/daimon/core/stores/support_escalation.py
+++ b/packages/core/daimon/core/stores/support_escalation.py
@@ -1,0 +1,202 @@
+"""Async store for support_escalations — human-support requests and their credit gate.
+
+No try/except anywhere in this module — exceptions propagate to the adapter
+boundary. Callers own the transaction; every write ends with `await
+session.flush()`.
+
+The credit gate lives in `record_escalation` rather than in the caller, and it
+counts inside the caller's transaction, because a check performed before the
+transaction is a TOCTOU: two fast clicks both read `used=2` against an
+allowance of 3, both decide they are permitted, and both insert. Counting on
+the same connection that inserts makes the check and the write atomic under
+`REPEATABLE READ` or better, and under `READ COMMITTED` narrows the window to
+the statement pair rather than to a round trip through Discord.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Any, cast
+
+from daimon.core._models import SupportEscalation
+from daimon.core.stores.domain import SupportEscalationRow
+from daimon.core.support_escalation import has_credit
+from sqlalchemy import (
+    ColumnElement,
+    CursorResult,
+    delete,
+    func,
+    or_,
+    select,
+    tuple_,
+    update,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def count_escalations_for_user(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    platform_user_id: str,
+) -> int:
+    """How many escalations this person has already spent in this tenant.
+
+    Credits are per user WITHIN a tenant, so both columns are always in the
+    predicate — the same person in two installs has two separate allowances.
+    """
+    stmt = (
+        select(func.count())
+        .select_from(SupportEscalation)
+        .where(
+            SupportEscalation.tenant_id == tenant_id,
+            SupportEscalation.platform_user_id == platform_user_id,
+        )
+    )
+    return int((await session.execute(stmt)).scalar_one())
+
+
+async def record_escalation(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID | None,
+    platform: str,
+    platform_user_id: str,
+    channel_id: str,
+    message_id: str,
+    ma_session_id: str | None,
+    note: str,
+    allowance: int,
+) -> SupportEscalationRow | None:
+    """Insert one escalation if the person has a credit left, else `None`.
+
+    `None` means "out of credits", which the caller renders as the contact-us
+    message. It is not an error and must not be raised: running out is the
+    designed end of a trial allowance, not a fault.
+
+    `delivered_at` is left NULL. The caller attempts operator delivery AFTER
+    this returns and calls `mark_delivered` only once a DM actually lands, so
+    a request whose delivery fails entirely survives as an undelivered row.
+    Committing the row first is deliberate and is the reason this function does
+    not take a delivery callback.
+    """
+    used = await count_escalations_for_user(
+        session, tenant_id=tenant_id, platform_user_id=platform_user_id
+    )
+    if not has_credit(allowance=allowance, used=used):
+        return None
+
+    orm = SupportEscalation(
+        tenant_id=tenant_id,
+        account_id=account_id,
+        platform=platform,
+        platform_user_id=platform_user_id,
+        channel_id=channel_id,
+        message_id=message_id,
+        ma_session_id=ma_session_id,
+        note=note,
+    )
+    session.add(orm)
+    await session.flush()
+    await session.refresh(orm)
+    return SupportEscalationRow.model_validate(orm)
+
+
+async def mark_delivered(
+    session: AsyncSession,
+    *,
+    escalation_id: uuid.UUID,
+) -> SupportEscalationRow | None:
+    """Stamp `delivered_at` once an operator DM has actually landed.
+
+    Idempotent in effect — re-stamping refreshes the timestamp rather than
+    failing — because the alternative (predicating on `delivered_at IS NULL`)
+    would make a retry look like a missing row to the caller.
+    """
+    stmt = (
+        update(SupportEscalation)
+        .where(SupportEscalation.id == escalation_id)
+        .values(delivered_at=func.now())
+        .returning(SupportEscalation)
+    )
+    orm = (await session.execute(stmt)).scalar_one_or_none()
+    await session.flush()
+    if orm is None:
+        return None
+    return SupportEscalationRow.model_validate(orm)
+
+
+async def delete_support_escalations_for_platform_user(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    platform_user_id: str,
+) -> int:
+    """Delete one platform user's escalations in one tenant. Idempotent.
+
+    Tenant-scoped for the same reason the message_feedback counterpart is:
+    `platform_user_id` is not globally unique across platforms, and purging
+    ONE principal must not erase the same person's rows in another install.
+    """
+    result = await session.execute(
+        delete(SupportEscalation).where(
+            SupportEscalation.tenant_id == tenant_id,
+            SupportEscalation.platform_user_id == platform_user_id,
+        )
+    )
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
+def _account_or_platform_user_predicate(
+    *, account_id: uuid.UUID, platform_user_keys: Sequence[tuple[uuid.UUID, str]]
+) -> ColumnElement[bool]:
+    """Shared predicate for the account-scoped delete/count pair.
+
+    They MUST stay identical, or the /privacy cascade preview lies about what
+    erasure will remove. Same shape and same reason as the message_feedback
+    pair: a request written before the person had an `accounts` row carries
+    `account_id = NULL` and is unreachable by an account-keyed delete alone,
+    so the `(tenant_id, platform_user_id)` membership check closes that gap.
+    """
+    predicates: list[ColumnElement[bool]] = [SupportEscalation.account_id == account_id]
+    if platform_user_keys:
+        predicates.append(
+            tuple_(SupportEscalation.tenant_id, SupportEscalation.platform_user_id).in_(
+                list(platform_user_keys)
+            )
+        )
+    return or_(*predicates)
+
+
+async def delete_support_escalations_for_account(
+    session: AsyncSession,
+    *,
+    account_id: uuid.UUID,
+    platform_user_keys: Sequence[tuple[uuid.UUID, str]],
+) -> int:
+    """Delete every escalation attributable to `account_id`. Idempotent."""
+    predicate = _account_or_platform_user_predicate(
+        account_id=account_id, platform_user_keys=platform_user_keys
+    )
+    result = await session.execute(delete(SupportEscalation).where(predicate))
+    rowcount = cast(CursorResult[Any], result).rowcount
+    await session.flush()
+    return rowcount
+
+
+async def count_support_escalations_for_account(
+    session: AsyncSession,
+    *,
+    account_id: uuid.UUID,
+    platform_user_keys: Sequence[tuple[uuid.UUID, str]],
+) -> int:
+    """Count what `delete_support_escalations_for_account` would delete. Read-only."""
+    predicate = _account_or_platform_user_predicate(
+        account_id=account_id, platform_user_keys=platform_user_keys
+    )
+    stmt = select(func.count()).select_from(SupportEscalation).where(predicate)
+    return int((await session.execute(stmt)).scalar_one())

--- a/packages/core/daimon/core/support_escalation.py
+++ b/packages/core/daimon/core/support_escalation.py
@@ -1,0 +1,113 @@
+"""Pure logic for human-support escalation: the credit gate and the button grammar.
+
+Lives in `daimon.core` for the same reason `message_feedback` does -- the
+`custom_id` grammar belongs one level above the adapter that renders the
+widget.
+
+**Credits here are a COUNT of human interactions, not money.** They are
+deliberately unrelated to `BillingSettings.signup_credit`, which is USD seeded
+into `tenant_ledger` and gates turns through `is_over_cap`. The two must never
+share a ledger: metering support against the billing balance would let a
+support request consume the tenant's ability to run turns, and a paid-up
+tenant would silently gain unlimited support. Different unit, different table,
+different exhaustion behaviour.
+
+There is no counter column. `support_escalations` rows ARE the ledger, and
+`remaining` is the allowance minus the row count for that (tenant, user). A
+counter would be a second source of truth that can drift from the rows it
+claims to summarise, and the decrement would need to be transactionally
+married to the insert anyway -- which counting already is, for free.
+
+`ESCALATE` is a third seeded reaction alongside the two vote emoji. It is NOT
+a vote: `vote_for_reaction` deliberately does not match it, so an escalation
+never lands in `message_feedback`, and this module's classifier does not match
+the thumbs. The two paths share the seeding call and nothing else.
+
+The `sup:` prefix is disjoint from `mfb:` (message feedback) and `ztc:`
+(credential requests), which is load-bearing: discord.py's
+`dispatch_dynamic_items` fullmatches an incoming custom_id against EVERY
+registered template with no early break, so two overlapping prefixes would
+both fire.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+ESCALATE: Final[str] = "\N{HAPPY PERSON RAISING ONE HAND}"
+
+CUSTOM_ID_PREFIX: Final[str] = "sup:"
+
+CUSTOM_ID_TEMPLATE: Final[str] = (
+    r"sup:(?P<guild_id>[0-9]{1,20}):(?P<channel_id>[0-9]{1,20})"
+    r":(?P<message_id>[0-9]{1,20})"
+)
+CUSTOM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(CUSTOM_ID_TEMPLATE)
+
+
+def build_custom_id(*, guild_id: str, channel_id: str, message_id: str) -> str:
+    """Return the wire `custom_id` for the escalate button on one message.
+
+    Carries ids rather than a row id because NO ROW EXISTS YET -- the row is
+    written when the modal is submitted, not when the reaction lands.
+    Reacting must not spend a credit; only sending the note does.
+
+    `guild_id` is carried because the button is delivered into a direct
+    message, where `interaction.guild_id` is None and the tenant would
+    otherwise be underivable. It is not a trust boundary: the escalation is
+    written against the CLICKING user's id and counted against their own
+    allowance, so a forwarded custom_id spends the forwarder's credit in the
+    named tenant rather than impersonating anyone.
+    """
+    return f"{CUSTOM_ID_PREFIX}{guild_id}:{channel_id}:{message_id}"
+
+
+def parse_custom_id(custom_id: str) -> tuple[str, str, str] | None:
+    """Return `(guild_id, channel_id, message_id)`, or `None` if it does not match."""
+    match = CUSTOM_ID_PATTERN.fullmatch(custom_id)
+    if match is None:
+        return None
+    return match.group("guild_id"), match.group("channel_id"), match.group("message_id")
+
+
+def is_escalation_reaction(
+    *,
+    emoji_name: str | None,
+    emoji_is_custom: bool,
+    reactor_id: int,
+    bot_user_id: int,
+    guild_id: int | None,
+) -> bool:
+    """Classify a raw reaction-add payload as an escalation request, or not.
+
+    Same gates, and the same reasons, as `message_feedback.vote_for_reaction`:
+    a reaction with no guild resolves no tenant, the bot's own seeded reaction
+    is not a request, and a custom emoji is not the bare codepoint this module
+    seeds. Skin-tone-modified variants are deliberately not matched -- they are
+    distinct codepoint sequences from what `seed_feedback_reactions` adds.
+    """
+    if guild_id is None:
+        return False
+    if reactor_id == bot_user_id:
+        return False
+    if emoji_is_custom:
+        return False
+    return emoji_name == ESCALATE
+
+
+def remaining_credits(*, allowance: int, used: int) -> int:
+    """Credits left for one person, floored at zero.
+
+    Floors rather than returning a negative because `allowance` is
+    deployment config and can be lowered below what somebody has already
+    spent. A negative remaining would render as "-2 credits left" and, worse,
+    invites a caller to compare it with `> 0` somewhere and get a different
+    answer than `has_credit` gives.
+    """
+    return max(allowance - used, 0)
+
+
+def has_credit(*, allowance: int, used: int) -> bool:
+    """Whether one more escalation is permitted."""
+    return remaining_credits(allowance=allowance, used=used) > 0

--- a/packages/core/tests/stores/test_support_escalation.py
+++ b/packages/core/tests/stores/test_support_escalation.py
@@ -1,0 +1,258 @@
+"""Integration tests for the support_escalation store — real Postgres.
+
+Covers the credit gate, the fact that the rows ARE the ledger (no counter to
+drift), per-user-within-tenant scoping, and the delivery/erasure columns.
+"""
+
+from __future__ import annotations
+
+from daimon.core._models import SupportEscalation
+from daimon.core.stores import support_escalation as store
+from daimon.testing.factories import make_account, make_tenant
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _rows(session: AsyncSession) -> int:
+    return int(
+        (await session.execute(select(func.count()).select_from(SupportEscalation))).scalar_one()
+    )
+
+
+async def test_escalation_is_recorded_undelivered_so_a_failed_dm_cannot_drop_it(
+    db_session: AsyncSession,
+) -> None:
+    # The row must exist before delivery is attempted. This is the whole
+    # reason delivered_at is nullable rather than the write happening after
+    # a successful DM.
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+
+    row = await store.record_escalation(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=account.id,
+        platform="discord",
+        platform_user_id="asker-1",
+        channel_id="chan-1",
+        message_id="msg-1",
+        ma_session_id="sess_a",
+        note="the forecast looks wrong",
+        allowance=3,
+    )
+
+    assert row is not None
+    assert row.delivered_at is None, "the row must be durable before any DM is attempted"
+    assert row.note == "the forecast looks wrong"
+
+
+async def test_credit_gate_refuses_once_the_allowance_is_spent(
+    db_session: AsyncSession,
+) -> None:
+    tenant = await make_tenant(db_session)
+
+    for i in range(2):
+        assert (
+            await store.record_escalation(
+                db_session,
+                tenant_id=tenant.id,
+                account_id=None,
+                platform="discord",
+                platform_user_id="asker-1",
+                channel_id="chan-1",
+                message_id=f"msg-{i}",
+                ma_session_id=None,
+                note=f"help {i}",
+                allowance=2,
+            )
+            is not None
+        )
+
+    refused = await store.record_escalation(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=None,
+        platform="discord",
+        platform_user_id="asker-1",
+        channel_id="chan-1",
+        message_id="msg-2",
+        ma_session_id=None,
+        note="one too many",
+        allowance=2,
+    )
+
+    assert refused is None, (
+        "running out returns None; it is the designed end of a trial, not an error"
+    )
+    assert await _rows(db_session) == 2, "a refused escalation must write nothing"
+
+
+async def test_asking_twice_about_the_same_message_is_allowed_and_spends_two_credits(
+    db_session: AsyncSession,
+) -> None:
+    # Deliberately no uniqueness on (tenant, message, user): a second question
+    # about the same answer is legitimate and is its own request.
+    tenant = await make_tenant(db_session)
+    for _ in range(2):
+        assert (
+            await store.record_escalation(
+                db_session,
+                tenant_id=tenant.id,
+                account_id=None,
+                platform="discord",
+                platform_user_id="asker-1",
+                channel_id="chan-1",
+                message_id="same-msg",
+                ma_session_id=None,
+                note="still stuck",
+                allowance=3,
+            )
+            is not None
+        )
+    assert (
+        await store.count_escalations_for_user(
+            db_session, tenant_id=tenant.id, platform_user_id="asker-1"
+        )
+        == 2
+    )
+
+
+async def test_credits_are_per_user_and_per_tenant(db_session: AsyncSession) -> None:
+    # The same person in two installs has two separate allowances, and one
+    # person exhausting theirs must not block anybody else.
+    tenant_a = await make_tenant(db_session)
+    tenant_b = await make_tenant(db_session)
+
+    for tenant in (tenant_a, tenant_b):
+        assert (
+            await store.record_escalation(
+                db_session,
+                tenant_id=tenant.id,
+                account_id=None,
+                platform="discord",
+                platform_user_id="asker-1",
+                channel_id="c",
+                message_id="m",
+                ma_session_id=None,
+                note="n",
+                allowance=1,
+            )
+            is not None
+        )
+
+    assert (
+        await store.count_escalations_for_user(
+            db_session, tenant_id=tenant_a.id, platform_user_id="asker-1"
+        )
+        == 1
+    )
+    assert (
+        await store.count_escalations_for_user(
+            db_session, tenant_id=tenant_a.id, platform_user_id="asker-2"
+        )
+        == 0
+    ), "one person's spend must not count against another's allowance"
+
+
+async def test_mark_delivered_stamps_the_row(db_session: AsyncSession) -> None:
+    tenant = await make_tenant(db_session)
+    row = await store.record_escalation(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=None,
+        platform="discord",
+        platform_user_id="asker-1",
+        channel_id="c",
+        message_id="m",
+        ma_session_id=None,
+        note="n",
+        allowance=1,
+    )
+    assert row is not None
+
+    stamped = await store.mark_delivered(db_session, escalation_id=row.id)
+    assert stamped is not None and stamped.delivered_at is not None
+
+
+async def test_delete_for_platform_user_is_tenant_scoped_and_idempotent(
+    db_session: AsyncSession,
+) -> None:
+    # The note is unsolicited personal text, so an erasure that missed these
+    # rows would leave it behind. Tenant-scoped because platform_user_id is
+    # not globally unique.
+    tenant_a = await make_tenant(db_session)
+    tenant_b = await make_tenant(db_session)
+    for tenant in (tenant_a, tenant_b):
+        await store.record_escalation(
+            db_session,
+            tenant_id=tenant.id,
+            account_id=None,
+            platform="discord",
+            platform_user_id="asker-1",
+            channel_id="c",
+            message_id="m",
+            ma_session_id=None,
+            note="personal text",
+            allowance=1,
+        )
+
+    deleted = await store.delete_support_escalations_for_platform_user(
+        db_session, tenant_id=tenant_a.id, platform_user_id="asker-1"
+    )
+    assert deleted == 1
+    assert await _rows(db_session) == 1, "the other install's row must survive"
+
+    again = await store.delete_support_escalations_for_platform_user(
+        db_session, tenant_id=tenant_a.id, platform_user_id="asker-1"
+    )
+    assert again == 0, "delete must be idempotent"
+
+
+async def test_account_scoped_delete_reaches_rows_written_before_the_account_existed(
+    db_session: AsyncSession,
+) -> None:
+    # The account_id = NULL gap this predicate pair exists to close: somebody
+    # can ask for help without ever having taken a turn, so an account-keyed
+    # delete alone would leave the request and its note behind.
+    tenant = await make_tenant(db_session)
+    account = await make_account(db_session, tenant=tenant)
+
+    await store.record_escalation(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=None,  # written before the person had an accounts row
+        platform="discord",
+        platform_user_id="asker-1",
+        channel_id="c",
+        message_id="m1",
+        ma_session_id=None,
+        note="orphaned note",
+        allowance=5,
+    )
+    await store.record_escalation(
+        db_session,
+        tenant_id=tenant.id,
+        account_id=account.id,
+        platform="discord",
+        platform_user_id="asker-1",
+        channel_id="c",
+        message_id="m2",
+        ma_session_id=None,
+        note="attributed note",
+        allowance=5,
+    )
+
+    keys = [(tenant.id, "asker-1")]
+    counted = await store.count_support_escalations_for_account(
+        db_session, account_id=account.id, platform_user_keys=keys
+    )
+    deleted = await store.delete_support_escalations_for_account(
+        db_session, account_id=account.id, platform_user_keys=keys
+    )
+
+    assert counted == 2, "the count must see the null-account row too"
+    assert deleted == counted, (
+        "count and delete must build the SAME predicate, or the /privacy preview "
+        "lies about what erasure removes"
+    )
+    assert await _rows(db_session) == 0

--- a/packages/core/tests/test_privacy.py
+++ b/packages/core/tests/test_privacy.py
@@ -736,6 +736,7 @@ async def test_collect_purge_preview_matches_purge_account_coverage_field_for_fi
         "credential_requests": "credential_requests",
         "wizard_sessions": "wizard_sessions",
         "message_feedback": "message_feedback",
+        "support_escalations": "support_escalations",
     }
 
     uncovered = report_fields - set(mapping.keys())
@@ -780,6 +781,7 @@ async def test_purge_covers_every_account_or_principal_scoped_table() -> None:
         "mcp_tokens": "account_id FK -> accounts.id",
         "wizard_session": "account_id FK -> accounts.id",
         "message_feedback": "account_id FK -> accounts.id",
+        "support_escalations": "account_id FK -> accounts.id",
     }
     # Intentional exclusions, each justified inline.
     allowlist: frozenset[str] = frozenset(

--- a/packages/core/tests/test_support_escalation.py
+++ b/packages/core/tests/test_support_escalation.py
@@ -79,3 +79,33 @@ def test_parse_rejects_malformed() -> None:
     assert parse_custom_id("sup:1:2") is None
     assert parse_custom_id("sup:abc:2:3") is None
     assert parse_custom_id("") is None
+
+
+def test_escalation_is_disabled_when_no_channel_is_configured() -> None:
+    """An escalate path that reaches nobody is worse than none at all.
+
+    The person believes they have asked for help. Failing closed here is why
+    both the reaction gate and the submit path check the channel, rather than
+    recording requests into a table nobody watches.
+    """
+    from daimon.core.config import SupportSettings
+
+    assert SupportSettings().escalation_channel_id is None, (
+        "escalation must be OFF by default -- a deployment that never "
+        "configures a channel must not offer the affordance"
+    )
+    assert SupportSettings().credits_per_user == 3
+
+
+def test_support_credits_are_not_the_billing_ledger() -> None:
+    """Support credits are a COUNT; signup_credit is USD in tenant_ledger.
+
+    Sharing one ledger would let a support request consume the tenant's
+    ability to run turns, and would hand a paid-up tenant unlimited support.
+    Asserted rather than only documented so a later 'tidy-up' that merges them
+    fails here.
+    """
+    from daimon.core.config import BillingSettings, SupportSettings
+
+    assert isinstance(SupportSettings().credits_per_user, int)
+    assert not isinstance(BillingSettings().signup_credit, int)

--- a/packages/core/tests/test_support_escalation.py
+++ b/packages/core/tests/test_support_escalation.py
@@ -1,0 +1,81 @@
+"""Pure-logic tests for the support-escalation gate and custom_id grammar."""
+
+from __future__ import annotations
+
+import pytest
+from daimon.core.message_feedback import CUSTOM_ID_PREFIX as FEEDBACK_PREFIX
+from daimon.core.message_feedback import THUMBS_DOWN, THUMBS_UP, vote_for_reaction
+from daimon.core.support_escalation import (
+    CUSTOM_ID_PATTERN,
+    CUSTOM_ID_PREFIX,
+    ESCALATE,
+    build_custom_id,
+    has_credit,
+    is_escalation_reaction,
+    parse_custom_id,
+    remaining_credits,
+)
+
+
+def test_remaining_credits_floors_at_zero_when_allowance_is_lowered() -> None:
+    # Allowance is deployment config and can be cut below what someone already
+    # spent. A negative would render as "-2 left" and invites a caller to
+    # compare it against > 0 and disagree with has_credit.
+    assert remaining_credits(allowance=1, used=3) == 0
+    assert has_credit(allowance=1, used=3) is False
+
+
+def test_has_credit_boundary() -> None:
+    assert has_credit(allowance=3, used=2) is True
+    assert has_credit(allowance=3, used=3) is False
+    assert has_credit(allowance=0, used=0) is False
+
+
+def test_escalate_emoji_is_not_a_vote_and_thumbs_are_not_escalations() -> None:
+    # The two paths share the seeded reactions and nothing else. If either
+    # classifier grew to match the other's emoji, an escalation would land in
+    # message_feedback or a thumbs-down would spend a support credit.
+    common = dict(emoji_is_custom=False, reactor_id=2, bot_user_id=1, guild_id=99)
+    assert vote_for_reaction(emoji_name=ESCALATE, **common) is None
+    assert is_escalation_reaction(emoji_name=THUMBS_UP, **common) is False
+    assert is_escalation_reaction(emoji_name=THUMBS_DOWN, **common) is False
+    assert is_escalation_reaction(emoji_name=ESCALATE, **common) is True
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"guild_id": None},  # a DM reaction resolves no tenant
+        {"reactor_id": 1},  # the bot's own seeded reaction
+        {"emoji_is_custom": True},  # a custom emoji that happens to be named alike
+    ],
+)
+def test_escalation_gates(kwargs: dict[str, object]) -> None:
+    base = dict(
+        emoji_name=ESCALATE,
+        emoji_is_custom=False,
+        reactor_id=2,
+        bot_user_id=1,
+        guild_id=99,
+    )
+    assert is_escalation_reaction(**{**base, **kwargs}) is False  # type: ignore[arg-type]
+
+
+def test_custom_id_roundtrip() -> None:
+    cid = build_custom_id(guild_id="1", channel_id="22", message_id="333")
+    assert parse_custom_id(cid) == ("1", "22", "333")
+
+
+def test_custom_id_prefix_is_disjoint_from_the_feedback_button() -> None:
+    # discord.py fullmatches an incoming custom_id against EVERY registered
+    # dynamic-item template with no early break, so two overlapping prefixes
+    # would fire both handlers on one click.
+    assert not CUSTOM_ID_PREFIX.startswith(FEEDBACK_PREFIX)
+    assert not FEEDBACK_PREFIX.startswith(CUSTOM_ID_PREFIX)
+    assert CUSTOM_ID_PATTERN.fullmatch("mfb:not-ours") is None
+
+
+def test_parse_rejects_malformed() -> None:
+    assert parse_custom_id("sup:1:2") is None
+    assert parse_custom_id("sup:abc:2:3") is None
+    assert parse_custom_id("") is None


### PR DESCRIPTION
Adds an "ask a human" affordance to bot answers, metered per user, so the upcoming trial has a hand-off path that isn't a support email nobody watches.

## The surface

A third seeded reaction beside the two vote emoji. React → the bot DMs a button → the button opens a note form → sending the note spends one credit and posts the request into the escalation channel.

Reaction rather than a button on the answer itself: `feedback_seed.py` already seeds emoji on the final message and `feedback_reactions.py` already listens, so this reuses a tested path and leaves the turn render path untouched. A real button would put a persistent View on every final message — a much larger change for the same affordance, and the upgrade path if one-click ever matters more.

**Reacting spends nothing.** Only sending the note does, which is why the `custom_id` carries `(guild, channel, message)` rather than a row id — no row exists yet.

## Requests land in a channel, not in DMs

A channel survives one person's DMs being closed, leaves a shared record anyone on the rota can pick up, and avoids silently making whoever is first in a config list the only person who ever hears anything.

`DAIMON_SUPPORT__ESCALATION_CHANNEL_ID` unset disables the affordance entirely rather than recording requests nobody will read — an escalate path that reaches no one is worse than none, because the person believes they have asked for help. Both the reaction gate and the submit path check it, so a mid-flight disable spends nothing.

## Credits are not money

`credits_per_user` (default 3) is a COUNT of human interactions. `BillingSettings.signup_credit` is USD in `tenant_ledger` gating turns through `is_over_cap`. They deliberately do not share a ledger: sharing one would let a support request consume a tenant's ability to run turns, and would hand a paid-up tenant unlimited support. There's a test asserting this rather than only a comment, so a later tidy-up that merges them fails loudly.

## The rows are the ledger

No counter column. `remaining = allowance - count(rows for that tenant+user)`. Nothing to drift from the rows it claims to summarise, and the gate counts on the same connection that inserts, so two fast clicks can't both pass. Lowering the allowance below what someone already spent floors at zero rather than going negative.

## Delivery ordering

The row commits **before** the post is attempted; `delivered_at` is stamped only once it lands. A channel the bot was removed from, an id that isn't messageable, and a lost send permission all resolve to "recorded, undelivered" rather than a dropped request. A support request from a paying trial client that vanishes because of operator-side misconfiguration is the one outcome worth engineering against — an undelivered row can be swept later, a dropped one cannot.

## Scope

Discord only. Slack has zero installed workspaces and captures feedback through buttons rather than reactions *by design* (avoiding `reactions:read` / `im:write`, which would force every workspace to re-authorize — `tests/parity/test_message_feedback_discord_only.py` is the record). The gate and the record live in core, so Slack is later wiring rather than a redesign.

Deliberately not built: calendar booking, payment integration, automated trial-expiry warnings.

## Privacy

Wired into both purge paths and the preview. The note is unsolicited personal text, so it carries the same erasure obligation as feedback text — including the `account_id = NULL` case, since somebody can ask for help without ever having taken a turn. Both schema drift guards in `test_privacy.py` caught this before I did.

**Pre-existing gap noticed, not fixed here** (#159): `message_feedback`, `credential_requests` and `wizard_sessions` are all in `PurgePreview` but rendered by neither adapter's cascade panel, so their counts are invisible to the user. This change matches that precedent rather than changing three unrelated rows' output inside a feature PR.

## Deploying it

Set `DAIMON_SUPPORT__ESCALATION_CHANNEL_ID` to the channel the team watches. `DAIMON_SUPPORT__CREDITS_PER_USER` defaults to 3. Both are config, so changing the allowance or turning the feature off is not a code change.

## Verification

Full suite green, `pyright` 0 errors project-wide, `lint-imports` 7/7 contracts kept, all pre-commit gates green, 10/10 CI checks passing. Migration `0012` applied against a real database and confirmed at head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUzSCHR516E2S6GJsKNKHE