### PR TITLE
feat(mcp): name the conversation kind on Slack channel rows

### DIFF
--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_models.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict
+
+SlackConversationType = Literal["public_channel", "private_channel", "im", "mpim"]
 
 
 class SlackChannelRow(BaseModel):
     id: str
     name: str
+    type: SlackConversationType
+    # Group DMs and 1:1 DMs are is_private on the wire too; ``type`` is what
+    # separates them from a private channel.
     is_private: bool
     topic: str | None = None
     num_members: int | None = None

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_read.py
@@ -36,6 +36,7 @@ from daimon.adapters.mcp.tools.slack._leak_policy import (
 from daimon.adapters.mcp.tools.slack._models import (
     SlackChannelResult,
     SlackChannelRow,
+    SlackConversationType,
     SlackMessageRow,
     SlackThreadResult,
 )
@@ -71,6 +72,28 @@ def _slack_error_code(err: SlackApiError) -> str:
 def _is_im(channel: dict[str, Any]) -> bool:
     """True when the source is a 1:1 direct message."""
     return bool(channel.get("is_im"))
+
+
+def _conversation_type(channel: dict[str, Any]) -> SlackConversationType:
+    if channel.get("is_im"):
+        return "im"
+    if channel.get("is_mpim"):
+        return "mpim"
+    if channel.get("is_private"):
+        return "private_channel"
+    return "public_channel"
+
+
+def _to_channel_row(ch: dict[str, Any]) -> SlackChannelRow:
+    topic = cast(dict[str, Any], ch.get("topic") or {})
+    return SlackChannelRow(
+        id=str(ch["id"]),
+        name=str(ch.get("name", "")),
+        type=_conversation_type(ch),
+        is_private=bool(ch.get("is_private")),
+        topic=str(topic["value"]) if topic.get("value") else None,
+        num_members=int(ch["num_members"]) if ch.get("num_members") else None,
+    )
 
 
 async def _gate_user_source(
@@ -188,16 +211,7 @@ async def _slack_list_channels_impl(  # pyright: ignore[reportUnusedFunction]  #
             # their contents: only surfaced when the destination is a DM.
             if _is_im(ch) and not is_dm_destination(destination):
                 continue
-            topic = cast(dict[str, Any], ch.get("topic") or {})
-            rows.append(
-                SlackChannelRow(
-                    id=str(ch["id"]),
-                    name=str(ch.get("name", "")),
-                    is_private=bool(ch.get("is_private")),
-                    topic=str(topic["value"]) if topic.get("value") else None,
-                    num_members=int(ch["num_members"]) if ch.get("num_members") else None,
-                )
-            )
+            rows.append(_to_channel_row(ch))
         return rows
 
     # Bot path: unchanged shipped behavior (bot's channels ∩ caller visibility).
@@ -223,16 +237,7 @@ async def _slack_list_channels_impl(  # pyright: ignore[reportUnusedFunction]  #
             is_member=str(ch["id"]) in user_channel_ids,
         ):
             continue
-        topic = cast(dict[str, Any], ch.get("topic") or {})
-        rows.append(
-            SlackChannelRow(
-                id=str(ch["id"]),
-                name=str(ch.get("name", "")),
-                is_private=bool(ch.get("is_private")),
-                topic=str(topic["value"]) if topic.get("value") else None,
-                num_members=int(ch["num_members"]) if ch.get("num_members") else None,
-            )
-        )
+        rows.append(_to_channel_row(ch))
     return rows
 
 

--- a/packages/adapters/mcp/tests/tools/test_slack_read.py
+++ b/packages/adapters/mcp/tests/tools/test_slack_read.py
@@ -291,6 +291,10 @@ async def test_list_channels_omits_private_channels_user_is_not_in(
     assert {r.id for r in rows} == {"C_PUB", "C_PRIV_IN"}, (
         "private channels the caller is not in must be silently omitted"
     )
+    assert {r.id: r.type for r in rows} == {
+        "C_PUB": "public_channel",
+        "C_PRIV_IN": "private_channel",
+    }, "bot-path rows carry the conversation type as well"
 
 
 @pytest.mark.asyncio
@@ -1120,6 +1124,43 @@ async def test_list_channels_user_path_dm_destination_shows_public_private_and_i
     assert {r.id for r in rows} == {"C_PUB", "C_PRIV", "D_IM", "G_MPIM"}, (
         "DM destination should permit listing all private-ish entries too"
     )
+
+
+@pytest.mark.asyncio
+async def test_list_channels_rows_carry_conversation_type(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A group DM is is_private on the wire; only ``type`` tells it apart from a private channel."""
+    runtime = await _make_runtime(committing_sessionmaker)
+    auth = _auth()
+    await _seed_user_token(runtime, committing_sessionmaker)
+    await _seed_turn_context(committing_sessionmaker, auth, channel_id="D_DEST")
+    with aioresponses() as m:
+        m.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_CONVERSATIONS,
+            payload={
+                "ok": True,
+                "channels": [
+                    {"id": "C_PUB", "name": "general", "is_private": False},
+                    {"id": "C_PRIV", "name": "sekret", "is_private": True},
+                    {"id": "D_IM", "name": "", "is_im": True, "is_private": True},
+                    {
+                        "id": "G_MPIM",
+                        "name": "mpdm-alice--bob--carol-1",
+                        "is_mpim": True,
+                        "is_private": True,
+                    },
+                ],
+                "response_metadata": {"next_cursor": ""},
+            },
+        )
+        rows = await _slack_list_channels_impl(runtime, auth)
+    assert {r.id: r.type for r in rows} == {
+        "C_PUB": "public_channel",
+        "C_PRIV": "private_channel",
+        "D_IM": "im",
+        "G_MPIM": "mpim",
+    }, "type must follow Slack's conversation kinds, not the is_private flag"
 
 
 def _recorded_limit(m: aioresponses, path: str) -> str:


### PR DESCRIPTION
## Summary

`list_channels` on Slack returns every conversation the caller belongs to once their user token is connected, including group DMs. Until now a row carried only `id`, `name`, `is_private`, `topic` and `num_members`. A group DM is `is_private: true` on the wire just like a private channel, so the agent could only identify one by the `mpdm-` prefix and the `--`-joined usernames in the name string. This came up while QA'ing MPIM support on daimon-qa: the daimon reported the shape "has no type enum, so MPIMs are only identifiable by the name".

Each `SlackChannelRow` now carries `type`, one of Slack's own conversation kinds: `public_channel`, `private_channel`, `im`, `mpim`. The mapping is one function shared by the user-token and bot-token listing paths. The Discord `ChannelRow` already has a `type` field, so this brings the two rows in line.

Additive change to the tool's return shape; no existing field moves or changes meaning.

## Checklist

- [x] Tests added or updated for any behavior change — a user-path test asserts all four kinds, and the bot-path test asserts `type` on its rows
- [x] `uv run pytest` passes locally — `packages/adapters/mcp` suite
- [x] `uv run pyright` passes locally (strict mode)
- [x] `uv run ruff check .` is clean
- [x] `uv run lint-imports` passes (package boundary contracts)
