### PR TITLE
fix(core): derive reader variants without the source's MCP servers

### DIFF
--- a/packages/core/daimon/core/reader_agent.py
+++ b/packages/core/daimon/core/reader_agent.py
@@ -25,9 +25,6 @@ from typing import cast
 
 from anthropic import AsyncAnthropic
 from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsSkillParams
-from anthropic.types.beta.beta_managed_agents_url_mcp_server_params import (
-    BetaManagedAgentsURLMCPServerParams,
-)
 from daimon.core.defaults.ma_index import find_agent_by_daimon_tag, find_agents_by_daimon_tag
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_READER_OF,
@@ -162,10 +159,11 @@ async def ensure_reader_variant(
         # create-params shape rejects, and a reader has no use for the
         # source's toolset overrides anyway.
         tools=None,
-        mcp_servers=cast(
-            "list[BetaManagedAgentsURLMCPServerParams] | None",
-            [server.model_dump(mode="json") for server in source_ma.mcp_servers] or None,
-        ),
+        # Likewise the source's MCP servers are not carried over: a reader has
+        # none by construction, and a spec that names servers without their
+        # paired toolset (which is exactly what the source looks like once its
+        # tools are dropped) fails the spec's own validator.
+        mcp_servers=None,
         skills=source_skills,
     )
     reader_spec = derive_reader_spec(source_spec)

--- a/packages/core/tests/test_reader_agent.py
+++ b/packages/core/tests/test_reader_agent.py
@@ -426,14 +426,16 @@ async def test_ensure_reader_variant_raises_for_unknown_source() -> None:
         )
 
 
-async def test_ensure_reader_variant_ignores_the_source_toolset_shape() -> None:
+async def test_ensure_reader_variant_ignores_the_source_toolset_and_servers() -> None:
     """A live agent's toolset carries per-config fields the create shape rejects.
 
     Managed Agents returns each toolset config entry with a ``type`` next to
     its ``name`` (and ``enabled`` / ``permission_policy`` filled in). Feeding
     that back into an agent spec fails validation, which is exactly what
-    happened on the first live publish. The reader must be created from the
-    base toolset alone, whatever the source carries.
+    happened on the first live publish. The same live agent also names the
+    daimon-mcp server, and once its tools are gone a spec that names a server
+    without its toolset fails the spec's own rule. The reader must be created
+    from the base toolset alone, with no servers, whatever the source carries.
     """
     source = _source_agent_dict(id_="ag_src", spec_hash="src-hash-1")
     source["tools"] = [
@@ -450,6 +452,9 @@ async def test_ensure_reader_variant_ignores_the_source_toolset_shape() -> None:
                 for name in ("bash", "read", "edit", "grep", "glob", "write")
             ],
         }
+    ]
+    source["mcp_servers"] = [
+        {"type": "url", "name": "daimon-mcp", "url": "https://mcp.example.test/mcp"}
     ]
     router = _router([source])
     created: dict[str, Any] = {}
@@ -474,4 +479,7 @@ async def test_ensure_reader_variant_ignores_the_source_toolset_shape() -> None:
     )
     assert tools[0]["default_config"]["permission_policy"] == {"type": "always_allow"}, (
         "readers run headless, so the dump step must inject always-allow"
+    )
+    assert "mcp_servers" not in created or not created["mcp_servers"], (
+        "a reader must be created with no MCP servers, whatever the source names"
     )


### PR DESCRIPTION
## What broke

After #157 the reader derivation no longer round-trips the source agent's toolset, but it still copied the source's MCP server list. The spec model requires a paired `mcp_toolset` for every named server, so building the source spec failed with `agent declares mcp_servers but no matching mcp_toolset entry in tools` on the very next live publish.

## Fix

A reader variant carries no MCP servers by construction, so the derivation leaves `mcp_servers` unset as well. The reader is created from the base toolset alone, with no servers, whatever the source agent looks like.

## Proof

- The regression test now builds the source agent with both live-shape fields the real publish tripped on: a toolset whose config entries carry `type`, and a `daimon-mcp` server entry. It fails against the previous module and passes with this change.
- Full reader-agent suite green; pyright, ruff and import-linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJPPkRT2D8mdGA95jKXoNW