### PR TITLE
fix(report-host): coerce budget strings before formatting the meter

### DIFF
--- a/apps/report-host/src/report_host/viewer/app.js
+++ b/apps/report-host/src/report_host/viewer/app.js
@@ -47,7 +47,9 @@ function applyState(s) {
   state = s;
   $("title").textContent = s.title;
   if (s.recipient_name) $("reader").textContent = `Reading as ${s.recipient_name}`;
-  const b = s.budget, frac = b.cap_usd ? Math.min(1, b.spent_usd / b.cap_usd) : 1;
+  // Money arrives as decimal strings (the API never emits floats for it); coerce once.
+  const b = { spent_usd: Number(s.budget.spent_usd), cap_usd: Number(s.budget.cap_usd), reserve_usd: Number(s.budget.reserve_usd) };
+  const frac = b.cap_usd ? Math.min(1, b.spent_usd / b.cap_usd) : 1;
   $("meter").innerHTML = `Question budget · $${b.spent_usd.toFixed(2)} of $${b.cap_usd.toFixed(2)} · up to $${b.reserve_usd.toFixed(2)} per answer` +
     `<div class="bar"><div class="fill ${frac >= 1 ? "over" : frac >= 0.75 ? "warn" : ""}" style="width:${(frac * 100).toFixed(0)}%"></div></div>`;
   const banner = $("banner");


### PR DESCRIPTION
## What broke

Opening a recipient link showed the title and sidebar but no PDF, and asking a question never produced an answer. The state API serialises money as decimal strings; the viewer called `toFixed` on them directly. That exception fired inside the state handler, before the PDF was requested or the thread list drawn, and again on every poll after an ask.

## Fix

Coerce the three budget fields to numbers once and format from those. Two lines in the viewer script; no server change.

## Proof

Headless Chromium on a live staging room before the fix: `b.spent_usd.toFixed is not a function` in the page text, zero canvases. The same run after deploy is the acceptance check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJPPkRT2D8mdGA95jKXoNW