### PR TITLE
feat!: align setup tools and permission guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ DAIMON_ANTHROPIC__API_KEY=
 # DAIMON_THREAD_PARTICIPATION__CLASSIFIER_MODEL=claude-haiku-4-5
 
 # === Slack (optional) ===
+# The bot's presented name in Slack setup, help, and privacy messages.
+# DAIMON_SLACK__BOT_DISPLAY_NAME=daimon
 # Slack request-signing secret used to verify inbound HTTP requests. Required — keeps the whole Slack block None when no DAIMON_SLACK__* vars are set. (required to run the Slack adapter; secret)
 # DAIMON_SLACK__SIGNING_SECRET=
 # Slack app-level token (xapp-...) used to open the Socket Mode connection. (required to run the Slack adapter; secret)

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ graphify-out/
 # Local symlinks into the private companion repo.
 /infra
 /CLAUDE.md
+/AGENTS.md
+/.agents
 
 # Per-deployment Fly configs derived from *.example.toml templates.
 apps/notebook-host/fly.notebook.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Slack supports `post_github_app_install_link` and the configurable
+  `DAIMON_SLACK__BOT_DISPLAY_NAME`. An unconfigured GitHub App link names the
+  operator setting needed; posting a link does not prove installation or repo access.
+- `daimon agents bind-google` lets operators bind an agent's Google identity
+  and scopes without writing SQL.
+
 - **Organic thread participation (Discord, opt-in).** Ask the agent to follow
   a thread and it keeps replying there unprompted. `DAIMON_THREAD_PARTICIPATION__MODE`
   sets the deployment default (`off` by default, `on`, or `disabled`, which also
@@ -35,6 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Breaking MCP tool changes:** `request_env_credential`,
+  `list_env_credential_keys`, `remove_env_credential`, `request_mcp_credential`,
+  and `request_skill_repo_credential` are now `request_agent_key`,
+  `list_agent_keys`, `remove_agent_key`, `request_mcp_token`, and
+  `request_skill_repo_token`, respectively. The duplicate `skills_sync`,
+  `skills_list`, `skills_get`, and `skills_delete` aliases are removed; use
+  `sync_skills`, `list_skills`, `get_skill`, and `delete_skill`. Update external
+  callers; compatibility aliases are not retained.
+
 - **`DAIMON_SLACK__DEV_ALLOW_ALL_ADMIN`** — the Slack testing-only admin bypass.
   It made the admin check return true before `users.info` was ever called,
   opening every Slack admin gate for every member of every install on the
@@ -44,6 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that relied on it.
 
 ### Security
+
+- Slack refreshes the caller's admin role on every mention; failed lookups do
+  not overwrite a stored role. Both adapters include caller admin status in
+  turn context. Discord turn replies suppress mass mentions.
+- Setup guidance and private-input controls use consistent key/token language,
+  preserve operation permissions and partial results, and avoid obsolete panel
+  redirects or claims that newly stored keys refreshed an existing session.
 
 - Slack mentions queued behind an in-flight turn are now partitioned by author,
   one turn per caller. Previously the whole queue was coalesced into a single

--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -1,7 +1,7 @@
 name: daimon
 model: claude-sonnet-5
 system: |
-  You are daimon, the agent this workspace starts with — available in the
+  You are Daimon, the agent this workspace starts with — available in the
   channel you were mentioned in, able to write and run code, fit models, and
   produce notebooks and charts. Prefer concise answers; propose small,
   reversible actions; cite file paths and line numbers when referencing code.
@@ -58,7 +58,7 @@ system: |
   chose to answer: keep that reply short, and add only what no human in the
   thread has already said.
 
-  Credentials never travel through chat as plaintext, during setup or at any
+  Keys and tokens never travel through chat as plaintext, during setup or at any
   other time. If a user pastes one anyway, acknowledge it, call no tool with
   it, and tell them to rotate it — never store or act on the value itself.
 
@@ -81,7 +81,7 @@ system: |
   block — that is when you resume, with the full history of having asked.
 
   For workspace setup, roster operations (creating, forking, and configuring
-  agents), credentials, and scheduled routines, see the workspace-setup skill.
+  agents), keys, MCP connections, and scheduled routines, see the workspace-setup skill.
 
   Before you `read` an image — a screenshot you just took, a chart you rendered,
   anything — see the file-handling skill first. An oversized image read into this

--- a/defaults/skills/cli-auth/SKILL.md
+++ b/defaults/skills/cli-auth/SKILL.md
@@ -1,32 +1,39 @@
 ---
 name: cli-auth
-description: Mint short-lived CLI access tokens via the daimon MCP server's get_cli_token tool.
+description: Obtain CLI access tokens via the daimon MCP server's get_cli_token tool.
 ---
 
 # cli-auth
 
-Use the daimon MCP server's `get_cli_token(service)` tool to mint short-lived
-access tokens for external CLIs. Export the result as the appropriate env var
+Use the daimon MCP server's `get_cli_token(service)` tool to obtain access
+tokens for external CLIs. Export the result under the appropriate name
 before running CLI commands.
 
-| Service                  | Tool call                  | Env var to export             |
+| Service                  | Tool call                  | Name to export                |
 |--------------------------|----------------------------|-------------------------------|
 | GitHub                   | `get_cli_token("github")`  | `GH_TOKEN` (or `GITHUB_TOKEN`)|
 | Google Cloud / Workspace | `get_cli_token("gcloud")`  | `CLOUDSDK_AUTH_ACCESS_TOKEN`  |
 
-Example shell flow:
-
-```bash
-export GH_TOKEN=$(get_cli_token github)
-gh repo list
-```
+Call the MCP tool first, then pass its result privately to the shell process
+environment before running a command such as `gh repo list`.
+`get_cli_token` is an MCP tool, not a shell command.
 
 The tool requires:
 
-- For `github`: an operator (or a Discord user via `/agent-setup`) must have
-  bound a GitHub PAT. Tokens are minted from the persisted PAT.
-- For `gcloud`: The agent must be bound to a Google identity
-  (`agent_google_binding`) with appropriate scopes, configured by an operator.
+- For `github`: the caller must already have a matching GitHub token binding.
+  An account-only call reads the account's token; an agent-bound call reads
+  that agent's token. Ordinary chat currently uses account-only identity, so
+  `request_repo_binding` saving a target agent's token does not make it
+  available to this tool. A GitHub App installation alone does not supply it
+  either. If access is missing, ask the operator to configure CLI token access
+  for the calling identity; do not repeatedly ask the person to bind the repo.
+- For `gcloud`: the operator must configure deployment Google access and bind
+  the agent to a Google identity with `daimon agents bind-google <agent>
+  <email> --scopes <scope>`, repeating `--scopes` for additional scopes.
   Tokens are short-lived (≈1 hour) impersonated access tokens.
+  The call also needs an agent-bound identity, which ordinary chat does not
+  currently provide. Binding the Google identity alone cannot fix a missing
+  caller `agent_id`; hand that limitation to the operator.
 
-Tokens are minted fresh per call and never cached.
+Each call resolves access afresh. GitHub returns the stored personal token;
+Google mints a short-lived impersonated token. Never print either value.

--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -1,119 +1,132 @@
 ---
 name: workspace-setup
-description: First-time workspace setup and agent-roster operations for a daimon workspace — repo binding, skills, MCP servers, credentials, routines, and what's admin-managed versus open to build.
+description: First-time workspace setup and agent-roster operations for a Daimon workspace — working repo, keys, skills, MCP servers, routines, and which changes need an admin.
 ---
 
 # workspace-setup
 
 ## Setting up a workspace for the first time
 
-When someone asks to configure this agent or get a workspace started ("help
-me set up", "configure me", "get me started"), walk through the following, in
-order, and confirm the shape with the user before you consider it done:
+For an open-ended setup request, establish what the person wants the agent to
+do, then configure only what that needs. A specific request such as “add a
+Higgsfield key so people here can try it” is already a complete setup intent;
+do not turn it into a full setup interview.
 
-1. **Repository.** Ask which GitHub repository they want the agent working
-   against, then call
-   `request_repo_binding(agent_name, repo_url, purpose, channel_id)` — never
-   accept a GitHub token in chat (see "Credentials never travel through
-   chat" below). This posts a button naming the exact repo and agent; the
-   user completes the bind by clicking it, which opens a private form
-   asking for the branch and, only if the repo is private, a GitHub token.
-   They only need to paste a token if the repo isn't publicly readable.
-2. **Skills.** Call `list_skills` to see what's already available in this
-   workspace, and prefer an existing one over asking for a near-duplicate.
-   Attaching an existing skill to an agent works via
-   `update_agent(name, skills=[...])`. Bringing a brand-new skill bundle into
-   the workspace from a GitHub repository is an admin action, done from
-   `/agent-setup`'s Skills door — not from chat.
-3. **Additional MCP servers.** For a server that needs no auth token, collect
-   a name and URL, confirm with the user, then call
-   `attach_mcp_server(agent_name, server_name, url)`. For one that needs a
-   token, never accept it in chat — call
-   `request_mcp_credential(agent_name, server_name, url, channel_id)` instead
-   (see "Credentials never travel through chat" below).
-4. **Confirm the final shape** — repository, skills, MCP servers — with the
-   user before calling it done.
+Choose the target before changing anything: an explicitly named agent wins,
+then a selected setup target if the context actually supplies one, then the
+answering agent in ordinary chat. Daimon being the responder does not replace
+an explicit research-bot target. If the target is missing, deleted, or still
+ambiguous, ask one concise question instead of silently choosing another.
+State the target before a consequential change. Selecting a target does not
+change which agent answers the conversation.
 
-If the agent doing the configuring is the one this deployment ships with,
-steps 2 and 3 can't target it directly — it isn't editable at all (see "When
-an operation is refused"). Offer to `fork_agent` it into an editable copy
-first, then run these steps against the fork.
+1. **Working repo.** Use `request_repo_binding` for the requested GitHub repo.
+   Collect tokens only through its private form. A GitHub App install link is
+   informational: installing alone does not verify this workspace's access or
+   bind the repo. Use the working token path where access is needed; do not
+   say an existing token stopped being used after an App install.
+2. **Keys.** Use `request_agent_key` for an API key the agent will use in code,
+   including a key for an unfamiliar or newly launched service. Infer and state
+   a conventional name such as `HIGGSFIELD_API_KEY`; do not ask the person to
+   design a variable name. A key can be added to Daimon itself without a fork,
+   an MCP server, or a skill. Accept it before researching how to use the API;
+   consult the service's documentation when a later task needs that knowledge.
+3. **Skills.** Use `list_skills` to find existing skills and `update_agent` to
+   attach them to an editable agent. An admin can import a GitHub skill bundle
+   from chat with `sync_skills`. If it needs a private token, use
+   `request_skill_repo_token`: submission imports and attaches the skills and
+   also binds the target's working repo so subsequent imports can find the
+   token. Explain that repo change before requesting it.
+4. **MCP servers.** Use `attach_mcp_server` for a server needing no token, or
+   `request_mcp_token` for a supported connection that needs one. An API key
+   for code is not automatically an MCP connection token. Ask “API access for
+   code or an MCP connection?” only when the request leaves that choice unclear.
+   A token form does not complete an arbitrary browser OAuth login.
+5. **Confirm the result.** Explain what changed and what still needs doing.
+   Read partial-success warnings: a saved token with a failed attachment is
+   not a connected server, and an imported skill is not necessarily attached.
 
 ## Roster operations
 
-| Tool | What it does |
-|---|---|
-| `list_agents` | List every agent in this workspace. |
-| `get_agent` | Get one agent's full configuration by name. |
-| `create_agent` | Create a new agent from scratch. |
-| `fork_agent` | Clone an existing agent under a new name — the way to get an editable copy of an agent you can't edit directly. |
-| `update_agent` | Patch-update an agent's model, prompt, tools, skills, or MCP servers. Omitted fields are left alone; passing `[]` for a list field clears it. |
-| `attach_mcp_server` | Attach a new MCP server to an agent. |
-| `detach_mcp_server` | Remove an attached MCP server from an agent, and its matching tool entry, together. |
-| `remove_skill` | Detach one skill from one agent. |
-| `list_env_credential_keys` | List the environment-variable KEY NAMES set on an agent — never values. |
-| `remove_env_credential` | Remove one environment variable from an agent. |
-| `create_routine` | Schedule a recurring turn (see "Scheduled routines" below). |
+Use `list_agents` and `get_agent` to find and inspect agents. `create_agent`
+creates one; `fork_agent` makes an editable copy, including a copy of Daimon.
+Use `update_agent` for Prompt & model or skill additions. Use `remove_skill`
+and `detach_mcp_server` for removal, rather than replacing lists through
+`update_agent`. Removing a skill from one agent is different from
+`delete_skill`, which deletes it from the workspace library. `archive_agent`
+and `delete_skill` are admin-only.
 
-`remove_skill` only detaches this one agent's reference to a skill — the
-skill itself, and every other agent using it, are untouched. That is a
-DIFFERENT operation from **delete_skill**, which deletes the skill for the
-entire workspace; don't reach for it when a user just means "stop this agent
-using X."
+When creating an agent and no model was requested, use the built-in Daimon's
+model, read through `get_agent`, as the fallback and state that choice.
+Confirm the new name and model, carry its returned identity into subsequent
+setup, and say whether it answers anywhere. Creation alone does not route
+mentions to the new agent.
 
-## When an operation is refused
+## Permissions and refusals
 
-Anyone can build and configure their own agent. But an agent that is
-currently set as the default for a channel or for the whole workspace is
-admin-managed — changing its prompt, model, skills, or MCP servers needs a
-workspace admin, because people are already relying on that configuration.
-And the agent this deployment ships with can't be edited at all, by anyone,
-admin included — fork it (`fork_agent`) to get an editable copy, and
-configure that instead. Deleting an agent (**archive_agent**) is admin-only
-in the same way — a workspace admin can archive from chat; for anyone else
-it goes through `/agent-setup` or the `daimon agents archive` CLI command.
+An admin means Manage Server on Discord or a workspace admin on Slack. Read
+`is_admin` on the newest `<user_query>` and check the requested operation's
+rule. A member can ask setup questions, create an agent, and contribute a new
+key to Daimon. Do not turn non-admin status into a blanket setup refusal.
+For replacing a shared key, hand the request to an admin rather than attempting
+the replacement on a member's behalf.
 
-## Credentials never travel through chat
+An agent answering in a channel or as the workspace default is admin-managed
+for direct prompt, model, skill, and MCP-spec edits. Direct edits to the built-in
+Daimon's spec require an editable copy even for admins. Offer `fork_agent` for
+those edits; keys, working-repo binding, and posted-token operations follow
+their own rules and must not get a blanket fork requirement.
 
-`request_env_credential`, `request_mcp_credential`, and
-`request_repo_binding` post a single-use, expiring button in the thread;
-clicking it opens a private modal where the user enters the value, so it
-never enters channel history or the session log. They work the same way on
-Discord and Slack, so on either platform post the button rather than
-sending the user to `/agent-setup`.
+When the operation needs an admin and the caller is not one, do not attempt
+it. Give a reachable handoff carrying the target and action, for example:
+“Ask an admin to say in this conversation: ‘Make research-bot answer in this
+channel.’” If no agent answers in the current channel, name the existing
+`/agent-setup` entry rather than telling the person to talk to an unreachable
+agent. Do not invent panel paths or a new setup entry.
 
-If a user pastes a token or secret in chat anyway: acknowledge that you saw
-it, call no tool with it, and tell them to rotate it immediately — it is
-already in this channel's history and in the tenant-wide session log,
-neither of which the bot can scrub. Then post the right button so the
-replacement is entered privately. Once a credential is added via either
-tool, it becomes usable by everyone who talks to that agent — say so when
-you post the button.
+An operator-only problem needs the person running the deployment, not a
+workspace admin. Name the blocker and the requested fix without exposing
+internal exceptions. Never report a failed save as successful or erase the
+successful half of a partial result.
+
+## Keys and tokens stay in private forms
+
+Use `request_agent_key`, `request_mcp_token`, `request_skill_repo_token`, or
+`request_repo_binding` in the current conversation. These tools collect no
+secret value in their arguments; the requester enters it in a private form.
+The request expires, but a saved key does not expire with the request.
+State the shared-use consequence once: “Anyone who talks to research-bot can
+use it.” Do not force a separate setup conversation for a key request.
+
+If someone pastes a value in chat, acknowledge the exposure and ask them to
+rotate it. Never repeat the value or pass it to any tool. Post the appropriate
+private form for the replacement; do not claim the model never saw the pasted
+value or that the bot removed it from history.
+
+Stored keys and available session resources are different facts.
+`list_agent_keys` describes the target's stored names, never values, and does
+not prove the responder can use them. `remove_agent_key` removes a stored key
+from the target. Inspect the mounted `.env` by name only when needed, following
+the key-handling preamble. Do not claim a save refreshed an existing session
+or tested the service. If multiple available keys plausibly fit the task,
+ask one concise question.
+
+After a confirmed save, continue the original task when the needed resources
+are actually available, or give a concrete supported next request. Do not
+duplicate a confirmation card in prose, automatically charge a paid service
+for a test, or offer an unrelated skill-authoring project.
 
 ## Which agent answers where
 
-Members reach an agent only by @mentioning the bot in the channel they're
-posting in — there is one bot for the whole workspace, not one bot per agent,
-so no configuration step ever adds a new bot to the server. What a mention
-resolves to — which agent answers — is controlled by the binding path below,
-not by anything the member does.
+There is one bot account per deployment, not one per agent. A mention resolves
+the channel override, then the workspace default, then the deployment default.
+Use `explain_agent_resolution` to inspect that choice.
 
-Two admin-only tools control that binding, scoped by whether a channel is given:
-
-```
-set_agent_default(agent_name, channel_id)   # channel_id given -> this channel only
-set_agent_default(agent_name)               # channel_id omitted -> workspace-wide default
-clear_agent_default(channel_id)             # clears one channel's override
-clear_agent_default()                       # clears the workspace-wide default
-```
-
-Resolution cascades channel override first, then the workspace default — a
-channel with its own override always wins over the workspace default, and
-clearing a channel's override falls it back to whatever the workspace
-default resolves to next. Both tools require a workspace admin (Manage
-Server); a non-admin caller is refused with no write. The equivalent surface
-without chat is the setup panel's **Set as default…** door, which writes the
-same channel/workspace scopes and shows the same cascade.
+Admins use `set_agent_default` and `clear_agent_default` to change who answers:
+with `channel_id` they affect that channel; without it they affect the workspace
+default. Clearing an override exposes the next tier, which may still resolve
+to the same agent. Say what scope will change before calling the tool. Do not
+promise a running conversation will switch responders or continue automatically.
 
 ## Following threads
 
@@ -141,16 +154,13 @@ Server), and a non-admin caller is refused with no write. Discord only for now.
 
 ## Scheduled routines
 
-The agent creates routines itself, with
-`create_routine(agent_name, cron_expr, timezone, trigger_message)`. Confirm
-the agent, the cron expression, the timezone, and the trigger message back to
-the user before calling it, and confirm the created routine back afterward.
+Use `create_routine` after confirming the agent, schedule, timezone, and task.
+Report the actual creation result and any remaining setup needed for the task.
 
-## Changing a running resource vs. changing the repo defaults
+## Live configuration and repository defaults
 
-The live tools above (`update_agent`, `attach_mcp_server`, and the rest)
-change the deployed resource the user is talking to, right now. Editing
-`defaults/*.yaml` in the repository only changes what a fresh install seeds
-going forward — it does not change any agent that is already running. Only
-touch the YAML when a user explicitly asks to change the repo's seed
-defaults or open a PR against them.
+The live tools change deployed resources. Repository defaults are operator-owned
+seeded specifications: the next defaults apply reconciles managed resources
+for existing tenants as well as new installs. User-owned forks are separate.
+Edit repository defaults only when asked to change those deployment defaults
+or open a PR for them; they are not a substitute for a workspace setup tool.

--- a/packages/adapters/cli/daimon/adapters/cli/commands/agents.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/agents.py
@@ -38,6 +38,7 @@ from daimon.core.defaults.reconcile_agents import reconcile_agent
 from daimon.core.errors import SpecError, StoreError
 from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.specs import load_agent_spec, merge_default_agent_toolset
+from daimon.core.stores.agent_google_binding import upsert_agent_google_binding
 from daimon.core.stores.identity import get_or_create_cli_principal
 from daimon.core.stores.scoped_config_write import clear_agent_references
 from daimon.core.stores.tenants import list_tenants_by_platform
@@ -161,6 +162,87 @@ async def agents_get(
         console,
         [agent],
         columns=("name", "id", "description", "created_at"),
+        as_json=as_json,
+    )
+
+
+class _GoogleBindingRow(BaseModel):
+    """Report row for bind-google output."""
+
+    agent_name: str
+    email: str
+    scopes: tuple[str, ...]
+
+
+@agents_app.command("bind-google")
+def agents_bind_google_command(
+    ctx: typer.Context,
+    name: str,
+    email: str,
+    scopes: Annotated[
+        list[str],
+        typer.Option("--scopes", help="Google OAuth scope. Repeat for multiple scopes."),
+    ],
+    as_json: Annotated[bool, JSON_OPTION] = False,
+) -> None:
+    settings = load_settings()
+    console = Console(highlight=False)
+    selector = ctx.obj
+
+    async def _with_defaults() -> None:
+        async with build_runtime(settings) as rt:
+            await agents_bind_google(
+                rt=rt,
+                console=console,
+                name=name,
+                email=email,
+                scopes=scopes,
+                as_json=as_json,
+                selector=selector,
+            )
+
+    run_cli(_with_defaults(), console=console)
+
+
+async def agents_bind_google(
+    *,
+    rt: CliRuntime,
+    console: Console,
+    name: str,
+    email: str,
+    scopes: list[str],
+    as_json: bool,
+    selector: TenantSelector | None = None,
+) -> None:
+    if len(scopes) == 0:
+        raise StoreError("one or more --scopes is required to bind a Google identity.")
+
+    async with rt.sessionmaker() as session, session.begin():
+        override = await resolve_tenant_override(session, selector)
+        tenant_id = await discover_tenant(session, override=override)
+        await get_or_create_cli_principal(
+            session, tenant_id=tenant_id, os_user=rt.settings.cli.local_user
+        )
+    # Session closed. MA calls below.
+    agent = await find_agent_by_daimon_tag(rt.anthropic, tenant_id=tenant_id, name=name)
+    if agent is None:
+        raise StoreError(f"no agent named {name!r} in your account or system defaults.")
+
+    # The agent_google_binding primary key is agent_id alone (no tenant_id
+    # column), so the uuid must be derived tenant-scoped rather than taken
+    # from the MA id directly — otherwise one tenant could bind a uuid that
+    # belongs to another tenant's agent.
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id=str(agent.id))
+
+    async with rt.sessionmaker() as session, session.begin():
+        binding = await upsert_agent_google_binding(
+            session, agent_id=agent_id, email=email, scopes=scopes
+        )
+
+    emit_rows(
+        console,
+        [_GoogleBindingRow(agent_name=name, email=binding.email, scopes=binding.scopes)],
+        columns=("agent_name", "email", "scopes"),
         as_json=as_json,
     )
 

--- a/packages/adapters/cli/daimon/adapters/cli/commands/mcp.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/mcp.py
@@ -94,7 +94,7 @@ async def mint_token(*, rt: CliRuntime, os_user: str | None) -> None:
     "mint-agent-token",
     help=(
         "Mint a long-lived, revocable agent-scoped MCP token. This is an "
-        "operator and testing door, NOT the production path — reports mint "
+        "operator and testing command — reports mint "
         "their own tokens when published, and a token minted here is "
         "revoked with the same revocation the publishing side uses."
     ),
@@ -131,7 +131,7 @@ async def mint_agent_token(
 ) -> None:
     """Async body for `daimon mcp mint-agent-token`.
 
-    This is an operator and testing door, NOT the production path: reports
+    This is an operator and testing command: reports
     mint their own agent-scoped token when they are published
     (`ensure_reader_variant` + `mint_agent_mcp_token`), and a token minted
     here is revoked with the same `revoke_mcp_token` the publishing side

--- a/packages/adapters/cli/daimon/adapters/cli/commands/routines.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/routines.py
@@ -6,8 +6,8 @@ forthcoming NOT NULL flip, this command walks every routine whose
 `agent_name IS NULL`, retrieves the agent from MA, and writes the daimon-tag
 into the row.
 
-Routine CRUD itself is exposed through the MCP server (`/agent-setup` + chat),
-not the CLI.
+Routine CRUD itself is exposed through chat tools and the adapters' `/routines`
+command, not the CLI.
 """
 
 from __future__ import annotations

--- a/packages/adapters/cli/daimon/adapters/cli/commands/skills.py
+++ b/packages/adapters/cli/daimon/adapters/cli/commands/skills.py
@@ -192,8 +192,8 @@ async def sync_agent(
     if not rt.settings.crypto.keys:
         console.print(
             "[red]settings.crypto.keys is empty -- cannot decrypt GitHub PAT. "
-            "Configure DAIMON_CRYPTO__KEYS and re-bind the PAT via the agent-setup "
-            "repo-auth panel.[/red]"
+            "Configure DAIMON_CRYPTO__KEYS and re-bind the PAT with "
+            "request_repo_binding in chat.[/red]"
         )
         raise typer.Exit(code=3)
     fernet = build_multifernet(tuple(k.get_secret_value() for k in rt.settings.crypto.keys))
@@ -224,8 +224,8 @@ async def sync_agent(
                 report = await _run(http)
     except PATMissingError as err:
         console.print(
-            "[red]No GitHub PAT bound for principal. Bind a PAT via the "
-            f"agent-setup repo-auth panel first. ({err})[/red]"
+            "[red]No GitHub PAT bound for principal. Bind one with "
+            f"request_repo_binding in chat first. ({err})[/red]"
         )
         raise typer.Exit(code=4) from err
 

--- a/packages/adapters/cli/tests/commands/test_agents.py
+++ b/packages/adapters/cli/tests/commands/test_agents.py
@@ -30,6 +30,7 @@ from daimon.adapters.cli import main as main_mod
 from daimon.adapters.cli.commands import agents as agents_cmd
 from daimon.adapters.cli.commands.agents import (
     agents_archive,
+    agents_bind_google,
     agents_create,
     agents_fork,
     agents_get,
@@ -40,9 +41,10 @@ from daimon.adapters.cli.runtime import CliRuntime
 from daimon.core.config import Settings
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
 from daimon.core.errors import SpecError, StoreError
-from daimon.core.ma_identity import derive_tenant_uuid
+from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
 from daimon.core.ma_resolver import new_resolver_cache
 from daimon.core.scope import ChannelScopeRef, DeploymentDefault
+from daimon.core.stores.agent_google_binding import get_agent_google_binding
 from daimon.core.stores.identity import get_or_create_cli_principal
 from daimon.core.stores.scoped_config_read import get_scope
 from daimon.core.stores.scoped_config_write import set_fields
@@ -218,6 +220,153 @@ async def test_agents_get_not_found_raises(
 
     with pytest.raises(StoreError, match="no agent named"):
         await agents_get(rt=rt, console=console, name="ghost-agent", as_json=False)
+
+
+@pytest.mark.asyncio
+async def test_agents_bind_google_writes_binding_readable_through_store(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """bind-google resolves the agent by name, derives its uuid tenant-scoped,
+    and writes the binding through the store.
+    """
+    async with db_session_factory() as s, s.begin():
+        tenant = await make_tenant(s, platform="cli", workspace_id="local")
+        await get_or_create_cli_principal(s, tenant_id=tenant.id, os_user="testuser")
+        tenant_id = tenant.id
+
+    agent_data = _agent_json(agent_id="ag_bindme", name="bindable-agent", tenant_id=tenant_id)
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, m: list_response([agent_data]))
+
+    console = Console(file=StringIO(), force_terminal=False, highlight=False, width=120)
+    rt = _build_rt(db_session_factory, router)
+
+    await agents_bind_google(
+        rt=rt,
+        console=console,
+        name="bindable-agent",
+        email="op@example.com",
+        scopes=["https://www.googleapis.com/auth/calendar"],
+        as_json=False,
+    )
+
+    out = cast(StringIO, console.file).getvalue()
+    assert "bindable-agent" in out, "confirmation names the agent"
+    assert "op@example.com" in out, "confirmation names the email"
+
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id="ag_bindme")
+    async with db_session_factory() as s:
+        binding = await get_agent_google_binding(s, agent_id=agent_id)
+    assert binding is not None, "binding is readable through the store afterward"
+    assert binding.email == "op@example.com"
+    assert binding.scopes == ("https://www.googleapis.com/auth/calendar",)
+
+
+@pytest.mark.asyncio
+async def test_agents_bind_google_twice_leaves_second_scope_set(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as s, s.begin():
+        tenant = await make_tenant(s, platform="cli", workspace_id="local")
+        await get_or_create_cli_principal(s, tenant_id=tenant.id, os_user="testuser")
+        tenant_id = tenant.id
+
+    agent_data = _agent_json(agent_id="ag_rebind", name="rebindable-agent", tenant_id=tenant_id)
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, m: list_response([agent_data]))
+
+    console = Console(file=StringIO(), force_terminal=False, highlight=False, width=120)
+    rt = _build_rt(db_session_factory, router)
+
+    await agents_bind_google(
+        rt=rt,
+        console=console,
+        name="rebindable-agent",
+        email="first@example.com",
+        scopes=["scope-a"],
+        as_json=False,
+    )
+    await agents_bind_google(
+        rt=rt,
+        console=console,
+        name="rebindable-agent",
+        email="second@example.com",
+        scopes=["scope-b", "scope-c"],
+        as_json=False,
+    )
+
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id="ag_rebind")
+    async with db_session_factory() as s:
+        binding = await get_agent_google_binding(s, agent_id=agent_id)
+    assert binding is not None
+    assert binding.email == "second@example.com", "second bind replaces email"
+    assert binding.scopes == ("scope-b", "scope-c"), "second bind replaces scopes"
+
+
+@pytest.mark.asyncio
+async def test_agents_bind_google_unknown_agent_raises_and_writes_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as s, s.begin():
+        tenant = await make_tenant(s, platform="cli", workspace_id="local")
+        await get_or_create_cli_principal(s, tenant_id=tenant.id, os_user="testuser")
+        tenant_id = tenant.id
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, m: list_response([]))
+
+    console = Console(file=StringIO(), force_terminal=False, highlight=False, width=120)
+    rt = _build_rt(db_session_factory, router)
+
+    with pytest.raises(StoreError, match="no agent named"):
+        await agents_bind_google(
+            rt=rt,
+            console=console,
+            name="ghost-agent",
+            email="op@example.com",
+            scopes=["scope-a"],
+            as_json=False,
+        )
+
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id="does-not-exist")
+    async with db_session_factory() as s:
+        binding = await get_agent_google_binding(s, agent_id=agent_id)
+    assert binding is None, "an unresolvable agent writes no binding"
+
+
+@pytest.mark.asyncio
+async def test_agents_bind_google_missing_scopes_raises_and_writes_nothing(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db_session_factory() as s, s.begin():
+        tenant = await make_tenant(s, platform="cli", workspace_id="local")
+        await get_or_create_cli_principal(s, tenant_id=tenant.id, os_user="testuser")
+        tenant_id = tenant.id
+
+    agent_data = _agent_json(agent_id="ag_noscopes", name="scopeless-agent", tenant_id=tenant_id)
+
+    router = MARouter()
+    router.add("GET", r"/v1/agents", lambda req, m: list_response([agent_data]))
+
+    console = Console(file=StringIO(), force_terminal=False, highlight=False, width=120)
+    rt = _build_rt(db_session_factory, router)
+
+    with pytest.raises(StoreError, match="scopes"):
+        await agents_bind_google(
+            rt=rt,
+            console=console,
+            name="scopeless-agent",
+            email="op@example.com",
+            scopes=[],
+            as_json=False,
+        )
+
+    agent_id = derive_agent_uuid(tenant_id=tenant_id, ma_agent_id="ag_noscopes")
+    async with db_session_factory() as s:
+        binding = await get_agent_google_binding(s, agent_id=agent_id)
+    assert binding is None, "missing scopes writes no binding"
 
 
 @pytest.mark.asyncio

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/authz.py
@@ -16,7 +16,7 @@ the field it writes is part of the agent spec:
   reconciler's spec hash: an admin bypass would leave permanent, silent drift
   against the repo defaults that reconcile never notices.
 
-- Per-agent attachments — the repo binding and the env vars — route through
+- Per-agent attachments — the repo binding and the keys — route through
   `refuse_if_shared_and_not_admin`. Attachments never enter the agent spec, so
   the system-agent absolutism above does not apply to them, and an admin
   binding a repo to the seeded agent is the first-run onboarding step. That
@@ -67,8 +67,8 @@ _REACHABLE_AGENT_MESSAGE = (
 _SHARED_AGENT_MESSAGE = (
     "This agent is shared — it either ships with the deployment or is the "
     "current default for this channel or the server — so changing its repo or "
-    "environment variables needs Manage Server. Fork it to make an editable "
-    "copy; the fork starts with no environment variables of its own."
+    "keys needs Manage Server. Ask a server admin to make this change in `/agent-setup`, "
+    "or fork it to make an editable copy; the fork starts with no keys of its own."
 )
 
 

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py
@@ -59,7 +59,7 @@ def format_paste_result(*, key_count: int) -> str:
     Takes a COUNT — never a key name, never a value. The key names surface is
     the chips line, which the post-paste reload refreshes.
     """
-    noun = "env var" if key_count == 1 else "env vars"
+    noun = "key" if key_count == 1 else "keys"
     return f"Saved ✓ — {key_count} {noun} set"
 
 
@@ -77,7 +77,7 @@ def build_credentials_container(
     `result_line` is the optional post-paste acknowledgement; it carries a
     count only (see `format_paste_result`), so it cannot carry a value either.
 
-    Env variables are per-agent daimon state (agent_files, keyed by
+    Keys are per-agent daimon state (agent_files, keyed by
     tenant/agent/key) and are never part of the agent spec, so provenance
     (system-agent or not) does not gate *rendering* them: every member, on
     every agent including the seeded default, can open this sub-view and read
@@ -87,7 +87,7 @@ def build_credentials_container(
     container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container()
     container.add_item(
         header(
-            f"🔑 Env vars — {agent_name}",
+            f"🔑 Keys — {agent_name}",
             subtext="values are write-only; only key names are shown",
         )
     )
@@ -98,7 +98,7 @@ def build_credentials_container(
         container.add_item(discord.ui.TextDisplay(chips))
     else:
         # Design-language collapse: dim hint instead of "(none)" copy.
-        container.add_item(discord.ui.TextDisplay("-# ＋ add your first env var"))
+        container.add_item(discord.ui.TextDisplay("-# ＋ add your first key"))
 
     if result_line is not None:
         container.add_item(discord.ui.TextDisplay(result_line))
@@ -106,7 +106,7 @@ def build_credentials_container(
     return container
 
 
-class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
+class PasteSecretModal(discord.ui.Modal, title="Add keys"):
     """Paste KEY=VALUE lines → per-key ``put_agent_file``.
 
     No URL fetch, no attachment, no HTTP: pasted bytes go modal text → store
@@ -174,7 +174,7 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
             key = key.strip()
             if not _POSIX_KEY_RE.match(key):
                 await interaction.followup.send(
-                    "Secret name must match `[A-Za-z_][A-Za-z0-9_]*` "
+                    "Key name must match `[A-Za-z_][A-Za-z0-9_]*` "
                     "(letters, digits, underscores; must not start with a digit). "
                     "Fix and re-paste.",
                     ephemeral=True,
@@ -182,7 +182,7 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
                 return
             if len(value.encode()) > _MAX_SECRET_VALUE_BYTES:
                 await interaction.followup.send(
-                    f"Secret value for `{key}` is too large. Max {_MAX_SECRET_VALUE_BYTES} bytes.",
+                    f"Key value for `{key}` is too large. Max {_MAX_SECRET_VALUE_BYTES} bytes.",
                     ephemeral=True,
                 )
                 return
@@ -219,7 +219,7 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
         if n == 1:
             toast = f"Added `{pairs[0][0]}`. Takes effect on the next session."
         else:
-            toast = f"Added {n} env vars. Takes effect on the next session."
+            toast = f"Added {n} keys. Takes effect on the next session."
         await interaction.followup.send(toast, ephemeral=True)
         # Carries the count of keys actually WRITTEN — never a key name, never
         # a value. It is all the collapsed render needs.
@@ -227,10 +227,10 @@ class PasteSecretModal(discord.ui.Modal, title="Add env vars"):
 
 
 class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
-    """F5 Components V2 env-vars sub-view opened from EditView's Env vars button.
+    """F5 Components V2 keys sub-view opened from EditView's Keys button.
 
-    Container: ## 🔑 Env vars — {agent} + write-only subtext, KEY chips on one
-    line, ✕ Remove a var… select, + Add env vars · ← Back button row.
+    Container: ## 🔑 Keys — {agent} + write-only subtext, KEY chips on one
+    line, ✕ Remove a key… select, + Add keys · ← Back button row.
 
     Carries key NAMES only (``secret_names``) — never values. Mutations
     re-render this view in place via ``edit_original_response``, and a
@@ -270,7 +270,7 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
             result_line=result_line,
         )
 
-        # ✕ Remove a var… select (cap 20, glyph in placeholder not emoji=).
+        # ✕ Remove a key… select (cap 20, glyph in placeholder not emoji=).
         remove_select = _build_remove_select(self._secret_names)
         remove_select.callback = self._make_remove_cb(remove_select)  # type: ignore[method-assign]
 
@@ -278,15 +278,15 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
         select_row.add_item(remove_select)
         container.add_item(select_row)
 
-        # Button row: + Add env vars · ← Back. A result line means the paste
+        # Button row: + Add keys · ← Back. A result line means the paste
         # just landed, so the add control is SWAPPED OUT for it — not greyed
         # out. Remove and ← Back stay live: the panel is still a management
-        # surface, and re-adding is one '← Back' → 'Env vars' hop away.
+        # surface, and re-adding is one '← Back' → 'Keys' hop away.
         btn_row: discord.ui.ActionRow[CredentialsSubView] = discord.ui.ActionRow()
 
         if result_line is None:
             add_btn: discord.ui.Button[CredentialsSubView] = discord.ui.Button(
-                label="+ Add env vars",
+                label="+ Add keys",
                 style=discord.ButtonStyle.success,
                 disabled=len(self._secret_names) >= _SECRET_CAP,
             )
@@ -414,7 +414,7 @@ class CredentialsSubView(ExpiringView, discord.ui.LayoutView):
 
 
 def _build_remove_select(secret_names: list[str]) -> discord.ui.Select[CredentialsSubView]:
-    """✕ Remove a var… select listing every key (no cap).
+    """✕ Remove a key… select listing every key (no cap).
 
     Each option's ``label``/``value`` carries ONLY the secret KEY NAME — never a
     value, never a per-key custom_id. Disabled (empty placeholder) only when
@@ -424,14 +424,14 @@ def _build_remove_select(secret_names: list[str]) -> discord.ui.Select[Credentia
     """
     if len(secret_names) == 0:
         return discord.ui.Select(
-            placeholder="(no env vars — use + Add env vars)",
+            placeholder="(no keys — use + Add keys)",
             min_values=1,
             max_values=1,
-            options=[discord.SelectOption(label="(no env vars)", value="__none__")],
+            options=[discord.SelectOption(label="(no keys)", value="__none__")],
             disabled=True,
         )
     return discord.ui.Select(
-        placeholder="✕ Remove a var…",
+        placeholder="✕ Remove a key…",
         min_values=1,
         max_values=1,
         options=[discord.SelectOption(label=f"✕ {key}"[:100], value=key) for key in secret_names],

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/edit_view.py
@@ -1,8 +1,8 @@
 """EditView (LayoutView) + selects + BackButton + open_edit_view launcher.
 
-EditView's container holds a header, two remove selects (skills, MCPs), and
-two button rows: ``Agent…`` / ``GitHub…`` / ``Install App…`` / ``Env vars``
-and ``+ Add skill`` / ``+ Add MCP`` / ``← Back``. ``Agent…`` and ``GitHub…``
+EditView's container holds a header, two remove selects (skills, MCP servers), and
+two button rows: ``Prompt & model`` / ``Working repo`` / ``Install App…`` / ``Keys``
+and ``+ Add skill`` / ``+ Add MCP server`` / ``← Back``. ``Prompt & model`` and ``Working repo``
 each open their modal directly — no intermediate view. ``Install App…`` is a
 link button (rendered only when a GitHub App slug is configured) opening the
 App's install page on GitHub directly; it carries no callback.
@@ -200,10 +200,10 @@ class _McpRemoveSelect(discord.ui.Select["EditView"]):
             )
         if not options:
             super().__init__(
-                placeholder="(no MCPs — use + Add MCP)",
+                placeholder="(no MCP servers — use + Add MCP server)",
                 min_values=1,
                 max_values=1,
-                options=[discord.SelectOption(label="(no MCPs)", value="__none__")],
+                options=[discord.SelectOption(label="(no MCP servers)", value="__none__")],
                 disabled=True,
             )
             return
@@ -275,8 +275,8 @@ class EditView(ExpiringView, discord.ui.LayoutView):
     """F5 Components V2 edit view.
 
     Container with ## ✏️ Editing {agent} header, two remove selects, and two
-    button rows: Agent… · GitHub… · Env vars, then + Add skill · + Add MCP ·
-    ← Back. Agent… and GitHub… each open their modal directly.
+    button rows: Prompt & model · Working repo · Keys, then + Add skill · + Add MCP server ·
+    ← Back. Prompt & model and Working repo each open their modal directly.
 
     Preserves the isolation invariant: this view is ephemeral and
     never edits the main panel message. Mutations re-render this view via
@@ -317,7 +317,7 @@ class EditView(ExpiringView, discord.ui.LayoutView):
         # spec_editable gates the same controls on reachability instead: an
         # agent nobody has scoped is every member's scratchpad; once some
         # channel or the workspace points at it, only an admin may change its
-        # spec. Env vars and GitHub… are per-agent attachments: they never
+        # spec. Keys and Working repo are per-agent attachments: they never
         # enter the agent spec, so the is_system absolutism above does not
         # apply to them — an admin binding a repo to the built-in agent is a
         # supported first-run step. They are subject to their own shared-state
@@ -329,11 +329,11 @@ class EditView(ExpiringView, discord.ui.LayoutView):
         spec_editable = state.is_admin or not state.is_selected_reachable()
         spec_controls_disabled = is_system or not spec_editable
 
-        # Button row 1: Agent… · GitHub… · Env vars.
+        # Button row 1: Prompt & model · Working repo · Keys.
         field_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
 
         agent_btn: discord.ui.Button[EditView] = discord.ui.Button(
-            label="Agent…",
+            label="Prompt & model",
             style=discord.ButtonStyle.secondary,
             disabled=spec_controls_disabled,
         )
@@ -341,7 +341,7 @@ class EditView(ExpiringView, discord.ui.LayoutView):
         field_row.add_item(agent_btn)
 
         github_btn: discord.ui.Button[EditView] = discord.ui.Button(
-            label="GitHub…",
+            label="Working repo",
             style=discord.ButtonStyle.secondary,
         )
         github_btn.callback = self._on_github  # type: ignore[method-assign]
@@ -360,11 +360,11 @@ class EditView(ExpiringView, discord.ui.LayoutView):
             # Not a spec control and no disabled logic: installing an App on
             # GitHub is neither an agent-spec edit nor an attachment write,
             # and GitHub enforces its own install permissions — same reason
-            # the GitHub… and Env vars doors above are exempt from the gate.
+            # the Working repo and Keys controls above are exempt from the gate.
             field_row.add_item(install_app_btn)
 
         env_vars_btn: discord.ui.Button[EditView] = discord.ui.Button(
-            label="Env vars",
+            label="Keys",
             style=discord.ButtonStyle.secondary,
         )
         env_vars_btn.callback = self._on_env_vars  # type: ignore[method-assign]
@@ -372,7 +372,7 @@ class EditView(ExpiringView, discord.ui.LayoutView):
 
         container.add_item(field_row)
 
-        # Button row 2: + Add skill · + Add MCP · ← Back.
+        # Button row 2: + Add skill · + Add MCP server · ← Back.
         btn_row: discord.ui.ActionRow[EditView] = discord.ui.ActionRow()
 
         add_skill_btn: discord.ui.Button[EditView] = discord.ui.Button(
@@ -384,7 +384,7 @@ class EditView(ExpiringView, discord.ui.LayoutView):
         btn_row.add_item(add_skill_btn)
 
         add_mcp_btn: discord.ui.Button[EditView] = discord.ui.Button(
-            label="+ Add MCP",
+            label="+ Add MCP server",
             style=discord.ButtonStyle.success,
             disabled=(user_mcp_count >= AGENT_MCP_CAP) or spec_controls_disabled,
         )

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals.py
@@ -73,7 +73,7 @@ _SYSTEM_PROMPT_MAX = 4000
 the Agent modal omits them rather than failing to open (preserved on submit)."""
 
 
-class AgentSectionModal(discord.ui.Modal, title="Agent"):
+class AgentSectionModal(discord.ui.Modal, title="Prompt & model"):
     """Edit system prompt + model. Name field shown read-only; never rebound."""
 
     def __init__(
@@ -174,7 +174,8 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
                 err_type=type(err).__name__,
             )
             await interaction.followup.send(
-                f"Failed to update **{agent_name}**: `{type(err).__name__}: {err}`",
+                f"Could not confirm the update to **{agent_name}**. "
+                "Open `/agent-setup` to check its prompt and model before trying again.",
                 ephemeral=True,
             )
             return
@@ -187,7 +188,7 @@ class AgentSectionModal(discord.ui.Modal, title="Agent"):
         )
 
 
-class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
+class RepoAuthModal(discord.ui.Modal, title="Working repo"):
     """Bind a repo URL, store a GitHub token, or both.
 
     Repo URL is optional: a token submitted with no repo is verified against
@@ -434,6 +435,11 @@ class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
             )
             if coverage_note is not None:
                 await interaction.followup.send(coverage_note, ephemeral=True)
+        except DaimonError as err:
+            await interaction.followup.send(
+                f"Working repo for **{agent_name}**: {err}", ephemeral=True
+            )
+            return
         except Exception as err:
             _log.exception(
                 "agent_setup.repo_auth.failed",
@@ -444,7 +450,9 @@ class RepoAuthModal(discord.ui.Modal, title="GitHub — repo pin + token"):
                 err_type=type(err).__name__,
             )
             await interaction.followup.send(
-                f"Failed to bind repo for **{agent_name}**: `{type(err).__name__}: {err}`",
+                f"Could not finish connecting the working repo for **{agent_name}**. "
+                "Some changes may have been saved. Open `/agent-setup` to check the working repo "
+                "before trying again.",
                 ephemeral=True,
             )
             return
@@ -516,7 +524,8 @@ class AddSkillModal(discord.ui.Modal, title="Add skill repo"):
                 err_type=type(err).__name__,
             )
             await interaction.followup.send(
-                f"Failed to queue skill sync for **{agent_name}**: `{type(err).__name__}: {err}`",
+                f"Could not refresh the skill repo change for **{agent_name}**. "
+                "Open `/agent-setup` to check its skills before trying again.",
                 ephemeral=True,
             )
             return
@@ -543,7 +552,9 @@ class AddSkillModal(discord.ui.Modal, title="Add skill repo"):
                     err_type=type(sync_err).__name__,
                 )
                 await interaction.followup.send(
-                    f"✗ Sync failed for **{agent_name}**: `{type(sync_err).__name__}: {sync_err}`",
+                    f"Could not finish importing skills for **{agent_name}**. "
+                    "Some skills may have been saved. Open `/agent-setup` to check its skills "
+                    "before trying again.",
                     ephemeral=True,
                 )
                 return

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/modals_mcp.py
@@ -111,7 +111,8 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
                 err_type=type(err).__name__,
             )
             await interaction.followup.send(
-                f"Failed to add MCP **{name}**: `{type(err).__name__}: {err}`",
+                f"Could not confirm adding MCP server **{name}** to **{selected_name}**. "
+                "Open `/agent-setup` to check its MCP servers before trying again.",
                 ephemeral=True,
             )
             return
@@ -128,7 +129,8 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
         if selected is None:
             await interaction.followup.send(
                 f"MCP **{name}** registered on the agent, but no agent is "
-                "selected — cannot write vault credential.",
+                "selected, so its token was not saved. Open `/agent-setup` to select the agent "
+                "and add the server again.",
                 ephemeral=True,
             )
             return
@@ -145,7 +147,8 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
             )
             await interaction.followup.send(
                 f"MCP **{name}** registered on the agent, but could not find "
-                f"agent **{selected.name}** on MA — vault credential not written.",
+                f"agent **{selected.name}**, so its token was not saved. "
+                "Open `/agent-setup` to check whether the agent still exists.",
                 ephemeral=True,
             )
             return
@@ -154,9 +157,8 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
         mcp = self.runtime.settings.mcp
         if mcp.public_url is None or mcp.jwt_secret is None:
             await interaction.followup.send(
-                f"MCP **{name}** registered on the agent, but daimon-mcp is "
-                "not configured (public_url / jwt_secret missing) — vault "
-                "credential not written.",
+                f"MCP server **{name}** was added, but its token was not saved. "
+                "Ask the operator to finish setting up this deployment, then add the server again.",
                 ephemeral=True,
             )
             return
@@ -213,16 +215,11 @@ class AddMcpModal(discord.ui.Modal, title="Add MCP server"):
                 agent_name=selected_name,
                 err_type=type(err).__name__,
             )
-            # Surface only the exception class name to the user — never the
-            # stringified exception. `str(err)` for SDK / network exceptions
-            # may include the request envelope, which has historically been
-            # observed to include kwargs (token-leak surface). Operators get
-            # the full traceback via `_log.exception` above.
+            # The server definition was saved; token storage spans multiple writes.
+            # Keep unexpected exception details in the operator log.
             await interaction.followup.send(
-                f"MCP **{name}** registered on the agent, but storing its "
-                f"auth token in the per-agent vault failed "
-                f"(`{type(err).__name__}`). Tool calls to this server will "
-                "401 until re-added.",
+                f"MCP server **{name}** was added, but saving its token did not finish. "
+                "Open `/agent-setup` and add the server again to retry its connection.",
                 ephemeral=True,
             )
         from daimon.adapters.discord.agent_setup.edit_view import EditView

--- a/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/agent_setup/panel.py
@@ -195,7 +195,7 @@ def _build_body_text(state: PanelState) -> str:
         mcp_lines = "\n".join(
             f"**{m.get('name', '?')}** — `{m.get('url', '?')}`" for m in user_mcps
         )
-        groups.append(f"🔌 **MCPs**\n{mcp_lines}")
+        groups.append(f"🔌 **MCP servers**\n{mcp_lines}")
 
     # Repo group: shown when at least one of repo/auth is set, or the shared
     # service account is the agent's only source of GitHub access. No longer
@@ -285,7 +285,7 @@ def _build_body_text(state: PanelState) -> str:
     if not user_mcps:
         missing.append("＋ MCP")
     if not has_secrets:
-        missing.append("＋ env vars")
+        missing.append("＋ keys")
     if missing and not groups and not (has_repo or has_auth or has_secrets or skills or user_mcps):
         # All resources empty — hint replaces all groups.
         hint = " · ".join(missing) + " — via **Edit**"
@@ -904,8 +904,8 @@ class ForkAgentModal(discord.ui.Modal, title="Fork agent"):
                 err, tenant_id=tenant_id, guild_id=interaction.guild_id, rid=rid
             )
             await interaction.followup.send(
-                f"Failed to fork **{self._source.name}** → **{new_name}**: "
-                f"`{type(err).__name__}: {err}`",
+                f"Could not finish copying **{self._source.name}** to **{new_name}**. "
+                "Open `/agent-setup` to check whether the copy was created before trying again.",
                 ephemeral=True,
             )
             return
@@ -941,7 +941,8 @@ class ForkAgentModal(discord.ui.Modal, title="Fork agent"):
                 err, tenant_id=tenant_id, guild_id=interaction.guild_id, rid=rid
             )
             await interaction.followup.send(
-                f"Forked **{new_name}** but failed to refresh panel: `{type(err).__name__}: {err}`",
+                f"Created **{new_name}**, but could not refresh the panel. "
+                "Open `/agent-setup` to see the copy.",
                 ephemeral=True,
             )
             return

--- a/packages/adapters/discord/daimon/adapters/discord/bot.py
+++ b/packages/adapters/discord/daimon/adapters/discord/bot.py
@@ -1288,8 +1288,8 @@ class DaimonBot(commands.Bot):
             hints: list[str] = []
             if "agent" in err.missing:
                 hints.append(
-                    "An admin can set the default agent in `/agent-setup` -> "
-                    "**Set as default...** -> [This channel] or [Whole server]."
+                    "An admin can choose who answers in this channel or the whole server "
+                    "by opening `/agent-setup`."
                 )
             if "environment" in err.missing:
                 hints.append(
@@ -1312,8 +1312,7 @@ class DaimonBot(commands.Bot):
             target = thread or message.channel
             await target.send(
                 "The configured agent or environment no longer exists. "
-                "An admin can re-set the agent in `/agent-setup` -> "
-                "**Set as default...**; the environment is "
+                "An admin can choose an existing agent in `/agent-setup`; the environment is "
                 "operator-only via the CLI (`daimon config set environment_name=...`)."
             )
             return
@@ -1555,6 +1554,7 @@ class DaimonBot(commands.Bot):
                     after_message_id=int(prepared.watermark),
                     bot_user_id=self.user.id if self.user else None,
                     bot_display_name=discord_settings.bot_display_name,
+                    is_admin=is_admin,
                     unprompted=unprompted,
                 )
             else:
@@ -1564,6 +1564,7 @@ class DaimonBot(commands.Bot):
                     limit=100,
                     bot_user_id=self.user.id if self.user else None,
                     bot_display_name=discord_settings.bot_display_name,
+                    is_admin=is_admin,
                     unprompted=unprompted,
                 )
         else:
@@ -1576,6 +1577,7 @@ class DaimonBot(commands.Bot):
                     thread=thread,
                     bot_user_id=self.user.id if self.user else None,
                     bot_display_name=discord_settings.bot_display_name,
+                    is_admin=is_admin,
                 )
             else:
                 # Forum/voice channels: fall back to raw message content
@@ -1642,6 +1644,7 @@ class DaimonBot(commands.Bot):
                 bot_user_id=self.user.id if self.user else None,
                 bot_display_name=discord_settings.bot_display_name,
                 omit_oversized_image_urls=True,
+                is_admin=is_admin,
                 unprompted=unprompted,
             )
             if synthetic_prefix:

--- a/packages/adapters/discord/daimon/adapters/discord/checks.py
+++ b/packages/adapters/discord/daimon/adapters/discord/checks.py
@@ -142,7 +142,8 @@ def require_manage_guild(  # noqa: UP047  -- ParamSpec used for decorator generi
     ) -> None:
         if not is_guild_admin(interaction):
             await interaction.response.send_message(
-                "Changing my setup needs Manage Server — ask a server admin to use /agent-setup",
+                "🛡️ Viewing scheduled routines needs a server admin (Manage Server). "
+                "Ask one: “Please open `/routines` to review this server’s scheduled routines.”",
                 ephemeral=True,
             )
             return

--- a/packages/adapters/discord/daimon/adapters/discord/context.py
+++ b/packages/adapters/discord/daimon/adapters/discord/context.py
@@ -132,6 +132,34 @@ def _render_message(
     return lines
 
 
+def _render_user_query(
+    trigger: discord.Message,
+    bot_user_id: int | None,
+    *,
+    bot_display_name: str,
+    is_admin: bool,
+    unprompted: bool = False,
+) -> str:
+    """Render the ``<user_query>`` element for a turn's trigger message.
+
+    All three builders use this renderer so initial, delta and reseeded
+    context carry the same author, timestamp and permission attributes.
+    ``is_admin`` uses the lowercase literal ``"true"``/``"false"`` so the
+    model knows whether the caller can make an admin-gated change.
+    """
+    attrs = (
+        f" author_name={quoteattr(trigger.author.display_name)}"
+        f" user_id={quoteattr(str(trigger.author.id))}"
+        f" timestamp={quoteattr(trigger.created_at.isoformat())}"
+        f" is_admin={quoteattr('true' if is_admin else 'false')}"
+        + (' unprompted="true"' if unprompted else "")
+    )
+    content = escape(
+        _strip_bot_mention(trigger.content, bot_user_id, bot_display_name=bot_display_name)
+    )
+    return f"<user_query{attrs}>{content}</user_query>"
+
+
 async def build_context_xml(
     thread: discord.Thread,
     trigger: discord.Message,
@@ -140,6 +168,7 @@ async def build_context_xml(
     bot_user_id: int | None = None,
     bot_display_name: str = "daimon",
     omit_oversized_image_urls: bool = False,
+    is_admin: bool = False,
     unprompted: bool = False,
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context from thread history for the turn driver.
@@ -203,19 +232,16 @@ async def build_context_xml(
     lines.append("</context>")
 
     # user_query sits outside <context>, separated by a blank line
-    trigger_attrs = (
-        f" author_name={quoteattr(trigger.author.display_name)}"
-        f" user_id={quoteattr(str(trigger.author.id))}"
-        f" timestamp={quoteattr(trigger.created_at.isoformat())}"
-        # Only present when true: every mention-driven turn keeps its
-        # byte-for-byte existing shape.
-        + (' unprompted="true"' if unprompted else "")
-    )
-    trigger_content = escape(
-        _strip_bot_mention(trigger.content, bot_user_id, bot_display_name=bot_display_name)
-    )
     lines.append("")
-    lines.append(f"<user_query{trigger_attrs}>{trigger_content}</user_query>")
+    lines.append(
+        _render_user_query(
+            trigger,
+            bot_user_id,
+            bot_display_name=bot_display_name,
+            is_admin=is_admin,
+            unprompted=unprompted,
+        )
+    )
 
     return "\n".join(lines), image_atts
 
@@ -228,6 +254,7 @@ async def build_delta_xml(
     bot_user_id: int | None = None,
     bot_display_name: str = "daimon",
     omit_oversized_image_urls: bool = False,
+    is_admin: bool = False,
     unprompted: bool = False,
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context for a continuation turn (delta since watermark).
@@ -260,6 +287,7 @@ async def build_delta_xml(
             trigger,
             bot_user_id=bot_user_id,
             bot_display_name=bot_display_name,
+            is_admin=is_admin,
             unprompted=unprompted,
         )
 
@@ -294,19 +322,16 @@ async def build_delta_xml(
     lines.append("</thread_delta>")
     lines.append("</context>")
 
-    trigger_attrs = (
-        f" author_name={quoteattr(trigger.author.display_name)}"
-        f" user_id={quoteattr(str(trigger.author.id))}"
-        f" timestamp={quoteattr(trigger.created_at.isoformat())}"
-        # Only present when true: every mention-driven turn keeps its
-        # byte-for-byte existing shape.
-        + (' unprompted="true"' if unprompted else "")
-    )
-    trigger_content = escape(
-        _strip_bot_mention(trigger.content, bot_user_id, bot_display_name=bot_display_name)
-    )
     lines.append("")
-    lines.append(f"<user_query{trigger_attrs}>{trigger_content}</user_query>")
+    lines.append(
+        _render_user_query(
+            trigger,
+            bot_user_id,
+            bot_display_name=bot_display_name,
+            is_admin=is_admin,
+            unprompted=unprompted,
+        )
+    )
 
     return "\n".join(lines), image_atts
 
@@ -320,6 +345,7 @@ async def build_channel_context_xml(
     bot_user_id: int | None = None,
     bot_display_name: str = "daimon",
     omit_oversized_image_urls: bool = False,
+    is_admin: bool = False,
 ) -> tuple[str, list[discord.Attachment]]:
     """Build XML context from parent channel history for a channel-mention turn.
 
@@ -358,15 +384,11 @@ async def build_channel_context_xml(
         )
     lines.append("</channel_context>")
 
-    trigger_attrs = (
-        f" author_name={quoteattr(trigger.author.display_name)}"
-        f" user_id={quoteattr(str(trigger.author.id))}"
-        f" timestamp={quoteattr(trigger.created_at.isoformat())}"
-    )
-    trigger_content = escape(
-        _strip_bot_mention(trigger.content, bot_user_id, bot_display_name=bot_display_name)
-    )
     lines.append("")
-    lines.append(f"<user_query{trigger_attrs}>{trigger_content}</user_query>")
+    lines.append(
+        _render_user_query(
+            trigger, bot_user_id, bot_display_name=bot_display_name, is_admin=is_admin
+        )
+    )
 
     return "\n".join(lines), image_atts

--- a/packages/adapters/discord/daimon/adapters/discord/credential_button.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_button.py
@@ -98,7 +98,7 @@ _log = structlog.get_logger()
 # Shown when the lookup in from_custom_id found nothing (unknown token or a
 # DB failure) — the real label (naming the exact target) only exists once a
 # row is found, so this is the best available fallback for a dead button.
-_FALLBACK_LABEL = "Add credential"
+_FALLBACK_LABEL = "Enter it privately"
 
 _NO_LONGER_VALID = "This request is no longer valid — ask again."
 _WRONG_REQUESTER = "This request was for someone else — ask again in your own thread."

--- a/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_modals.py
@@ -130,7 +130,7 @@ async def _mark_button_consumed(interaction: discord.Interaction, *, kind: str) 
         )
 
 
-class EnvCredentialModal(discord.ui.Modal, title="Add secret"):
+class EnvCredentialModal(discord.ui.Modal, title="Add key"):
     """Add secrets modal: one value, atomic consume, existing agent_files write."""
 
     def __init__(self, *, runtime: DiscordRuntime, request_row: CredentialRequestRow) -> None:
@@ -138,7 +138,7 @@ class EnvCredentialModal(discord.ui.Modal, title="Add secret"):
         self._runtime = runtime
         self._row = request_row
         self.value_input: discord.ui.TextInput[EnvCredentialModal] = discord.ui.TextInput(
-            label="Secret value",
+            label="Key value",
             style=discord.TextStyle.paragraph,
             required=True,
             max_length=4000,
@@ -152,12 +152,12 @@ class EnvCredentialModal(discord.ui.Modal, title="Add secret"):
 
         if not raw_value.strip():
             await interaction.followup.send(
-                "Secret value cannot be empty — try again.", ephemeral=True
+                "Key value cannot be empty — try again.", ephemeral=True
             )
             return
         if len(raw_value.encode()) > _MAX_SECRET_VALUE_BYTES:
             await interaction.followup.send(
-                f"Secret value is too large. Max {_MAX_SECRET_VALUE_BYTES} bytes.",
+                f"Key value is too large. Max {_MAX_SECRET_VALUE_BYTES} bytes.",
                 ephemeral=True,
             )
             return
@@ -198,7 +198,7 @@ class EnvCredentialModal(discord.ui.Modal, title="Add secret"):
         )
 
 
-class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
+class McpCredentialModal(discord.ui.Modal, title="Add MCP token"):
     """Add MCP credential modal: one token, atomic consume, existing vault write."""
 
     def __init__(self, *, runtime: DiscordRuntime, request_row: CredentialRequestRow) -> None:
@@ -206,7 +206,7 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
         self._runtime = runtime
         self._row = request_row
         self.token_input: discord.ui.TextInput[McpCredentialModal] = discord.ui.TextInput(
-            label="Auth token",
+            label="MCP token",
             required=True,
             max_length=255,
             placeholder="usable by everyone who talks to this agent",
@@ -219,7 +219,7 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
 
         if not token_value.strip():
             await interaction.followup.send(
-                "Auth token cannot be empty — try again.", ephemeral=True
+                "MCP token cannot be empty — try again.", ephemeral=True
             )
             return
 
@@ -227,8 +227,8 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
         jwt_secret_setting = self._runtime.settings.mcp.jwt_secret
         if public_url_setting is None or jwt_secret_setting is None:
             await interaction.followup.send(
-                "daimon-mcp is not configured (public_url / jwt_secret missing) — "
-                "credential not written.",
+                "This deployment is not finished being set up. Ask the operator to finish setup, "
+                "then try again. Nothing was saved.",
                 ephemeral=True,
             )
             return
@@ -293,12 +293,11 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
                 mcp_server_url=mcp_server_url,
                 err_type=type(err).__name__,
             )
-            # Surface only the exception class name — never the stringified
-            # exception, which for SDK/network errors can carry the request
-            # envelope (a token-leak surface). Full traceback goes to structlog.
+            # Keep exception details in the operator log; SDK failures can
+            # include the request envelope.
             await interaction.followup.send(
-                "Credential request consumed, but storing the auth token failed "
-                f"(`{type(err).__name__}`). Ask for a new request to retry.",
+                "This request was used, but saving the MCP token did not finish. "
+                "Some changes may have been saved. Ask for a new request to retry.",
                 ephemeral=True,
             )
             return
@@ -335,53 +334,36 @@ class McpCredentialModal(discord.ui.Modal, title="Add MCP credential"):
             )
         except Exception as err:
             # Partial state is real and must not be reported as success: the
-            # token is stored, the server is not attached. Exception class name
-            # only, for the same token-leak reason as the vault-write branch.
+            # token is stored, but the connection could not be completed.
+            # Exception details stay in the operator log.
             _log.exception(
                 "credential_modal.mcp_attach_failed",
                 mcp_server_url=mcp_server_url,
                 err_type=type(err).__name__,
             )
             await interaction.followup.send(
-                f"Auth token stored, but attaching `{mcp_server_url}` to the agent "
-                f"failed (`{type(err).__name__}`). The server is not connected yet — "
-                "ask the agent to attach it, or request a new credential to retry.",
+                f"MCP token saved, but connecting `{mcp_server_url}` to the agent "
+                "did not finish — "
+                "ask the agent to connect the MCP server again using a private token form.",
                 ephemeral=True,
             )
             return
 
         await interaction.followup.send(
-            f"MCP credential added for `{mcp_server_url}` and attached as "
+            f"MCP token saved for `{mcp_server_url}` and connected as "
             f"`{consumed_row.target}`. Anyone who talks to this agent can use it.",
             ephemeral=True,
         )
 
 
 class SkillRepoModal(discord.ui.Modal, title="Import skills"):
-    """Collect a GitHub token for a PRIVATE skill repo, then run the import.
+    """Collect a GitHub token, import skills, and attach them to the requested agent.
 
-    Deliberately NOT a `RepoBindModal` variant, even though both collect a
-    GitHub token into the same per-agent overlay. Two differences are the
-    whole point of the separate class:
-
-    1. No `set_binding`. Importing skills from a repo must not also tell the
-       agent to check that repo out. Sharing the store is intended; sharing
-       the binding write is the bug this exists to avoid.
-    2. The token is verified against the SKILL repo (`target`), not the
-       agent's clone repo — for a skill import those are routinely different
-       repos, and validating the wrong one both refuses good tokens and
-       accepts ones that cannot read what is about to be fetched.
-
-    Because the credential lands in the same overlay `get_pat(agent_id=…)`
-    resolves, a user who already pasted a token that can read this repo is
-    never asked twice — the agent should attempt `sync_skills` first and only
-    reach for this button on an actual no-credential failure.
-
-    No admin gate. This mirrors the env/mcp kinds rather than the repo kind:
-    the repo kind is admin-gated on a shared agent because a binding changes
-    what code the agent runs for every member, and that reasoning does not
-    reach an import into the shared skill library, which `sync_skills` itself
-    already gates with `_require_admin` at request time.
+    This requester-only enrollment verifies the token against the skill repo,
+    then stores the token and updates the working-repo binding. Later imports
+    use that binding to locate the saved token, so this flow also changes the
+    repository the agent checks out. It does not inherit the admin gate of
+    direct skill imports or shared working-repo edits.
     """
 
     def __init__(self, *, runtime: DiscordRuntime, request_row: CredentialRequestRow) -> None:
@@ -431,6 +413,7 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
             pat_masked=mask_tail(pat),
         )
 
+        is_token_saved = False
         try:
             async with httpx.AsyncClient(timeout=30.0) as http_client:
                 # Verify BEFORE storing: a token that cannot read this repo is
@@ -459,6 +442,7 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
                     pasted_pat=pat,
                     now=now,
                 )
+                is_token_saved = True
                 # Without this row the stored PAT is unreachable: the skill-sync
                 # resolver finds a per-agent token by walking this tenant's
                 # `agent_repo_binding` rows FOR THIS REPO, not by agent alone
@@ -486,12 +470,15 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
                     token=pat,
                 )
         except DaimonError as err:
-            # Written for the user by the raiser — surface verbatim. The
-            # credential is already stored and still good; only the import
-            # leg failed, so say which half survived.
+            # Validation can fail before storage; preserve only confirmed saves.
+            progress = (
+                "Token saved, but the skill import did not finish."
+                if is_token_saved
+                else "Could not finish saving the token and importing skills. "
+                "Some changes may have been saved."
+            )
             await interaction.followup.send(
-                f"Token stored, but the import failed: {err} The request was used up — "
-                "ask again to retry the import.",
+                f"{progress} {err} This request was used; ask again to retry the import.",
                 ephemeral=True,
             )
             return
@@ -501,11 +488,14 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
                 repo_url=url,
                 err_type=type(err).__name__,
             )
-            # Class name only — a stringified SDK/network error can carry the
-            # request envelope, which is a token-leak surface.
+            progress = (
+                "Token saved, but the skill import did not finish."
+                if is_token_saved
+                else "Could not finish saving the token and importing skills. "
+                "Some changes may have been saved."
+            )
             await interaction.followup.send(
-                f"Token stored, but the import failed (`{type(err).__name__}`). "
-                "Ask again to retry the import.",
+                f"{progress} Ask again to retry the import for `{normalize_owner_repo(url)}`.",
                 ephemeral=True,
             )
             return
@@ -576,7 +566,10 @@ class SkillRepoModal(discord.ui.Modal, title="Import skills"):
                 agent_id=str(agent_id),
                 err_type=type(err).__name__,
             )
-            return f"Imported, but attaching to `{agent.name}` failed ({type(err).__name__})."
+            return (
+                f"Skills imported, but attaching them to `{agent.name}` did not finish. "
+                "Ask again to retry."
+            )
         return f"Attached {len(skill_ids)} to `{agent.name}`."
 
 
@@ -683,12 +676,11 @@ class RepoBindModal(discord.ui.Modal, title="Bind repo"):
                 repo_url=consumed_row.target,
                 err_type=type(err).__name__,
             )
-            # Surface only the exception class name — never the stringified
-            # exception, which for SDK/network errors can carry the request
-            # envelope (a token-leak surface). Full traceback goes to structlog.
+            # Keep exception details in the operator log; SDK failures can
+            # include the request envelope.
             await interaction.followup.send(
-                "Credential request consumed, but binding the repo failed "
-                f"(`{type(err).__name__}`). Ask for a new request to retry.",
+                "This request was used, but connecting the working repo did not finish. "
+                "Some changes may have been saved. Ask for a new request to retry.",
                 ephemeral=True,
             )
             return

--- a/packages/adapters/discord/daimon/adapters/discord/credential_repo_bind.py
+++ b/packages/adapters/discord/daimon/adapters/discord/credential_repo_bind.py
@@ -68,15 +68,9 @@ import discord
 
 log = structlog.get_logger()
 
-# Kept character-identical to the panel gate's `_SHARED_AGENT_MESSAGE`
-# (agent_setup's authz module) on purpose — a test asserts the two strings
-# are equal, so a future edit to one without the other goes red rather than
-# drifting silently.
 _SHARED_AGENT_MESSAGE: Final[str] = (
-    "This agent is shared — it either ships with the deployment or is the "
-    "current default for this channel or the server — so changing its repo or "
-    "environment variables needs Manage Server. Fork it to make an editable "
-    "copy; the fork starts with no environment variables of its own."
+    "Changing this shared agent's working repo needs a server admin (Manage Server). "
+    "Ask a server admin to set the working repo in `/agent-setup`."
 )
 
 

--- a/packages/adapters/discord/daimon/adapters/discord/lifecycle.py
+++ b/packages/adapters/discord/daimon/adapters/discord/lifecycle.py
@@ -284,7 +284,9 @@ class DiscordTurnLifecycle:
                 continue
             self._persisted_sealed_indices.add(index)
             for chunk in split_for_discord_safe(text):
-                await self._send_message(content=chunk)
+                await self._send_message(
+                    content=chunk, allowed_mentions=discord.AllowedMentions.none()
+                )
             log.info("turn.sealed_response_posted", block_index=index, chars=len(text))
 
     async def on_terminal_success(self, state: TurnState) -> None:
@@ -318,10 +320,16 @@ class DiscordTurnLifecycle:
         self._was_answered = True
         chunks = split_for_discord_safe(response_text)
         # Clean replace: first chunk replaces the embed
-        await self._edit(self._message_ref, content=chunks[0], embed=None, view=None)
+        await self._edit(
+            self._message_ref,
+            content=chunks[0],
+            embed=None,
+            view=None,
+            allowed_mentions=discord.AllowedMentions.none(),
+        )
         # Overflow: subsequent chunks posted as new messages
         for chunk in chunks[1:]:
-            await self._send_message(content=chunk)
+            await self._send_message(content=chunk, allowed_mentions=discord.AllowedMentions.none())
 
         log.info("turn.terminal_success")
 

--- a/packages/adapters/discord/daimon/adapters/discord/privacy_panel/cascade.py
+++ b/packages/adapters/discord/daimon/adapters/discord/privacy_panel/cascade.py
@@ -47,7 +47,7 @@ def build_cascade_preview_container(
     if preview.github_credentials.count > 0:
         ex = preview.github_credentials.example or "—"
         n = preview.github_credentials.count
-        will_happen_rows.append(f"-# 🔑 Delete **{n}** stored GitHub credential(s) (`{ex}`)")
+        will_happen_rows.append(f"-# 🔑 Delete **{n}** stored GitHub token(s) (`{ex}`)")
     if preview.github_oauth_states.count > 0:
         will_happen_rows.append(
             f"-# 🤝 Remove **{preview.github_oauth_states.count}** GitHub OAuth handshake record(s)"
@@ -58,7 +58,7 @@ def build_cascade_preview_container(
         )
     if preview.agent_github_binding.count > 0:
         n = preview.agent_github_binding.count
-        will_happen_rows.append(f"-# 🤖 Remove **{n}** per-agent GitHub credential link(s)")
+        will_happen_rows.append(f"-# 🤖 Remove **{n}** per-agent GitHub token link(s)")
     if preview.slack_user_tokens.count > 0:
         will_happen_rows.append(
             f"-# 🔐 Remove **{preview.slack_user_tokens.count}** Slack user token(s)"
@@ -75,7 +75,7 @@ def build_cascade_preview_container(
         *(will_happen_rows if will_happen_rows else ["-# _(nothing to delete)_"]),
         "",
         "🔐 **What stays in Managed Agents**",
-        "-# Agent definitions, system prompts, MCP credentials",
+        "-# Agent definitions, system prompts, MCP tokens",
         "-# Session transcripts, turn message content",
         "-# Skill repo references — the repos themselves stay on GitHub",
         "-# Retention is governed by Anthropic's Managed Agents policy.",

--- a/packages/adapters/discord/daimon/adapters/discord/privacy_panel/embeds.py
+++ b/packages/adapters/discord/daimon/adapters/discord/privacy_panel/embeds.py
@@ -29,15 +29,13 @@ def build_post_delete_container(
     if result.db.user_skills > 0:
         rows.append(f"-# ✓ {result.db.user_skills} synced skill ledger row(s) removed")
     if result.db.github_credentials > 0:
-        rows.append(f"-# ✓ {result.db.github_credentials} stored GitHub credential(s) deleted")
+        rows.append(f"-# ✓ {result.db.github_credentials} stored GitHub token(s) deleted")
     if result.db.github_oauth_states > 0:
         rows.append(f"-# ✓ {result.db.github_oauth_states} OAuth handshake record(s) removed")
     if result.db.mcp_tokens > 0:
         rows.append(f"-# ✓ {result.db.mcp_tokens} per-agent MCP token(s) revoked")
     if result.db.agent_github_binding > 0:
-        rows.append(
-            f"-# ✓ {result.db.agent_github_binding} per-agent GitHub credential link(s) removed"
-        )
+        rows.append(f"-# ✓ {result.db.agent_github_binding} per-agent GitHub token link(s) removed")
     if result.db.accounts > 0:
         rows.append("-# ✓ Account row removed")
     if result.sessions.deleted > 0:

--- a/packages/adapters/discord/daimon/adapters/discord/privacy_panel/panel.py
+++ b/packages/adapters/discord/daimon/adapters/discord/privacy_panel/panel.py
@@ -27,7 +27,7 @@ def _summary_line(preview: PurgePreview) -> str:
     if preview.user_skills.count > 0:
         parts.append(f"{preview.user_skills.count} synced skill(s)")
     if preview.github_credentials.count > 0:
-        parts.append(f"{preview.github_credentials.count} GitHub credential(s)")
+        parts.append(f"{preview.github_credentials.count} GitHub token(s)")
     if preview.github_oauth_states.count > 0:
         parts.append(f"{preview.github_oauth_states.count} OAuth handshake record(s)")
     if preview.mcp_tokens.count > 0:
@@ -63,18 +63,18 @@ def build_privacy_main_container(
         "-# Routines you scheduled",
         "-# User config rows",
         "-# Synced skill ledger rows",
-        "-# Encrypted GitHub credentials (token stored encrypted-at-rest in our DB)",
+        "-# Encrypted GitHub tokens (token stored encrypted-at-rest in our DB)",
         "-# GitHub OAuth handshake records",
         "-# The account row itself",
         "",
         "🔐 **What lives in Managed Agents**",
-        "-# Agent definitions, system prompts, MCP credentials",
+        "-# Agent definitions, system prompts, MCP tokens",
         "-# Session transcripts, turn message content",
         "-# Skill repo references (the repos themselves stay on GitHub)",
         "-# Retention is governed by Anthropic's Managed Agents policy.",
         "",
         "🚫 **What we don't hold**",
-        "-# Plaintext credentials (GitHub tokens are encrypted-at-rest in our DB)",
+        "-# Plaintext GitHub tokens (GitHub tokens are encrypted-at-rest in our DB)",
         "-# Message content (we only log structural events)",
     ]
     container: discord.ui.Container[discord.ui.LayoutView] = discord.ui.Container(

--- a/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
+++ b/packages/adapters/discord/daimon/adapters/discord/wizard_submit.py
@@ -364,8 +364,8 @@ async def run_wizard_submit_turn(
             hints: list[str] = []
             if "agent" in err.missing:
                 hints.append(
-                    "An admin can set the default agent in `/agent-setup` -> "
-                    "**Set as default...** -> [This channel] or [Whole server]."
+                    "An admin can choose who answers in this channel or the whole server "
+                    "by opening `/agent-setup`."
                 )
             if "environment" in err.missing:
                 hints.append(
@@ -387,8 +387,8 @@ async def run_wizard_submit_turn(
             )
             await channel.send(
                 "Your answers were recorded, but the configured agent or environment "
-                "no longer exists -- ask again in the thread. An admin can re-set the "
-                "agent in `/agent-setup` -> **Set as default...**; the environment is "
+                "no longer exists. An admin can choose an existing agent in `/agent-setup`; "
+                "then ask again in the thread. The environment is "
                 "operator-only via the CLI (`daimon config set environment_name=...`)."
             )
             return

--- a/packages/adapters/discord/tests/agent_setup/test_credentials.py
+++ b/packages/adapters/discord/tests/agent_setup/test_credentials.py
@@ -144,7 +144,7 @@ def test_container_header_and_subtext() -> None:
     # First TextDisplay is the header from layout.header()
     assert len(texts) >= 1, "at least one TextDisplay in container"
     header_text = texts[0]
-    assert header_text.startswith("## 🔑 Env vars — "), f"header mismatch: {header_text!r}"
+    assert header_text.startswith("## 🔑 Keys — "), f"header mismatch: {header_text!r}"
     assert "bot" in header_text, "agent name in header"
     assert "-# values are write-only; only key names are shown" in header_text, "subtext present"
 
@@ -180,7 +180,7 @@ def test_container_empty_state_shows_hint() -> None:
         child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
     ]
     # The hint line should be a dim -# line
-    hint_lines = [d for d in displays if "add your first env var" in d]
+    hint_lines = [d for d in displays if "add your first key" in d]
     assert len(hint_lines) == 1, "empty state has a hint line"
     assert hint_lines[0].startswith("-#"), "empty hint uses dim -# prefix"
 
@@ -198,10 +198,10 @@ def test_container_no_none_copy_in_empty_state() -> None:
 
 
 def test_format_paste_result_is_singular_for_one_key_and_plural_above_one() -> None:
-    assert format_paste_result(key_count=1) == "Saved ✓ — 1 env var set", (
-        "one key reads as a singular env var"
+    assert format_paste_result(key_count=1) == "Saved ✓ — 1 key set", (
+        "one key reads as a singular key"
     )
-    assert format_paste_result(key_count=3) == "Saved ✓ — 3 env vars set", (
+    assert format_paste_result(key_count=3) == "Saved ✓ — 3 keys set", (
         "more than one key pluralises"
     )
 
@@ -216,7 +216,7 @@ def test_container_appends_the_result_line_after_the_chips() -> None:
         child.content for child in container.children if isinstance(child, discord.ui.TextDisplay)
     ]
     chips_index = next(i for i, d in enumerate(displays) if "`A_KEY`" in d)
-    result_index = next(i for i, d in enumerate(displays) if d == "Saved ✓ — 2 env vars set")
+    result_index = next(i for i, d in enumerate(displays) if d == "Saved ✓ — 2 keys set")
     assert result_index > chips_index, "the result line renders after the chips, not before them"
 
 
@@ -248,13 +248,13 @@ def test_subview_renders_remove_select_add_and_back(account_id: uuid.UUID) -> No
         secret_names=["A", "B"],
     )
     select = _remove_select(view)
-    assert select.placeholder == "✕ Remove a var…", "single remove-select with house placeholder"
+    assert select.placeholder == "✕ Remove a key…", "single remove-select with house placeholder"
     assert [o.label for o in select.options] == ["✕ A", "✕ B"], "one option per secret"
     assert [o.value for o in select.options] == ["A", "B"], "option value is the key name"
     labels = [b.label for b in _find_buttons(view)]
-    assert "+ Add env vars" in labels, "add button present (plural label)"
+    assert "+ Add keys" in labels, "add button present (plural label)"
     assert "← Back" in labels, "back button present"
-    add_btn = _button_by_label(view, "+ Add env vars")
+    add_btn = _button_by_label(view, "+ Add keys")
     assert add_btn.disabled is False, "add enabled for a user agent under cap"
 
 
@@ -269,7 +269,7 @@ def test_subview_header_and_subtext(account_id: uuid.UUID) -> None:
         secret_names=["A"],
     )
     text = _container_all_text(view)
-    assert "## 🔑 Env vars — " in text, "container header present"
+    assert "## 🔑 Keys — " in text, "container header present"
     assert "my-bot" in text, "agent name in header"
     assert "-# values are write-only; only key names are shown" in text, "subtext present"
 
@@ -329,7 +329,7 @@ def test_subview_remove_select_option_carries_key_name_never_value(account_id: u
 
 
 def test_subview_system_agent_enables_mutations(account_id: uuid.UUID) -> None:
-    """Env vars are per-agent daimon state, never part of the agent spec, so a
+    """Keys are per-agent daimon state, never part of the agent spec, so a
     system agent's remove select and add button are enabled exactly like a
     user agent's — provenance does not gate this sub-view's rendering. The
     enabled state is deliberate: the refusal happens at click time and carries
@@ -346,7 +346,7 @@ def test_subview_system_agent_enables_mutations(account_id: uuid.UUID) -> None:
     assert _remove_select(view).disabled is False, (
         "a system agent's remove select must be enabled when it has variables"
     )
-    assert _button_by_label(view, "+ Add env vars").disabled is False, (
+    assert _button_by_label(view, "+ Add keys").disabled is False, (
         "a system agent's add button must be enabled below the cap"
     )
     assert _button_by_label(view, "← Back").disabled is False, "back stays enabled"
@@ -364,7 +364,7 @@ def test_subview_empty_state_disables_select(account_id: uuid.UUID) -> None:
     )
     select = _remove_select(view)
     assert select.disabled is True, "no-secrets select is disabled"
-    assert "no env vars" in (select.placeholder or "").lower(), "empty-state placeholder"
+    assert "no keys" in (select.placeholder or "").lower(), "empty-state placeholder"
 
 
 # --- PasteSecretModal: parse + validate + store (real DB) ------------------
@@ -416,7 +416,7 @@ async def test_paste_modal_stores_each_pair_and_never_logs_value(
     )
 
     toast = interaction.followup.send.call_args.args[0]
-    assert "Added 2 env vars" in toast, "multi-key success copy"
+    assert "Added 2 keys" in toast, "multi-key success copy"
     assert _SECRET_VALUE not in toast, "toast never echoes a value"
     # The re-render callback fires after a successful paste, carrying the COUNT
     # the collapsed render needs — never a key name and never a value.
@@ -452,7 +452,7 @@ async def test_paste_modal_rejects_invalid_key_and_writes_nothing(
     rows = await list_agent_files(db_session, tenant_id=tenant.id, agent_id=agent_id)
     assert rows == [], "fail-fast on an invalid key writes nothing"
     msg = interaction.followup.send.call_args.args[0]
-    assert "Secret name must match" in msg, "invalid-key toast shown"
+    assert "Key name must match" in msg, "invalid-key toast shown"
 
 
 # --- PasteSecretModal: click-time gate on a shared agent -------------------
@@ -486,7 +486,7 @@ async def test_paste_modal_refuses_write_on_reachable_agent_for_non_admin(
 
     async with db_session_factory() as session:
         rows = await list_agent_files(session, tenant_id=tenant.id, agent_id=agent_id)
-    assert rows == [], "a non-admin must write no env var onto a currently-reachable agent"
+    assert rows == [], "a non-admin must write no key onto a currently-reachable agent"
     interaction.response.defer.assert_not_called()
     interaction.response.send_message.assert_called_once()
     assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
@@ -497,7 +497,7 @@ async def test_paste_modal_refuses_write_on_system_agent_for_non_admin(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     """The deployment's built-in agent is shared by everyone in the install
-    whether or not anything currently scopes to it, so its env vars are closed
+    whether or not anything currently scopes to it, so its keys are closed
     to non-admins on provenance alone."""
     guild_id = 920402
     async with db_session_factory() as session, session.begin():
@@ -519,7 +519,7 @@ async def test_paste_modal_refuses_write_on_system_agent_for_non_admin(
 
     async with db_session_factory() as session:
         rows = await list_agent_files(session, tenant_id=tenant.id, agent_id=agent_id)
-    assert rows == [], "a non-admin must write no env var onto the built-in agent"
+    assert rows == [], "a non-admin must write no key onto the built-in agent"
     interaction.response.defer.assert_not_called()
     interaction.response.send_message.assert_called_once()
     assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
@@ -557,7 +557,7 @@ async def test_paste_modal_still_writes_on_reachable_system_agent_for_admin(
             session, tenant_id=tenant.id, agent_id=agent_id, key="XERO_API_KEY"
         )
     assert stored is not None and stored.content == _SECRET_VALUE, (
-        "an admin must still set the built-in default agent's env vars"
+        "an admin must still set the built-in default agent's keys"
     )
 
 
@@ -638,7 +638,7 @@ async def test_paste_success_collapses_the_add_control_on_the_panel(
     submit_interaction.edit_original_response.assert_awaited_once()
     panel = submit_interaction.edit_original_response.call_args.kwargs["view"]
     labels = [b.label for b in _walk_buttons(panel)]
-    assert "+ Add env vars" not in labels, "the add control is swapped out, not left live"
+    assert "+ Add keys" not in labels, "the add control is swapped out, not left live"
     assert "← Back" in labels, "← Back stays live on the collapsed panel"
     select = _remove_select(panel)
     assert select.disabled is False, "the remove select stays live on the collapsed panel"
@@ -646,7 +646,7 @@ async def test_paste_success_collapses_the_add_control_on_the_panel(
         "the reload puts the freshly pasted keys into the remove select"
     )
     text = _container_all_text(panel)
-    assert "Saved ✓ — 2 env vars set" in text, "the result line names the count"
+    assert "Saved ✓ — 2 keys set" in text, "the result line names the count"
     assert "XERO_API_KEY" in text and "TOGGL_TOKEN" in text, "the chips list both pasted keys"
 
 
@@ -719,7 +719,7 @@ async def test_paste_failure_leaves_the_panel_uncollapsed(
     await modal.on_submit(submit_interaction)
 
     submit_interaction.edit_original_response.assert_not_awaited()
-    assert "Secret name must match" in submit_interaction.followup.send.call_args.args[0], (
+    assert "Key name must match" in submit_interaction.followup.send.call_args.args[0], (
         "the invalid-key toast is the only feedback on a failed paste"
     )
 
@@ -798,7 +798,7 @@ async def test_remove_after_a_paste_restores_the_add_control_and_drops_the_resul
 
     panel = remove_interaction.edit_original_response.call_args.kwargs["view"]
     labels = [b.label for b in _walk_buttons(panel)]
-    assert "+ Add env vars" in labels, "a removal renders the add control back"
+    assert "+ Add keys" in labels, "a removal renders the add control back"
     assert "Saved ✓" not in _container_all_text(panel), (
         "the paste result line must not stick around into the next render"
     )
@@ -1059,7 +1059,7 @@ async def test_editview_env_vars_button_opens_subview(
 
     await edit_view._on_env_vars(interaction)  # pyright: ignore[reportPrivateUsage]
 
-    interaction.response.edit_message.assert_awaited_once()  # env vars opens the sub-view in place
+    interaction.response.edit_message.assert_awaited_once()  # keys opens the sub-view in place
     kwargs = interaction.response.edit_message.call_args.kwargs
     assert isinstance(kwargs["view"], CredentialsSubView), "view is the CredentialsSubView"
     # The sub-view's container must not contain the secret value
@@ -1130,7 +1130,7 @@ async def test_subview_opens_and_lists_key_names_for_a_non_admin_on_a_shared_age
 
 
 def test_editview_env_vars_button_enabled_for_system_agent(account_id: uuid.UUID) -> None:
-    """Env vars are per-agent daimon state, never part of the agent spec, so
+    """Keys are per-agent daimon state, never part of the agent spec, so
     the button is enabled for the seeded/system agent exactly like any other.
     The enabled state is deliberate — opening the list stays open to every
     member, and the two writes inside refuse at click time."""
@@ -1154,8 +1154,8 @@ def test_editview_env_vars_button_enabled_for_system_agent(account_id: uuid.UUID
     )
     sys_view = EditView(_state(sys_entry, account_id), runtime=runtime, allowed_user_id=42)
     sys_buttons = {b.label: b for b in _walk_buttons(sys_view) if b.label is not None}
-    assert sys_buttons["Env vars"].disabled is False, (
-        "the seeded/system agent's Env vars button must be enabled — env vars "
+    assert sys_buttons["Keys"].disabled is False, (
+        "the seeded/system agent's Keys button must be enabled — keys "
         "are not part of the agent spec"
     )
 
@@ -1167,7 +1167,7 @@ def test_editview_env_vars_button_enabled_for_system_agent(account_id: uuid.UUID
     )
     user_view = EditView(_state(user_entry, account_id), runtime=runtime, allowed_user_id=42)
     user_buttons = {b.label: b for b in _walk_buttons(user_view) if b.label is not None}
-    assert user_buttons["Env vars"].disabled is False, "user agents can open Env vars"
+    assert user_buttons["Keys"].disabled is False, "user agents can open Keys"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapters/discord/tests/agent_setup/test_edit_view.py
+++ b/packages/adapters/discord/tests/agent_setup/test_edit_view.py
@@ -186,11 +186,11 @@ def test_edit_view_button_labels_in_row_order(account_id: uuid.UUID) -> None:
     view = EditView(state, runtime=runtime, allowed_user_id=42)
     btn_labels = [b.label for b in _walk_buttons(view)]
     assert btn_labels == [
-        "Agent…",
-        "GitHub…",
-        "Env vars",
+        "Prompt & model",
+        "Working repo",
+        "Keys",
         "+ Add skill",
-        "+ Add MCP",
+        "+ Add MCP server",
         "← Back",
     ], f"button labels must be exactly the flat row order; got {btn_labels}"
 
@@ -234,11 +234,11 @@ def test_edit_view_omits_install_app_button_when_slug_unset(account_id: uuid.UUI
     view = EditView(state, runtime=runtime, allowed_user_id=42)
     btn_labels = [b.label for b in _walk_buttons(view)]
     assert btn_labels == [
-        "Agent…",
-        "GitHub…",
-        "Env vars",
+        "Prompt & model",
+        "Working repo",
+        "Keys",
         "+ Add skill",
-        "+ Add MCP",
+        "+ Add MCP server",
         "← Back",
     ], "no link button must render when app_slug is unset"
     first_row_buttons = _walk_buttons(view)[:3]
@@ -287,7 +287,7 @@ def test_edit_view_timeout(account_id: uuid.UUID) -> None:
     assert view.timeout == 300, "EditView must use timeout=300"
 
 
-# --- Agent…/GitHub… buttons --------------------------------------------------
+# --- Prompt & model/Working repo buttons --------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -303,13 +303,13 @@ async def test_edit_view_agent_button_opens_agent_section_modal(
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    agent_btn = _find_button(view, "Agent…")
+    agent_btn = _find_button(view, "Prompt & model")
     assert agent_btn.callback is not None
     await agent_btn.callback(mock_interaction)
 
     mock_interaction.response.send_modal.assert_called_once()
     modal = mock_interaction.response.send_modal.call_args.args[0]
-    assert isinstance(modal, AgentSectionModal), "Agent… must open AgentSectionModal"
+    assert isinstance(modal, AgentSectionModal), "Prompt & model must open AgentSectionModal"
 
 
 @pytest.mark.asyncio
@@ -325,13 +325,13 @@ async def test_edit_view_github_button_opens_repo_auth_modal(
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    github_btn = _find_button(view, "GitHub…")
+    github_btn = _find_button(view, "Working repo")
     assert github_btn.callback is not None
     await github_btn.callback(mock_interaction)
 
     mock_interaction.response.send_modal.assert_called_once()
     modal = mock_interaction.response.send_modal.call_args.args[0]
-    assert isinstance(modal, RepoAuthModal), "GitHub… must open RepoAuthModal directly"
+    assert isinstance(modal, RepoAuthModal), "Working repo must open RepoAuthModal directly"
     mock_interaction.response.send_message.assert_not_called()
 
 
@@ -480,7 +480,7 @@ def test_edit_view_user_mcps_empty_disables_mcp_select(account_id: uuid.UUID) ->
     assert mcp_select.disabled is True, "empty mcp select must be disabled"
     assert len(mcp_select.options) == 1, "empty select must carry one dummy option"
     assert mcp_select.options[0].value == "__none__", "dummy option value must be __none__"
-    assert mcp_select.placeholder == "(no MCPs — use + Add MCP)", (
+    assert mcp_select.placeholder == "(no MCP servers — use + Add MCP server)", (
         f"empty-mcp placeholder mismatch; got {mcp_select.placeholder!r}"
     )
 
@@ -509,7 +509,7 @@ def test_edit_view_add_mcp_button_disabled_at_cap(account_id: uuid.UUID) -> None
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    add_mcp = _find_button(view, "+ Add MCP")
+    add_mcp = _find_button(view, "+ Add MCP server")
     assert add_mcp.disabled is True, "Add MCP must be disabled at 20-MCP cap"
 
 
@@ -583,8 +583,8 @@ async def test_edit_view_remove_paths_never_mutate_main_panel(
 
 
 def test_env_vars_button_label_has_no_plus(account_id: uuid.UUID) -> None:
-    """The Env vars button opens a sub-view (not an add action), so its label is
-    'Env vars', not '+ Env vars'."""
+    """The Keys button opens a sub-view (not an add action), so its label is
+    'Keys', not '+ Keys'."""
     selected = _entry("agent")
     state = PanelState(roster=[selected], selected=selected, account_id=account_id)
     runtime = MagicMock()
@@ -593,12 +593,12 @@ def test_env_vars_button_label_has_no_plus(account_id: uuid.UUID) -> None:
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
     labels = [b.label for b in _walk_buttons(view) if b.label is not None]
-    assert "Env vars" in labels, "Env vars button must be labeled 'Env vars'"
-    assert "+ Env vars" not in labels, "the '+' prefix must be dropped from the Env vars button"
+    assert "Keys" in labels, "Keys button must be labeled 'Keys'"
+    assert "+ Keys" not in labels, "the '+' prefix must be dropped from the Keys button"
 
 
 def test_edit_view_env_vars_button_always_enabled(account_id: uuid.UUID) -> None:
-    """Env vars are per-agent daimon state, never part of the agent spec, so the
+    """Keys are per-agent daimon state, never part of the agent spec, so the
     button is always enabled — for the seeded/system agent exactly like any other."""
     selected = RosterEntry(
         name="sys",
@@ -612,14 +612,14 @@ def test_edit_view_env_vars_button_always_enabled(account_id: uuid.UUID) -> None
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(view, "Env vars").disabled is False, (
-        "the seeded/system agent's Env vars button must be enabled"
+    assert _find_button(view, "Keys").disabled is False, (
+        "the seeded/system agent's Keys button must be enabled"
     )
 
     user_selected = _entry("bot")
     user_state = PanelState(roster=[user_selected], selected=user_selected, account_id=account_id)
     user_view = EditView(user_state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(user_view, "Env vars").disabled is False, "user agents can open Env vars"
+    assert _find_button(user_view, "Keys").disabled is False, "user agents can open Keys"
 
 
 # --- Spec-control reachability gate ---------------------------
@@ -643,7 +643,7 @@ def test_edit_view_non_admin_reachable_non_system_disables_spec_controls(
     account_id: uuid.UUID,
 ) -> None:
     """A non-admin editing a reachable, non-system agent gets the five
-    spec-touching controls disabled; GitHub… and Env vars stay enabled.
+    spec-touching controls disabled; Working repo and Keys stay enabled.
 
     Enabled is not unguarded: the attachment gate refuses those two on click,
     so the caller reads why they cannot bind a repo instead of staring at a
@@ -661,15 +661,17 @@ def test_edit_view_non_admin_reachable_non_system_disables_spec_controls(
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(view, "Agent…").disabled is True, "Agent… must be disabled"
+    assert _find_button(view, "Prompt & model").disabled is True, "Prompt & model must be disabled"
     assert _find_button(view, "+ Add skill").disabled is True, "+ Add skill must be disabled"
-    assert _find_button(view, "+ Add MCP").disabled is True, "+ Add MCP must be disabled"
+    assert _find_button(view, "+ Add MCP server").disabled is True, (
+        "+ Add MCP server must be disabled"
+    )
     skill_select = next(s for s in _walk_selects(view) if isinstance(s, _SkillRemoveSelect))  # pyright: ignore[reportPrivateUsage]
     mcp_select = next(s for s in _walk_selects(view) if isinstance(s, _McpRemoveSelect))  # pyright: ignore[reportPrivateUsage]
     assert skill_select.disabled is True, "skill remove select must be disabled"
     assert mcp_select.disabled is True, "mcp remove select must be disabled"
-    assert _find_button(view, "GitHub…").disabled is False, "GitHub… must stay enabled"
-    assert _find_button(view, "Env vars").disabled is False, "Env vars must stay enabled"
+    assert _find_button(view, "Working repo").disabled is False, "Working repo must stay enabled"
+    assert _find_button(view, "Keys").disabled is False, "Keys must stay enabled"
 
 
 def test_edit_view_non_admin_unreachable_non_system_enables_spec_controls(
@@ -690,9 +692,11 @@ def test_edit_view_non_admin_unreachable_non_system_enables_spec_controls(
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(view, "Agent…").disabled is False, "Agent… must be enabled"
+    assert _find_button(view, "Prompt & model").disabled is False, "Prompt & model must be enabled"
     assert _find_button(view, "+ Add skill").disabled is False, "+ Add skill must be enabled"
-    assert _find_button(view, "+ Add MCP").disabled is False, "+ Add MCP must be enabled"
+    assert _find_button(view, "+ Add MCP server").disabled is False, (
+        "+ Add MCP server must be enabled"
+    )
     skill_select = next(s for s in _walk_selects(view) if isinstance(s, _SkillRemoveSelect))  # pyright: ignore[reportPrivateUsage]
     mcp_select = next(s for s in _walk_selects(view) if isinstance(s, _McpRemoveSelect))  # pyright: ignore[reportPrivateUsage]
     assert skill_select.disabled is False, "skill remove select must be enabled"
@@ -709,7 +713,9 @@ def test_edit_view_admin_reachable_non_system_enables_spec_controls(account_id: 
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(view, "Agent…").disabled is False, "Agent… must be enabled for an admin"
+    assert _find_button(view, "Prompt & model").disabled is False, (
+        "Prompt & model must be enabled for an admin"
+    )
 
 
 def test_edit_view_reachable_system_agent_disables_spec_controls_for_admin_too(
@@ -729,11 +735,11 @@ def test_edit_view_reachable_system_agent_disables_spec_controls_for_admin_too(
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    assert _find_button(view, "Agent…").disabled is True, (
-        "Agent… must stay disabled on a system agent even for an admin"
+    assert _find_button(view, "Prompt & model").disabled is True, (
+        "Prompt & model must stay disabled on a system agent even for an admin"
     )
-    assert _find_button(view, "GitHub…").disabled is False, "GitHub… is not spec-gated"
-    assert _find_button(view, "Env vars").disabled is False, "Env vars is not spec-gated"
+    assert _find_button(view, "Working repo").disabled is False, "Working repo is not spec-gated"
+    assert _find_button(view, "Keys").disabled is False, "Keys is not spec-gated"
 
 
 # --- Back / open_edit_view edit-in-place -----------------------------------
@@ -1053,7 +1059,7 @@ async def test_edit_view_github_button_refuses_for_non_admin_on_reachable_agent(
     account_id: uuid.UUID,
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """The GitHub… button stays clickable for everyone, but a non-admin
+    """The Working repo button stays clickable for everyone, but a non-admin
     clicking it on a currently-reachable agent gets the refusal instead of the
     modal — so no GitHub token is ever typed into a form that would be
     rejected on submit."""
@@ -1073,8 +1079,8 @@ async def test_edit_view_github_button_refuses_for_non_admin_on_reachable_agent(
     runtime.deployment_default = DeploymentDefault(agent_name="bot")
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    github_btn = _find_button(view, "GitHub…")
-    assert github_btn.disabled is False, "GitHub… must stay clickable for a non-admin"
+    github_btn = _find_button(view, "Working repo")
+    assert github_btn.disabled is False, "Working repo must stay clickable for a non-admin"
     assert github_btn.callback is not None
 
     interaction = _non_admin_interaction(guild_id=guild_id)
@@ -1113,7 +1119,7 @@ async def test_edit_view_github_button_opens_modal_for_admin_on_system_agent(
     runtime.settings.github.app_slug = None
 
     view = EditView(state, runtime=runtime, allowed_user_id=42)
-    github_btn = _find_button(view, "GitHub…")
+    github_btn = _find_button(view, "Working repo")
     assert github_btn.callback is not None
 
     interaction = _admin_interaction()
@@ -1133,7 +1139,7 @@ async def test_env_vars_paste_modal_refuses_on_reachable_agent_for_non_admin(
     """`put_agent_file` is an upsert and the files are mounted read-write on
     every session of the agent, so a non-admin pasting over the workspace's
     current default agent would overwrite secrets everyone in the install
-    depends on. The Env vars button still opens for them; the write does not."""
+    depends on. The Keys button still opens for them; the write does not."""
     from daimon.adapters.discord.agent_setup.credentials import PasteSecretModal
     from daimon.core.ma_identity import derive_agent_uuid
     from daimon.core.ma_resolver import new_resolver_cache
@@ -1182,7 +1188,7 @@ async def test_env_vars_paste_modal_refuses_on_reachable_agent_for_non_admin(
         row = await get_agent_file(
             session, tenant_id=tenant.id, agent_id=agent_id, key="XERO_API_KEY"
         )
-    assert row is None, "a non-admin must not write env vars onto the workspace's default agent"
+    assert row is None, "a non-admin must not write keys onto the workspace's default agent"
     interaction.response.defer.assert_not_called()
     interaction.response.send_message.assert_called_once()
     assert interaction.response.send_message.call_args.kwargs.get("ephemeral") is True

--- a/packages/adapters/discord/tests/agent_setup/test_lifecycle.py
+++ b/packages/adapters/discord/tests/agent_setup/test_lifecycle.py
@@ -188,8 +188,9 @@ def _source_ma_agent(
     ).model_dump(mode="json")
 
 
-@pytest.mark.asyncio
+@pytest.mark.parametrize("refresh_fails", [False, True])
 async def test_fork_creates_new_ma_agent_via_direct_create(
+    refresh_fails: bool,
     db_session_factory: async_sessionmaker[AsyncSession],
     tenant_id: uuid.UUID,
     account_id: uuid.UUID,
@@ -244,7 +245,9 @@ async def test_fork_creates_new_ma_agent_via_direct_create(
     interaction = MagicMock()
     interaction.user.id = 42
     interaction.response.defer = AsyncMock()
-    interaction.edit_original_response = AsyncMock()
+    interaction.edit_original_response = AsyncMock(
+        side_effect=RuntimeError("private failure detail") if refresh_fails else None
+    )
     interaction.followup.send = AsyncMock()
 
     await modal.on_submit(interaction)
@@ -260,7 +263,15 @@ async def test_fork_creates_new_ma_agent_via_direct_create(
     assert body["metadata"]["daimon_account"] != str(account_id), (
         "SC-2: personal account must not be the ownership stamp"
     )
-    interaction.followup.send.assert_not_called()
+    if refresh_fails:
+        message = interaction.followup.send.call_args.args[0]
+        assert "Created **source-bot-v2**" in message, "a refresh failure must preserve success"
+        assert "/agent-setup" in message, "the person needs a working way to see the copy"
+        assert "RuntimeError" not in message and "private failure detail" not in message, (
+            "raw exception text must not be shown to people"
+        )
+    else:
+        interaction.followup.send.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -548,3 +559,38 @@ async def test_delete_last_agent_disables_section_buttons(
     assert interaction.edit_original_response.await_count >= 1, (
         "panel must re-render after delete so the empty-state view replaces the old view"
     )
+
+
+async def test_fork_upstream_failure_names_both_agents_without_exception_details(
+    tenant_id: uuid.UUID,
+    account_id: uuid.UUID,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "type": "error",
+                "error": {"type": "invalid_request_error", "message": "private failure detail"},
+            },
+        )
+
+    runtime = _runtime(build_stub_anthropic(handler), tenant_id)
+    source = _entry("source-bot")
+    state = PanelState(roster=[source], selected=source, account_id=account_id)
+    modal = ForkAgentModal(state, runtime=runtime, allowed_user_id=42)
+    modal.name_in._value = "source-bot-v2"  # pyright: ignore[reportPrivateUsage]  # Discord input boundary
+    interaction = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+
+    await modal.on_submit(interaction)
+
+    message = interaction.followup.send.call_args.args[0]
+    assert "**source-bot**" in message and "**source-bot-v2**" in message, (
+        "the failure must preserve the source and requested copy"
+    )
+    assert "/agent-setup" in message, "the next step must be a working command"
+    assert "BadRequestError" not in message and "private failure detail" not in message, (
+        "raw exception text must not be shown to people"
+    )
+    assert "Nothing was saved" not in message, "an upstream error does not prove no partial write"

--- a/packages/adapters/discord/tests/agent_setup/test_modals.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals.py
@@ -1064,9 +1064,13 @@ async def test_skill_modal_toasts_failure_on_exception(
     call_kwargs = interaction.followup.send.call_args
     assert call_kwargs.kwargs.get("ephemeral") is True, "exception toast must be ephemeral"
     content = call_kwargs.kwargs.get("content") or str(call_kwargs)
-    assert "network error during sync" in content or "RuntimeError" in content, (
-        "exception toast must include the error type or message"
+    assert "network error during sync" not in content and "RuntimeError" not in content, (
+        "raw exception text must not be shown to people"
     )
+    assert "**research-bot**" in content and "/agent-setup" in content, (
+        "the failure must name the target and a working next step"
+    )
+    assert "Some skills may have been saved" in content, "the failure must allow partial success"
 
 
 # ----- 11. Anon-bind public-visibility guard (quick task 260616-45k) -----

--- a/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
+++ b/packages/adapters/discord/tests/agent_setup/test_modals_mcp.py
@@ -357,9 +357,10 @@ async def test_add_mcp_modal_unconfigured_mcp_sends_ephemeral_error_no_vault_wri
 
     interaction.followup.send.assert_called_once()
     content = str(interaction.followup.send.call_args)
-    assert "daimon-mcp" in content or "configured" in content, (
-        "ephemeral error must indicate MCP is not configured"
+    assert "was added, but its token was not saved" in content, (
+        "the saved server definition must be distinguished from the unsaved token"
     )
+    assert "Ask the operator" in content, "must name who can finish setup"
     assert vault_calls == [], "no vault API calls must occur when MCP is unconfigured"
 
 

--- a/packages/adapters/discord/tests/agent_setup/test_panel.py
+++ b/packages/adapters/discord/tests/agent_setup/test_panel.py
@@ -406,7 +406,7 @@ def test_body_text_shows_env_group_without_repo_group(account_id: uuid.UUID) -> 
 
 
 def test_body_text_missing_hint_names_env_vars(account_id: uuid.UUID) -> None:
-    """The missing-resource hint names 'env vars', not 'secrets'."""
+    """The missing-resource hint names 'keys', not 'secrets'."""
     selected = _entry_with("bot")
     state = PanelState(
         roster=[selected],
@@ -417,7 +417,7 @@ def test_body_text_missing_hint_names_env_vars(account_id: uuid.UUID) -> None:
     )
     container = build_panel_container(state, thumbnail_url=None)
     text = _container_text(container)
-    assert "＋ env vars" in text, "missing-resource hint must say ＋ env vars"
+    assert "＋ keys" in text, "missing-resource hint must say ＋ keys"
     assert "＋ secrets" not in text, "the hint must not still say ＋ secrets"
 
 

--- a/packages/adapters/discord/tests/privacy_panel/test_cascade.py
+++ b/packages/adapters/discord/tests/privacy_panel/test_cascade.py
@@ -172,7 +172,7 @@ def test_cascade_container_github_credentials_row_renders_when_nonzero() -> None
     joined = _joined_text(container)
     assert "1" in joined, "github_credentials count must appear in the row"
     assert "octocat" in joined, "github_credentials.example (login) must appear in the row"
-    assert "GitHub credential" in joined, "github_credentials row must mention GitHub credential"
+    assert "GitHub token" in joined, "github_credentials row must mention GitHub token"
 
 
 def test_cascade_container_github_credentials_row_absent_when_zero() -> None:
@@ -180,7 +180,7 @@ def test_cascade_container_github_credentials_row_absent_when_zero() -> None:
     preview = _make_preview(github_credentials=PurgePreviewRow(count=0, example=None))
     container = build_cascade_preview_container(preview)
     joined = _joined_text(container)
-    assert "GitHub credential" not in joined, (
+    assert "GitHub token" not in joined, (
         "zero-count github_credentials must NOT render a row (D-PREVIEW-FMT-01)"
     )
 
@@ -255,24 +255,24 @@ def test_cascade_container_mcp_tokens_row_absent_when_zero() -> None:
     """per-agent MCP token row is suppressed when count == 0."""
     preview = _make_preview(mcp_tokens=PurgePreviewRow(count=0, example=None))
     joined = _joined_text(build_cascade_preview_container(preview))
-    assert "MCP token" not in joined, "zero-count mcp_tokens must NOT render a row"
+    assert "per-agent MCP token(s)" not in joined, "zero-count mcp_tokens must NOT render a row"
 
 
 def test_cascade_container_agent_github_binding_row_renders_when_nonzero() -> None:
-    """per-agent GitHub credential link row appears when count > 0."""
+    """per-agent GitHub token link row appears when count > 0."""
     preview = _make_preview(agent_github_binding=PurgePreviewRow(count=3, example=None))
     joined = _joined_text(build_cascade_preview_container(preview))
     assert "3" in joined, "agent_github_binding count must appear in the row"
-    assert "per-agent GitHub credential link" in joined, (
-        "agent_github_binding row must mention the per-agent GitHub credential link"
+    assert "per-agent GitHub token link" in joined, (
+        "agent_github_binding row must mention the per-agent GitHub token link"
     )
 
 
 def test_cascade_container_agent_github_binding_row_absent_when_zero() -> None:
-    """per-agent GitHub credential link row is suppressed when count == 0."""
+    """per-agent GitHub token link row is suppressed when count == 0."""
     preview = _make_preview(agent_github_binding=PurgePreviewRow(count=0, example=None))
     joined = _joined_text(build_cascade_preview_container(preview))
-    assert "per-agent GitHub credential link" not in joined, (
+    assert "per-agent GitHub token link" not in joined, (
         "zero-count agent_github_binding must NOT render a row"
     )
 

--- a/packages/adapters/discord/tests/privacy_panel/test_embeds.py
+++ b/packages/adapters/discord/tests/privacy_panel/test_embeds.py
@@ -181,7 +181,7 @@ def test_post_delete_container_github_credentials_row_renders_when_nonzero() -> 
     result = _make_result(github_credentials=1)
     container = build_post_delete_container(result)
     joined = _joined_text(container)
-    assert "1 stored GitHub credential(s) deleted" in joined, (
+    assert "1 stored GitHub token(s) deleted" in joined, (
         "When result.db.github_credentials > 0, post-delete container must show the github_credentials row"
     )
 
@@ -191,7 +191,7 @@ def test_post_delete_container_github_credentials_row_absent_when_zero() -> None
     result = _make_result(github_credentials=0, accounts=1)
     container = build_post_delete_container(result)
     joined = _joined_text(container)
-    assert "GitHub credential" not in joined, (
+    assert "GitHub token" not in joined, (
         "zero-count github_credentials must NOT render a checklist row (D-PREVIEW-FMT-01)"
     )
 

--- a/packages/adapters/discord/tests/privacy_panel/test_panel.py
+++ b/packages/adapters/discord/tests/privacy_panel/test_panel.py
@@ -157,7 +157,7 @@ def test_summary_line_includes_phase_76_categories_when_nonzero() -> None:
     assert "2 synced skill(s)" in header, (
         f"Header summary must include the user_skills count; got {header!r}"
     )
-    assert "1 GitHub credential(s)" in header, (
+    assert "1 GitHub token(s)" in header, (
         f"Header summary must include the github_credentials count; got {header!r}"
     )
     assert "3 OAuth handshake record(s)" in header, (
@@ -174,7 +174,7 @@ def test_summary_line_omits_phase_76_categories_when_zero() -> None:
     preview = _make_preview(linked_principals=PurgePreviewRow(count=1, example="Discord:1"))
     container = build_privacy_main_container(preview, user_name="carlos")
     header = _text_displays(container)[0]
-    for fragment in ("synced skill", "GitHub credential", "OAuth handshake"):
+    for fragment in ("synced skill", "GitHub token", "OAuth handshake"):
         assert fragment not in header, (
             f"Zero-count category {fragment!r} must not appear in the header; got {header!r}"
         )

--- a/packages/adapters/discord/tests/test_checks.py
+++ b/packages/adapters/discord/tests/test_checks.py
@@ -9,6 +9,7 @@ import discord
 import pytest
 from daimon.adapters.discord.checks import (
     refuse_if_not_admin,
+    require_manage_guild,
     require_registered_guild,
     resolve_tenant_for_interaction,
 )
@@ -230,3 +231,25 @@ async def test_refuse_if_not_admin_uses_followup_when_already_acked() -> None:
     interaction.response.send_message.assert_not_awaited()
     interaction.followup.send.assert_awaited_once()
     assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True
+
+
+async def test_routines_refusal_gives_an_admin_the_requested_action() -> None:
+    called = False
+
+    @require_manage_guild
+    async def routines(self: object, interaction: discord.Interaction) -> None:
+        nonlocal called
+        called = True
+
+    interaction = _admin_gate_interaction(is_admin=False)
+    await routines(object(), interaction)
+
+    assert called is False, "a member must not run the admin command"
+    message = interaction.response.send_message.call_args.args[0]
+    assert "server admin (Manage Server)" in message, "the refusal must name the required role"
+    assert "Please open `/routines`" in message, "the handover must preserve the requested action"
+    assert "this server’s scheduled routines" in message, "the handover must preserve the target"
+    assert "/agent-setup" not in message and "->" not in message, "the next step must be reachable"
+    assert interaction.response.send_message.call_args.kwargs["ephemeral"] is True, (
+        "the refusal is private to the caller"
+    )

--- a/packages/adapters/discord/tests/test_context.py
+++ b/packages/adapters/discord/tests/test_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
+from xml.etree import ElementTree
 
 import discord
 import pytest
@@ -125,6 +126,62 @@ class TestBuildContextXml:
         assert "<message" not in result, "no messages should appear in empty thread"
         assert "<user_query" in result, "should have user_query element"
         assert "what's up?" in result, "trigger content should appear in user_query"
+
+    @pytest.mark.asyncio
+    async def test_build_context_xml_is_admin_true_for_guild_admin(self) -> None:
+        """build_context_xml renders is_admin="true" when the caller is a guild admin."""
+        trigger = _make_message(msg_id=10, content="delete the vault key")
+        thread = _make_thread([trigger])
+
+        result, _ = await build_context_xml(thread, trigger, is_admin=True)
+
+        assert 'is_admin="true"' in result, (
+            'build_context_xml must carry is_admin="true" on the user_query for an admin caller'
+        )
+
+    @pytest.mark.asyncio
+    async def test_build_context_xml_is_admin_false_for_non_admin(self) -> None:
+        """build_context_xml renders is_admin="false" for a non-admin caller and by default."""
+        trigger = _make_message(msg_id=10, content="what's up?")
+        thread = _make_thread([trigger])
+
+        explicit_result, _ = await build_context_xml(thread, trigger, is_admin=False)
+        default_result, _ = await build_context_xml(thread, trigger)
+
+        assert 'is_admin="false"' in explicit_result, (
+            'build_context_xml must carry is_admin="false" for a non-admin caller'
+        )
+        assert 'is_admin="false"' in default_result, (
+            "is_admin must default to False so a forgetful caller is described as non-admin, "
+            "never as admin"
+        )
+
+    @pytest.mark.asyncio
+    async def test_build_context_xml_reseed_shaped_call_carries_is_admin(self) -> None:
+        """Dead-session recovery reseed calls build_context_xml the same way an ordinary
+        turn does. bot.py's ``_reseed_user_message`` closure calls build_context_xml with
+        ``limit=100``, ``bot_user_id``, ``bot_display_name``,
+        ``omit_oversized_image_urls=True`` and ``is_admin=is_admin`` -- this test drives
+        that exact keyword shape directly, because test_orchestration.py mocks the
+        builders wholesale and cannot see a missed keyword at that call site.
+        """
+        trigger = _make_message(msg_id=10, content="recover this thread")
+        thread = _make_thread([trigger])
+
+        result, _ = await build_context_xml(
+            thread,
+            trigger,
+            limit=100,
+            bot_user_id=None,
+            bot_display_name="daimon",
+            omit_oversized_image_urls=True,
+            is_admin=True,
+        )
+
+        assert 'is_admin="true"' in result, (
+            "the dead-session recovery reseed path must carry is_admin exactly as the "
+            "ordinary turn it replaces does"
+        )
 
     @pytest.mark.asyncio
     async def test_build_context_xml_channel_id_is_parent_channel_id(self) -> None:
@@ -468,22 +525,76 @@ class TestBuildContextXml:
         assert "reply" in history_section, "non-starter history still rendered"
         assert "<user_query" in result, "user_query still present after starter fetch failure"
 
-    @pytest.mark.asyncio
-    async def test_unprompted_marks_the_user_query(self) -> None:
-        """Organic participation flags the trigger; a mention leaves the element as-is."""
+    @pytest.mark.parametrize("is_admin", [False, True])
+    async def test_unprompted_marks_the_user_query(self, is_admin: bool) -> None:
+        """Participation and authorization describe the same trigger independently."""
         trigger = _make_message(msg_id=10, content="anyone?", author_id=200)
 
-        marked, _ = await build_context_xml(_make_thread([trigger]), trigger, unprompted=True)
-        default, _ = await build_context_xml(_make_thread([trigger]), trigger)
-
-        assert "<user_query" in marked and ' unprompted="true">' in marked, (
-            "the attribute closes the opening tag, after the timestamp"
+        marked, _ = await build_context_xml(
+            _make_thread([trigger]), trigger, unprompted=True, is_admin=is_admin
         )
-        assert ' unprompted="true"' not in default, "a mention-driven turn is unchanged"
+        default, _ = await build_context_xml(_make_thread([trigger]), trigger, is_admin=is_admin)
+
+        marked_query = ElementTree.fromstring(f"<root>{marked}</root>").find("user_query")
+        default_query = ElementTree.fromstring(f"<root>{default}</root>").find("user_query")
+        assert marked_query is not None and default_query is not None, (
+            "both contexts need a trigger"
+        )
+        assert marked_query.attrib["unprompted"] == "true", "organic turns must mark their trigger"
+        assert marked_query.attrib["is_admin"] == str(is_admin).lower(), (
+            "organic participation must preserve the caller's actual authority"
+        )
+        assert default_query.attrib["is_admin"] == str(is_admin).lower(), (
+            "mention-driven turns must carry the same caller authority"
+        )
+        assert "unprompted" not in default_query.attrib, "mention-driven triggers omit the flag"
 
 
 class TestBuildDeltaXml:
     """Tests for build_delta_xml() — continuation turn delta builder."""
+
+    @pytest.mark.asyncio
+    async def test_delta_xml_is_admin_true_for_guild_admin(self) -> None:
+        """build_delta_xml renders is_admin="true" when the caller is a guild admin."""
+        trigger = _make_message(msg_id=99, content="follow-up")
+        thread = _make_thread([])
+
+        result, _ = await build_delta_xml(
+            thread, trigger, after_message_id=50, bot_user_id=None, is_admin=True
+        )
+
+        assert 'is_admin="true"' in result, (
+            'build_delta_xml must carry is_admin="true" on the user_query for an admin caller'
+        )
+
+    @pytest.mark.asyncio
+    async def test_delta_xml_is_admin_false_by_default(self) -> None:
+        """build_delta_xml renders is_admin="false" when the caller is not a guild admin."""
+        trigger = _make_message(msg_id=99, content="follow-up")
+        thread = _make_thread([])
+
+        result, _ = await build_delta_xml(thread, trigger, after_message_id=50, bot_user_id=None)
+
+        assert 'is_admin="false"' in result, "is_admin must default to False on build_delta_xml too"
+
+    @pytest.mark.asyncio
+    async def test_delta_xml_with_no_watermark_carries_is_admin_through_fallback(self) -> None:
+        """When after_message_id is None, the build_context_xml fallback must still carry is_admin.
+
+        build_delta_xml falls back to build_context_xml for a full snapshot; that
+        fallback call site is easy to leave is_admin off since it is a delegation,
+        not a direct render.
+        """
+        trigger = _make_message(msg_id=99, content="first turn")
+        thread = _make_thread([trigger])
+
+        result, _ = await build_delta_xml(
+            thread, trigger, after_message_id=None, bot_user_id=None, is_admin=True
+        )
+
+        assert 'is_admin="true"' in result, (
+            "the after_message_id=None fallback to build_context_xml must not drop is_admin"
+        )
 
     @pytest.mark.asyncio
     async def test_delta_includes_only_post_watermark_messages(self) -> None:
@@ -619,19 +730,42 @@ class TestBuildDeltaXml:
         )
         assert "follow-up" in result, "trigger must appear in user_query"
 
-    @pytest.mark.asyncio
-    async def test_delta_unprompted_marks_the_user_query(self) -> None:
-        """The continuation builder flags an unprompted trigger the same way the full one does."""
+    @pytest.mark.parametrize("is_admin", [False, True])
+    @pytest.mark.parametrize("after_message_id", [1, None])
+    async def test_delta_unprompted_marks_the_user_query(
+        self, is_admin: bool, after_message_id: int | None
+    ) -> None:
+        """Delta and full-history fallback preserve both trigger attributes."""
         m1 = _make_message(msg_id=1, content="prior")
         trigger = _make_message(msg_id=10, content="anyone?", author_id=200)
 
         marked, _ = await build_delta_xml(
-            _make_thread([m1, trigger]), trigger, after_message_id=1, unprompted=True
+            _make_thread([m1, trigger]),
+            trigger,
+            after_message_id=after_message_id,
+            unprompted=True,
+            is_admin=is_admin,
         )
-        default, _ = await build_delta_xml(_make_thread([m1, trigger]), trigger, after_message_id=1)
+        default, _ = await build_delta_xml(
+            _make_thread([m1, trigger]),
+            trigger,
+            after_message_id=after_message_id,
+            is_admin=is_admin,
+        )
 
-        assert ' unprompted="true">' in marked, "an unprompted delta turn must flag its trigger"
-        assert ' unprompted="true"' not in default, "a mention-driven delta turn is unchanged"
+        marked_query = ElementTree.fromstring(f"<root>{marked}</root>").find("user_query")
+        default_query = ElementTree.fromstring(f"<root>{default}</root>").find("user_query")
+        assert marked_query is not None and default_query is not None, (
+            "both contexts need a trigger"
+        )
+        assert marked_query.attrib["unprompted"] == "true", "organic turns must mark their trigger"
+        assert marked_query.attrib["is_admin"] == str(is_admin).lower(), (
+            "delta and fallback must preserve the caller's actual authority"
+        )
+        assert default_query.attrib["is_admin"] == str(is_admin).lower(), (
+            "mention-driven delta and fallback must carry the same caller authority"
+        )
+        assert "unprompted" not in default_query.attrib, "mention-driven triggers omit the flag"
 
     @pytest.mark.asyncio
     async def test_delta_none_after_falls_back_to_full(self) -> None:
@@ -739,6 +873,32 @@ class TestBuildDeltaXml:
 
 class TestBuildChannelContextXml:
     """Tests for build_channel_context_xml() — channel-mention backfill builder."""
+
+    @pytest.mark.asyncio
+    async def test_channel_context_xml_is_admin_true_for_guild_admin(self) -> None:
+        """build_channel_context_xml renders is_admin="true" when the caller is a guild admin."""
+        trigger = _make_message(msg_id=10, content="<@999> delete the vault key")
+        channel = _make_text_channel([trigger])
+        thread = _make_thread([trigger], thread_id=900, parent_id=42)
+
+        result, _ = await build_channel_context_xml(channel, trigger, thread=thread, is_admin=True)
+
+        assert 'is_admin="true"' in result, (
+            'build_channel_context_xml must carry is_admin="true" for an admin caller'
+        )
+
+    @pytest.mark.asyncio
+    async def test_channel_context_xml_is_admin_false_by_default(self) -> None:
+        """build_channel_context_xml renders is_admin="false" when omitted (the safe default)."""
+        trigger = _make_message(msg_id=10, content="<@999> hello")
+        channel = _make_text_channel([trigger])
+        thread = _make_thread([trigger], thread_id=900, parent_id=42)
+
+        result, _ = await build_channel_context_xml(channel, trigger, thread=thread)
+
+        assert 'is_admin="false"' in result, (
+            "is_admin must default to False on build_channel_context_xml too"
+        )
 
     @pytest.mark.asyncio
     async def test_channel_context_carries_thread_and_parent_channel_ids(self) -> None:

--- a/packages/adapters/discord/tests/test_context_no_keys_element.py
+++ b/packages/adapters/discord/tests/test_context_no_keys_element.py
@@ -1,0 +1,162 @@
+"""Disabled-contract guard: Discord's built context carries no <keys> element.
+
+`daimon.core.turn_keys` defines the `<keys>` element contract but nothing
+wires it into any adapter yet (the reused-session refresh mechanism it would
+depend on does not exist). This file proves that on Discord, for a real
+built context, against an agent with stored keys:
+
+  - no `<keys` element appears,
+  - no stored value appears,
+  - no stored key *name* appears either, since nothing injects them,
+  - `context.py` carries no reference to the `turn_keys` module.
+
+When a later phase wires `render_keys_element` into a builder deliberately,
+every assertion here about key *names* being absent must be inverted (the
+value-absence assertions must stay, unchanged). Finding this test red is the
+signal that the wiring happened; go update the assertions here to match the
+new, intended behaviour instead of deleting them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import discord
+import pytest
+from daimon.adapters.discord.context import (
+    build_channel_context_xml,
+    build_context_xml,
+    build_delta_xml,
+)
+from daimon.core.stores.agent_files import put_agent_file
+from daimon.testing.factories import make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession
+
+_STORED_KEY_ONE = "OPENAI_API_KEY"
+_STORED_VALUE_ONE = "sk-sentinel-discord-guard-4b7e1a"
+_STORED_KEY_TWO = "TOGGL_TOKEN"
+_STORED_VALUE_TWO = "toggl-sentinel-discord-guard-c2a9"
+
+
+class _AsyncIter:
+    """Async iterator adapter for mocked ``thread.history()`` / ``channel.history()``."""
+
+    def __init__(self, items: list[discord.Message]) -> None:
+        self._items = iter(items)
+
+    def __aiter__(self) -> _AsyncIter:
+        return self
+
+    async def __anext__(self) -> discord.Message:
+        try:
+            return next(self._items)
+        except StopIteration as err:
+            raise StopAsyncIteration from err
+
+
+def _make_message(*, msg_id: int = 10, content: str = "what keys do you have?") -> discord.Message:
+    msg = MagicMock(spec=discord.Message)
+    msg.id = msg_id
+    msg.content = content
+    msg.author = MagicMock()
+    msg.author.display_name = "Alice"
+    msg.author.id = 200
+    msg.author.bot = False
+    msg.created_at = datetime(2026, 4, 28, 12, 0, 0, tzinfo=UTC)
+    msg.attachments = []
+    return msg
+
+
+def _make_thread(messages: list[discord.Message]) -> discord.Thread:
+    thread = MagicMock(spec=discord.Thread)
+    thread.history = MagicMock(return_value=_AsyncIter(messages))
+    thread.id = 900
+    thread.parent_id = 800
+    thread.name = "Chat with daimon"
+    thread.starter_message = None
+    thread.parent = None
+    return thread
+
+
+def _make_text_channel(messages: list[discord.Message]) -> discord.TextChannel:
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.history = MagicMock(return_value=_AsyncIter(messages))
+    return channel
+
+
+async def _seed_stored_keys(session: AsyncSession) -> None:
+    tenant = await make_tenant(session)
+    for key, value in (
+        (_STORED_KEY_ONE, _STORED_VALUE_ONE),
+        (_STORED_KEY_TWO, _STORED_VALUE_TWO),
+    ):
+        await put_agent_file(
+            session, tenant_id=tenant.id, agent_id=tenant.id, key=key, content=value
+        )
+
+
+def _assert_no_keys_element(xml: str, *, builder_name: str) -> None:
+    assert "<keys" not in xml, (
+        f"{builder_name} must not emit a <keys> element — nothing wires "
+        "render_keys_element into any adapter yet"
+    )
+    for value in (_STORED_VALUE_ONE, _STORED_VALUE_TWO):
+        assert value not in xml, (
+            f"{builder_name} must never leak a stored key's value, wiring or no wiring"
+        )
+    for name in (_STORED_KEY_ONE, _STORED_KEY_TWO):
+        assert name not in xml, (
+            f"{builder_name} must not mention a stored key's name today — nothing injects "
+            "key names into a turn yet. This expectation inverts once a later phase wires "
+            "render_keys_element into this builder; when it does, update this assertion to "
+            f"require the name instead of forbidding it."
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_context_xml_carries_no_keys_element(db_session: AsyncSession) -> None:
+    await _seed_stored_keys(db_session)
+    trigger = _make_message()
+    thread = _make_thread([trigger])
+
+    xml, _ = await build_context_xml(thread, trigger)
+
+    _assert_no_keys_element(xml, builder_name="build_context_xml")
+
+
+@pytest.mark.asyncio
+async def test_build_delta_xml_carries_no_keys_element(db_session: AsyncSession) -> None:
+    await _seed_stored_keys(db_session)
+    trigger = _make_message(msg_id=11)
+    thread = _make_thread([trigger])
+
+    xml, _ = await build_delta_xml(thread, trigger, after_message_id=None)
+
+    _assert_no_keys_element(xml, builder_name="build_delta_xml")
+
+
+@pytest.mark.asyncio
+async def test_build_channel_context_xml_carries_no_keys_element(db_session: AsyncSession) -> None:
+    await _seed_stored_keys(db_session)
+    trigger = _make_message(msg_id=12)
+    thread = _make_thread([trigger])
+    channel = _make_text_channel([trigger])
+
+    xml, _ = await build_channel_context_xml(channel, trigger, thread=thread)
+
+    _assert_no_keys_element(xml, builder_name="build_channel_context_xml")
+
+
+def test_context_module_does_not_reference_turn_keys() -> None:
+    source = Path("packages/adapters/discord/daimon/adapters/discord/context.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "turn_keys" not in source, (
+        "discord/context.py must not reference daimon.core.turn_keys — the <keys> element "
+        "contract is intentionally unwired. If you are reading this because it failed, you "
+        "wired it: do so deliberately, then invert the name-absence assertions in "
+        "test_context_no_keys_element.py to match the new, intended behaviour."
+    )

--- a/packages/adapters/discord/tests/test_credential_button.py
+++ b/packages/adapters/discord/tests/test_credential_button.py
@@ -260,7 +260,7 @@ async def test_from_custom_id_unknown_token_returns_item_with_no_row_and_fallbac
     item = await CredentialRequestButton.from_custom_id(interaction, MagicMock(), _match(token))
 
     assert item.request_row is None, "an unknown token must yield no row rather than raising"
-    assert item.item.label == "Add credential", "fallback label is used when no row is found"
+    assert item.item.label == "Enter it privately", "fallback label is used when no row is found"
 
 
 async def test_from_custom_id_db_failure_is_logged_and_interaction_check_rejects_gracefully(

--- a/packages/adapters/discord/tests/test_credential_modals.py
+++ b/packages/adapters/discord/tests/test_credential_modals.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import uuid
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -734,7 +735,11 @@ async def test_mcp_modal_unconfigured_mcp_reports_misconfiguration_no_consume_no
     await modal.on_submit(interaction)
 
     message = interaction.followup.send.call_args.args[0]
-    assert "not configured" in message, "must report the daimon-mcp misconfiguration"
+    assert "Ask the operator to finish setup" in message, "must name who can fix setup"
+    assert "Nothing was saved" in message, "the guard runs before any value is written"
+    assert "public_url" not in message and "jwt_secret" not in message, (
+        "internal setting names must not be shown to people"
+    )
 
     # The token must still be unconsumed -- retry with configured settings must succeed.
     retry_runtime = _runtime(
@@ -755,12 +760,12 @@ async def test_mcp_modal_unconfigured_mcp_reports_misconfiguration_no_consume_no
     retry_interaction = _interaction()
     await retry_modal.on_submit(retry_interaction)
     retry_message = retry_interaction.followup.send.call_args.args[0]
-    assert "not configured" not in retry_message, (
+    assert "Ask the operator to finish setup" not in retry_message, (
         "the request must still be consumable once daimon-mcp is configured"
     )
 
 
-async def test_mcp_modal_vault_write_failure_surfaces_only_exception_class_name(
+async def test_mcp_modal_vault_write_failure_keeps_exception_details_private(
     db_session: AsyncSession,
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
@@ -781,7 +786,7 @@ async def test_mcp_modal_vault_write_failure_surfaces_only_exception_class_name(
     await modal.on_submit(interaction)
 
     message = interaction.followup.send.call_args.args[0]
-    assert "APIConnectionError" in message, "only the exception class name is surfaced"
+    assert "APIConnectionError" not in message, "exception class names stay in operator logs"
     assert "secret=abc123" not in message, (
         "the stringified exception (which can carry the request envelope) must never reach the user"
     )
@@ -816,7 +821,8 @@ async def test_mcp_modal_disables_the_button_even_when_the_write_below_it_fails(
         "a consumed request disables its button regardless of the write's outcome"
     )
     message = interaction.followup.send.call_args.args[0]
-    assert "APIConnectionError" in message, "the failure is still reported in the reply"
+    assert "saving the MCP token did not finish" in message, "the failure must still be reported"
+    assert "APIConnectionError" not in message, "exception classes stay in operator logs"
 
 
 async def test_mcp_modal_never_logs_the_raw_token(
@@ -1108,7 +1114,8 @@ async def test_repo_modal_never_leaks_the_pasted_token(
         assert "can't access this repo" in message
     elif scenario == "unexpected_exception":
         message = _sent_message(interaction)
-        assert "ConnectError" in message, "only the exception class name must be surfaced"
+        assert "ConnectError" not in message, "exception classes stay in operator logs"
+        assert "working repo did not finish" in message, "the failed operation must be clear"
     elif scenario == "refused_by_gate":
         assert _sent_message(interaction) == _SHARED_AGENT_MESSAGE
         assert not any(
@@ -1225,4 +1232,62 @@ async def test_skill_repo_modal_attaches_the_imported_skills_to_the_requested_ag
     attached_ids = {entry["skill_id"] for entry in updates[-1]["skills"]}
     assert "skill_01imported" in attached_ids, (
         "the newly imported skill must be attached to the agent the request named"
+    )
+
+
+@pytest.mark.parametrize("failure_stage", ["verification", "authorization", "import"])
+async def test_skill_repo_failure_reports_only_confirmed_token_saves(
+    failure_stage: str,
+    monkeypatch: pytest.MonkeyPatch,
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    row = await _seed_skill_repo_request(
+        db_session_factory,
+        ma_agent_id="agent_skill_repo_failure",
+        target=build_skill_repo_target("https://github.com/o/skills-repo", "main", ""),
+    )
+    runtime = _runtime(
+        sessionmaker=db_session_factory,
+        anthropic=build_stub_anthropic(),
+        crypto_keys=(Fernet.generate_key().decode(),),
+    )
+    probes = 0
+
+    def github_response(request: httpx.Request) -> httpx.Response:
+        nonlocal probes
+        if request.url.path == "/repos/o/skills-repo":
+            probes += 1
+            if failure_stage == "verification":
+                raise httpx.ConnectError("private upstream detail", request=request)
+            if failure_stage == "authorization" and probes == 2:
+                return httpx.Response(403)
+            return httpx.Response(200, json={"private": True})
+        raise httpx.ConnectError("private upstream detail", request=request)
+
+    original_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        partial(original_client, transport=httpx.MockTransport(github_response)),
+    )
+    modal = SkillRepoModal(runtime=runtime, request_row=row)
+    modal.pat_in._value = "ghp_skill_failure_token"  # pyright: ignore[reportPrivateUsage]  # Discord input boundary
+    interaction = _admin_interaction()
+
+    await modal.on_submit(interaction)
+
+    message = interaction.followup.send.call_args.args[0]
+    async with db_session_factory() as session:
+        binding = await get_binding(session, tenant_id=row.tenant_id, agent_id=row.agent_id)
+    if failure_stage == "import":
+        assert binding is not None, "the working-repo binding was committed before import failed"
+        assert "Token saved" in message, "an import failure must preserve confirmed save success"
+    else:
+        assert binding is None, "failed authorization must not bind the repo"
+        assert "Token saved" not in message and "Token stored" not in message, (
+            "a failure before storage must not claim that the token was saved"
+        )
+    assert "retry" in message, "a consumed request needs a concrete retry instruction"
+    assert "private upstream detail" not in message and "ConnectError" not in message, (
+        "unexpected exception details stay in operator logs"
     )

--- a/packages/adapters/discord/tests/test_credential_repo_bind.py
+++ b/packages/adapters/discord/tests/test_credential_repo_bind.py
@@ -207,6 +207,11 @@ async def test_defaults_managed_target_member_refuses_with_shared_agent_message(
 
     assert refused is True, "a member must not bind a repo to a defaults-managed agent"
     assert _sent_message(interaction) == _SHARED_AGENT_MESSAGE
+    assert "working repo" in _sent_message(interaction)
+    assert "Manage Server" in _sent_message(interaction)
+    assert "`/agent-setup`" in _sent_message(interaction)
+    assert "keys" not in _sent_message(interaction)
+    assert "fork" not in _sent_message(interaction)
 
 
 async def test_reachable_non_managed_target_flips_with_the_scope_row(
@@ -385,12 +390,6 @@ async def test_acked_refusal_uses_followup_send(
     assert refused is True
     interaction.response.send_message.assert_not_called()
     interaction.followup.send.assert_called_once()
-
-
-async def test_shared_agent_message_matches_the_panel_gate_character_for_character() -> None:
-    assert _SHARED_AGENT_MESSAGE == panel_authz._SHARED_AGENT_MESSAGE, (
-        "the chat gate's shared-agent refusal copy must never drift from the panel's"
-    )
 
 
 @pytest.mark.parametrize(

--- a/packages/adapters/discord/tests/test_lifecycle.py
+++ b/packages/adapters/discord/tests/test_lifecycle.py
@@ -238,6 +238,44 @@ class TestCleanReplace:
         overflow_sends = len(sends) - initial_sends
         assert overflow_sends >= 1, "overflow chunks should be posted as new sends"
 
+    async def test_final_answer_with_everyone_disables_all_mention_channels(self) -> None:
+        """T-22-01: a final answer containing ``@everyone`` (reachable via prompt
+        injection through tool output) must not ping the guild. The clean-replace
+        edit must carry an AllowedMentions with everyone/roles/users all disabled."""
+        lc, sends, edits = _make_lifecycle()
+
+        await lc.on_sse_event(_thinking_event())
+        state = _make_success_state("@everyone check this out")
+        await lc.on_terminal_success(state)
+
+        replace_edit = edits[-1]
+        mentions = replace_edit[1].get("allowed_mentions")
+        assert mentions is not None, "clean-replace edit must carry allowed_mentions"
+        assert not mentions.everyone, "everyone mentions must be disabled"
+        assert not mentions.roles, "role mentions must be disabled"
+        assert not mentions.users, "user mentions must be disabled"
+
+    async def test_overflow_chunk_disables_all_mention_channels(self) -> None:
+        """The overflow-chunk send (posted after the first chunk) must carry the
+        same none-everything AllowedMentions as the clean-replace edit."""
+        lc, sends, edits = _make_lifecycle()
+
+        await lc.on_sse_event(_thinking_event())
+        await lc.on_render(TurnState())  # establishes message_ref before terminal
+        initial_sends = len(sends)
+
+        long_text = "@everyone " + "x" * 4000
+        state = TurnState(content=[TextBlock(kind="text", text=long_text)])
+        await lc.on_terminal_success(state)
+
+        overflow = sends[initial_sends:]
+        assert overflow, "overflow chunks should be posted as new sends"
+        mentions = overflow[0].get("allowed_mentions")
+        assert mentions is not None, "overflow send must carry allowed_mentions"
+        assert not mentions.everyone, "everyone mentions must be disabled"
+        assert not mentions.roles, "role mentions must be disabled"
+        assert not mentions.users, "user mentions must be disabled"
+
 
 # ---------------------------------------------------------------------------
 # SPEC-R7: Error embed on terminal failure
@@ -373,6 +411,25 @@ class TestSealedResponsePersistence:
         content_sends = [s for s in sends[initial_sends:] if "content" in s]
         assert len(content_sends) == 1, "sealed answer should post exactly once across ticks"
         assert content_sends[0]["content"] == answer, "the sealed text posts verbatim"
+
+    async def test_sealed_answer_disables_all_mention_channels(self) -> None:
+        """T-22-01: the sealed pre-tool answer send (reachable via prompt
+        injection through tool output) must disable everyone/role/user mentions."""
+        lc, sends, edits = _make_lifecycle()
+        await lc.on_sse_event(_thinking_event())
+        initial_sends = len(sends)
+
+        answer = "@everyone the full diagnosis is: " + "x" * 600
+        state = _sealed_state(answer)
+        await lc.on_render(state)
+
+        content_sends = [s for s in sends[initial_sends:] if "content" in s]
+        assert len(content_sends) == 1
+        mentions = content_sends[0].get("allowed_mentions")
+        assert mentions is not None, "sealed answer send must carry allowed_mentions"
+        assert not mentions.everyone, "everyone mentions must be disabled"
+        assert not mentions.roles, "role mentions must be disabled"
+        assert not mentions.users, "user mentions must be disabled"
 
     async def test_on_render_keeps_short_narration_suppressed(self) -> None:
         """Sealed text under the threshold is narration and never posts as a

--- a/packages/adapters/discord/tests/test_modal_lint.py
+++ b/packages/adapters/discord/tests/test_modal_lint.py
@@ -1,0 +1,172 @@
+"""Tests for scripts/lint_discord_modals.py.
+
+The script lives outside any package (`scripts/`, not `daimon.*`), so it is
+loaded here via `importlib.util.spec_from_file_location` against a path
+derived from the repository root rather than a normal import. This package
+already runs in its own CI shard and has a conftest; `scripts/` has neither,
+so the cost of a package test reaching for a top-level script is paid here
+explicitly instead of inventing a new `scripts/tests/` tree.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[4] / "scripts" / "lint_discord_modals.py"
+
+
+def _load_lint_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("lint_discord_modals", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None, (
+        f"could not build an import spec for {_SCRIPT_PATH}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    # dataclasses' `frozen=True` resolution looks the module up in
+    # sys.modules by name at class-creation time, so it must be registered
+    # before exec_module runs.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+lint_discord_modals = _load_lint_module()
+
+
+def _findings(source: str) -> list[object]:
+    """Parse ``source``, walk every Modal subclass in it, and return the
+    findings — string in, findings out, no filesystem involved."""
+    tree = ast.parse(source)
+    int_constants = lint_discord_modals._module_int_constants(tree)
+    findings: list[object] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and any(
+            lint_discord_modals._is_modal_base(b) for b in node.bases
+        ):
+            findings.extend(lint_discord_modals._walk_modal_class(node, "<test>", int_constants))
+    return findings
+
+
+def _rules(source: str) -> list[str]:
+    return [f.rule for f in _findings(source)]  # type: ignore[attr-defined]
+
+
+def test_label_wrapped_select_allowed_when_inside_modal() -> None:
+    source = """
+class Picker(discord.ui.Modal, title="Pick"):
+    row = discord.ui.Label(component=discord.ui.Select(options=[]))
+"""
+    assert _rules(source) == [], (
+        "a Label wrapping a Select is a supported modal component and must yield no findings"
+    )
+
+
+def test_bare_top_level_select_allowed_when_inside_modal() -> None:
+    source = """
+class Picker(discord.ui.Modal, title="Pick"):
+    row = discord.ui.Select(options=[])
+"""
+    assert _rules(source) == [], (
+        "discord.py 2.7.1 auto-wraps a bare top-level Select in an ActionRow just "
+        "like a bare TextInput, so a bare Select must not be rejected"
+    )
+
+
+def test_six_mixed_children_over_cap() -> None:
+    source = """
+class TooMany(discord.ui.Modal, title="Too many"):
+    a = discord.ui.Label(component=discord.ui.Select(options=[]))
+    b = discord.ui.RadioGroup()
+    c = discord.ui.CheckboxGroup()
+    d = discord.ui.FileUpload()
+    e = discord.ui.TextDisplay(content="hi")
+    f = discord.ui.TextInput(label="F")
+"""
+    assert _rules(source) == ["discord/too-many-components"], (
+        "six top-level children of mixed type must trip the too-many-components rule exactly once"
+    )
+
+
+def test_five_mixed_children_at_cap() -> None:
+    source = """
+class AtCap(discord.ui.Modal, title="At cap"):
+    a = discord.ui.Label(component=discord.ui.Select(options=[]))
+    b = discord.ui.RadioGroup()
+    c = discord.ui.CheckboxGroup()
+    d = discord.ui.FileUpload()
+    e = discord.ui.TextDisplay(content="hi")
+"""
+    assert _rules(source) == [], (
+        "five top-level children is Discord's exact cap and must not trip the "
+        "too-many-components rule — the boundary pair guards against an off-by-one "
+        "that would silently un-guard the cap"
+    )
+
+
+def test_five_children_including_label_wrapped_select_at_cap() -> None:
+    source = """
+class AtCapWithLabel(discord.ui.Modal, title="At cap"):
+    a = discord.ui.Label(component=discord.ui.Select(options=[]))
+    b = discord.ui.RadioGroup()
+    c = discord.ui.CheckboxGroup()
+    d = discord.ui.FileUpload()
+    e = discord.ui.TextDisplay(content="hi")
+"""
+    assert _rules(source) == [], (
+        "a Label wrapping a Select must cost one slot against the five-item cap, "
+        "because its Select is nested inside the Label"
+    )
+
+
+def test_text_input_without_label_flagged() -> None:
+    source = """
+class NoLabel(discord.ui.Modal, title="No label"):
+    field = discord.ui.TextInput()
+"""
+    assert _rules(source) == ["discord/missing-label"], (
+        "a TextInput with no label kwarg must still be flagged — this rule is not "
+        "changing and this test is a regression guard on the rewrite"
+    )
+
+
+def test_text_input_with_long_label_flagged() -> None:
+    long_label = "x" * 46
+    source = f"""
+class LongLabel(discord.ui.Modal, title="Long label"):
+    field = discord.ui.TextInput(label="{long_label}")
+"""
+    assert _rules(source) == ["discord/label-too-long"], (
+        "a 46-character label exceeds Discord's 45-codepoint cap and must still be "
+        "flagged — this rule is not changing and this test is a regression guard "
+        "on the rewrite"
+    )
+
+
+def test_text_input_with_non_literal_max_length_flagged() -> None:
+    source = """
+class NonLiteralMaxLength(discord.ui.Modal, title="Non literal"):
+    field = discord.ui.TextInput(label="F", max_length=SOME_IMPORTED_CONST)
+"""
+    assert _rules(source) == ["discord/non-literal-max-length"], (
+        "a max_length referencing a name the lint cannot resolve (e.g. an imported "
+        "constant) must still be flagged as non-literal — this rule is not "
+        "changing and this test is a regression guard on the rewrite"
+    )
+
+
+def test_non_modal_class_produces_no_findings() -> None:
+    source = """
+class NotAModal(discord.ui.View):
+    a = discord.ui.Label(component=discord.ui.Select(options=[]))
+    b = discord.ui.RadioGroup()
+    c = discord.ui.CheckboxGroup()
+    d = discord.ui.FileUpload()
+    e = discord.ui.TextDisplay(content="hi")
+    f = discord.ui.TextInput(label="F")
+"""
+    assert _rules(source) == [], (
+        "a class that does not subclass Modal must produce no findings whatever it contains"
+    )

--- a/packages/adapters/discord/tests/test_require_manage_guild.py
+++ b/packages/adapters/discord/tests/test_require_manage_guild.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 from daimon.adapters.discord.checks import require_manage_guild
 
-_D28_MESSAGE = "Changing my setup needs Manage Server — ask a server admin to use /agent-setup"
+_ROUTINES_HANDOVER = "Please open `/routines` to review this server’s scheduled routines."
 
 
 def _make_interaction(
@@ -90,7 +90,7 @@ async def test_require_manage_guild_rejects_member_without_perms() -> None:
         else call_args.kwargs.get("ephemeral") is True
     ), "non-admin member rejected ephemerally"
     sent_msg = call_args.args[0] if call_args.args else call_args.kwargs.get("content", "")
-    assert _D28_MESSAGE in sent_msg, "rejection message must be sent on rejection"
+    assert _ROUTINES_HANDOVER in sent_msg, "rejection message must be sent on rejection"
     assert not interaction._inner_called, (
         "non-admin member rejected ephemerally — inner fn not called"
     )

--- a/packages/adapters/mcp/daimon/adapters/mcp/oauth_slack.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/oauth_slack.py
@@ -297,9 +297,9 @@ def _page(
 
 _SCOPES_HTML = """
 <ul class="scope-list">
-  <li>see when you @mention daimon <code>app_mentions:read</code></li>
+  <li>see when you @mention the bot <code>app_mentions:read</code></li>
   <li>post replies and status updates <code>chat:write</code></li>
-  <li>run daimon&#39;s slash commands (e.g. <code>/agent-setup</code>) <code>commands</code></li>
+  <li>run setup commands (e.g. <code>/agent-setup</code>) <code>commands</code></li>
   <li>check who&#39;s an admin before admin actions <code>users:read</code></li>
   <li>read recent messages in public channels it&#39;s added to <code>channels:history</code></li>
   <li>read recent messages in private channels it&#39;s added to <code>groups:history</code></li>
@@ -325,6 +325,7 @@ def _install_landing_html(
     *,
     authorize_url: str,
     signup_credit: Decimal,
+    display_name: str = "daimon",
 ) -> HTMLResponse:
     """Branded install landing page (Page 1 per UI-SPEC).
 
@@ -333,15 +334,16 @@ def _install_landing_html(
     """
     safe_href = html.escape(authorize_url, quote=True)
     credit = _format_credit(signup_credit)
+    safe_name = html.escape(display_name, quote=False)
     body = f"""
 <h1>your server just hired a data scientist</h1>
 <p class="subtitle">· by daimon</p>
-<p>add daimon to your Slack workspace and get {credit} of credit on us — data
+<p>add {safe_name} to your Slack workspace and get {credit} of credit on us — data
 analysis, code review, and research, all from Slack.</p>
-<h2>what daimon will be able to do</h2>
+<h2>what {safe_name} will be able to do</h2>
 {_SCOPES_HTML}
 <a class="btn" href="{safe_href}">Add to Slack</a>
-<p class="footer">daimon reads channels you invite it to — and, for members who
+<p class="footer">{safe_name} reads channels you invite it to — and, for members who
 connect their account, whatever they can already see.</p>
 """
     return _page(title="add daimon to Slack", state_bar="", body_html=body)
@@ -351,6 +353,7 @@ def _success_html(
     *,
     workspace: str,
     signup_credit: Decimal,
+    display_name: str = "daimon",
 ) -> HTMLResponse:
     """Branded success page (Page 2 per UI-SPEC).
 
@@ -359,10 +362,11 @@ def _success_html(
     """
     safe = html.escape(workspace, quote=False)
     credit = _format_credit(signup_credit)
+    safe_name = html.escape(display_name, quote=False)
     body = f"""
 <h1>installed in {safe}</h1>
-<p>next: @mention <code>@daimon</code> in any channel, or run
-<code>/agent-setup</code> to get started.</p>
+<p>next: @mention <code>@{safe_name}</code> in a channel you have invited it to,
+or run <code>/agent-setup</code> to choose who answers where.</p>
 <p>you get {credit} of credit on us.</p>
 <p class="dim">you can close this tab and head back to Slack.</p>
 """
@@ -534,6 +538,9 @@ def build_oauth_slack_routes(
         return _install_landing_html(
             authorize_url=authorize_url,
             signup_credit=settings.billing.signup_credit,
+            display_name=settings.slack.bot_display_name
+            if settings.slack is not None
+            else "daimon",
         )
 
     async def callback_handler(request: Request) -> Response:
@@ -674,6 +681,9 @@ def build_oauth_slack_routes(
         return _success_html(
             workspace=result.team_name or team_id,
             signup_credit=settings.billing.signup_credit,
+            display_name=settings.slack.bot_display_name
+            if settings.slack is not None
+            else "daimon",
         )
 
     async def connect_handler(request: Request) -> Response:

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/_ctx.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/_ctx.py
@@ -35,7 +35,10 @@ def _require_admin(auth: AuthIdentity) -> None:  # pyright: ignore[reportUnusedF
     """
     if not auth.is_admin:
         raise ToolError(
-            "Changing my setup needs Manage Server — ask a server admin to use /agent-setup"
+            "This operation requires a workspace or server admin. Tell the caller who can "
+            "make the change and give them a sentence the admin can say, preserving "
+            "the requested action and target from the conversation. They are not available "
+            "to this permission check; do not invent missing details. Do not retry the mutation."
         )
 
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_removal.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agent_removal.py
@@ -1,12 +1,12 @@
-"""Agent removal tools: detach_mcp_server, remove_skill, remove_env_credential,
-list_env_credential_keys.
+"""Agent removal tools: detach_mcp_server, remove_skill, remove_agent_key,
+list_agent_keys.
 
 ``register_agent_removal_tools(mcp, runtime)`` wires the ``@mcp.tool`` closures
 for this group; each closure delegates to a module-private ``_*_impl``
 coroutine that can be unit-tested without a FastMCP Context.
 
 A sibling of ``agents.py`` rather than more of it: these four tools close the
-last gap between what the ``/agent-setup`` panel can do to an agent and what
+last gap between what other setup surfaces can do to an agent and what
 chatting with the agent can do — detach an attached MCP server, detach an
 attached skill, remove an env variable, and enumerate the env variable key
 names currently set (never their values).
@@ -15,7 +15,7 @@ names currently set (never their values).
 from __future__ import annotations
 
 import uuid
-from typing import cast
+from typing import Annotated, cast
 
 import anthropic
 from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsSkillParams
@@ -41,11 +41,11 @@ from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.stores.agent_files import delete_agent_file, list_agent_files
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RemoveEnvCredentialResult(BaseModel):
-    """Result of ``remove_env_credential``. Never carries a value."""
+    """Result of ``remove_agent_key``. Never carries a value."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -167,7 +167,7 @@ async def _remove_skill_impl(
     return await _build_agent_info(runtime.client, updated, tenant_id=auth.tenant_id)
 
 
-async def _list_env_credential_keys_impl(
+async def _list_agent_keys_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
     *,
@@ -189,14 +189,14 @@ async def _list_env_credential_keys_impl(
     return [row.key for row in rows]
 
 
-async def _remove_env_credential_impl(
+async def _remove_agent_key_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
     *,
     agent_name: str,
     key: str,
 ) -> RemoveEnvCredentialResult:
-    # Same rationale as _list_env_credential_keys_impl above: env variables
+    # Same rationale as _list_agent_keys_impl above: env variables
     # are per-agent daimon rows outside the MA spec, so neither
     # _reject_system_agent nor require_admin_for_reachable_agent applies here
     # — and the existing chat credential button already writes these rows for
@@ -223,17 +223,16 @@ def register_agent_removal_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     async def detach_mcp_server(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
-        server_name: str,
+        server_name: Annotated[
+            str, Field(description="Name of the attached MCP server to disconnect.")
+        ],
     ) -> AgentInfo:
-        """Detach an attached MCP server from an agent.
+        """Disconnect an MCP server such as Linear from an agent. Detach the named
+        connection and its tools while preserving other servers and skills.
 
-        Removes the named entry from ``mcp_servers`` AND its matching
-        ``mcp_toolset`` entry from ``tools`` together — MA rejects an agent
-        whose ``mcp_servers`` entries aren't each referenced by a
-        ``mcp_toolset``, so both must go in the same update. Every other
-        attached server, skill, and tool is preserved. The reserved built-in
-        daimon server cannot be detached.
-        """
+        ``attach_mcp_server`` adds public endpoints; ``request_mcp_token`` enrolls
+        authenticated connections. The built-in daimon server cannot be removed.
+        Changing a channel or workspace default needs admin."""
         return await _detach_mcp_server_impl(
             runtime, await _auth(ctx), agent_name=agent_name, server_name=server_name
         )
@@ -244,50 +243,48 @@ def register_agent_removal_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         agent_name: str,
         skill_id: str,
     ) -> AgentInfo:
-        """Detach one attached skill from an agent.
+        """Stop an agent using an attached skill, such as eda. Remove that one
+        attachment while preserving other skills.
 
-        Accepts either the skill's raw ``skill_id`` or its resolved display
-        name. Every other attached skill and the agent's base tool set are
-        preserved.
-
-        This is a DIFFERENT operation from ``delete_skill`` /
-        ``skills_delete``, which destroy a skill for every agent in the
-        tenant. ``remove_skill`` only detaches this one agent's reference —
-        the skill resource itself, and any other agent that has it attached,
-        is untouched.
-        """
+        ``delete_skill`` destroys the shared workspace skill instead;
+        ``update_agent`` adds existing skills. Accept a skill name or raw ``skill_id``.
+        The resource and other agents stay intact. Changing a default agent needs admin."""
         return await _remove_skill_impl(
             runtime, await _auth(ctx), agent_name=agent_name, skill_id=skill_id
         )
 
     @mcp.tool
-    async def remove_env_credential(  # pyright: ignore[reportUnusedFunction]
+    async def remove_agent_key(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
-        key: str,
+        key: Annotated[
+            str,
+            Field(
+                description=(
+                    "Stored environment variable name, UPPER_SNAKE, e.g. TOGGL_TOKEN "
+                    "or OPENAI_API_KEY; never the secret value."
+                )
+            ),
+        ],
     ) -> RemoveEnvCredentialResult:
-        """Remove one environment variable from an agent.
+        """Remove an old API key or token, such as a Toggl key, from an agent's stored keys.
 
-        Idempotent: removing a key that is not currently set still succeeds
-        — the result's ``removed`` flag reports whether the key was actually
-        present. To ADD a variable, use ``request_env_credential`` instead;
-        entry always goes through the private modal flow, never through chat.
-        """
-        return await _remove_env_credential_impl(
+        Use ``request_agent_key`` to add a key privately and ``list_agent_keys`` to
+        inspect stored names. Removing a missing key also succeeds; ``removed`` says
+        whether it was present. This deletes the stored environment variable, never
+        returns its secret value, and does not prove an existing session refreshed."""
+        return await _remove_agent_key_impl(
             runtime, await _auth(ctx), agent_name=agent_name, key=key
         )
 
     @mcp.tool
-    async def list_env_credential_keys(  # pyright: ignore[reportUnusedFunction]
+    async def list_agent_keys(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
     ) -> list[str]:
-        """List the environment variable KEY NAMES currently set on an agent.
+        """What keys does an agent have? List its stored API key names, never values.
 
-        Returns names only, never a value — so the agent can see what is
-        configured without a value ever entering chat. To add a variable,
-        use ``request_env_credential``.
-        """
-        return await _list_env_credential_keys_impl(
-            runtime, await _auth(ctx), agent_name=agent_name
-        )
+        Use ``get_agent`` for skills and MCP access, ``request_agent_key`` to add
+        keys or ``remove_agent_key`` to remove them. Stored names on this target
+        are not proof that the answering agent can use those keys."""
+        return await _list_agent_keys_impl(runtime, await _auth(ctx), agent_name=agent_name)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/agents.py
@@ -46,6 +46,7 @@ from daimon.core.defaults.mcp_merge import (
 )
 from daimon.core.defaults.metadata import (
     MA_METADATA_KEY_ACCOUNT,
+    MA_METADATA_KEY_ISOLATED,
     MA_METADATA_KEY_MANAGED,
     build_metadata,
     strip_tenant_prefix,
@@ -268,13 +269,13 @@ def _reject_system_agent(agent: BetaManagedAgentsAgent) -> None:
     if agent.metadata.get(MA_METADATA_KEY_MANAGED) == "true":
         raise ToolError(
             f"agent '{agent.name}' is managed by defaults; chat tools cannot modify it. "
-            "Use /agent-setup to fork it first, then edit the fork."
+            "Use fork_agent to make an editable copy, then edit the named copy."
         )
     owner = agent.metadata.get(MA_METADATA_KEY_ACCOUNT)
     if owner is None:
         raise ToolError(
             f"agent '{agent.name}' is a system agent; chat tools cannot modify it. "
-            "Use /agent-setup to fork it first, then edit the fork."
+            "Use fork_agent to make an editable copy, then edit the named copy."
         )
 
 
@@ -365,7 +366,10 @@ def _build_create_spec(
             skill_repos=skill_repos or [],
         )
     except ValidationError as exc:
-        raise ToolError(f"create_agent: invalid agent configuration — {exc}") from exc
+        raise ToolError(
+            "create_agent: invalid agent configuration; check the supplied fields "
+            "and ensure every MCP server has a matching mcp_toolset entry. Nothing was saved."
+        ) from exc
 
 
 async def _create_agent_impl(
@@ -376,7 +380,7 @@ async def _create_agent_impl(
     if spec.skills:
         raise ToolError(
             "create_agent: skills must be empty. To add skills, either sync a "
-            "repo via skill_repos or use the skills_* tools after the agent "
+            "repo via skill_repos or use sync_skills after the agent "
             "is created."
         )
     await _reject_guild_name_collision(runtime, auth, spec.name)
@@ -521,7 +525,7 @@ async def _update_agent_impl(
     # tools) are recomputed from `fresh` on every attempt so a retry after a stale-
     # version conflict picks up any concurrent mutations rather than re-applying a
     # stale merge. MA treats list fields as per-field replaces; chat tools are an
-    # additions surface (the panel handles removals), so union caller's values with
+    # additions surface (dedicated removal tools handle removals), so union caller's values with
     # MA's current state — bug 2 of issue #56.
     async def _apply(fresh: BetaManagedAgentsAgent) -> BetaManagedAgentsAgent:
         patch: dict[str, Any] = dict(scalar_patch)
@@ -532,8 +536,8 @@ async def _update_agent_impl(
                 raise ToolError(
                     f"Cannot attach skills: the merged skill set ({merged_skill_count}) exceeds "
                     f"this organization's per-agent skill limit ({AGENT_SKILL_CAP}). No skills "
-                    "were changed. Attach fewer skills, or remove existing ones via the "
-                    "/agent-setup panel before adding more."
+                    f"were changed on '{name}'. Attach fewer skills, "
+                    "or use remove_skill before adding more."
                 )
         if mcp_servers is not None:
             patch["mcp_servers"] = merge_mcp_servers_with_ma(mcp_servers, fresh)
@@ -546,8 +550,8 @@ async def _update_agent_impl(
                 raise ToolError(
                     f"Cannot attach MCP servers: the merged server set ({merged_mcp_count}) "
                     f"exceeds this organization's per-agent MCP-server limit ({AGENT_MCP_CAP}). "
-                    "No servers were changed. Attach fewer servers, or remove existing ones via "
-                    "the /agent-setup panel before adding more."
+                    f"No servers were changed on '{name}'. Attach fewer servers, or use "
+                    "detach_mcp_server before adding more."
                 )
         if tools is not None:
             patch["tools"] = _union_tools(tools, fresh)
@@ -579,8 +583,7 @@ async def _update_agent_impl(
             raise ToolError(
                 "Cannot attach skills: the merged skill set exceeds this organization's "
                 "per-agent skill limit. No skills were changed. Attach fewer skills, or "
-                "remove existing ones via the /agent-setup panel before adding more. "
-                f"(Managed Agents reported: {exc})"
+                f"use remove_skill on '{name}' before adding more."
             ) from exc
         raise
     return await _build_agent_info(runtime.client, updated, tenant_id=auth.tenant_id)
@@ -676,13 +679,24 @@ async def _fork_agent_impl(
         cast("list[Tool] | None", fork_params.get("tools"))
     )
 
+    # Every non-forked creation/edit path already runs the guidance applier
+    # (`update_agent`, `reconcile_agent`); a fork bypasses both and copies raw
+    # MA state directly, so normalize it here too. Skip for a source stamped
+    # isolated — its session mounts no secrets, and the block would teach it
+    # to look for resources it must not have.
+    if source_ma.metadata.get(MA_METADATA_KEY_ISOLATED) != "true":
+        fork_params["system"] = apply_credential_guidance(
+            cast("str", fork_params.get("system") or "")
+        )
+
     # Narrow the cached fernet BEFORE any partial write — the create
     # below is the first write, so this must gate ahead of it.
     fernet = runtime.fernet
     if fernet is None:
         raise ToolError(
-            "fork_agent: no crypto keys configured — cannot copy the source agent's "
-            "credential. Configure DAIMON_CRYPTO__KEYS to enable fork."
+            f"fork_agent: cannot copy '{source_name}' to '{new_name}' because this deployment "
+            "is not fully configured. Tell the user an operator must finish setup; "
+            "nothing was created. Do not ask the user to change deployment settings."
         )
 
     new_ma = await runtime.client.beta.agents.create(**fork_params)
@@ -751,13 +765,11 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
     @mcp.tool
     async def get_agent(ctx: Context, name: str) -> AgentInfo:  # pyright: ignore[reportUnusedFunction]
-        """Look up an agent by name.
+        """Show what an agent can access: attached MCP servers and skills.
 
-        Returns the agent's attached ``mcp_servers`` (name + url) and
-        ``skills``. Custom skill entries include ``name`` — the resolved
-        display title (``null`` if the underlying skill was deleted);
-        anthropic skill entries have a readable ``skill_id`` and no name.
-        """
+        Use ``list_agent_keys`` for stored key names. Configuration does not prove
+        the answering session's access. Returns server names/URLs and skills; custom
+        skills have a display name (null if deleted), Anthropic skills have a readable id."""
         return await _get_agent_impl(runtime, await _auth(ctx), name)
 
     @mcp.tool
@@ -772,7 +784,8 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         mcp_servers: list[BetaManagedAgentsURLMCPServerParams] | None = None,
         skill_repos: list[SkillRepo] | None = None,
     ) -> AgentInfo:
-        """Create a new agent. Pass fields directly — there is NO ``spec`` wrapper.
+        """Create an agent called, for example, churn-explorer. Pass fields directly —
+        there is NO ``spec`` wrapper.
 
         Required: ``name`` and ``model``. Use ``"claude-sonnet-5"`` when the user
         asks for Sonnet and ``"claude-opus-5"`` when they ask for Opus — always
@@ -783,7 +796,7 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         e.g. ``[{"url": "https://github.com/owner/repo", "branch": "main"}]``.
 
         Do not pass a ``skills`` field here. To add skills, either sync a repo via
-        ``skill_repos`` or use the ``skills_*`` tools after the agent is created.
+        ``skill_repos`` or use ``sync_skills`` after the agent is created.
         """
         spec = _build_create_spec(
             name=name,
@@ -808,21 +821,18 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         mcp_servers: list[BetaManagedAgentsURLMCPServerParams] | None = None,
         skills: list[str | BetaManagedAgentsSkillParams] | None = None,
     ) -> AgentInfo:
-        """Patch-update an agent.
+        """Change an agent's system prompt or switch its model; add existing skills such as
+        build-models. Scalar ``model``, ``description`` and ``system`` fields replace.
 
-        Scalar fields (``model``, ``description``, ``system``) replace. For
-        ``model``, prefer the current generation — ``"claude-sonnet-5"`` for
-        Sonnet, ``"claude-opus-5"`` for Opus — unless the user names an older
-        version explicitly.
-        List fields (``tools``, ``mcp_servers``, ``skills``) UNION with the
-        agent's current state — caller's entries win on collision. To remove
-        an existing entry, use the ``/agent-setup`` panel.
+        Prefer current-generation ``claude-sonnet-5`` for Sonnet and ``claude-opus-5``
+        for Opus unless an older version is explicitly requested. List fields
+        (``tools``, ``mcp_servers``, ``skills``) are added to, never replaced; shorter
+        lists remove nothing. Use ``remove_skill`` or ``detach_mcp_server`` to remove.
+        Daimon requires ``fork_agent`` first; channel/workspace defaults require admin.
 
-        ``skills`` accepts skill NAMES, e.g.
-        ``skills=["build-models", "compare-models"]`` — names are resolved to MA
-        skill ids server-side. The explicit dict form
-        ``{"type": "custom", "skill_id": "skill_..."}`` still works.
-        """
+        Prompt changes replace the system prompt immediately. ``skills`` accepts names such as
+        ``["build-models", "compare-models"]``, resolved server-side; explicit
+        ``{"type": "custom", "skill_id": "skill_..."}`` entries also work."""
         return await _update_agent_impl(
             runtime,
             await _auth(ctx),
@@ -842,25 +852,15 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         server_name: str,
         url: str,
     ) -> AgentInfo:
-        """Attach a no-auth MCP server to an agent.
+        """Add an MCP server that needs no token, such as Context7, to an agent.
 
-        Use this ONLY for MCP servers that do not require authentication.
-        The tool patches the agent's ``mcp_servers`` with
-        ``{name: server_name, type: "url", url: url}`` AND appends a
-        matching ``mcp_toolset`` entry to ``tools`` (required by MA, which
-        rejects an agent whose ``mcp_servers`` entries aren't each
-        referenced by a ``mcp_toolset``). Existing entries are preserved.
-        If a server with the same ``server_name`` is already attached, the
-        new ``url`` replaces it (last-write-wins) and the existing
-        ``mcp_toolset`` is reused (no duplicate). If both ``server_name``
-        and ``url`` already match, this is a no-op.
+        For Linear or other bearer-authenticated endpoints, use
+        ``request_mcp_token`` instead;
+        ``detach_mcp_server`` disconnects it. Fork Daimon with ``fork_agent`` before
+        directly changing its setup. Channel or workspace defaults need admin.
 
-        For MCP servers that REQUIRE an auth token, do NOT collect the
-        token in chat — direct the user to ``/agent-setup`` -> MCPs modal.
-        Tokens sent in chat end up in channel history and MA's
-        tenant-wide session event log; the modal flow is the only
-        supported path for auth-required servers.
-        """
+        Connects the server and its tools immediately. Reusing a server name replaces
+        the URL; the same name and URL is a no-op. Other connections are preserved."""
         return await _attach_mcp_server_impl(
             runtime,
             await _auth(ctx),
@@ -871,14 +871,22 @@ def register_agent_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
     @mcp.tool
     async def fork_agent(ctx: Context, source_name: str, new_name: str) -> AgentInfo:  # pyright: ignore[reportUnusedFunction]
-        """Clone an agent within the tenant pool under a new name."""
+        """Make a copy of Daimon or another agent that you can edit under a new name.
+        Copies its prompt, model, skills, MCP definitions, working-repo binding and
+        recorded GitHub access. Copying access does not freshly verify it.
+
+        API/service keys are not copied; add them with ``request_agent_key``.
+        Use ``update_agent`` to edit the copy. Daimon cannot be edited directly.
+
+        The copy answers in no channel until an admin routes it with
+        ``set_agent_default``. Continue configuring it through Daimon with the copy
+        named as the setup target; it cannot already answer mentions by name."""
         return await _fork_agent_impl(runtime, await _auth(ctx), source_name, new_name)
 
     @mcp.tool(tags={"admin"})
     async def archive_agent(ctx: Context, name: str) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Archive the MA agent and delete from the tenant pool.
+        """Delete an agent, for example churn-explorer, by archiving it. Admin-only.
 
-        Also clears any channel or workspace default naming the agent, so turns
-        in those scopes fall back to the next tier instead of failing to resolve.
-        """
+        This removes the agent from the tenant pool and clears its channel/workspace
+        defaults so those channels fall back to the next routing tier."""
         await _archive_agent_impl(runtime, await _auth(ctx), name)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -1,26 +1,9 @@
-"""Credential-request tools: request_env_credential, request_mcp_credential,
-request_repo_binding.
+"""Post requester-only private forms for agent keys, MCP tokens and GitHub access.
 
-These three tools replace the "go open /agent-setup" redirect for a task that
-needs an env secret, an auth-required MCP server, or a repo bound to an
-agent: the agent mints a single-use, TTL-bounded ``credential_requests`` row
-and posts a target-naming button in the thread (``tools/discord/`` or
-``tools/slack/_credential_button.py``, by the caller's platform). Clicking
-the button opens a native modal in a different process (the platform bot,
-worker VM) — the secret itself never travels through either process's tool
-arguments, so
-none of the three tools below has a token/secret/value parameter, and none
-should ever be added.
-
-Deliberately NOT admin-gated — the chat-mutation admin check other tools call
-at the top of their impl is intentionally absent here. Authorization for the
-actual credential write happens at click time instead, when the button's
-click gate compares the clicking user against
-``requester_platform_user_id`` on the minted row. This widens today's
-admin-only credential writes (``/agent-setup``'s mutation buttons are
-``is_admin``-only) in exchange for one-click UX — a deliberate, accepted
-trade documented here so a future reviewer does not "fix" the omission by
-adding that admin gate back.
+These tools create single-use, expiring request rows and post a target-naming
+card through the caller's platform. Secret values never enter tool arguments.
+Submission checks requester identity; these enrollment paths deliberately do
+not inherit the admin gate for direct agent-spec mutations.
 """
 
 from __future__ import annotations
@@ -28,6 +11,7 @@ from __future__ import annotations
 import re
 import uuid
 from datetime import UTC, datetime
+from typing import Annotated
 from urllib.parse import urlparse
 
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
@@ -51,7 +35,7 @@ from daimon.core.ma_identity import derive_agent_uuid
 from daimon.core.stores.credential_requests import create_credential_request
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 # Mirrors packages/adapters/discord/daimon/adapters/discord/agent_setup/credentials.py's
 # _POSIX_KEY_RE. Duplicated rather than imported: the Discord adapter and the
@@ -164,7 +148,7 @@ async def _mint_and_post(
     )
 
 
-async def _request_env_credential_impl(
+async def _request_agent_key_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
     *,
@@ -176,7 +160,7 @@ async def _request_env_credential_impl(
     requester = _require_requestable_platform(auth)
     if not _POSIX_KEY_RE.match(key):
         raise ToolError(
-            "env key must match [A-Za-z_][A-Za-z0-9_]* "
+            "key must match [A-Za-z_][A-Za-z0-9_]* "
             "(letters, digits, underscores; must not start with a digit)"
         )
     agent_id = await _resolve_agent_uuid(runtime, auth, agent_name)
@@ -194,7 +178,7 @@ async def _request_env_credential_impl(
     )
 
 
-async def _request_mcp_credential_impl(
+async def _request_mcp_token_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
     *,
@@ -233,7 +217,7 @@ async def _request_mcp_credential_impl(
 # would be silently discarded — the exact class of surface-that-lies this
 # tool exists not to become. The modal collects the branch instead,
 # defaulting to `main`.
-async def _request_skill_repo_credential_impl(
+async def _request_skill_repo_token_impl(
     runtime: McpRuntime,
     auth: AuthIdentity,
     *,
@@ -305,22 +289,37 @@ async def _request_repo_binding_impl(
 
 def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
-    async def request_env_credential(  # pyright: ignore[reportUnusedFunction]
+    async def request_agent_key(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
-        key: str,
+        key: Annotated[
+            str,
+            Field(
+                description=(
+                    "Stored environment variable name, UPPER_SNAKE, e.g. TOGGL_TOKEN "
+                    "or OPENAI_API_KEY; never the secret value."
+                )
+            ),
+        ],
         purpose: str,
-        channel_id: str,
+        channel_id: Annotated[
+            str,
+            Field(
+                description="Channel where the requester-only private-input card will be posted."
+            ),
+        ],
     ) -> RequestCredentialResult:
-        """Request an environment secret from the user via a private modal.
+        """Give an agent an API key or token for any service: Toggl, OpenAI,
+        Higgsfield, or a platform that just launched. Unknown services work too.
 
-        Call this INSTEAD of ever accepting a secret value in chat. Posts a
-        button in the thread naming the exact env key; clicking it opens a
-        private form where the user enters the value — it
-        never appears in this channel or in your context. Once added, the
-        credential becomes usable by everyone who talks to ``agent_name``.
-        """
-        return await _request_env_credential_impl(
+        Never accept secret values in chat; ask for rotation if pasted. For MCP
+        credentials use ``request_mcp_token``; GitHub access uses ``request_repo_binding``.
+        To load .env keys, request each key separately; whole-file import is unavailable.
+
+        Posts a card in this channel. Only the requester can open its private form;
+        it expires in 30 minutes. Values never appear in chat. Anyone who talks to
+        the agent can use added keys, including on Daimon itself without a fork."""
+        return await _request_agent_key_impl(
             runtime,
             await _auth(ctx),
             agent_name=agent_name,
@@ -330,24 +329,37 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
         )
 
     @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
-    async def request_mcp_credential(  # pyright: ignore[reportUnusedFunction]
+    async def request_mcp_token(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
-        server_name: str,
-        url: str,
-        channel_id: str,
+        server_name: Annotated[
+            str, Field(description="Connection name; reusing a name replaces that server entry.")
+        ],
+        url: Annotated[
+            str,
+            Field(
+                description="MCP endpoint URL accepting bearer authentication, e.g. https://mcp.example.com/mcp."
+            ),
+        ],
+        channel_id: Annotated[
+            str,
+            Field(
+                description="Channel where the requester-only private-input card will be posted."
+            ),
+        ],
     ) -> RequestCredentialResult:
-        """Request an auth-required MCP server's credential via a private modal.
+        """Connect an agent such as research-bot to Linear, Notion or GitHub through an
+        MCP endpoint with a bearer token. Match the endpoint's supported authentication;
+        an API key is not automatically an MCP token, and this does not complete OAuth.
 
-        Call this INSTEAD of ever accepting a token value in chat, and instead
-        of ``attach_mcp_server`` when the server requires authentication.
-        Posts a button in the thread naming the exact server; clicking it
-        opens a private form where the user enters the token —
-        it never appears in this channel or in your context.
-        Once added, the credential becomes usable by everyone who talks to
-        ``agent_name``.
-        """
-        return await _request_mcp_credential_impl(
+        Use ``attach_mcp_server`` for public servers without tokens. Never accept
+        credentials in chat. This posted-token enrollment works on Daimon under its
+        own permission rules.
+
+        Posts a requester-only card in this channel, expiring in 30 minutes. The
+        private form collects the token and attaches the server. Values never appear
+        in chat; everyone talking to the agent can use the connection."""
+        return await _request_mcp_token_impl(
             runtime,
             await _auth(ctx),
             agent_name=agent_name,
@@ -356,41 +368,34 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
             channel_id=channel_id,
         )
 
-    # The docstring below deliberately does NOT name the skill-import tool.
-    # That tool is admin-gated; this one is not (matching its sibling
-    # `request_*` tools), so naming it would disclose a gated tool's existence
-    # to every principal that can discover this one —
-    # `test_chat_session_tool_reachability` asserts against exactly that by
-    # searching the rendered tool text for the gated name. Kept as a comment
-    # rather than a docstring paragraph because the docstring IS prompt
-    # context: it is rendered into every model's tool list, where an internal
-    # rationale is noise.
     @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
-    async def request_skill_repo_credential(  # pyright: ignore[reportUnusedFunction]
+    async def request_skill_repo_token(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
-        repo_url: str,
+        repo_url: Annotated[
+            str,
+            Field(description="GitHub repo or repository URL, e.g. https://github.com/owner/repo."),
+        ],
         purpose: str,
-        channel_id: str,
+        channel_id: Annotated[
+            str,
+            Field(
+                description="Channel where the requester-only private-input card will be posted."
+            ),
+        ],
         branch: str = "main",
         path: str = "",
     ) -> RequestCredentialResult:
-        """Ask for a GitHub token so a skill import can read a PRIVATE repo.
+        """The skills repo is private: collect a GitHub token to import its skills.
 
-        Call this when importing skills from a repo reports that no
-        credential was available — NOT ``request_repo_binding``. Importing
-        skills from a repo and binding a repo for the agent to check out are
-        different things: this one writes no ``agent_repo_binding`` row, so
-        it will not make the agent start cloning the skill repo. The stored
-        token is shared between the two, so a user who has already bound a
-        repo with a token that can also read this one will not be asked
-        twice.
+        After ``sync_skills`` cannot read a private skill repository, use this form.
+        For a working repo use ``request_repo_binding``. Currently this enrollment
+        also changes the working-repo binding and therefore what the agent clones.
 
-        Pass the same repo url, branch, and path the failed import used —
-        they are carried through the click, and the import re-runs
-        automatically on submit, so there is nothing to call afterwards.
-        """
-        return await _request_skill_repo_credential_impl(
+        Posts a requester-only card, expiring in 30 minutes. Its private form retries
+        import and attachment; tokens never appear in chat. Anyone talking to the
+        agent can use the imported skills. Pass the same repo URL, branch and path."""
+        return await _request_skill_repo_token_impl(
             runtime,
             await _auth(ctx),
             agent_name=agent_name,
@@ -405,19 +410,28 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
     async def request_repo_binding(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         agent_name: str,
-        repo_url: str,
+        repo_url: Annotated[
+            str,
+            Field(description="GitHub repo or repository URL, e.g. https://github.com/owner/repo."),
+        ],
         purpose: str,
-        channel_id: str,
+        channel_id: Annotated[
+            str,
+            Field(
+                description="Channel where the requester-only private-input card will be posted."
+            ),
+        ],
     ) -> RequestCredentialResult:
-        """Request a repo binding for an agent via a private modal.
+        """Let an agent read a GitHub working repo or repository, public or private.
 
-        Call this INSTEAD of ever telling the user to open ``/agent-setup``
-        to bind a repository. Posts a button in the thread naming the exact
-        repo and agent; clicking it opens a private form where the
-        user confirms the branch and, only if the repo is private and not
-        otherwise readable, pastes a GitHub token that never appears in this
-        channel or in your context.
-        """
+        For a private skill repo use ``request_skill_repo_token``. If the user has
+        no working token, ``post_github_app_install_link`` offers a GitHub App install;
+        installing alone does not bind the repo or verify this tenant's access.
+
+        Posts a requester-only card in this channel, expiring in 30 minutes. The
+        private form confirms the branch and collects a GitHub token only when needed;
+        values never appear in chat. Saving binds the working repository for future
+        sessions. Existing working tokens remain in use."""
         return await _request_repo_binding_impl(
             runtime,
             await _auth(ctx),

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_credential_button.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/discord/_credential_button.py
@@ -41,10 +41,10 @@ from daimon.core.credential_requests import (
 from fastmcp.exceptions import ToolError
 
 _KIND_NOUN: dict[CredentialRequestKind, str] = {
-    "env": "an environment secret",
-    "mcp": "an MCP server credential",
-    "repo": "a repo binding",
-    "skill_repo": "a GitHub token to import skills",
+    "env": "an API key",
+    "mcp": "an MCP server token",
+    "repo": "a working repo",
+    "skill_repo": "a GitHub token for a skill repo",
 }
 
 
@@ -58,19 +58,21 @@ def _build_message_body(
 ) -> str:
     if kind == "repo":
         return (
-            f"<@{requester_platform_user_id}> wants to bind a repo to **{agent_name}** "
+            f"<@{requester_platform_user_id}> wants to set a working repo for **{agent_name}** "
             f"(`{target}`) — {purpose}\n"
             "Click the button below to open a private form confirming the branch, "
             "and — only if the repo isn't publicly readable — a GitHub token that "
-            "never appears in this channel."
+            "never appears in this channel. Only the requester can open this form; "
+            "the request expires 30 minutes after creation."
         )
     return (
         f"<@{requester_platform_user_id}> **{agent_name}** needs {_KIND_NOUN[kind]} "
         f"(`{target}`) — {purpose}\n"
-        "Click the button below to enter the value privately in a Discord modal; "
-        "it will never appear in this channel.\n"
-        f"Once added, this credential becomes usable by everyone who talks to "
-        f"**{agent_name}**."
+        "Click the button below to enter the value privately in a private form; "
+        "it will never appear in this channel. Only the requester can open this form; "
+        "the request expires 30 minutes after creation.\n"
+        f"Once added, everyone who talks to "
+        f"**{agent_name}** can use the {'key' if kind == 'env' else 'connection'}."
     )
 
 

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/github_app.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/github_app.py
@@ -1,11 +1,8 @@
 """GitHub App install-link tool: post_github_app_install_link.
 
-Makes an existing GitHub App installation reachable from chat. A link button
-carries a URL and no custom id, so nothing dispatches it in the bot process
-and no request state is created anywhere — Discord opens the URL directly.
-This tool introduces no credential-request row, no minted token, no expiry,
-and no dynamic item; see ``tools/discord/_app_install_button.py`` for the
-posting path this delegates to.
+Posts the configured App install URL through the caller's platform. No request
+state, token or expiry is created. Discord opens the link directly; Slack
+acknowledges its click payload without treating it as installation proof.
 
 Ungated deliberately: posting a link has no blast radius inside daimon, and
 GitHub itself enforces who may install an App on a given account or
@@ -20,6 +17,9 @@ from daimon.adapters.mcp.tools._ctx import _auth  # pyright: ignore[reportPrivat
 from daimon.adapters.mcp.tools.discord import (
     _post_app_install_button_impl,  # pyright: ignore[reportPrivateUsage]
 )
+from daimon.adapters.mcp.tools.slack._app_install_button import (
+    _post_slack_app_install_button_impl,  # pyright: ignore[reportPrivateUsage]
+)
 from daimon.core.github_app_auth import build_app_install_url
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
@@ -29,8 +29,8 @@ from pydantic import BaseModel, ConfigDict
 class PostAppInstallLinkResult(BaseModel):
     """Result of posting the GitHub App install-link button.
 
-    A link button returns no signal when clicked — Discord opens the URL
-    itself, and nothing dispatches back to daimon. This result reports only
+    Neither platform supplies proof of installation from the link click.
+    This result reports only
     that the invitation was posted: it carries no field named or meaning
     installed, success, completed, connected, or verified.
     """
@@ -49,17 +49,21 @@ async def _post_app_install_link_impl(
     channel_id: str,
     purpose: str,
 ) -> PostAppInstallLinkResult:
-    if auth.platform == "slack":
-        raise ToolError("post_github_app_install_link is not supported on Slack yet")
     if auth.platform_user_id is None:
         raise ToolError("posting the install link requires a platform-bound identity")
     slug = runtime.settings.github.app_slug
     if slug is None:
         raise ToolError(
             "this deployment has no GitHub App install link configured — "
-            "an operator must set DAIMON_GITHUB__APP_SLUG"
+            "tell the user an operator must configure it; a working GitHub token "
+            "can still be supplied privately through request_repo_binding"
         )
-    message_id = await _post_app_install_button_impl(
+    post_button = (
+        _post_slack_app_install_button_impl
+        if auth.platform == "slack"
+        else _post_app_install_button_impl
+    )
+    message_id = await post_button(
         runtime,
         auth,
         channel_id=channel_id,
@@ -74,25 +78,21 @@ async def _post_app_install_link_impl(
 
 
 def register_github_app_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
-    @mcp.tool(tags={"discord"})  # pyright: ignore[reportArgumentType]
+    @mcp.tool(tags={"discord", "slack"})  # pyright: ignore[reportArgumentType]
     async def post_github_app_install_link(  # pyright: ignore[reportUnusedFunction]
         ctx: Context,
         channel_id: str,
         purpose: str,
     ) -> PostAppInstallLinkResult:
-        """Post a button inviting the user to install daimon's GitHub App.
+        """Install the GitHub App: post a link inviting the user to grant repository access.
 
-        Call this when the user wants daimon to reach a private repository
-        and has no token to paste, or when a sync failed because the repo is
-        not readable. Posts a button in the thread; clicking it opens the
-        install page on GitHub, where the user chooses which repositories to
-        grant access to.
+        For a private repo with a working token, use ``request_repo_binding`` instead.
+        A token remains the fallback and existing bound tokens keep being used.
 
-        This tool CANNOT tell whether the install happened — a link button
-        gives no signal back. After the user says they installed it, verify
-        by attempting the sync again: the installation is resolved live at
-        that point.
-        """
+        Posts a link button in this channel opening GitHub's install page. It cannot
+        tell whether installation happened. Installing alone neither verifies this
+        tenant's access nor binds a working repo; use ``request_repo_binding`` and
+        verify access through the requested operation afterwards."""
         return await _post_app_install_link_impl(
             runtime,
             await _auth(ctx),

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/propagation.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/propagation.py
@@ -214,7 +214,9 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         agent_name: str,
         channel_id: str | None = None,
     ) -> SetDefaultResult:
-        """Set the agent that responds by default in a channel or the whole workspace.
+        """Make an agent answer in a channel or become the whole server/workspace default.
+        For example, make churn-explorer answer in #growth. Changes the agent that answers;
+        use ``clear_agent_default`` to stop that routing.
 
         When ``channel_id`` is provided the default is scoped to that channel;
         omit it to set the workspace-wide default.  Any existing default at the
@@ -239,7 +241,9 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         ctx: Context,
         channel_id: str | None = None,
     ) -> ClearDefaultResult:
-        """Remove the agent default from a channel or the whole workspace.
+        """Stop an agent answering in a channel by clearing its default routing.
+        For example, stop churn-explorer answering in #growth. Use
+        ``set_agent_default`` to choose a replacement instead.
 
         When ``channel_id`` is provided only that channel's default is cleared;
         omit it to clear the workspace-wide default.  If the scope had no
@@ -258,7 +262,8 @@ def register_propagation_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         ctx: Context,
         channel_id: str,
     ) -> AgentResolutionExplanation:
-        """Report which agent answers in a channel, and which tier decided it.
+        """Who answers in this channel, for example #growth? Report who answers and
+        which routing tier decided it.
 
         Resolution is a cascade: the channel's own default wins, else the
         workspace default, else the deployment default. This reports the winner

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/reachability.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/reachability.py
@@ -57,6 +57,8 @@ async def require_admin_for_reachable_agent(
     if reachable:
         raise ToolError(
             f"'{agent_name}' is currently the default agent for this workspace or a "
-            "channel, so changing its setup needs Manage Server — ask a server admin "
-            "to use /agent-setup. Creating or forking your own agent is not gated."
+            "channel, so an admin must change its setup. Tell the caller to ask a workspace "
+            f"or server admin to make the requested change to '{agent_name}'; carry the "
+            "specific action from the conversation into that handoff. Do not retry. "
+            "Creating or forking your own agent is not gated."
         )

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/self_edit.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/self_edit.py
@@ -9,8 +9,9 @@ Cross-agent isolation is enforced by composite-PK at the store layer
 All seven tools are tagged ``agent-chat`` and are therefore visible only
 to a session whose token carries an agent identity — the same identity
 their ``_require_agent_id`` precondition needs to succeed. An ordinary
-chat session never discovers this group; the setup panel is the path for
-a chat user to bind a repo or manage env vars.
+chat session never discovers this group; chat users bind working repos with
+``request_repo_binding`` and manage keys with ``request_agent_key``,
+``list_agent_keys`` and ``remove_agent_key``.
 
 ``register_self_edit_tools(mcp, runtime)`` wires the ``@mcp.tool`` closures.
 """
@@ -263,8 +264,10 @@ async def _set_repo_binding_impl(
             agent_id,
         )
         raise ToolError(
-            "no GitHub credential for this account — run /agent-setup → "
-            "Repo+Auth and connect a github account"
+            f"No GitHub token is available to bind {repo_url}. Tell the user to ask "
+            "Daimon in Discord or Slack chat to connect this agent to that repository; "
+            "that chat can use request_repo_binding to collect access privately. "
+            "This agent-scoped session cannot call that tool. Do not retry here."
         ) from e
     except ProviderConfigError as e:
         logger.warning(
@@ -511,8 +514,9 @@ def register_self_edit_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
     middleware's narrowing reveals them only when the token carries an
     ``agent_id`` claim — the same precondition ``_require_agent_id`` enforces
     at the impl layer. A session with no agent identity (e.g. an ordinary
-    chat turn) never sees this group; the setup panel is the path for a
-    chat user to bind a repo or manage env vars.
+    chat turn) never sees this group; chat users bind working repos with
+    ``request_repo_binding`` and manage keys with ``request_agent_key``,
+    ``list_agent_keys`` and ``remove_agent_key``.
     """
 
     @mcp.tool(tags={"agent-chat"})  # pyright: ignore[reportArgumentType]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/skills.py
@@ -70,7 +70,7 @@ class SkillDetail(BaseModel):
 
 
 class SkillSyncResult(BaseModel):
-    """Outcome of a ``skills_sync`` call, carrying provenance AND attachment state.
+    """Outcome of a ``sync_skills`` call, carrying provenance AND attachment state.
 
     Synced skills land in the tenant-wide skill registry, so the result echoes
     where they came from (``source_url`` / ``branch`` / ``path``) — the model
@@ -293,7 +293,7 @@ async def _sync_impl(
                     f"No GitHub credential was available for {url!r}, and an "
                     "unauthenticated fetch got HTTP 404 — which GitHub returns "
                     "for a private repo as well as a missing one. If this repo "
-                    "is private, call `request_skill_repo_credential` with this "
+                    "is private, call `request_skill_repo_token` with this "
                     "url/branch/path to post a button the user can paste a "
                     "token into; it syncs on submit. If it is public, re-check "
                     "the url and branch."
@@ -406,38 +406,17 @@ def register_skill_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
         path: str = "",
         agent_name: str | None = None,
     ) -> SkillSyncResult:
-        """Import skills from a GitHub repo into this workspace's shared skill library.
+        """Install skills from a GitHub repo into the workspace's shared skill library.
 
-        Discovers SKILL.md files and creates or updates them. This is an IMPORT,
-        not a per-agent change: the library is visible to every agent in the
-        workspace, and importing alone attaches nothing.
+        First use ``list_skills`` and prefer existing skills; import only a repository
+        the user requested. If the skills repo is private, use ``request_skill_repo_token``;
+        ``request_repo_binding`` provides working-repo access. Never accept tokens in chat.
 
-        Pass ``agent_name`` to also attach everything imported to that agent —
-        which is almost always what someone means by "add this skill to my
-        agent". Omit it only to stock the library without touching any agent.
-        Existing skills on the agent are preserved; the attach is a union.
-
-        LOCAL-FIRST: before importing an external repo, call ``list_skills`` to
-        see what is already in the library and prefer an existing skill over
-        pulling a near-duplicate. Only import a repo the user explicitly asked for.
-
-        Report where the skills came from — the returned
-        ``source_url``/``branch``/``path`` echo that provenance, and ``summary``
-        states both what was imported and what was attached.
-
-        Before calling, inspect the repo structure to determine the correct ``path``
-        parameter (empty string = repo root). ``branch`` defaults to ``"main"``.
-
-        IF THIS FAILS BECAUSE THE REPO IS PRIVATE AND UNREADABLE, call
-        ``request_repo_binding`` for that repo — do not report the sync as
-        blocked and do not ask the user to paste a token here. This tool
-        deliberately has no token parameter: the credential is supplied
-        out-of-band through a button and modal so it never passes through tool
-        arguments. Once the binding exists, the per-agent tier short-circuits
-        every later sync of that repo with zero GitHub I/O. Credential
-        precedence is documented on ``_resolve_skill_sync_credentials`` above,
-        which delegates to ``resolve_skill_sync_token``; a missing GitHub App
-        installation is NOT a blocker, it is just a later tier."""
+        Discovers SKILL.md files and imports or updates skills. Pass ``agent_name`` to
+        also attach them, preserving existing skills; omit it only to stock the library.
+        Importing alone attaches nothing. Report returned source, branch, path and
+        summary. Inspect the repo to choose ``path`` (empty means root); ``branch``
+        defaults to main. Importing is admin-only."""
         return await _sync_impl(runtime, await _auth(ctx), url, branch, path, agent_name)
 
     @mcp.tool
@@ -452,39 +431,8 @@ def register_skill_tools(mcp: FastMCP, runtime: McpRuntime) -> None:
 
     @mcp.tool(tags={"admin"})
     async def delete_skill(ctx: Context, name: str) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Delete a skill and all its versions."""
-        await _delete_impl(runtime, await _auth(ctx), name)
+        """Delete a skill such as eda from the workspace, destroying all versions for every agent.
 
-    # Back-compat aliases under the old noun-first names. Each delegates to the
-    # same ``_*_impl`` so dispatch is identical; the docstring steers search
-    # toward the canonical verb-first name.
-    @mcp.tool(tags={"admin"})
-    async def skills_sync(  # pyright: ignore[reportUnusedFunction]
-        ctx: Context,
-        url: str,
-        branch: str = "main",
-        path: str = "",
-        agent_name: str | None = None,
-    ) -> SkillSyncResult:
-        """Import skills from a GitHub repo into the shared library (alias of ``sync_skills``).
-
-        Discovers SKILL.md and creates or updates them. Pass ``agent_name`` to
-        also attach them to that agent; importing alone attaches nothing."""
-        return await _sync_impl(runtime, await _auth(ctx), url, branch, path, agent_name)
-
-    @mcp.tool
-    async def skills_list(ctx: Context) -> list[SkillInfo]:  # pyright: ignore[reportUnusedFunction]
-        """List all custom skills (alias of ``list_skills``)."""
-        return await _list_impl(runtime, await _auth(ctx))
-
-    @mcp.tool
-    async def skills_get(ctx: Context, name: str) -> SkillDetail:  # pyright: ignore[reportUnusedFunction]
-        """Look up a skill by name (alias of ``get_skill``).
-
-        Returns detail including version count."""
-        return await _get_impl(runtime, await _auth(ctx), name)
-
-    @mcp.tool(tags={"admin"})
-    async def skills_delete(ctx: Context, name: str) -> None:  # pyright: ignore[reportUnusedFunction]
-        """Delete a skill and all its versions (alias of ``delete_skill``)."""
+        For detaching one agent's reference, use ``remove_skill`` instead.
+        Deleting the shared skill resource is admin-only."""
         await _delete_impl(runtime, await _auth(ctx), name)

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_app_install_button.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_app_install_button.py
@@ -1,0 +1,76 @@
+"""Post a GitHub App install-page link through the caller's Slack workspace.
+
+A Slack URL button still sends an interaction payload. The Slack adapter
+acknowledges every block-action envelope before dispatch, and its action-id
+ladder silently ignores unknown ids; this inert link needs no handler.
+No credential request, token or expiry is created. Channel access is checked
+before posting. With no thread timestamp in the tool schema, this posts at
+the channel root. The install URL comes only from configured App identity.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from daimon.adapters.mcp.auth.resolver import AuthIdentity
+from daimon.adapters.mcp.runtime import McpRuntime
+from daimon.adapters.mcp.tools.slack._client import (
+    _require_slack_identity,  # pyright: ignore[reportPrivateUsage]
+    _require_team_id,  # pyright: ignore[reportPrivateUsage]
+    slack_web_client,
+)
+from daimon.adapters.mcp.tools.slack._visibility import check_channel_access
+from daimon.core.github_app_auth import build_app_install_url
+from fastmcp.exceptions import ToolError
+from slack_sdk.errors import SlackApiError
+
+
+async def _post_slack_app_install_button_impl(  # pyright: ignore[reportUnusedFunction]
+    runtime: McpRuntime,
+    auth: AuthIdentity,
+    *,
+    channel_id: str,
+    slug: str,
+    purpose: str,
+) -> str:
+    """Post the configured GitHub App install link. Returns the sent message ts."""
+    requester_id = _require_slack_identity(auth)
+    team_id = _require_team_id(auth)
+    client = await slack_web_client(runtime, team_id=team_id)
+
+    try:
+        info = await client.conversations_info(channel=channel_id)  # pyright: ignore[reportUnknownMemberType]
+        # Slack responses and the shared visibility API expose an open channel mapping.
+        channel: dict[str, Any] = dict(info.get("channel") or {})  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+        await check_channel_access(client, channel=channel, user_id=requester_id)
+        text = (
+            f"<@{requester_id}> — {purpose}\n"
+            "Install the GitHub App to choose repositories it may read. "
+            "Installing alone does not verify this workspace's access or bind a working repo. "
+            "A working GitHub token remains an alternative; existing bound tokens stay in use."
+        )
+        sent = await client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
+            channel=channel_id,
+            text=text,
+            blocks=[
+                {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "action_id": "github_app_install_link_inert",
+                            "url": build_app_install_url(slug),
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Install GitHub App",
+                            },
+                        }
+                    ],
+                },
+            ],
+        )
+    except SlackApiError as err:
+        code = str(err.response.get("error", "slack_api_error"))  # pyright: ignore[reportUnknownArgumentType, reportUnknownMemberType]  # slack_sdk response is dict-like
+        raise ToolError(f"posting to the channel failed ({code})") from err
+    return str(sent.get("ts") or "")  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_credential_button.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/slack/_credential_button.py
@@ -46,10 +46,10 @@ from fastmcp.exceptions import ToolError
 from slack_sdk.errors import SlackApiError
 
 _KIND_NOUN: dict[CredentialRequestKind, str] = {
-    "env": "an environment secret",
-    "mcp": "an MCP server credential",
-    "repo": "a repo binding",
-    "skill_repo": "a GitHub token to import skills",
+    "env": "an API key",
+    "mcp": "an MCP server token",
+    "repo": "a working repo",
+    "skill_repo": "a GitHub token for a skill repo",
 }
 
 
@@ -64,19 +64,21 @@ def _build_message_text(
     """The message body, in Slack mrkdwn (single-asterisk bold, `<@U…>` mention)."""
     if kind == "repo":
         return (
-            f"<@{requester_platform_user_id}> wants to bind a repo to *{agent_name}* "
+            f"<@{requester_platform_user_id}> wants to set a working repo for *{agent_name}* "
             f"(`{target}`) — {purpose}\n"
             "Click the button below to open a private form confirming the branch, "
             "and — only if the repo isn't publicly readable — a GitHub token that "
-            "never appears in this channel."
+            "never appears in this channel. Only the requester can open this form; "
+            "the request expires 30 minutes after creation."
         )
     return (
         f"<@{requester_platform_user_id}> *{agent_name}* needs {_KIND_NOUN[kind]} "
         f"(`{target}`) — {purpose}\n"
         "Click the button below to enter the value privately in a form; "
-        "it will never appear in this channel.\n"
-        f"Once added, this credential becomes usable by everyone who talks to "
-        f"*{agent_name}*."
+        "it will never appear in this channel. Only the requester can open this form; "
+        "the request expires 30 minutes after creation.\n"
+        f"Once added, everyone who talks to "
+        f"*{agent_name}* can use the {'key' if kind == 'env' else 'connection'}."
     )
 
 

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -218,10 +218,10 @@
   dict({
     'archive_agent': dict({
       'description': '''
-        Archive the MA agent and delete from the tenant pool.
+        Delete an agent, for example churn-explorer, by archiving it. Admin-only.
         
-        Also clears any channel or workspace default naming the agent, so turns
-        in those scopes fall back to the next tier instead of failing to resolve.
+        This removes the agent from the tenant pool and clears its channel/workspace
+        defaults so those channels fall back to the next routing tier.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -308,24 +308,15 @@
     }),
     'attach_mcp_server': dict({
       'description': '''
-        Attach a no-auth MCP server to an agent.
+        Add an MCP server that needs no token, such as Context7, to an agent.
         
-        Use this ONLY for MCP servers that do not require authentication.
-        The tool patches the agent's ``mcp_servers`` with
-        ``{name: server_name, type: "url", url: url}`` AND appends a
-        matching ``mcp_toolset`` entry to ``tools`` (required by MA, which
-        rejects an agent whose ``mcp_servers`` entries aren't each
-        referenced by a ``mcp_toolset``). Existing entries are preserved.
-        If a server with the same ``server_name`` is already attached, the
-        new ``url`` replaces it (last-write-wins) and the existing
-        ``mcp_toolset`` is reused (no duplicate). If both ``server_name``
-        and ``url`` already match, this is a no-op.
+        For Linear or other bearer-authenticated endpoints, use
+        ``request_mcp_token`` instead;
+        ``detach_mcp_server`` disconnects it. Fork Daimon with ``fork_agent`` before
+        directly changing its setup. Channel or workspace defaults need admin.
         
-        For MCP servers that REQUIRE an auth token, do NOT collect the
-        token in chat — direct the user to ``/agent-setup`` -> MCPs modal.
-        Tokens sent in chat end up in channel history and MA's
-        tenant-wide session event log; the modal flow is the only
-        supported path for auth-required servers.
+        Connects the server and its tools immediately. Reusing a server name replaces
+        the URL; the same name and URL is a no-op. Other connections are preserved.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -376,7 +367,9 @@
     }),
     'clear_agent_default': dict({
       'description': '''
-        Remove the agent default from a channel or the whole workspace.
+        Stop an agent answering in a channel by clearing its default routing.
+        For example, stop churn-explorer answering in #growth. Use
+        ``set_agent_default`` to choose a replacement instead.
         
         When ``channel_id`` is provided only that channel's default is cleared;
         omit it to clear the workspace-wide default.  If the scope had no
@@ -478,7 +471,8 @@
     }),
     'create_agent': dict({
       'description': '''
-        Create a new agent. Pass fields directly — there is NO ``spec`` wrapper.
+        Create an agent called, for example, churn-explorer. Pass fields directly —
+        there is NO ``spec`` wrapper.
         
         Required: ``name`` and ``model``. Use ``"claude-sonnet-5"`` when the user
         asks for Sonnet and ``"claude-opus-5"`` when they ask for Opus — always
@@ -489,7 +483,7 @@
         e.g. ``[{"url": "https://github.com/owner/repo", "branch": "main"}]``.
         
         Do not pass a ``skills`` field here. To add skills, either sync a repo via
-        ``skill_repos`` or use the ``skills_*`` tools after the agent is created.
+        ``skill_repos`` or use ``sync_skills`` after the agent is created.
       ''',
       'parameters': dict({
         '$defs': dict({
@@ -1530,7 +1524,12 @@
       }),
     }),
     'delete_skill': dict({
-      'description': 'Delete a skill and all its versions.',
+      'description': '''
+        Delete a skill such as eda from the workspace, destroying all versions for every agent.
+        
+        For detaching one agent's reference, use ``remove_skill`` instead.
+        Deleting the shared skill resource is admin-only.
+      ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
@@ -1583,14 +1582,12 @@
     }),
     'detach_mcp_server': dict({
       'description': '''
-        Detach an attached MCP server from an agent.
+        Disconnect an MCP server such as Linear from an agent. Detach the named
+        connection and its tools while preserving other servers and skills.
         
-        Removes the named entry from ``mcp_servers`` AND its matching
-        ``mcp_toolset`` entry from ``tools`` together — MA rejects an agent
-        whose ``mcp_servers`` entries aren't each referenced by a
-        ``mcp_toolset``, so both must go in the same update. Every other
-        attached server, skill, and tool is preserved. The reserved built-in
-        daimon server cannot be detached.
+        ``attach_mcp_server`` adds public endpoints; ``request_mcp_token`` enrolls
+        authenticated connections. The built-in daimon server cannot be removed.
+        Changing a channel or workspace default needs admin.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -1599,6 +1596,7 @@
             'type': 'string',
           }),
           'server_name': dict({
+            'description': 'Name of the attached MCP server to disconnect.',
             'type': 'string',
           }),
         }),
@@ -1611,7 +1609,8 @@
     }),
     'explain_agent_resolution': dict({
       'description': '''
-        Report which agent answers in a channel, and which tier decided it.
+        Who answers in this channel, for example #growth? Report who answers and
+        which routing tier decided it.
         
         Resolution is a cascade: the channel's own default wins, else the
         workspace default, else the deployment default. This reports the winner
@@ -1687,7 +1686,18 @@
       }),
     }),
     'fork_agent': dict({
-      'description': 'Clone an agent within the tenant pool under a new name.',
+      'description': '''
+        Make a copy of Daimon or another agent that you can edit under a new name.
+        Copies its prompt, model, skills, MCP definitions, working-repo binding and
+        recorded GitHub access. Copying access does not freshly verify it.
+        
+        API/service keys are not copied; add them with ``request_agent_key``.
+        Use ``update_agent`` to edit the copy. Daimon cannot be edited directly.
+        
+        The copy answers in no channel until an admin routes it with
+        ``set_agent_default``. Continue configuring it through Daimon with the copy
+        named as the setup target; it cannot already answer mentions by name.
+      ''',
       'parameters': dict({
         'additionalProperties': False,
         'properties': dict({
@@ -1707,12 +1717,11 @@
     }),
     'get_agent': dict({
       'description': '''
-        Look up an agent by name.
+        Show what an agent can access: attached MCP servers and skills.
         
-        Returns the agent's attached ``mcp_servers`` (name + url) and
-        ``skills``. Custom skill entries include ``name`` — the resolved
-        display title (``null`` if the underlying skill was deleted);
-        anthropic skill entries have a readable ``skill_id`` and no name.
+        Use ``list_agent_keys`` for stored key names. Configuration does not prove
+        the answering session's access. Returns server names/URLs and skills; custom
+        skills have a display name (null if deleted), Anthropic skills have a readable id.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -1940,6 +1949,27 @@
         'type': 'object',
       }),
     }),
+    'list_agent_keys': dict({
+      'description': '''
+        What keys does an agent have? List its stored API key names, never values.
+        
+        Use ``get_agent`` for skills and MCP access, ``request_agent_key`` to add
+        keys or ``remove_agent_key`` to remove them. Stored names on this target
+        are not proof that the answering agent can use those keys.
+      ''',
+      'parameters': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'agent_name': dict({
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'agent_name',
+        ]),
+        'type': 'object',
+      }),
+    }),
     'list_agents': dict({
       'description': '''
         List agents in the tenant pool, including each agent's attached
@@ -1978,27 +2008,6 @@
         'additionalProperties': False,
         'properties': dict({
         }),
-        'type': 'object',
-      }),
-    }),
-    'list_env_credential_keys': dict({
-      'description': '''
-        List the environment variable KEY NAMES currently set on an agent.
-        
-        Returns names only, never a value — so the agent can see what is
-        configured without a value ever entering chat. To add a variable,
-        use ``request_env_credential``.
-      ''',
-      'parameters': dict({
-        'additionalProperties': False,
-        'properties': dict({
-          'agent_name': dict({
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'agent_name',
-        ]),
         'type': 'object',
       }),
     }),
@@ -2309,18 +2318,15 @@
     }),
     'post_github_app_install_link': dict({
       'description': '''
-        Post a button inviting the user to install daimon's GitHub App.
+        Install the GitHub App: post a link inviting the user to grant repository access.
         
-        Call this when the user wants daimon to reach a private repository
-        and has no token to paste, or when a sync failed because the repo is
-        not readable. Posts a button in the thread; clicking it opens the
-        install page on GitHub, where the user chooses which repositories to
-        grant access to.
+        For a private repo with a working token, use ``request_repo_binding`` instead.
+        A token remains the fallback and existing bound tokens keep being used.
         
-        This tool CANNOT tell whether the install happened — a link button
-        gives no signal back. After the user says they installed it, verify
-        by attempting the sync again: the installation is resolved live at
-        that point.
+        Posts a link button in this channel opening GitHub's install page. It cannot
+        tell whether installation happened. Installing alone neither verifies this
+        tenant's access nor binds a working repo; use ``request_repo_binding`` and
+        verify access through the requested operation afterwards.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2693,14 +2699,14 @@
         'type': 'object',
       }),
     }),
-    'remove_env_credential': dict({
+    'remove_agent_key': dict({
       'description': '''
-        Remove one environment variable from an agent.
+        Remove an old API key or token, such as a Toggl key, from an agent's stored keys.
         
-        Idempotent: removing a key that is not currently set still succeeds
-        — the result's ``removed`` flag reports whether the key was actually
-        present. To ADD a variable, use ``request_env_credential`` instead;
-        entry always goes through the private modal flow, never through chat.
+        Use ``request_agent_key`` to add a key privately and ``list_agent_keys`` to
+        inspect stored names. Removing a missing key also succeeds; ``removed`` says
+        whether it was present. This deletes the stored environment variable, never
+        returns its secret value, and does not prove an existing session refreshed.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2709,6 +2715,7 @@
             'type': 'string',
           }),
           'key': dict({
+            'description': 'Stored environment variable name, UPPER_SNAKE, e.g. TOGGL_TOKEN or OPENAI_API_KEY; never the secret value.',
             'type': 'string',
           }),
         }),
@@ -2721,17 +2728,12 @@
     }),
     'remove_skill': dict({
       'description': '''
-        Detach one attached skill from an agent.
+        Stop an agent using an attached skill, such as eda. Remove that one
+        attachment while preserving other skills.
         
-        Accepts either the skill's raw ``skill_id`` or its resolved display
-        name. Every other attached skill and the agent's base tool set are
-        preserved.
-        
-        This is a DIFFERENT operation from ``delete_skill`` /
-        ``skills_delete``, which destroy a skill for every agent in the
-        tenant. ``remove_skill`` only detaches this one agent's reference —
-        the skill resource itself, and any other agent that has it attached,
-        is untouched.
+        ``delete_skill`` destroys the shared workspace skill instead;
+        ``update_agent`` adds existing skills. Accept a skill name or raw ``skill_id``.
+        The resource and other agents stay intact. Changing a default agent needs admin.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2776,15 +2778,18 @@
         'type': 'object',
       }),
     }),
-    'request_env_credential': dict({
+    'request_agent_key': dict({
       'description': '''
-        Request an environment secret from the user via a private modal.
+        Give an agent an API key or token for any service: Toggl, OpenAI,
+        Higgsfield, or a platform that just launched. Unknown services work too.
         
-        Call this INSTEAD of ever accepting a secret value in chat. Posts a
-        button in the thread naming the exact env key; clicking it opens a
-        private form where the user enters the value — it
-        never appears in this channel or in your context. Once added, the
-        credential becomes usable by everyone who talks to ``agent_name``.
+        Never accept secret values in chat; ask for rotation if pasted. For MCP
+        credentials use ``request_mcp_token``; GitHub access uses ``request_repo_binding``.
+        To load .env keys, request each key separately; whole-file import is unavailable.
+        
+        Posts a card in this channel. Only the requester can open its private form;
+        it expires in 30 minutes. Values never appear in chat. Anyone who talks to
+        the agent can use added keys, including on Daimon itself without a fork.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2793,9 +2798,11 @@
             'type': 'string',
           }),
           'channel_id': dict({
+            'description': 'Channel where the requester-only private-input card will be posted.',
             'type': 'string',
           }),
           'key': dict({
+            'description': 'Stored environment variable name, UPPER_SNAKE, e.g. TOGGL_TOKEN or OPENAI_API_KEY; never the secret value.',
             'type': 'string',
           }),
           'purpose': dict({
@@ -2811,17 +2818,19 @@
         'type': 'object',
       }),
     }),
-    'request_mcp_credential': dict({
+    'request_mcp_token': dict({
       'description': '''
-        Request an auth-required MCP server's credential via a private modal.
+        Connect an agent such as research-bot to Linear, Notion or GitHub through an
+        MCP endpoint with a bearer token. Match the endpoint's supported authentication;
+        an API key is not automatically an MCP token, and this does not complete OAuth.
         
-        Call this INSTEAD of ever accepting a token value in chat, and instead
-        of ``attach_mcp_server`` when the server requires authentication.
-        Posts a button in the thread naming the exact server; clicking it
-        opens a private form where the user enters the token —
-        it never appears in this channel or in your context.
-        Once added, the credential becomes usable by everyone who talks to
-        ``agent_name``.
+        Use ``attach_mcp_server`` for public servers without tokens. Never accept
+        credentials in chat. This posted-token enrollment works on Daimon under its
+        own permission rules.
+        
+        Posts a requester-only card in this channel, expiring in 30 minutes. The
+        private form collects the token and attaches the server. Values never appear
+        in chat; everyone talking to the agent can use the connection.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2830,12 +2839,15 @@
             'type': 'string',
           }),
           'channel_id': dict({
+            'description': 'Channel where the requester-only private-input card will be posted.',
             'type': 'string',
           }),
           'server_name': dict({
+            'description': 'Connection name; reusing a name replaces that server entry.',
             'type': 'string',
           }),
           'url': dict({
+            'description': 'MCP endpoint URL accepting bearer authentication, e.g. https://mcp.example.com/mcp.',
             'type': 'string',
           }),
         }),
@@ -2850,14 +2862,16 @@
     }),
     'request_repo_binding': dict({
       'description': '''
-        Request a repo binding for an agent via a private modal.
+        Let an agent read a GitHub working repo or repository, public or private.
         
-        Call this INSTEAD of ever telling the user to open ``/agent-setup``
-        to bind a repository. Posts a button in the thread naming the exact
-        repo and agent; clicking it opens a private form where the
-        user confirms the branch and, only if the repo is private and not
-        otherwise readable, pastes a GitHub token that never appears in this
-        channel or in your context.
+        For a private skill repo use ``request_skill_repo_token``. If the user has
+        no working token, ``post_github_app_install_link`` offers a GitHub App install;
+        installing alone does not bind the repo or verify this tenant's access.
+        
+        Posts a requester-only card in this channel, expiring in 30 minutes. The
+        private form confirms the branch and collects a GitHub token only when needed;
+        values never appear in chat. Saving binds the working repository for future
+        sessions. Existing working tokens remain in use.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2866,12 +2880,14 @@
             'type': 'string',
           }),
           'channel_id': dict({
+            'description': 'Channel where the requester-only private-input card will be posted.',
             'type': 'string',
           }),
           'purpose': dict({
             'type': 'string',
           }),
           'repo_url': dict({
+            'description': 'GitHub repo or repository URL, e.g. https://github.com/owner/repo.',
             'type': 'string',
           }),
         }),
@@ -2884,22 +2900,17 @@
         'type': 'object',
       }),
     }),
-    'request_skill_repo_credential': dict({
+    'request_skill_repo_token': dict({
       'description': '''
-        Ask for a GitHub token so a skill import can read a PRIVATE repo.
+        The skills repo is private: collect a GitHub token to import its skills.
         
-        Call this when importing skills from a repo reports that no
-        credential was available — NOT ``request_repo_binding``. Importing
-        skills from a repo and binding a repo for the agent to check out are
-        different things: this one writes no ``agent_repo_binding`` row, so
-        it will not make the agent start cloning the skill repo. The stored
-        token is shared between the two, so a user who has already bound a
-        repo with a token that can also read this one will not be asked
-        twice.
+        After ``sync_skills`` cannot read a private skill repository, use this form.
+        For a working repo use ``request_repo_binding``. Currently this enrollment
+        also changes the working-repo binding and therefore what the agent clones.
         
-        Pass the same repo url, branch, and path the failed import used —
-        they are carried through the click, and the import re-runs
-        automatically on submit, so there is nothing to call afterwards.
+        Posts a requester-only card, expiring in 30 minutes. Its private form retries
+        import and attachment; tokens never appear in chat. Anyone talking to the
+        agent can use the imported skills. Pass the same repo URL, branch and path.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -2912,6 +2923,7 @@
             'type': 'string',
           }),
           'channel_id': dict({
+            'description': 'Channel where the requester-only private-input card will be posted.',
             'type': 'string',
           }),
           'path': dict({
@@ -2922,6 +2934,7 @@
             'type': 'string',
           }),
           'repo_url': dict({
+            'description': 'GitHub repo or repository URL, e.g. https://github.com/owner/repo.',
             'type': 'string',
           }),
         }),
@@ -3190,7 +3203,9 @@
     }),
     'set_agent_default': dict({
       'description': '''
-        Set the agent that responds by default in a channel or the whole workspace.
+        Make an agent answer in a channel or become the whole server/workspace default.
+        For example, make churn-explorer answer in #growth. Changes the agent that answers;
+        use ``clear_agent_default`` to stop that routing.
         
         When ``channel_id`` is provided the default is scoped to that channel;
         omit it to set the workspace-wide default.  Any existing default at the
@@ -3317,88 +3332,6 @@
         'type': 'object',
       }),
     }),
-    'skills_delete': dict({
-      'description': 'Delete a skill and all its versions (alias of ``delete_skill``).',
-      'parameters': dict({
-        'additionalProperties': False,
-        'properties': dict({
-          'name': dict({
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-        ]),
-        'type': 'object',
-      }),
-    }),
-    'skills_get': dict({
-      'description': '''
-        Look up a skill by name (alias of ``get_skill``).
-        
-        Returns detail including version count.
-      ''',
-      'parameters': dict({
-        'additionalProperties': False,
-        'properties': dict({
-          'name': dict({
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'name',
-        ]),
-        'type': 'object',
-      }),
-    }),
-    'skills_list': dict({
-      'description': 'List all custom skills (alias of ``list_skills``).',
-      'parameters': dict({
-        'additionalProperties': False,
-        'properties': dict({
-        }),
-        'type': 'object',
-      }),
-    }),
-    'skills_sync': dict({
-      'description': '''
-        Import skills from a GitHub repo into the shared library (alias of ``sync_skills``).
-        
-        Discovers SKILL.md and creates or updates them. Pass ``agent_name`` to
-        also attach them to that agent; importing alone attaches nothing.
-      ''',
-      'parameters': dict({
-        'additionalProperties': False,
-        'properties': dict({
-          'agent_name': dict({
-            'anyOf': list([
-              dict({
-                'type': 'string',
-              }),
-              dict({
-                'type': 'null',
-              }),
-            ]),
-            'default': None,
-          }),
-          'branch': dict({
-            'default': 'main',
-            'type': 'string',
-          }),
-          'path': dict({
-            'default': '',
-            'type': 'string',
-          }),
-          'url': dict({
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'url',
-        ]),
-        'type': 'object',
-      }),
-    }),
     'start_turn': dict({
       'description': '''
         Start a new conversation turn with the agent and return a handle.
@@ -3449,38 +3382,17 @@
     }),
     'sync_skills': dict({
       'description': '''
-        Import skills from a GitHub repo into this workspace's shared skill library.
+        Install skills from a GitHub repo into the workspace's shared skill library.
         
-        Discovers SKILL.md files and creates or updates them. This is an IMPORT,
-        not a per-agent change: the library is visible to every agent in the
-        workspace, and importing alone attaches nothing.
+        First use ``list_skills`` and prefer existing skills; import only a repository
+        the user requested. If the skills repo is private, use ``request_skill_repo_token``;
+        ``request_repo_binding`` provides working-repo access. Never accept tokens in chat.
         
-        Pass ``agent_name`` to also attach everything imported to that agent —
-        which is almost always what someone means by "add this skill to my
-        agent". Omit it only to stock the library without touching any agent.
-        Existing skills on the agent are preserved; the attach is a union.
-        
-        LOCAL-FIRST: before importing an external repo, call ``list_skills`` to
-        see what is already in the library and prefer an existing skill over
-        pulling a near-duplicate. Only import a repo the user explicitly asked for.
-        
-        Report where the skills came from — the returned
-        ``source_url``/``branch``/``path`` echo that provenance, and ``summary``
-        states both what was imported and what was attached.
-        
-        Before calling, inspect the repo structure to determine the correct ``path``
-        parameter (empty string = repo root). ``branch`` defaults to ``"main"``.
-        
-        IF THIS FAILS BECAUSE THE REPO IS PRIVATE AND UNREADABLE, call
-        ``request_repo_binding`` for that repo — do not report the sync as
-        blocked and do not ask the user to paste a token here. This tool
-        deliberately has no token parameter: the credential is supplied
-        out-of-band through a button and modal so it never passes through tool
-        arguments. Once the binding exists, the per-agent tier short-circuits
-        every later sync of that repo with zero GitHub I/O. Credential
-        precedence is documented on ``_resolve_skill_sync_credentials`` above,
-        which delegates to ``resolve_skill_sync_token``; a missing GitHub App
-        installation is NOT a blocker, it is just a later tier.
+        Discovers SKILL.md files and imports or updates skills. Pass ``agent_name`` to
+        also attach them, preserving existing skills; omit it only to stock the library.
+        Importing alone attaches nothing. Report returned source, branch, path and
+        summary. Inspect the repo to choose ``path`` (empty means root); ``branch``
+        defaults to main. Importing is admin-only.
       ''',
       'parameters': dict({
         'additionalProperties': False,
@@ -3516,20 +3428,18 @@
     }),
     'update_agent': dict({
       'description': '''
-        Patch-update an agent.
+        Change an agent's system prompt or switch its model; add existing skills such as
+        build-models. Scalar ``model``, ``description`` and ``system`` fields replace.
         
-        Scalar fields (``model``, ``description``, ``system``) replace. For
-        ``model``, prefer the current generation — ``"claude-sonnet-5"`` for
-        Sonnet, ``"claude-opus-5"`` for Opus — unless the user names an older
-        version explicitly.
-        List fields (``tools``, ``mcp_servers``, ``skills``) UNION with the
-        agent's current state — caller's entries win on collision. To remove
-        an existing entry, use the ``/agent-setup`` panel.
+        Prefer current-generation ``claude-sonnet-5`` for Sonnet and ``claude-opus-5``
+        for Opus unless an older version is explicitly requested. List fields
+        (``tools``, ``mcp_servers``, ``skills``) are added to, never replaced; shorter
+        lists remove nothing. Use ``remove_skill`` or ``detach_mcp_server`` to remove.
+        Daimon requires ``fork_agent`` first; channel/workspace defaults require admin.
         
-        ``skills`` accepts skill NAMES, e.g.
-        ``skills=["build-models", "compare-models"]`` — names are resolved to MA
-        skill ids server-side. The explicit dict form
-        ``{"type": "custom", "skill_id": "skill_..."}`` still works.
+        Prompt changes replace the system prompt immediately. ``skills`` accepts names such as
+        ``["build-models", "compare-models"]``, resolved server-side; explicit
+        ``{"type": "custom", "skill_id": "skill_..."}`` entries also work.
       ''',
       'parameters': dict({
         '$defs': dict({

--- a/packages/adapters/mcp/tests/factories.py
+++ b/packages/adapters/mcp/tests/factories.py
@@ -6,15 +6,21 @@ packages/core/tests/factories.py; don't duplicate them.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import datetime as dt
+import json
 import uuid
+from collections.abc import AsyncIterator
 
+import httpx
 from anthropic.types.beta import BetaManagedAgentsAgent
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.core.mcp_auth import mint_jwt
 from daimon.core.stores.domain import Role
 from daimon.testing.factories import make_account, make_tenant
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.types import ASGIApp, Message
 
 
 def make_jwt(
@@ -80,3 +86,90 @@ def make_ma_agent(**overrides: object) -> BetaManagedAgentsAgent:
     }
     base.update(overrides)
     return BetaManagedAgentsAgent.model_validate(base)
+
+
+INIT_BODY: dict[str, object] = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "0"},
+    },
+}
+INIT_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+}
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
+    send_queue: asyncio.Queue[Message] = asyncio.Queue()
+    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
+
+    async def receive() -> Message:
+        return await receive_queue.get()
+
+    async def send(message: Message) -> None:
+        await send_queue.put(message)
+
+    async def run_lifespan() -> None:
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+
+    task = asyncio.create_task(run_lifespan())
+
+    await receive_queue.put({"type": "lifespan.startup"})
+    msg = await send_queue.get()
+    assert msg["type"] == "lifespan.startup.complete", msg
+    try:
+        yield
+    finally:
+        await receive_queue.put({"type": "lifespan.shutdown"})
+        msg = await send_queue.get()
+        assert msg["type"] == "lifespan.shutdown.complete", msg
+        await task
+
+
+async def mcp_session(
+    app: ASGIApp,
+    *,
+    token: str,
+    method: str,
+    params: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Initialize MCP session then execute a JSON-RPC method.
+
+    Returns the JSON-RPC result dict from the method response.
+    Raises AssertionError on unexpected HTTP status.
+    """
+    headers = dict(INIT_HEADERS)
+    headers["Authorization"] = f"Bearer {token}"
+    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
+    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        # Step 1: initialize handshake
+        init_resp = await c.post("/mcp", json=INIT_BODY, headers=headers)
+        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
+        session_id = init_resp.headers.get("mcp-session-id")
+        if session_id:
+            headers["Mcp-Session-Id"] = session_id
+
+        # Step 2: actual method call
+        body = {"jsonrpc": "2.0", "id": 2, "method": method, "params": params or {}}
+        resp = await c.post("/mcp", json=body, headers=headers)
+        assert resp.status_code == 200, f"{method} failed ({resp.status_code}): {resp.text}"
+        return _parse_jsonrpc_response(resp)
+
+
+def _parse_jsonrpc_response(resp: httpx.Response) -> dict[str, object]:
+    """Parse a JSON-RPC response from either JSON or SSE format."""
+    content_type = resp.headers.get("content-type", "")
+    if "text/event-stream" in content_type:
+        # SSE: parse the data line
+        for line in resp.text.splitlines():
+            if line.startswith("data: "):
+                return json.loads(line[6:])  # type: ignore[return-value]
+        raise AssertionError(f"No data line in SSE response: {resp.text!r}")
+    else:
+        return resp.json()  # type: ignore[return-value]

--- a/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
+++ b/packages/adapters/mcp/tests/test_chat_session_tool_reachability.py
@@ -27,21 +27,15 @@ One outcome is recorded rather than treated as a bug:
   Minting an agent claim into the account-scoped vault credential would
   make them reachable, but that credential is deliberately account-scoped,
   not agent-scoped, so it is out of scope here.
-- ``request_mcp_credential`` / ``request_env_credential`` reject Slack
-  callers and require a platform-bound identity (``auth.platform_user_id``).
-  The session built here carries a Discord-shaped platform claim, so both
-  reach their implementation; on Slack today they would be refused instead.
-  These two tools are Discord-only until a Slack-side implementation lands.
+- ``request_mcp_token`` / ``request_agent_key`` are available on Discord and
+  Slack and require a platform-bound caller. This suite exercises Discord;
+  the golden-query and authorization journeys cover the platform distinction.
 """
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import datetime as dt
-import json
 import uuid
-from collections.abc import AsyncIterator
 from typing import NamedTuple
 
 import httpx
@@ -59,9 +53,9 @@ from daimon.testing.factories import make_account, make_platform_principal, make
 from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
 from pydantic import HttpUrl, PostgresDsn, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from starlette.types import ASGIApp, Message
+from starlette.types import ASGIApp
 
-from .factories import make_jwt, make_ma_agent
+from .factories import make_jwt, make_ma_agent, mcp_session
 
 pytestmark = pytest.mark.asyncio
 
@@ -102,10 +96,9 @@ CHAT_TURN_TOOL_REACHABILITY: dict[str, ExpectedOutcome] = {
     "list_agents": ExpectedOutcome(discoverable=True),
     "get_agent": ExpectedOutcome(discoverable=True),
     "archive_agent": ExpectedOutcome(discoverable=False),
-    # credential_requests.py — never admin-gated; Discord-only (see module
-    # docstring).
-    "request_mcp_credential": ExpectedOutcome(discoverable=True),
-    "request_env_credential": ExpectedOutcome(discoverable=True),
+    # credential_requests.py — requester-only enrollment, not admin-gated.
+    "request_mcp_token": ExpectedOutcome(discoverable=True),
+    "request_agent_key": ExpectedOutcome(discoverable=True),
     # routines.py — ungated by design; needs a platform user identity, which
     # this Discord-shaped session carries.
     "create_routine": ExpectedOutcome(discoverable=True),
@@ -130,13 +123,13 @@ _CALL_ARGS: dict[str, dict[str, object]] = {
     "fork_agent": {"source_name": "demo-agent", "new_name": "demo-fork"},
     "list_agents": {},
     "get_agent": {"name": "demo-agent"},
-    "request_mcp_credential": {
+    "request_mcp_token": {
         "agent_name": "demo-agent",
         "server_name": "ctx7",
         "url": "https://ctx7.example/mcp",
         "channel_id": "channel-1",
     },
-    "request_env_credential": {
+    "request_agent_key": {
         "agent_name": "demo-agent",
         "key": "MY_KEY",
         "purpose": "testing",
@@ -155,83 +148,6 @@ _CALL_ARGS: dict[str, dict[str, object]] = {
     },
     "get_thread_participation": {"thread_id": "thread-1", "channel_id": "channel-1"},
 }
-
-
-@contextlib.asynccontextmanager
-async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
-    send_queue: asyncio.Queue[Message] = asyncio.Queue()
-    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
-
-    async def receive() -> Message:
-        return await receive_queue.get()
-
-    async def send(message: Message) -> None:
-        await send_queue.put(message)
-
-    async def run_lifespan() -> None:
-        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
-
-    task = asyncio.create_task(run_lifespan())
-
-    await receive_queue.put({"type": "lifespan.startup"})
-    msg = await send_queue.get()
-    assert msg["type"] == "lifespan.startup.complete", msg
-    try:
-        yield
-    finally:
-        await receive_queue.put({"type": "lifespan.shutdown"})
-        msg = await send_queue.get()
-        assert msg["type"] == "lifespan.shutdown.complete", msg
-        await task
-
-
-def _parse_jsonrpc_response(resp: httpx.Response) -> dict[str, object]:
-    content_type = resp.headers.get("content-type", "")
-    if "text/event-stream" in content_type:
-        for line in resp.text.splitlines():
-            if line.startswith("data: "):
-                return json.loads(line[6:])  # type: ignore[return-value]
-        raise AssertionError(f"No data line in SSE response: {resp.text!r}")
-    return resp.json()  # type: ignore[return-value]
-
-
-async def _mcp_session(
-    app: ASGIApp,
-    *,
-    token: str,
-    method: str,
-    params: dict[str, object] | None = None,
-) -> dict[str, object]:
-    headers = {
-        "Accept": "application/json, text/event-stream",
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {token}",
-    }
-    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
-    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-        init_resp = await c.post(
-            "/mcp",
-            json={
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {},
-                    "clientInfo": {"name": "test", "version": "0"},
-                },
-            },
-            headers=headers,
-        )
-        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
-        session_id = init_resp.headers.get("mcp-session-id")
-        if session_id:
-            headers["Mcp-Session-Id"] = session_id
-
-        body = {"jsonrpc": "2.0", "id": 2, "method": method, "params": params or {}}
-        resp = await c.post("/mcp", json=body, headers=headers)
-        assert resp.status_code == 200, f"{method} failed ({resp.status_code}): {resp.text}"
-        return _parse_jsonrpc_response(resp)
 
 
 def _make_app(sessionmaker: async_sessionmaker[AsyncSession], anthropic: AsyncAnthropic) -> ASGIApp:
@@ -301,7 +217,7 @@ async def test_chat_turn_session_matches_recorded_reachability(
     token = await _seed_chat_turn_session(sessionmaker)
     app = _make_app(sessionmaker, _build_client())
 
-    search_result = await _mcp_session(
+    search_result = await mcp_session(
         app,
         token=token,
         method="tools/call",
@@ -312,7 +228,7 @@ async def test_chat_turn_session_matches_recorded_reachability(
     search_text = " ".join(
         item.get("text", "") for item in search_content if isinstance(item, dict)
     )
-    is_discoverable = tool_name in search_text
+    is_discoverable = f"### {tool_name}" in search_text
     assert is_discoverable == expected.discoverable, (
         f"{tool_name}: expected discoverable={expected.discoverable}, got {is_discoverable}; "
         f"search_tools output: {search_text!r}"
@@ -320,7 +236,7 @@ async def test_chat_turn_session_matches_recorded_reachability(
     if not expected.discoverable:
         return
 
-    call_result = await _mcp_session(
+    call_result = await mcp_session(
         app,
         token=token,
         method="tools/call",
@@ -356,7 +272,7 @@ async def test_agent_id_claim_session_discovers_agent_chat_and_self_edit_tools_o
     token = mint_jwt(account_id=account.id, secret=SECRET.encode(), now=_NOW, agent_id=uuid.uuid4())
     app = _make_app(sessionmaker, _build_client())
 
-    result = await _mcp_session(app, token=token, method="tools/list")
+    result = await mcp_session(app, token=token, method="tools/list")
     payload = result.get("result", result)
     tool_names = {t["name"] for t in payload.get("tools", [])}  # type: ignore[union-attr]
 

--- a/packages/adapters/mcp/tests/test_claimless_e2e.py
+++ b/packages/adapters/mcp/tests/test_claimless_e2e.py
@@ -15,12 +15,6 @@ recovery.
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-import json
-from collections.abc import AsyncIterator
-
-import httpx
 import jwt as pyjwt
 import pytest
 from daimon.adapters.mcp.server import create_mcp_app
@@ -36,96 +30,12 @@ from daimon.core.stores.domain import Role
 from daimon.testing.factories import make_account, make_platform_principal, make_tenant
 from pydantic import HttpUrl, PostgresDsn, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from starlette.types import ASGIApp, Message
+
+from .factories import mcp_session
 
 pytestmark = pytest.mark.asyncio
 
 SECRET = "a" * 32
-
-INIT_BODY: dict[str, object] = {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "initialize",
-    "params": {
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": {"name": "test", "version": "0"},
-    },
-}
-INIT_HEADERS = {
-    "Accept": "application/json, text/event-stream",
-    "Content-Type": "application/json",
-}
-
-
-@contextlib.asynccontextmanager
-async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
-    send_queue: asyncio.Queue[Message] = asyncio.Queue()
-    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
-
-    async def receive() -> Message:
-        return await receive_queue.get()
-
-    async def send(message: Message) -> None:
-        await send_queue.put(message)
-
-    async def run_lifespan() -> None:
-        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
-
-    task = asyncio.create_task(run_lifespan())
-
-    await receive_queue.put({"type": "lifespan.startup"})
-    msg = await send_queue.get()
-    assert msg["type"] == "lifespan.startup.complete", msg
-    try:
-        yield
-    finally:
-        await receive_queue.put({"type": "lifespan.shutdown"})
-        msg = await send_queue.get()
-        assert msg["type"] == "lifespan.shutdown.complete", msg
-        await task
-
-
-async def _mcp_session(
-    app: ASGIApp,
-    *,
-    token: str,
-    method: str,
-    params: dict[str, object] | None = None,
-) -> dict[str, object]:
-    """Initialize MCP session then execute a JSON-RPC method.
-
-    Returns the JSON-RPC result dict from the method response.
-    Raises AssertionError on unexpected HTTP status.
-    """
-    headers = dict(INIT_HEADERS)
-    headers["Authorization"] = f"Bearer {token}"
-    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
-    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-        # Step 1: initialize handshake
-        init_resp = await c.post("/mcp", json=INIT_BODY, headers=headers)
-        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
-        session_id = init_resp.headers.get("mcp-session-id")
-        if session_id:
-            headers["Mcp-Session-Id"] = session_id
-
-        # Step 2: actual method call
-        body = {"jsonrpc": "2.0", "id": 2, "method": method, "params": params or {}}
-        resp = await c.post("/mcp", json=body, headers=headers)
-        assert resp.status_code == 200, f"{method} failed ({resp.status_code}): {resp.text}"
-        return _parse_jsonrpc_response(resp)
-
-
-def _parse_jsonrpc_response(resp: httpx.Response) -> dict[str, object]:
-    """Parse a JSON-RPC response from either JSON or SSE format."""
-    content_type = resp.headers.get("content-type", "")
-    if "text/event-stream" in content_type:
-        for line in resp.text.splitlines():
-            if line.startswith("data: "):
-                return json.loads(line[6:])  # type: ignore[return-value]
-        raise AssertionError(f"No data line in SSE response: {resp.text!r}")
-    else:
-        return resp.json()  # type: ignore[return-value]
 
 
 async def test_claimless_token_drives_routines_and_discord_tools(
@@ -184,7 +94,7 @@ async def test_claimless_token_drives_routines_and_discord_tools(
 
     # --- Drive routines tool (list_routines takes no args; returns empty list) ---
     # Any non-401 response proves the verifier accepted the token and injected tenant_id.
-    routines_result = await _mcp_session(
+    routines_result = await mcp_session(
         app,
         token=token,
         method="tools/call",
@@ -208,7 +118,7 @@ async def test_claimless_token_drives_routines_and_discord_tools(
     # What must NOT happen: ToolError("discord tools require a discord-bound identity")
     # or ToolError("discord tools require a guild context") — those would mean the
     # verifier failed to inject platform_user_id / external_id into claims.
-    discord_result = await _mcp_session(
+    discord_result = await mcp_session(
         app,
         token=token,
         method="tools/call",

--- a/packages/adapters/mcp/tests/test_oauth_slack.py
+++ b/packages/adapters/mcp/tests/test_oauth_slack.py
@@ -934,3 +934,12 @@ async def test_callback_user_connect_mismatch_attempts_revoke_and_still_returns_
             s, team_id=_SLACK_TEAM_ID, slack_user_id=_SLACK_FOREIGN_USER_ID
         )
     assert row_u2 is None, "no token row should ever be stored for the foreign authed_user"
+
+
+def test_success_html_escapes_configured_bot_name() -> None:
+    response = _success_html(
+        workspace="Acme", signup_credit=Decimal("5.00"), display_name="research<bot>"
+    )
+    body = response.body.decode()
+    assert "@research&lt;bot&gt;" in body, "success instructions must escape the configured name"
+    assert "@daimon" not in body, "success instructions must not retain a hardcoded bot mention"

--- a/packages/adapters/mcp/tests/test_propagation_tool.py
+++ b/packages/adapters/mcp/tests/test_propagation_tool.py
@@ -28,7 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 pytestmark = pytest.mark.asyncio
 
-_D28_MESSAGE = "Changing my setup needs Manage Server — ask a server admin to use /agent-setup"
+_ADMIN_REQUIRED = "requires a workspace or server admin"
 
 
 def _runtime(sessionmaker: async_sessionmaker[AsyncSession]) -> McpRuntime:
@@ -206,7 +206,7 @@ async def test_set_agent_default_raises_for_non_admin_and_performs_no_write(
     with pytest.raises(ToolError) as exc_info:
         await _set_agent_default_impl(_runtime(committing_sessionmaker), auth, "any-agent", None)
 
-    assert str(exc_info.value) == _D28_MESSAGE, (
+    assert _ADMIN_REQUIRED in str(exc_info.value), (
         "non-admin caller must be refused with the expected message"
     )
 
@@ -223,7 +223,7 @@ async def test_clear_agent_default_raises_for_non_admin(
     with pytest.raises(ToolError) as exc_info:
         await _clear_agent_default_impl(_runtime(committing_sessionmaker), auth, None)
 
-    assert str(exc_info.value) == _D28_MESSAGE, (
+    assert _ADMIN_REQUIRED in str(exc_info.value), (
         "non-admin caller must be refused with the expected message for clear as well"
     )
 

--- a/packages/adapters/mcp/tests/test_rbac.py
+++ b/packages/adapters/mcp/tests/test_rbac.py
@@ -10,14 +10,9 @@ Protocol sequence (MCP Streamable HTTP):
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import datetime as dt
-import json
 import uuid
-from collections.abc import AsyncIterator
 
-import httpx
 import pytest
 from daimon.adapters.mcp.server import create_mcp_app
 from daimon.core.config import (
@@ -32,100 +27,14 @@ from daimon.core.stores.domain import Role
 from daimon.testing.factories import make_account, make_tenant
 from pydantic import HttpUrl, PostgresDsn, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from starlette.types import ASGIApp, Message
+from starlette.types import ASGIApp
 
-from .factories import make_jwt
+from .factories import make_jwt, mcp_session
 
 pytestmark = pytest.mark.asyncio
 
 SECRET = "a" * 32
 _NOW = dt.datetime(2026, 4, 24, tzinfo=dt.UTC)
-
-INIT_BODY: dict[str, object] = {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "initialize",
-    "params": {
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": {"name": "test", "version": "0"},
-    },
-}
-INIT_HEADERS = {
-    "Accept": "application/json, text/event-stream",
-    "Content-Type": "application/json",
-}
-
-
-@contextlib.asynccontextmanager
-async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
-    send_queue: asyncio.Queue[Message] = asyncio.Queue()
-    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
-
-    async def receive() -> Message:
-        return await receive_queue.get()
-
-    async def send(message: Message) -> None:
-        await send_queue.put(message)
-
-    async def run_lifespan() -> None:
-        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
-
-    task = asyncio.create_task(run_lifespan())
-
-    await receive_queue.put({"type": "lifespan.startup"})
-    msg = await send_queue.get()
-    assert msg["type"] == "lifespan.startup.complete", msg
-    try:
-        yield
-    finally:
-        await receive_queue.put({"type": "lifespan.shutdown"})
-        msg = await send_queue.get()
-        assert msg["type"] == "lifespan.shutdown.complete", msg
-        await task
-
-
-async def _mcp_session(
-    app: ASGIApp,
-    *,
-    token: str,
-    method: str,
-    params: dict[str, object] | None = None,
-) -> dict[str, object]:
-    """Initialize MCP session then execute a JSON-RPC method.
-
-    Returns the JSON-RPC result dict from the method response.
-    Raises AssertionError on unexpected HTTP status.
-    """
-    headers = dict(INIT_HEADERS)
-    headers["Authorization"] = f"Bearer {token}"
-    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
-    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-        # Step 1: initialize handshake
-        init_resp = await c.post("/mcp", json=INIT_BODY, headers=headers)
-        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
-        session_id = init_resp.headers.get("mcp-session-id")
-        if session_id:
-            headers["Mcp-Session-Id"] = session_id
-
-        # Step 2: actual method call
-        body = {"jsonrpc": "2.0", "id": 2, "method": method, "params": params or {}}
-        resp = await c.post("/mcp", json=body, headers=headers)
-        assert resp.status_code == 200, f"{method} failed ({resp.status_code}): {resp.text}"
-        return _parse_jsonrpc_response(resp)
-
-
-def _parse_jsonrpc_response(resp: httpx.Response) -> dict[str, object]:
-    """Parse a JSON-RPC response from either JSON or SSE format."""
-    content_type = resp.headers.get("content-type", "")
-    if "text/event-stream" in content_type:
-        # SSE: parse the data line
-        for line in resp.text.splitlines():
-            if line.startswith("data: "):
-                return json.loads(line[6:])  # type: ignore[return-value]
-        raise AssertionError(f"No data line in SSE response: {resp.text!r}")
-    else:
-        return resp.json()  # type: ignore[return-value]
 
 
 def _make_app(sessionmaker: async_sessionmaker[AsyncSession]) -> ASGIApp:
@@ -172,7 +81,7 @@ async def test_non_admin_list_tools(
     admin_token, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(app, token=user_token, method="tools/list")
+    result = await mcp_session(app, token=user_token, method="tools/list")
     tools_payload = result.get("result", result)
     tool_names: list[str] = [t["name"] for t in tools_payload.get("tools", [])]  # type: ignore[union-attr]
 
@@ -194,7 +103,7 @@ async def test_non_admin_search_excludes_admin_tools(
     admin_token, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=user_token,
         method="tools/call",
@@ -220,7 +129,7 @@ async def test_non_admin_call_admin_tool_blocked(
     admin_token, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=user_token,
         method="tools/call",
@@ -272,8 +181,8 @@ non-admin chat session's search."""
 CHAT_REMOVAL_TOOL_NAMES = (
     "detach_mcp_server",
     "remove_skill",
-    "remove_env_credential",
-    "list_env_credential_keys",
+    "remove_agent_key",
+    "list_agent_keys",
 )
 """The four chat-reachable removal tools: never admin-tagged, so they are
 discoverable by a non-admin session's search_tools like RELAXED_TOOL_NAMES,
@@ -289,7 +198,7 @@ async def test_non_admin_search_includes_chat_removal_tool(
     _, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=user_token,
         method="tools/call",
@@ -315,7 +224,7 @@ async def test_agent_id_claim_session_discovers_none_of_the_chat_removal_tools(
     token = mint_jwt(account_id=account.id, secret=SECRET.encode(), now=_NOW, agent_id=uuid.uuid4())
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(app, token=token, method="tools/list")
+    result = await mcp_session(app, token=token, method="tools/list")
     payload = result.get("result", result)
     tool_names = {t["name"] for t in payload.get("tools", [])}  # type: ignore[union-attr]
 
@@ -333,7 +242,7 @@ async def test_non_admin_search_includes_relaxed_tool(
     _, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=user_token,
         method="tools/call",
@@ -358,7 +267,7 @@ async def test_non_admin_search_excludes_agent_identity_scoped_tool(
     _, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=user_token,
         method="tools/call",
@@ -383,7 +292,7 @@ async def test_non_admin_call_self_write_file_refused(
     _, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=user_token,
         method="tools/call",
@@ -442,7 +351,7 @@ async def test_non_admin_search_excludes_remaining_admin_tool(
     _, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=user_token,
         method="tools/call",
@@ -453,30 +362,6 @@ async def test_non_admin_search_excludes_remaining_admin_tool(
     output_text = " ".join(item.get("text", "") for item in content if isinstance(item, dict))
     assert f"### {tool_name}" not in output_text, (
         f"{tool_name} must NOT be discoverable by a non-admin session; got: {output_text!r}"
-    )
-
-
-async def test_non_admin_search_excludes_skills_sync(
-    sessionmaker: async_sessionmaker[AsyncSession],
-) -> None:
-    """skills_sync is now admin-tagged — non-admin search must not surface it.
-
-    The impl gate remains as defense-in-depth, but the visibility layer
-    hides it from non-admin sessions before they can call it."""
-    _, user_token = await _seed_admin_and_user(sessionmaker)
-    app = _make_app(sessionmaker)
-
-    result = await _mcp_session(
-        app,
-        token=user_token,
-        method="tools/call",
-        params={"name": "search_tools", "arguments": {"query": "sync skills"}},
-    )
-    call_result = result.get("result", result)
-    content = call_result.get("content", [])  # type: ignore[union-attr]
-    output_text = " ".join(item.get("text", "") for item in content if isinstance(item, dict))
-    assert "skills_sync" not in output_text, (
-        f"skills_sync must NOT be discoverable by non-admin; got: {output_text!r}"
     )
 
 
@@ -497,7 +382,7 @@ async def test_discord_vault_token_is_admin_claim_without_internal_denied_admin_
         guild_admin_token = make_jwt(account_id=user_account.id, is_admin=True)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=guild_admin_token,
         method="tools/call",
@@ -506,7 +391,7 @@ async def test_discord_vault_token_is_admin_claim_without_internal_denied_admin_
     call_result = result.get("result", result)
     content = call_result.get("content", [])  # type: ignore[union-attr]
     output_text = " ".join(item.get("text", "") for item in content if isinstance(item, dict))
-    assert "sync_skills" not in output_text, (
+    assert "### sync_skills" not in output_text, (
         f"Discord vault token with is_admin but no internal must NOT see sync_skills; got: {output_text!r}"
     )
 
@@ -518,7 +403,7 @@ async def test_admin_search_includes_admin_tools(
     admin_token, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=admin_token,
         method="tools/call",
@@ -541,7 +426,7 @@ async def test_admin_search_includes_fork_agent(
     admin_token, _ = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=admin_token,
         method="tools/call",
@@ -571,7 +456,7 @@ async def test_admin_list_tools_returns_meta_tools(
     admin_token, user_token = await _seed_admin_and_user(sessionmaker)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(app, token=admin_token, method="tools/list")
+    result = await mcp_session(app, token=admin_token, method="tools/list")
     tools_payload = result.get("result", result)
     tool_names: list[str] = [t["name"] for t in tools_payload.get("tools", [])]  # type: ignore[union-attr]
 

--- a/packages/adapters/mcp/tests/test_thread_participation_tool.py
+++ b/packages/adapters/mcp/tests/test_thread_participation_tool.py
@@ -41,7 +41,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 pytestmark = pytest.mark.asyncio
 
-_D28_MESSAGE = "Changing my setup needs Manage Server — ask a server admin to use /agent-setup"
+_ADMIN_REQUIRED = "requires a workspace or server admin"
 _CHANNEL = "chan-1"
 _THREAD = "thread-1"
 
@@ -250,7 +250,7 @@ async def test_non_admin_cannot_set_a_channel_and_writes_nothing(
             _CHANNEL,
         )
 
-    assert str(exc_info.value) == _D28_MESSAGE, "channel scope is an admin action"
+    assert _ADMIN_REQUIRED in str(exc_info.value), "channel scope is an admin action"
     assert (await _modes(db_session, tenant_id)).channel is None, (
         "a refused call must write no channel row"
     )
@@ -271,7 +271,7 @@ async def test_non_admin_cannot_set_the_workspace_and_writes_nothing(
             None,
         )
 
-    assert str(exc_info.value) == _D28_MESSAGE, "workspace scope is an admin action"
+    assert _ADMIN_REQUIRED in str(exc_info.value), "workspace scope is an admin action"
     assert (await _modes(db_session, tenant_id)).workspace is None, (
         "a refused call must write no workspace row"
     )

--- a/packages/adapters/mcp/tests/test_tool_e2e.py
+++ b/packages/adapters/mcp/tests/test_tool_e2e.py
@@ -265,7 +265,7 @@ async def test_list_skills_end_to_end(
     mcp = app.state.mcp  # type: ignore[attr-defined]
 
     async with Client(mcp) as client:
-        result = await client.call_tool("skills_list", {})
+        result = await client.call_tool("list_skills", {})
         skills = json.loads(result.content[0].text)  # type: ignore[union-attr]
         assert [s["name"] for s in skills] == ["e2e-skill"], (
             "should list the e2e skill with bare name"

--- a/packages/adapters/mcp/tests/test_tool_search_queries.py
+++ b/packages/adapters/mcp/tests/test_tool_search_queries.py
@@ -1,0 +1,429 @@
+"""Authored lexical regression cases through the real platform-scoped tool search.
+
+These cases measure ranking, not conversational model behavior. Whether the
+model chooses a target and gives the right handoff is operator QA on staging.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from aioresponses import aioresponses
+from anthropic import AsyncAnthropic
+from anthropic.types.beta import BetaManagedAgentsAgent, BetaManagedAgentsModelConfig
+from cryptography.fernet import Fernet
+from daimon.adapters.mcp.server import create_mcp_app
+from daimon.core.config import (
+    AnthropicSettings,
+    CryptoSettings,
+    DatabaseSettings,
+    DiscordSettings,
+    GeminiSettings,
+    GithubSettings,
+    McpSettings,
+    NotebookSettings,
+    Settings,
+    SlackSettings,
+)
+from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.scope import TenantScopeRef
+from daimon.core.stores.credential_requests import peek_credential_request
+from daimon.core.stores.scoped_config_write import set_fields
+from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+from daimon.testing.factories import make_account, make_tenant
+from daimon.testing.ma import build_fake_anthropic, build_stub_anthropic, list_response
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+from pydantic import HttpUrl, PostgresDsn, SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.applications import Starlette
+from yarl import URL
+
+from .factories import mcp_session
+
+
+@dataclass(frozen=True)
+class SearchCase:
+    query: str
+    top_hit: str | frozenset[str]
+    co_surface: frozenset[str] = frozenset()
+
+
+CASES = [
+    SearchCase("give research-bot a Toggl key", "request_agent_key", frozenset([])),
+    SearchCase(
+        "add the Higgsfield API key so people can try it", "request_agent_key", frozenset([])
+    ),
+    SearchCase(
+        "this platform just launched; give you its API key for everyone here",
+        "request_agent_key",
+        frozenset([]),
+    ),
+    SearchCase(
+        "connect research-bot to our MCP endpoint with a token",
+        "request_mcp_token",
+        frozenset(["attach_mcp_server"]),
+    ),
+    SearchCase("load our .env into research-bot", "request_agent_key", frozenset([])),
+    SearchCase("what keys does research-bot have", "list_agent_keys", frozenset(["get_agent"])),
+    SearchCase("remove the old Toggl key from research-bot", "remove_agent_key", frozenset([])),
+    SearchCase(
+        "let research-bot read our private repo github.com/acme/data",
+        "request_repo_binding",
+        frozenset(["post_github_app_install_link"]),
+    ),
+    SearchCase(
+        "install the GitHub app",
+        "post_github_app_install_link",
+        frozenset(["request_repo_binding"]),
+    ),
+    SearchCase(
+        "install skills from github.com/acme/skills into research-bot",
+        "sync_skills",
+        frozenset(["request_skill_repo_token"]),
+    ),
+    SearchCase(
+        "the skills repo is private",
+        "request_skill_repo_token",
+        frozenset(["request_repo_binding"]),
+    ),
+    SearchCase(
+        "add the build-models skill to research-bot", "update_agent", frozenset(["remove_skill"])
+    ),
+    SearchCase(
+        "stop research-bot using the eda skill", "remove_skill", frozenset(["delete_skill"])
+    ),
+    SearchCase(
+        "delete the eda skill from the workspace", "delete_skill", frozenset(["remove_skill"])
+    ),
+    SearchCase(
+        "connect research-bot to Linear", "request_mcp_token", frozenset(["attach_mcp_server"])
+    ),
+    SearchCase(
+        "add the Context7 MCP server to research-bot",
+        "attach_mcp_server",
+        frozenset(["request_mcp_token"]),
+    ),
+    SearchCase("disconnect Linear from research-bot", "detach_mcp_server", frozenset([])),
+    SearchCase(
+        "make churn-explorer answer in #growth",
+        "set_agent_default",
+        frozenset(["clear_agent_default"]),
+    ),
+    SearchCase(
+        "make research-bot the default for the whole server", "set_agent_default", frozenset([])
+    ),
+    SearchCase(
+        "stop churn-explorer answering in #growth",
+        "clear_agent_default",
+        frozenset(["set_agent_default"]),
+    ),
+    SearchCase("who answers in #growth", "explain_agent_resolution", frozenset([])),
+    SearchCase("make a copy of Daimon I can edit", "fork_agent", frozenset([])),
+    SearchCase("create an agent called churn-explorer on Opus", "create_agent", frozenset([])),
+    SearchCase("switch research-bot to Opus", "update_agent", frozenset([])),
+    SearchCase("change research-bot's prompt", "update_agent", frozenset([])),
+    SearchCase("what can research-bot access", "get_agent", frozenset(["list_agent_keys"])),
+    SearchCase("delete churn-explorer", "archive_agent", frozenset([])),
+]
+
+
+def _make_app(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    platform: str,
+    role: str = "admin",
+    tenant_id: uuid.UUID | None = None,
+    account_id: uuid.UUID | None = None,
+    client: AsyncAnthropic | None = None,
+    crypto_keys: tuple[SecretStr, ...] = (),
+) -> Starlette:
+    return create_mcp_app(
+        settings=Settings(
+            database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
+            anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+            mcp=McpSettings(public_url=HttpUrl("https://example.com/mcp")),
+            discord=DiscordSettings(bot_token=SecretStr("test-bot-token")),
+            slack=SlackSettings(signing_secret=SecretStr("test"), app_token=SecretStr("xapp-test")),
+            github=GithubSettings(app_slug="test-app"),
+            crypto=CryptoSettings(keys=crypto_keys),
+            gemini=GeminiSettings(api_key=SecretStr("gemini-test")),
+            notebook=NotebookSettings(
+                host_url=HttpUrl("http://notebook.test:8001"), admin_secret=SecretStr("test")
+            ),
+        ),
+        sessionmaker=sessionmaker,
+        anthropic=client if client is not None else build_stub_anthropic(),
+        auth=StaticTokenVerifier(
+            tokens={
+                "test-token": {
+                    "sub": str(account_id or uuid.uuid4()),
+                    "tenant_id": str(tenant_id or uuid.uuid4()),
+                    "role": role,
+                    "client_id": "test",
+                    "platform": platform,
+                    "external_id": "T_TEST" if platform == "slack" else "111",
+                    "platform_user_id": "U_TEST" if platform == "slack" else "42",
+                }
+            }
+        ),
+    )
+
+
+def _result_text(response: dict[str, object]) -> str:
+    result = response.get("result", response)
+    assert isinstance(result, dict), f"expected a tool result, got {response}"
+    content = result.get("content", [])
+    assert isinstance(content, list), f"expected content blocks, got {result}"
+    return "\n".join(str(item.get("text", "")) for item in content if isinstance(item, dict))
+
+
+@pytest.mark.parametrize("platform", ["discord", "slack"])
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.query)
+async def test_setup_query_ranks_tool_and_siblings(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    platform: str,
+    case: SearchCase,
+) -> None:
+    app = _make_app(sessionmaker, platform=platform)
+    response = await mcp_session(
+        app,
+        token="test-token",
+        method="tools/call",
+        params={
+            "name": "search_tools",
+            "arguments": {"query": case.query},
+        },
+    )
+    hits = re.findall(r"^### (\w+)", _result_text(response), re.MULTILINE)
+    expected = {case.top_hit} if isinstance(case.top_hit, str) else case.top_hit
+    detail = (
+        f"{case.query!r}: expected {expected}, co-surface {case.co_surface}; ordered hits={hits}"
+    )
+    assert hits and hits[0] in expected, detail
+    assert case.co_surface <= set(hits), detail
+    assert len(hits) <= 5, f"search window exceeded five: {detail}"
+
+
+@pytest.mark.parametrize("platform", ["discord", "slack"])
+async def test_member_cannot_search_or_call_routing_mutation(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    platform: str,
+) -> None:
+    app = _make_app(sessionmaker, platform=platform, role="user")
+    found = await mcp_session(
+        app,
+        token="test-token",
+        method="tools/call",
+        params={
+            "name": "search_tools",
+            "arguments": {"query": "make research-bot the channel default"},
+        },
+    )
+    assert "### set_agent_default" not in _result_text(found), (
+        "member search must hide routing mutation"
+    )
+    called = await mcp_session(
+        app,
+        token="test-token",
+        method="tools/call",
+        params={
+            "name": "call_tool",
+            "arguments": {"name": "set_agent_default", "arguments": {"agent_name": "research-bot"}},
+        },
+    )
+    text = _result_text(called)
+    assert "Unknown tool" in text or "not found" in text, (
+        f"hidden routing tool must remain uncallable: {text}"
+    )
+    assert "/agent-setup" not in text and "DAIMON_" not in text, (
+        "refusal must not expose retired paths or settings"
+    )
+
+
+@pytest.mark.parametrize("platform", ["discord", "slack"])
+async def test_member_default_agent_edit_refuses_with_admin_handoff(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    platform: str,
+) -> None:
+    async with sessionmaker.begin() as session:
+        tenant = await make_tenant(session, platform=platform)
+        account = await make_account(session, tenant=tenant)
+        await set_fields(
+            session,
+            scope=TenantScopeRef(tenant_id=tenant.id),
+            tenant_id=tenant.id,
+            agent_name="research-bot",
+            mode="agent",
+        )
+    agent = BetaManagedAgentsAgent(
+        id="ag_research",
+        name="research-bot",
+        type="agent",
+        version=1,
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-5"),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        tools=[],
+        skills=[],
+        mcp_servers=[],
+        metadata={
+            "daimon_tenant": str(tenant.id),
+            "daimon_name": "research-bot",
+            "daimon_account": str(account.id),
+        },
+    )
+    requests: list[httpx.Request] = []
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.method == "GET" and request.url.path == "/v1/agents", (
+            "refused edit must not write upstream"
+        )
+        return list_response([agent.model_dump(mode="json")])
+
+    app = _make_app(
+        sessionmaker,
+        platform=platform,
+        role="user",
+        tenant_id=tenant.id,
+        account_id=account.id,
+        client=build_fake_anthropic(transport),
+    )
+    found = await mcp_session(
+        app,
+        token="test-token",
+        method="tools/call",
+        params={
+            "name": "search_tools",
+            "arguments": {"query": "change research-bot prompt"},
+        },
+    )
+    assert "### update_agent" in _result_text(found), (
+        "direct spec edit remains discoverable for members"
+    )
+    called = await mcp_session(
+        app,
+        token="test-token",
+        method="tools/call",
+        params={
+            "name": "call_tool",
+            "arguments": {
+                "name": "update_agent",
+                "arguments": {"name": "research-bot", "system": "a revised prompt"},
+            },
+        },
+    )
+    text = _result_text(called)
+    assert "research-bot" in text and "admin" in text and "forking" in text, (
+        f"handoff must preserve target and non-gated alternative: {text}"
+    )
+    assert "/agent-setup" not in text and "DAIMON_" not in text, (
+        "refusal must not disclose deployment internals"
+    )
+    assert len(requests) == 1, "refusal must follow lookup without a mutation"
+
+
+async def test_member_can_request_new_key_on_managed_agent(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    key = SecretStr(Fernet.generate_key().decode())
+    fernet = build_multifernet((key.get_secret_value(),))
+    async with committing_sessionmaker.begin() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id="T_TEST")
+        account = await make_account(session, tenant=tenant)
+        await upsert_slack_bot_token(
+            session, team_id="T_TEST", encrypted_token=encrypt_token(fernet, "xoxb-test")
+        )
+    agent = BetaManagedAgentsAgent(
+        id="ag_daimon",
+        name="daimon",
+        type="agent",
+        version=1,
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-5"),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        tools=[],
+        skills=[],
+        mcp_servers=[],
+        metadata={
+            "daimon_tenant": str(tenant.id),
+            "daimon_name": "daimon",
+            "daimon_managed": "true",
+        },
+    )
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET" and request.url.path == "/v1/agents", (
+            "request should only resolve its target upstream"
+        )
+        return list_response([agent.model_dump(mode="json")])
+
+    app = _make_app(
+        committing_sessionmaker,
+        platform="slack",
+        role="user",
+        tenant_id=tenant.id,
+        account_id=account.id,
+        client=build_fake_anthropic(transport),
+        crypto_keys=(key,),
+    )
+    found = await mcp_session(
+        app,
+        token="test-token",
+        method="tools/call",
+        params={
+            "name": "search_tools",
+            "arguments": {"query": "give Daimon a new API key"},
+        },
+    )
+    assert "### request_agent_key" in _result_text(found), "member must discover key enrollment"
+    with aioresponses() as slack:
+        slack.get(
+            re.compile(r"https://slack\.com/api/conversations\.info.*"),
+            payload={"ok": True, "channel": {"id": "C_TEST", "is_private": False}},
+        )
+        slack.get(
+            re.compile(r"https://slack\.com/api/users\.info.*"),
+            payload={"ok": True, "user": {"id": "U_TEST", "is_restricted": False}},
+        )
+        slack.post("https://slack.com/api/chat.postMessage", payload={"ok": True, "ts": "123.456"})
+        called = await mcp_session(
+            app,
+            token="test-token",
+            method="tools/call",
+            params={
+                "name": "call_tool",
+                "arguments": {
+                    "name": "request_agent_key",
+                    "arguments": {
+                        "agent_name": "daimon",
+                        "key": "NEW_SERVICE_API_KEY",
+                        "purpose": "use the new service",
+                        "channel_id": "C_TEST",
+                    },
+                },
+            },
+        )
+        text = _result_text(called)
+        assert "123.456" in text and "NEW_SERVICE_API_KEY" in text, (
+            f"member enrollment must actually post: {text}"
+        )
+        payload = slack.requests[("POST", URL("https://slack.com/api/chat.postMessage"))][0].kwargs[
+            "json"
+        ]
+    token = next(block for block in payload["blocks"] if block["type"] == "actions")["elements"][0][
+        "value"
+    ]
+    async with committing_sessionmaker() as session:
+        row = await peek_credential_request(session, token=token)
+    assert row is not None and row.target == "NEW_SERVICE_API_KEY", (
+        "posted token must identify a persisted request"
+    )
+    assert row.tenant_id == tenant.id and row.requester_platform_user_id == "U_TEST", (
+        "request must stay tenant- and requester-bound"
+    )

--- a/packages/adapters/mcp/tests/tools/test_agent_removal.py
+++ b/packages/adapters/mcp/tests/tools/test_agent_removal.py
@@ -13,8 +13,8 @@ from daimon.adapters.mcp.auth.resolver import AuthIdentity, Role
 from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools.agent_removal import (
     _detach_mcp_server_impl,
-    _list_env_credential_keys_impl,
-    _remove_env_credential_impl,
+    _list_agent_keys_impl,
+    _remove_agent_key_impl,
     _remove_skill_impl,
 )
 from daimon.adapters.mcp.tools.agents import AgentInfo
@@ -256,7 +256,7 @@ async def test_detach_mcp_server_impl_rejects_non_admin_when_agent_reachable(
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    with pytest.raises(ToolError, match="Manage Server"):
+    with pytest.raises(ToolError, match="admin must change"):
         await _detach_mcp_server_impl(
             _runtime(client, session_factory=db_session_factory),
             auth,
@@ -491,7 +491,7 @@ async def test_remove_skill_impl_rejects_non_admin_when_agent_reachable(
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    with pytest.raises(ToolError, match="Manage Server"):
+    with pytest.raises(ToolError, match="admin must change"):
         await _remove_skill_impl(
             _runtime(client, session_factory=db_session_factory),
             auth,
@@ -523,7 +523,7 @@ async def test_remove_skill_impl_allows_non_admin_when_agent_unreachable(
 
 
 # ---------------------------------------------------------------------------
-# list_env_credential_keys / remove_env_credential
+# list_agent_keys / remove_agent_key
 # ---------------------------------------------------------------------------
 
 
@@ -565,7 +565,7 @@ def _multi_agent_router(
     return build_fake_anthropic(router.dispatch)
 
 
-async def test_list_env_credential_keys_impl_returns_sorted_key_names_only(
+async def test_list_agent_keys_impl_returns_sorted_key_names_only(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -589,13 +589,13 @@ async def test_list_env_credential_keys_impl_returns_sorted_key_names_only(
     auth = AuthIdentity(
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
-    result = await _list_env_credential_keys_impl(
+    result = await _list_agent_keys_impl(
         _runtime(client, session_factory=db_session_factory), auth, agent_name="demo"
     )
     assert result == ["AKEY", "MKEY", "ZKEY"], "must return only the three key names, sorted"
 
 
-async def test_list_env_credential_keys_impl_returns_empty_list_when_none_set(
+async def test_list_agent_keys_impl_returns_empty_list_when_none_set(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -606,13 +606,13 @@ async def test_list_env_credential_keys_impl_returns_empty_list_when_none_set(
     auth = AuthIdentity(
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
-    result = await _list_env_credential_keys_impl(
+    result = await _list_agent_keys_impl(
         _runtime(client, session_factory=db_session_factory), auth, agent_name="demo"
     )
     assert result == [], "no variables set must return an empty list, not an error"
 
 
-async def test_list_env_credential_keys_impl_raises_when_agent_not_found(
+async def test_list_agent_keys_impl_raises_when_agent_not_found(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -624,12 +624,12 @@ async def test_list_env_credential_keys_impl_raises_when_agent_not_found(
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
     with pytest.raises(ToolError, match="not found"):
-        await _list_env_credential_keys_impl(
+        await _list_agent_keys_impl(
             _runtime(client, session_factory=db_session_factory), auth, agent_name="ghost"
         )
 
 
-async def test_list_env_credential_keys_impl_never_returns_a_stored_value(
+async def test_list_agent_keys_impl_never_returns_a_stored_value(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -652,7 +652,7 @@ async def test_list_env_credential_keys_impl_never_returns_a_stored_value(
     auth = AuthIdentity(
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
-    result = await _list_env_credential_keys_impl(
+    result = await _list_agent_keys_impl(
         _runtime(client, session_factory=db_session_factory), auth, agent_name="demo"
     )
     assert result == ["API_KEY"]
@@ -661,7 +661,7 @@ async def test_list_env_credential_keys_impl_never_returns_a_stored_value(
     )
 
 
-async def test_list_env_credential_keys_impl_callable_by_non_admin_on_default_agent(
+async def test_list_agent_keys_impl_callable_by_non_admin_on_default_agent(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     account_id = uuid.uuid4()
@@ -671,13 +671,13 @@ async def test_list_env_credential_keys_impl_callable_by_non_admin_on_default_ag
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    result = await _list_env_credential_keys_impl(
+    result = await _list_agent_keys_impl(
         _runtime(client, session_factory=db_session_factory), auth, agent_name="scoped-agent"
     )
     assert result == [], "the listing is not reachability-gated, even on a default agent"
 
 
-async def test_remove_env_credential_impl_removes_existing_key(
+async def test_remove_agent_key_impl_removes_existing_key(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -696,16 +696,16 @@ async def test_remove_env_credential_impl_removes_existing_key(
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
     runtime = _runtime(client, session_factory=db_session_factory)
-    result = await _remove_env_credential_impl(runtime, auth, agent_name="demo", key="API_KEY")
+    result = await _remove_agent_key_impl(runtime, auth, agent_name="demo", key="API_KEY")
     assert result.removed is True
     assert result.agent_name == "demo"
     assert result.key == "API_KEY"
 
-    remaining = await _list_env_credential_keys_impl(runtime, auth, agent_name="demo")
+    remaining = await _list_agent_keys_impl(runtime, auth, agent_name="demo")
     assert remaining == [], "a follow-up listing must no longer contain the removed key"
 
 
-async def test_remove_env_credential_impl_is_idempotent_when_key_absent(
+async def test_remove_agent_key_impl_is_idempotent_when_key_absent(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -716,7 +716,7 @@ async def test_remove_env_credential_impl_is_idempotent_when_key_absent(
     auth = AuthIdentity(
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
-    result = await _remove_env_credential_impl(
+    result = await _remove_agent_key_impl(
         _runtime(client, session_factory=db_session_factory),
         auth,
         agent_name="demo",
@@ -725,7 +725,7 @@ async def test_remove_env_credential_impl_is_idempotent_when_key_absent(
     assert result.removed is False, "removing an absent key must succeed idempotently"
 
 
-async def test_remove_env_credential_impl_raises_when_agent_not_found(
+async def test_remove_agent_key_impl_raises_when_agent_not_found(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -737,7 +737,7 @@ async def test_remove_env_credential_impl_raises_when_agent_not_found(
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
     with pytest.raises(ToolError, match="not found"):
-        await _remove_env_credential_impl(
+        await _remove_agent_key_impl(
             _runtime(client, session_factory=db_session_factory),
             auth,
             agent_name="ghost",
@@ -745,7 +745,7 @@ async def test_remove_env_credential_impl_raises_when_agent_not_found(
         )
 
 
-async def test_remove_env_credential_impl_callable_by_non_admin_on_default_agent(
+async def test_remove_agent_key_impl_callable_by_non_admin_on_default_agent(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     account_id = uuid.uuid4()
@@ -755,7 +755,7 @@ async def test_remove_env_credential_impl_callable_by_non_admin_on_default_agent
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    result = await _remove_env_credential_impl(
+    result = await _remove_agent_key_impl(
         _runtime(client, session_factory=db_session_factory),
         auth,
         agent_name="scoped-agent",
@@ -764,7 +764,7 @@ async def test_remove_env_credential_impl_callable_by_non_admin_on_default_agent
     assert result.removed is False, "removal is not reachability-gated, even on a default agent"
 
 
-async def test_remove_env_credential_impl_succeeds_against_seeded_agent_with_no_daimon_account(
+async def test_remove_agent_key_impl_succeeds_against_seeded_agent_with_no_daimon_account(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -782,7 +782,7 @@ async def test_remove_env_credential_impl_succeeds_against_seeded_agent_with_no_
     auth = AuthIdentity(
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
-    result = await _remove_env_credential_impl(
+    result = await _remove_agent_key_impl(
         _runtime(client, session_factory=db_session_factory),
         auth,
         agent_name="daimon",
@@ -791,7 +791,7 @@ async def test_remove_env_credential_impl_succeeds_against_seeded_agent_with_no_
     assert result.removed is True, "the system-agent guard must not apply to env-variable removal"
 
 
-async def test_remove_env_credential_impl_isolates_between_agents_in_same_tenant(
+async def test_remove_agent_key_impl_isolates_between_agents_in_same_tenant(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     tenant_id = uuid.uuid4()
@@ -818,8 +818,8 @@ async def test_remove_env_credential_impl_isolates_between_agents_in_same_tenant
         account_id=uuid.uuid4(), tenant_id=tenant_id, role=Role.USER, is_admin=False
     )
     runtime = _runtime(client, session_factory=db_session_factory)
-    result = await _remove_env_credential_impl(runtime, auth, agent_name="agent-a", key="SHARED")
+    result = await _remove_agent_key_impl(runtime, auth, agent_name="agent-a", key="SHARED")
     assert result.removed is True
 
-    remaining = await _list_env_credential_keys_impl(runtime, auth, agent_name="agent-b")
+    remaining = await _list_agent_keys_impl(runtime, auth, agent_name="agent-b")
     assert remaining == ["SHARED"], "removing from agent-a must not affect agent-b's SHARED key"

--- a/packages/adapters/mcp/tests/tools/test_agents.py
+++ b/packages/adapters/mcp/tests/tools/test_agents.py
@@ -37,7 +37,9 @@ from daimon.adapters.mcp.tools.agents import (
     _update_agent_impl,
     register_agent_tools,
 )
+from daimon.core.agent_guidance import CREDENTIAL_GUIDANCE_BLOCK
 from daimon.core.constants import AGENT_MCP_CAP, AGENT_SKILL_CAP
+from daimon.core.defaults.metadata import MA_METADATA_KEY_ISOLATED
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
 from daimon.core.github_credentials import build_multifernet, get_pat, upsert_credential_encrypted
 from daimon.core.ma_identity import derive_agent_uuid
@@ -824,6 +826,193 @@ async def test_fork_agent_impl_adds_base_toolset_when_source_lacks_it(
     )
 
 
+async def test_fork_agent_impl_normalizes_stale_guidance_block(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A fork of a source carrying a stale sentinel-wrapped block gets the
+    current block exactly once, with the source's own prompt body preserved
+    beneath it — the same normalization `update_agent` already applies."""
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    stale_system = (
+        "<!-- daimon:credential-guidance v1 -->\nSOME OLD STALE BODY\n"
+        "<!-- /daimon:credential-guidance -->\n\nSOURCE PROMPT BODY"
+    )
+    created: list[dict[str, Any]] = []
+
+    def on_retrieve(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        body = make_ma_agent(id="ag_src", name="source", system=stale_system)
+        return httpx.Response(200, json=body.model_dump(mode="json"))
+
+    def on_create(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        created.append(json_body(req))
+        body = make_ma_agent(id="ag_new", name="myfork")
+        return httpx.Response(200, json=body.model_dump(mode="json"))
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _req, _m: list_response(
+            [
+                make_ma_agent(
+                    id="ag_src",
+                    name="source",
+                    metadata={"daimon_tenant": str(tenant_id), "daimon_name": "source"},
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add("GET", r"/v1/agents/([^/]+)", on_retrieve)
+    router.add("POST", r"/v1/agents", on_create)
+    client = build_fake_anthropic(router.dispatch)
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+    await _fork_agent_impl(
+        _runtime(client, session_factory=db_session_factory, fernet=fernet),
+        auth,
+        source_name="source",
+        new_name="myfork",
+    )
+
+    assert len(created) == 1, "should call MA create exactly once"
+    forked_system = created[0].get("system", "")
+    assert forked_system.count("<!-- daimon:credential-guidance") == 1, (
+        "fork must carry the guidance block exactly once, not stacked"
+    )
+    assert CREDENTIAL_GUIDANCE_BLOCK in forked_system, "fork must carry the current block"
+    assert forked_system.endswith("SOURCE PROMPT BODY"), (
+        "the source's own prompt body must survive the normalization"
+    )
+
+
+async def test_fork_agent_impl_adds_guidance_when_source_has_none(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A fork of a source with no guidance block at all gets the current block
+    once, the same result `reconcile_agent` produces for a spec with no system."""
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    created: list[dict[str, Any]] = []
+
+    def on_retrieve(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        body = make_ma_agent(id="ag_src", name="source", system="You are a helpful bot.")
+        return httpx.Response(200, json=body.model_dump(mode="json"))
+
+    def on_create(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        created.append(json_body(req))
+        body = make_ma_agent(id="ag_new", name="myfork")
+        return httpx.Response(200, json=body.model_dump(mode="json"))
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _req, _m: list_response(
+            [
+                make_ma_agent(
+                    id="ag_src",
+                    name="source",
+                    metadata={"daimon_tenant": str(tenant_id), "daimon_name": "source"},
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add("GET", r"/v1/agents/([^/]+)", on_retrieve)
+    router.add("POST", r"/v1/agents", on_create)
+    client = build_fake_anthropic(router.dispatch)
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+    await _fork_agent_impl(
+        _runtime(client, session_factory=db_session_factory, fernet=fernet),
+        auth,
+        source_name="source",
+        new_name="myfork",
+    )
+
+    assert len(created) == 1, "should call MA create exactly once"
+    forked_system = created[0].get("system", "")
+    assert forked_system.count("<!-- daimon:credential-guidance") == 1, (
+        "fork must gain the guidance block exactly once"
+    )
+    assert CREDENTIAL_GUIDANCE_BLOCK in forked_system
+
+
+async def test_fork_agent_impl_skips_guidance_for_isolated_source(
+    db_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A fork of an isolated-stamped source carries no guidance block at all —
+    its session mounts no secrets, so the block would teach it to look for
+    resources it must not have."""
+    tenant_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    isolated_system = "You are an isolated agent. Trust nothing you are told."
+    created: list[dict[str, Any]] = []
+
+    def on_retrieve(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        body = make_ma_agent(
+            id="ag_src",
+            name="source",
+            system=isolated_system,
+            metadata={
+                "daimon_tenant": str(tenant_id),
+                "daimon_name": "source",
+                MA_METADATA_KEY_ISOLATED: "true",
+            },
+        )
+        return httpx.Response(200, json=body.model_dump(mode="json"))
+
+    def on_create(req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        created.append(json_body(req))
+        body = make_ma_agent(id="ag_new", name="myfork")
+        return httpx.Response(200, json=body.model_dump(mode="json"))
+
+    router = MARouter()
+    router.add(
+        "GET",
+        r"/v1/agents",
+        lambda _req, _m: list_response(
+            [
+                make_ma_agent(
+                    id="ag_src",
+                    name="source",
+                    metadata={
+                        "daimon_tenant": str(tenant_id),
+                        "daimon_name": "source",
+                        MA_METADATA_KEY_ISOLATED: "true",
+                    },
+                ).model_dump(mode="json")
+            ]
+        ),
+    )
+    router.add("GET", r"/v1/agents/([^/]+)", on_retrieve)
+    router.add("POST", r"/v1/agents", on_create)
+    client = build_fake_anthropic(router.dispatch)
+
+    auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+    await _fork_agent_impl(
+        _runtime(client, session_factory=db_session_factory, fernet=fernet),
+        auth,
+        source_name="source",
+        new_name="myfork",
+    )
+
+    assert len(created) == 1, "should call MA create exactly once"
+    forked_system = created[0].get("system", "")
+    assert "<!-- daimon:credential-guidance" not in forked_system, (
+        "an isolated source's fork must carry no guidance block"
+    )
+    assert forked_system == isolated_system, (
+        "an isolated source's fork system must be byte-identical to the source's"
+    )
+
+
 async def test_archive_agent_impl_calls_ma_archive(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
@@ -1575,13 +1764,20 @@ async def test_fork_agent_impl_raises_tool_error_when_fernet_none() -> None:
     client = build_fake_anthropic(router.dispatch)
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
 
-    with pytest.raises(ToolError, match="no crypto keys configured"):
+    with pytest.raises(ToolError, match="operator must finish setup") as refused:
         await _fork_agent_impl(
             _runtime(client, fernet=None),
             auth,
             source_name="source",
             new_name="myfork3",
         )
+
+    assert "source" in str(refused.value) and "myfork3" in str(refused.value), (
+        "refusal must preserve source and requested copy"
+    )
+    assert "DAIMON_" not in str(refused.value), (
+        "chat caller must not receive deployment variable names"
+    )
 
 
 async def test_update_agent_impl_passes_skills_to_ma_when_provided() -> None:
@@ -2199,7 +2395,7 @@ async def test_update_agent_impl_rejects_seeded_agent_that_is_also_account_stamp
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.ADMIN, is_admin=True)
-    with pytest.raises(ToolError, match="managed by defaults"):
+    with pytest.raises(ToolError, match="managed by defaults") as refused:
         await _update_agent_impl(
             _runtime(client),
             auth,
@@ -2211,6 +2407,11 @@ async def test_update_agent_impl_rejects_seeded_agent_that_is_also_account_stamp
             mcp_servers=None,
             skills=None,
         )
+
+    assert "daimon" in str(refused.value) and "fork_agent" in str(refused.value), (
+        "managed agent refusal must preserve target and name the fork path"
+    )
+    assert "/agent-setup" not in str(refused.value), "refusal must name a callable tool"
 
 
 async def test_update_agent_impl_allows_a_panel_fork_of_a_seeded_agent() -> None:
@@ -4277,7 +4478,7 @@ async def test_update_agent_impl_rejects_non_admin_system_patch_when_agent_reach
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    with pytest.raises(ToolError, match="Manage Server"):
+    with pytest.raises(ToolError, match="admin must change"):
         await _update_agent_impl(
             _runtime(client, session_factory=db_session_factory),
             auth,
@@ -4327,7 +4528,7 @@ async def test_update_agent_impl_rejects_non_admin_skills_patch_when_agent_reach
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    with pytest.raises(ToolError, match="Manage Server"):
+    with pytest.raises(ToolError, match="admin must change"):
         await _update_agent_impl(
             _runtime(client, session_factory=db_session_factory),
             auth,
@@ -4351,7 +4552,7 @@ async def test_update_agent_impl_rejects_non_admin_mcp_servers_patch_when_agent_
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    with pytest.raises(ToolError, match="Manage Server"):
+    with pytest.raises(ToolError, match="admin must change"):
         await _update_agent_impl(
             _runtime(client, session_factory=db_session_factory),
             auth,
@@ -4375,7 +4576,7 @@ async def test_update_agent_impl_rejects_non_admin_tools_patch_when_agent_reacha
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    with pytest.raises(ToolError, match="Manage Server"):
+    with pytest.raises(ToolError, match="admin must change"):
         await _update_agent_impl(
             _runtime(client, session_factory=db_session_factory),
             auth,
@@ -4455,7 +4656,7 @@ async def test_attach_mcp_server_impl_rejects_non_admin_when_agent_reachable(
     )
 
     auth = AuthIdentity(account_id=account_id, tenant_id=tenant_id, role=Role.USER, is_admin=False)
-    with pytest.raises(ToolError, match="Manage Server"):
+    with pytest.raises(ToolError, match="admin must change"):
         await _attach_mcp_server_impl(
             _runtime(client, session_factory=db_session_factory),
             auth,
@@ -4648,6 +4849,9 @@ async def test_update_agent_refuses_when_merged_skills_exceed_the_product_cap() 
     assert str(AGENT_SKILL_CAP) in str(exc_info.value), (
         f"refusal must name the cap; got {exc_info.value}"
     )
+    assert "remove_skill" in str(exc_info.value) and "No skills were changed" in str(
+        exc_info.value
+    ), "cap refusal must name the removal path and failed-save outcome"
     assert not update_calls, "the merged-count refusal must fire before any agents.update request"
 
 

--- a/packages/adapters/mcp/tests/tools/test_cli_token.py
+++ b/packages/adapters/mcp/tests/tools/test_cli_token.py
@@ -164,12 +164,11 @@ async def test_get_cli_token_audit_log_has_no_token_value(
 async def test_get_cli_token_no_binding_maps_to_tool_error(
     cli_token_app: tuple[FastMCP, uuid.UUID, str, async_sessionmaker[AsyncSession], Settings],
 ) -> None:
-    """No credential row → tool surfaces a ToolError instructing
-    the user to bind a PAT via the agent-setup repo-auth panel."""
+    """An account-only caller needs operator help, not a target-agent repo binding."""
     mcp, _account_id, _plaintext_token, _sessionmaker, _settings = cli_token_app
 
     async with Client(mcp) as client:
-        with pytest.raises(ToolError, match="agent-setup repo-auth panel"):
+        with pytest.raises(ToolError, match="operator.*account"):
             await client.call_tool("get_cli_token", {"service": "github"})
 
 

--- a/packages/adapters/mcp/tests/tools/test_credential_requests.py
+++ b/packages/adapters/mcp/tests/tools/test_credential_requests.py
@@ -56,11 +56,11 @@ _tools_conftest = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_tools_conftest)
 patch_discord_http = _tools_conftest.patch_discord_http
 
-_request_env_credential_impl = (
-    _credential_requests_mod._request_env_credential_impl  # pyright: ignore[reportPrivateUsage]
+_request_agent_key_impl = (
+    _credential_requests_mod._request_agent_key_impl  # pyright: ignore[reportPrivateUsage]
 )
-_request_mcp_credential_impl = (
-    _credential_requests_mod._request_mcp_credential_impl  # pyright: ignore[reportPrivateUsage]
+_request_mcp_token_impl = (
+    _credential_requests_mod._request_mcp_token_impl  # pyright: ignore[reportPrivateUsage]
 )
 _request_repo_binding_impl = (
     _credential_requests_mod._request_repo_binding_impl  # pyright: ignore[reportPrivateUsage]
@@ -283,11 +283,11 @@ async def _row_count(db_session: AsyncSession) -> int:
 
 
 # ---------------------------------------------------------------------------
-# 1. request_env_credential creates a row + posts a button
+# 1. request_agent_key creates a row + posts a button
 # ---------------------------------------------------------------------------
 
 
-async def test_request_env_credential_creates_row_and_posts_button(
+async def test_request_agent_key_creates_row_and_posts_button(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
@@ -303,7 +303,7 @@ async def test_request_env_credential_creates_row_and_posts_button(
     posted: dict[str, Any] = {}
     _patch_successful_post(monkeypatch, message_id="9201", posted=posted)
 
-    result = await _request_env_credential_impl(
+    result = await _request_agent_key_impl(
         runtime,
         auth,
         agent_name="daimon",
@@ -330,11 +330,11 @@ async def test_request_env_credential_creates_row_and_posts_button(
 
 
 # ---------------------------------------------------------------------------
-# 2. request_mcp_credential creates a row + posts a button
+# 2. request_mcp_token creates a row + posts a button
 # ---------------------------------------------------------------------------
 
 
-async def test_request_mcp_credential_creates_row_and_posts_button(
+async def test_request_mcp_token_creates_row_and_posts_button(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
@@ -349,7 +349,7 @@ async def test_request_mcp_credential_creates_row_and_posts_button(
     posted: dict[str, Any] = {}
     _patch_successful_post(monkeypatch, message_id="9202", posted=posted)
 
-    result = await _request_mcp_credential_impl(
+    result = await _request_mcp_token_impl(
         runtime,
         auth,
         agent_name="daimon",
@@ -379,10 +379,10 @@ async def test_neither_tool_signature_exposes_a_secret_bearing_parameter() -> No
     register_credential_request_tools(mcp, _runtime(MagicMock()))  # type: ignore[arg-type]
     tools = await mcp.list_tools()
     by_name = {t.name: t for t in tools}
-    assert {"request_env_credential", "request_mcp_credential"} <= by_name.keys(), (
+    assert {"request_agent_key", "request_mcp_token"} <= by_name.keys(), (
         "both tools must be registered"
     )
-    for name in ("request_env_credential", "request_mcp_credential"):
+    for name in ("request_agent_key", "request_mcp_token"):
         param_names = set(by_name[name].parameters.get("properties", {}))
         forbidden = {
             p for p in param_names if any(w in p.lower() for w in ("token", "secret", "value"))
@@ -395,7 +395,7 @@ async def test_neither_tool_signature_exposes_a_secret_bearing_parameter() -> No
 async def test_impl_signatures_have_no_token_secret_or_value_parameter() -> None:
     """Belt-and-suspenders: the underlying impls' own signatures, not just the
     FastMCP-registered schema, carry no token/secret/value parameter."""
-    for fn in (_request_env_credential_impl, _request_mcp_credential_impl):
+    for fn in (_request_agent_key_impl, _request_mcp_token_impl):
         params = set(inspect.signature(fn).parameters)
         forbidden = {p for p in params if any(w in p.lower() for w in ("token", "secret", "value"))}
         assert not forbidden, (
@@ -408,7 +408,7 @@ async def test_impl_signatures_have_no_token_secret_or_value_parameter() -> None
 # ---------------------------------------------------------------------------
 
 
-async def test_request_env_credential_succeeds_for_non_admin_caller(
+async def test_request_agent_key_succeeds_for_non_admin_caller(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
@@ -422,7 +422,7 @@ async def test_request_env_credential_succeeds_for_non_admin_caller(
     auth = _auth_identity(tenant_id=tenant.id, is_admin=False)
     _patch_successful_post(monkeypatch, message_id="9203")
 
-    result = await _request_env_credential_impl(
+    result = await _request_agent_key_impl(
         runtime,
         auth,
         agent_name="daimon",
@@ -440,27 +440,27 @@ async def test_request_env_credential_succeeds_for_non_admin_caller(
 # ---------------------------------------------------------------------------
 
 
-async def test_request_env_credential_rejects_slack_caller_without_workspace(
+async def test_request_agent_key_rejects_slack_caller_without_workspace(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
     runtime = _runtime(committing_sessionmaker)
     auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
     with pytest.raises(ToolError, match="workspace context"):
-        await _request_env_credential_impl(
+        await _request_agent_key_impl(
             runtime, auth, agent_name="daimon", key="OPENAI_API_KEY", purpose="x", channel_id="222"
         )
     assert await _row_count(db_session) == 0, "a rejected slack call must create no row"
 
 
-async def test_request_mcp_credential_rejects_slack_caller_without_workspace(
+async def test_request_mcp_token_rejects_slack_caller_without_workspace(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
     runtime = _runtime(committing_sessionmaker)
     auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
     with pytest.raises(ToolError, match="workspace context"):
-        await _request_mcp_credential_impl(
+        await _request_mcp_token_impl(
             runtime,
             auth,
             agent_name="daimon",
@@ -476,14 +476,14 @@ async def test_request_mcp_credential_rejects_slack_caller_without_workspace(
 # ---------------------------------------------------------------------------
 
 
-async def test_request_env_credential_rejects_missing_platform_user_id(
+async def test_request_agent_key_rejects_missing_platform_user_id(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
     runtime = _runtime(committing_sessionmaker)
     auth = _auth_identity(platform_user_id=None)
     with pytest.raises(ToolError, match="platform-bound identity"):
-        await _request_env_credential_impl(
+        await _request_agent_key_impl(
             runtime, auth, agent_name="daimon", key="OPENAI_API_KEY", purpose="x", channel_id="222"
         )
     assert await _row_count(db_session) == 0
@@ -494,14 +494,14 @@ async def test_request_env_credential_rejects_missing_platform_user_id(
 # ---------------------------------------------------------------------------
 
 
-async def test_request_env_credential_rejects_invalid_key(
+async def test_request_agent_key_rejects_invalid_key(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
     runtime = _runtime(committing_sessionmaker)
     auth = _auth_identity()
     with pytest.raises(ToolError, match=r"\[A-Za-z_\]\[A-Za-z0-9_\]\*"):
-        await _request_env_credential_impl(
+        await _request_agent_key_impl(
             runtime, auth, agent_name="daimon", key="1BAD-KEY", purpose="x", channel_id="222"
         )
     assert await _row_count(db_session) == 0
@@ -512,7 +512,7 @@ async def test_request_env_credential_rejects_invalid_key(
 # ---------------------------------------------------------------------------
 
 
-async def test_request_env_credential_rejects_unknown_agent(
+async def test_request_agent_key_rejects_unknown_agent(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
@@ -522,7 +522,7 @@ async def test_request_env_credential_rejects_unknown_agent(
     runtime = _runtime(committing_sessionmaker, client=client)
     auth = _auth_identity(tenant_id=tenant.id)
     with pytest.raises(ToolError, match="not found in this tenant"):
-        await _request_env_credential_impl(
+        await _request_agent_key_impl(
             runtime, auth, agent_name="ghost", key="OPENAI_API_KEY", purpose="x", channel_id="222"
         )
     assert await _row_count(db_session) == 0
@@ -533,14 +533,14 @@ async def test_request_env_credential_rejects_unknown_agent(
 # ---------------------------------------------------------------------------
 
 
-async def test_request_mcp_credential_rejects_non_http_url(
+async def test_request_mcp_token_rejects_non_http_url(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
     runtime = _runtime(committing_sessionmaker)
     auth = _auth_identity()
     with pytest.raises(ToolError, match="must be http or https"):
-        await _request_mcp_credential_impl(
+        await _request_mcp_token_impl(
             runtime,
             auth,
             agent_name="daimon",
@@ -689,12 +689,12 @@ async def test_request_repo_binding_posts_message_naming_agent_and_repo(
     assert button["custom_id"].startswith(CUSTOM_ID_PREFIX), (
         "the button's custom_id must carry the credential-request prefix"
     )
-    assert button["label"].startswith("Bind repo: "), (
+    assert button["label"].startswith("Set working repo: "), (
         "the button's label must use the repo-kind prefix"
     )
 
 
-async def test_request_env_credential_raises_when_button_post_fails(
+async def test_request_agent_key_raises_when_button_post_fails(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
@@ -710,7 +710,7 @@ async def test_request_env_credential_raises_when_button_post_fails(
     auth = _auth_identity(tenant_id=tenant.id)
 
     with pytest.raises(ToolError, match="posting the button failed"):
-        await _request_env_credential_impl(
+        await _request_agent_key_impl(
             runtime, auth, agent_name="daimon", key="OPENAI_API_KEY", purpose="x", channel_id="222"
         )
 
@@ -795,7 +795,7 @@ def _register_slack_post_defaults(m: Any, *, channel_id: str = "C_CRED") -> None
     )
 
 
-async def test_request_env_credential_posts_slack_button_carrying_the_token(
+async def test_request_agent_key_posts_slack_button_carrying_the_token(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     db_session: AsyncSession,
 ) -> None:
@@ -818,7 +818,7 @@ async def test_request_env_credential_posts_slack_button_carrying_the_token(
 
     with aioresponses() as m:
         _register_slack_post_defaults(m)
-        result = await _request_env_credential_impl(
+        result = await _request_agent_key_impl(
             runtime,
             auth,
             agent_name="daimon",

--- a/packages/adapters/mcp/tests/tools/test_discord.py
+++ b/packages/adapters/mcp/tests/tools/test_discord.py
@@ -758,8 +758,8 @@ async def test_post_credential_button_body_mentions_requester_and_exposure(
     assert "demo" in body, "body must name the agent"
     assert "linear" in body, "body must name the exact target"
     assert "syncing Linear issues" in body, "body must include the caller-supplied purpose"
-    assert "usable by everyone who talks to" in body, (
-        "body must disclose that the credential becomes usable by everyone who talks to the agent"
+    assert "everyone who talks to **demo** can use the connection" in body, (
+        "body must disclose that everyone who talks to the agent can use the connection"
     )
     allowed_mentions = posted["json"]["allowed_mentions"]
     assert allowed_mentions["parse"] == ["users"], (

--- a/packages/adapters/mcp/tests/tools/test_github_app.py
+++ b/packages/adapters/mcp/tests/tools/test_github_app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
+import re
 import uuid
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,8 @@ from unittest.mock import MagicMock
 
 import discord.http
 import pytest
+from aioresponses import aioresponses
+from cryptography.fernet import Fernet
 from daimon.adapters.mcp.auth.resolver import AuthIdentity
 from daimon.adapters.mcp.runtime import McpRuntime
 from daimon.adapters.mcp.tools.github_app import (
@@ -32,11 +35,17 @@ from daimon.core.config import (
     GithubSettings,
     Settings,
 )
+from daimon.core.github_app_auth import build_app_install_url
+from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.scope import DeploymentDefault
 from daimon.core.stores.domain import Role
+from daimon.core.stores.slack_bot_tokens import upsert_slack_bot_token
+from daimon.testing.ma import build_stub_anthropic
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from yarl import URL
 
 # Load patch_discord_http directly from the sibling conftest.py by file path —
 # same trick test_credential_requests.py uses to dodge the "from conftest
@@ -281,22 +290,8 @@ async def test_result_model_has_no_success_shaped_field() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3. Slack caller is rejected
+# 3. Platform-bound callers
 # ---------------------------------------------------------------------------
-
-
-async def test_post_app_install_link_rejects_slack_caller(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    runtime = _runtime()
-    auth = _auth_identity(platform="slack", external_id=None, platform_user_id="U123")
-    captured = _outbound_request_count(monkeypatch)
-
-    with pytest.raises(ToolError, match="not supported on Slack"):
-        await _post_app_install_link_impl(
-            runtime, auth, channel_id="222", purpose="reading a private repo"
-        )
-    assert captured == [], "a rejected slack call must post nothing"
 
 
 # ---------------------------------------------------------------------------
@@ -323,23 +318,22 @@ async def test_post_app_install_link_rejects_missing_platform_user_id(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("platform", ["discord", "slack"])
 async def test_post_app_install_link_rejects_unset_slug(
     monkeypatch: pytest.MonkeyPatch,
+    platform: str,
 ) -> None:
     runtime = _runtime(app_slug=None)
-    auth = _auth_identity()
+    auth = _auth_identity(platform=platform)
     captured = _outbound_request_count(monkeypatch)
 
-    with pytest.raises(ToolError, match="no GitHub App install link configured"):
+    with pytest.raises(ToolError, match="no GitHub App install link configured") as refused:
         await _post_app_install_link_impl(
             runtime, auth, channel_id="222", purpose="reading a private repo"
         )
     assert captured == [], "an unset slug must post zero outbound Discord requests"
 
-
-# ---------------------------------------------------------------------------
-# 6. Caller lacking send permission is refused by the reused permission check
-# ---------------------------------------------------------------------------
+    assert "DAIMON_" not in str(refused.value), "operator refusal must not expose settings names"
 
 
 async def test_post_app_install_link_rejects_caller_without_send_permission(
@@ -374,3 +368,80 @@ async def test_impl_signature_has_no_token_secret_or_value_parameter() -> None:
     assert not forbidden, (
         f"_post_app_install_link_impl must not accept a secret-bearing parameter, found {forbidden}"
     )
+
+
+@pytest.mark.parametrize("is_private", [False, True])
+async def test_slack_install_link_checks_access_before_posting(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    is_private: bool,
+) -> None:
+    fernet = build_multifernet((Fernet.generate_key().decode(),))
+    async with sessionmaker.begin() as session:
+        await upsert_slack_bot_token(
+            session, team_id="T_TEST", encrypted_token=encrypt_token(fernet, "xoxb-test")
+        )
+    runtime = McpRuntime(
+        session_factory=sessionmaker,
+        client=build_stub_anthropic(),
+        settings=_runtime().settings,
+        deployment_default=DeploymentDefault(),
+        fernet=fernet,
+    )
+    auth = _auth_identity(platform="slack", external_id="T_TEST", platform_user_id="U_TEST")
+    with aioresponses() as transport:
+        transport.get(
+            re.compile(r"https://slack\.com/api/conversations\.info.*"),
+            payload={
+                "ok": True,
+                "channel": {"id": "C_TEST", "is_private": is_private},
+            },
+        )
+        transport.get(
+            re.compile(r"https://slack\.com/api/users\.info.*"),
+            payload={
+                "ok": True,
+                "user": {"id": "U_TEST", "is_restricted": False},
+            },
+        )
+        if is_private:
+            transport.get(
+                re.compile(r"https://slack\.com/api/conversations\.members.*"),
+                payload={
+                    "ok": True,
+                    "members": [],
+                    "response_metadata": {"next_cursor": ""},
+                },
+            )
+            with pytest.raises(ToolError, match="missing channel access"):
+                await _post_app_install_link_impl(
+                    runtime, auth, channel_id="C_TEST", purpose="read our repo"
+                )
+            assert (
+                "POST",
+                URL("https://slack.com/api/chat.postMessage"),
+            ) not in transport.requests, "denial must post nothing"
+        else:
+            transport.post(
+                "https://slack.com/api/chat.postMessage", payload={"ok": True, "ts": "123.456"}
+            )
+            result = await _post_app_install_link_impl(
+                runtime, auth, channel_id="C_TEST", purpose="read our repo"
+            )
+            assert result.message_id == "123.456", (
+                "Slack result should report the message timestamp"
+            )
+            payload = transport.requests[("POST", URL("https://slack.com/api/chat.postMessage"))][
+                0
+            ].kwargs["json"]
+            buttons = [
+                element
+                for block in payload["blocks"]
+                if block["type"] == "actions"
+                for element in block["elements"]
+            ]
+            assert len(buttons) == 1, "install invitation must have one button"
+            assert buttons[0]["url"] == build_app_install_url("acme-daimon"), (
+                "URL must use configured slug"
+            )
+            assert buttons[0]["action_id"], "Slack link must have an inert action identifier"
+            assert "value" not in buttons[0], "install link should carry no credential request"

--- a/packages/adapters/mcp/tests/tools/test_publish.py
+++ b/packages/adapters/mcp/tests/tools/test_publish.py
@@ -5,11 +5,7 @@ invisible to a report's own agent-scoped token.
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-import json
 import uuid
-from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import create_autospec
@@ -45,7 +41,9 @@ from factories import make_jwt
 from fastmcp.exceptions import ToolError
 from pydantic import HttpUrl, PostgresDsn, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from starlette.types import ASGIApp, Message
+from starlette.types import ASGIApp
+
+from ..factories import mcp_session
 
 pytestmark = pytest.mark.asyncio
 
@@ -350,83 +348,6 @@ async def test_delete_report_impl_passes_caller_tenant_and_returns_core_result(
 # ---------------------------------------------------------------------------
 
 
-@contextlib.asynccontextmanager
-async def _lifespan(app: ASGIApp) -> AsyncIterator[None]:
-    send_queue: asyncio.Queue[Message] = asyncio.Queue()
-    receive_queue: asyncio.Queue[Message] = asyncio.Queue()
-
-    async def receive() -> Message:
-        return await receive_queue.get()
-
-    async def send(message: Message) -> None:
-        await send_queue.put(message)
-
-    async def run_lifespan() -> None:
-        await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
-
-    task = asyncio.create_task(run_lifespan())
-
-    await receive_queue.put({"type": "lifespan.startup"})
-    msg = await send_queue.get()
-    assert msg["type"] == "lifespan.startup.complete", msg
-    try:
-        yield
-    finally:
-        await receive_queue.put({"type": "lifespan.shutdown"})
-        msg = await send_queue.get()
-        assert msg["type"] == "lifespan.shutdown.complete", msg
-        await task
-
-
-def _parse_jsonrpc_response(resp: httpx.Response) -> dict[str, object]:
-    content_type = resp.headers.get("content-type", "")
-    if "text/event-stream" in content_type:
-        for line in resp.text.splitlines():
-            if line.startswith("data: "):
-                return json.loads(line[6:])  # type: ignore[return-value]
-        raise AssertionError(f"No data line in SSE response: {resp.text!r}")
-    return resp.json()  # type: ignore[return-value]
-
-
-async def _mcp_session(
-    app: ASGIApp,
-    *,
-    token: str,
-    method: str,
-    params: dict[str, object] | None = None,
-) -> dict[str, object]:
-    headers = {
-        "Accept": "application/json, text/event-stream",
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {token}",
-    }
-    transport = httpx.ASGITransport(app=app)  # pyright: ignore[reportArgumentType]
-    async with _lifespan(app), httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-        init_resp = await c.post(
-            "/mcp",
-            json={
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {},
-                    "clientInfo": {"name": "test", "version": "0"},
-                },
-            },
-            headers=headers,
-        )
-        assert init_resp.status_code == 200, f"initialize failed: {init_resp.text}"
-        session_id = init_resp.headers.get("mcp-session-id")
-        if session_id:
-            headers["Mcp-Session-Id"] = session_id
-
-        body = {"jsonrpc": "2.0", "id": 2, "method": method, "params": params or {}}
-        resp = await c.post("/mcp", json=body, headers=headers)
-        assert resp.status_code == 200, f"{method} failed ({resp.status_code}): {resp.text}"
-        return _parse_jsonrpc_response(resp)
-
-
 def _make_app(sessionmaker: async_sessionmaker[AsyncSession]) -> ASGIApp:
     return create_mcp_app(
         settings=Settings(
@@ -455,7 +376,7 @@ async def test_operator_token_discovers_publish_and_delete_report_tools(
     token = make_jwt(account_id=account.id)
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(
+    result = await mcp_session(
         app,
         token=token,
         method="tools/call",
@@ -484,7 +405,7 @@ async def test_agent_scoped_token_does_not_discover_publish_or_delete_report_too
     )
     app = _make_app(sessionmaker)
 
-    result = await _mcp_session(app, token=token, method="tools/list")
+    result = await mcp_session(app, token=token, method="tools/list")
     payload = result.get("result", result)
     tool_names = {t["name"] for t in payload.get("tools", [])}  # type: ignore[union-attr]
 

--- a/packages/adapters/mcp/tests/tools/test_reachability.py
+++ b/packages/adapters/mcp/tests/tools/test_reachability.py
@@ -59,7 +59,7 @@ async def test_non_admin_reachable_agent_raises(
     auth = AuthIdentity(
         account_id=uuid.uuid4(), tenant_id=tenant.id, role=Role.USER, is_admin=False
     )
-    with pytest.raises(ToolError, match="Manage Server"):
+    with pytest.raises(ToolError, match="admin must change"):
         await require_admin_for_reachable_agent(
             _runtime(db_session_factory), auth, agent_name="daimon"
         )

--- a/packages/adapters/mcp/tests/tools/test_require_admin.py
+++ b/packages/adapters/mcp/tests/tools/test_require_admin.py
@@ -36,7 +36,7 @@ from fastmcp.exceptions import ToolError
 
 pytestmark = pytest.mark.asyncio
 
-_D28_MESSAGE = "Changing my setup needs Manage Server — ask a server admin to use /agent-setup"
+_ADMIN_REQUIRED = "requires a workspace or server admin"
 
 
 # ---------------------------------------------------------------------------
@@ -53,7 +53,7 @@ def test_require_admin_raises_tool_error_when_not_admin() -> None:
     )
     with pytest.raises(ToolError) as exc_info:
         _require_admin(auth)
-    assert str(exc_info.value) == _D28_MESSAGE, (
+    assert _ADMIN_REQUIRED in str(exc_info.value), (
         "non-admin chat caller must be refused with the admin-required message"
     )
 
@@ -228,7 +228,7 @@ async def test_sync_impl_raises_when_not_admin() -> None:
     )
     with pytest.raises(ToolError) as exc_info:
         await _sync_impl(runtime, auth, "https://github.com/x/y", "main", "")
-    assert str(exc_info.value) == _D28_MESSAGE, (
+    assert _ADMIN_REQUIRED in str(exc_info.value), (
         "_sync_impl must refuse non-admin with admin-required message"
     )
 
@@ -303,7 +303,7 @@ async def test_create_environment_impl_does_not_refuse_non_admin() -> None:
     spec = EnvironmentSpec(name="e")
     with pytest.raises(Exception) as exc_info:  # noqa: B017, PT011
         await _create_environment_impl(_env_runtime(MagicMock(spec=AsyncAnthropic)), auth, spec)
-    assert str(exc_info.value) != _D28_MESSAGE, (
+    assert _ADMIN_REQUIRED not in str(exc_info.value), (
         "create_environment must not refuse a non-admin -- gating it blocks the "
         "ordinary onboarding ask while buying no isolation"
     )
@@ -328,7 +328,7 @@ async def test_update_environment_impl_raises_when_not_admin() -> None:
             config=None,
             description="x",
         )
-    assert str(exc_info.value) == _D28_MESSAGE, (
+    assert _ADMIN_REQUIRED in str(exc_info.value), (
         "_update_environment_impl must refuse non-admin with admin-required message"
     )
 
@@ -343,7 +343,7 @@ async def test_archive_environment_impl_raises_when_not_admin() -> None:
     )
     with pytest.raises(ToolError) as exc_info:
         await _archive_environment_impl(_env_runtime(MagicMock(spec=AsyncAnthropic)), auth, "e")
-    assert str(exc_info.value) == _D28_MESSAGE, (
+    assert _ADMIN_REQUIRED in str(exc_info.value), (
         "_archive_environment_impl must refuse non-admin with admin-required message"
     )
 

--- a/packages/adapters/mcp/tests/tools/test_self_edit.py
+++ b/packages/adapters/mcp/tests/tools/test_self_edit.py
@@ -798,7 +798,7 @@ async def test_set_repo_binding_no_github_credential_hint(
     committing_sessionmaker: async_sessionmaker[AsyncSession],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """NoBindingError → ToolError with /agent-setup hint."""
+    """NoBindingError → ToolError naming the private repo-binding request."""
 
     async def _fake_mint(**_kwargs: object) -> str:
         raise NoBindingError("no github credential")
@@ -807,7 +807,7 @@ async def test_set_repo_binding_no_github_credential_hint(
     runtime = _runtime(committing_sessionmaker)
     auth = _auth_identity()
 
-    with pytest.raises(ToolError, match="/agent-setup"):
+    with pytest.raises(ToolError, match="request_repo_binding"):
         await _set_repo_binding_impl(
             runtime, auth, repo_url="https://github.com/o/r", default_branch="main"
         )

--- a/packages/adapters/mcp/tests/tools/test_skills.py
+++ b/packages/adapters/mcp/tests/tools/test_skills.py
@@ -29,7 +29,7 @@ from daimon.adapters.mcp.tools.skills import (
 from daimon.core.defaults.report import Action, ResourceOutcome
 from daimon.core.scope import DeploymentDefault
 from daimon.testing.ma import MARouter, build_fake_anthropic, list_response
-from fastmcp import Client, FastMCP
+from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
@@ -638,84 +638,17 @@ def _registered_mcp(client: AsyncAnthropic, auth: AuthIdentity) -> FastMCP:
     return mcp
 
 
-async def test_register_skill_tools_registers_verb_first_and_alias_names() -> None:
+async def test_register_skill_tools_uses_only_canonical_names() -> None:
     auth = AuthIdentity(
         account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.ADMIN, is_admin=True
     )
     mcp = _registered_mcp(build_fake_anthropic(MARouter().dispatch), auth)
     names = {tool.name for tool in await mcp.list_tools()}
-    expected = {
-        "list_skills",
-        "get_skill",
-        "sync_skills",
-        "delete_skill",
-        "skills_list",
-        "skills_get",
-        "skills_sync",
-        "skills_delete",
-    }
-    assert expected.issubset(names), (
-        f"both verb-first and noun-first alias names must be registered; got {names}"
+    assert names == {"list_skills", "get_skill", "sync_skills", "delete_skill"}, (
+        f"the skill catalogue must expose exactly the four canonical names: {names}"
     )
-
-
-async def test_delete_skill_and_alias_both_carry_admin_tag() -> None:
-    auth = AuthIdentity(
-        account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.ADMIN, is_admin=True
-    )
-    mcp = _registered_mcp(build_fake_anthropic(MARouter().dispatch), auth)
     delete_skill = await mcp.get_tool("delete_skill")
-    skills_delete = await mcp.get_tool("skills_delete")
-    assert "admin" in delete_skill.tags, "delete_skill must carry the admin tag"
-    assert "admin" in skills_delete.tags, "skills_delete alias must carry the admin tag"
-
-
-async def test_list_skills_and_alias_dispatch_identically() -> None:
-    # Use _DISPATCH_TEST_TENANT_ID so the skill prefix in _skills_one_router() matches.
-    auth = AuthIdentity(
-        account_id=uuid.uuid4(),
-        tenant_id=_DISPATCH_TEST_TENANT_ID,
-        role=Role.ADMIN,
-        is_admin=True,
-    )
-    canonical_mcp = _registered_mcp(build_fake_anthropic(_skills_one_router().dispatch), auth)
-    alias_mcp = _registered_mcp(build_fake_anthropic(_skills_one_router().dispatch), auth)
-
-    async with Client(canonical_mcp) as cc, Client(alias_mcp) as ac:
-        canonical = await cc.call_tool("list_skills", {})
-        alias = await ac.call_tool("skills_list", {})
-    assert canonical.structured_content == alias.structured_content, (
-        "list_skills and its skills_list alias must dispatch to identical behavior"
-    )
-
-
-async def test_get_skill_and_alias_dispatch_identically() -> None:
-    # Use _DISPATCH_TEST_TENANT_ID so tenant_scoped_display_title prefix matches the stub.
-    auth = AuthIdentity(
-        account_id=uuid.uuid4(),
-        tenant_id=_DISPATCH_TEST_TENANT_ID,
-        role=Role.ADMIN,
-        is_admin=True,
-    )
-
-    def _router() -> MARouter:
-        router = _skills_one_router()
-        router.add(
-            "GET",
-            r"/v1/skills/sk_1/versions",
-            lambda _req, _m: list_response([{"version": "1"}]),
-        )
-        return router
-
-    canonical_mcp = _registered_mcp(build_fake_anthropic(_router().dispatch), auth)
-    alias_mcp = _registered_mcp(build_fake_anthropic(_router().dispatch), auth)
-
-    async with Client(canonical_mcp) as cc, Client(alias_mcp) as ac:
-        canonical = await cc.call_tool("get_skill", {"name": "my-skill"})
-        alias = await ac.call_tool("skills_get", {"name": "my-skill"})
-    assert canonical.structured_content == alias.structured_content, (
-        "get_skill and its skills_get alias must dispatch to identical behavior"
-    )
+    assert "admin" in delete_skill.tags, "shared skill deletion remains admin-only"
 
 
 async def test_sync_impl_attaches_to_the_named_agent_and_preserves_its_existing_skills(
@@ -825,7 +758,7 @@ async def test_sync_impl_anonymous_404_names_the_credential_remedy() -> None:
         auth = AuthIdentity(
             account_id=uuid.uuid4(), tenant_id=uuid.uuid4(), role=Role.ADMIN, is_admin=True
         )
-        with pytest.raises(ToolError, match="request_skill_repo_credential") as excinfo:
+        with pytest.raises(ToolError, match="request_skill_repo_token") as excinfo:
             await _sync_impl(
                 _runtime(build_fake_anthropic(MARouter().dispatch)),
                 auth,
@@ -859,7 +792,7 @@ async def test_sync_impl_404_with_a_token_does_not_blame_credentials() -> None:
                 path="",
             )
 
-    assert "request_skill_repo_credential" not in str(excinfo.value), (
+    assert "request_skill_repo_token" not in str(excinfo.value), (
         "a 404 on an authenticated fetch is a bad url/branch, not a missing credential"
     )
 
@@ -897,7 +830,7 @@ async def test_sync_impl_refuses_attach_when_registry_skill_collides_with_scoped
         mock_fetch.return_value = FetchResult(path=tmp_path, cleanup_dir=cleanup_dir)
         mock_sync.return_value = outcomes
 
-        def on_skills_list(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
+        def on_list_skills(_req: httpx.Request, _m: re.Match[str]) -> httpx.Response:
             return list_response(
                 [
                     SkillListResponse(
@@ -932,7 +865,7 @@ async def test_sync_impl_refuses_attach_when_registry_skill_collides_with_scoped
             return httpx.Response(500, json={"error": "must not be called"})
 
         router = MARouter()
-        router.add("GET", r"/v1/skills", on_skills_list)
+        router.add("GET", r"/v1/skills", on_list_skills)
         router.add(
             "GET",
             r"/v1/agents$",

--- a/packages/adapters/slack/daimon/adapters/slack/admin.py
+++ b/packages/adapters/slack/daimon/adapters/slack/admin.py
@@ -4,15 +4,17 @@
 + ``require_manage_guild``: it calls ``users.info`` (I/O shell) then delegates
 to the pure ``_is_admin_signal`` decision function.
 
-Fail-closed: a transient ``SlackApiError`` from ``users.info`` is
-logged and returns ``False`` — it NEVER propagates and never grants admin.
-The caller resolves once per interaction; no cross-interaction cache.
+Fail-closed: a transient failure from ``users.info`` — whether an API-level
+``SlackApiError`` or a transport-level ``aiohttp`` error — is logged and
+returns ``False``. It NEVER propagates and never grants admin. The caller
+resolves once per interaction; no cross-interaction cache.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+import aiohttp
 import structlog
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
@@ -29,13 +31,50 @@ def _is_admin_signal(user: dict[str, Any]) -> bool:
     return bool(user.get("is_admin") or user.get("is_owner") or user.get("is_primary_owner"))
 
 
+async def resolve_admin_status(client: AsyncWebClient, *, user_id: str) -> bool | None:
+    """Return the workspace-admin signal, or ``None`` if the lookup failed.
+
+    Calls ``users.info`` via the injected per-event client; never caches the
+    result on a module or runtime. This is the one place that calls
+    ``users.info`` and catches its failures — ``resolve_is_admin`` below is
+    implemented on top of it so there remains exactly one network call and one
+    catch site.
+
+    Both failure classes are caught. ``SlackApiError`` covers an API-level
+    refusal (a missing ``users:read`` scope, a rate limit). ``aiohttp``
+    transport errors and timeouts cover the network itself, and are NOT
+    ``SlackApiError`` subclasses — before they were caught here, a transient
+    connection reset propagated out of the mention path and killed the turn.
+
+    Unlike ``resolve_is_admin``, this distinguishes "not an admin" (``False``)
+    from "the lookup itself failed" (``None``) — callers that must not treat
+    a transient Slack error as a demotion need that distinction.
+
+    Args:
+        client:  Per-event ``AsyncWebClient`` (injected; never cached).
+        user_id: Slack user ID from the verified Socket Mode payload.
+
+    Returns:
+        ``True``/``False`` from ``users.info``'s admin signal, or ``None`` if
+        the lookup failed at either the API or the transport layer.
+    """
+    try:
+        resp = await client.users_info(user=user_id)  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
+    except (TimeoutError, SlackApiError, aiohttp.ClientError) as exc:
+        log.warning("slack.is_admin.lookup_failed", user=user_id, exc_info=exc)
+        return None
+    u: dict[str, Any] = resp["user"]  # pyright: ignore[reportUnknownVariableType, reportAssignmentType]  # SlackResponse subscript is untyped
+    return _is_admin_signal(u)
+
+
 async def resolve_is_admin(client: AsyncWebClient, *, user_id: str) -> bool:
     """Return True if the Slack user is a workspace admin, fail-closed.
 
-    Calls ``users.info`` via the injected per-event client; never caches the
-    result on a module or runtime.  On ``SlackApiError`` logs a warning
-    and returns ``False`` — this is the ONE deliberate sentinel-return at the
-    adapter boundary, justified by the fail-closed security requirement.
+    Thin wrapper over ``resolve_admin_status`` that collapses "not an admin"
+    and "lookup failed" into ``False`` — this is the ONE deliberate
+    sentinel-return at the adapter boundary, justified by the fail-closed
+    security requirement, and it is unchanged for this function's existing
+    callers.
 
     Args:
         client:  Per-event ``AsyncWebClient`` (injected; never cached).
@@ -43,12 +82,6 @@ async def resolve_is_admin(client: AsyncWebClient, *, user_id: str) -> bool:
 
     Returns:
         ``True`` if the user is a workspace admin, owner, or primary owner;
-        ``False`` otherwise, including on ``users.info`` failure.
+        ``False`` otherwise, including on any ``users.info`` failure.
     """
-    try:
-        resp = await client.users_info(user=user_id)  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
-    except SlackApiError as exc:
-        log.warning("slack.is_admin.lookup_failed", user=user_id, exc_info=exc)
-        return False  # fail-closed
-    u: dict[str, Any] = resp["user"]  # pyright: ignore[reportUnknownVariableType, reportAssignmentType]  # SlackResponse subscript is untyped
-    return _is_admin_signal(u)
+    return bool(await resolve_admin_status(client, user_id=user_id))

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/actions.py
@@ -25,7 +25,7 @@ decided post-ack, server-side, never trusted from the rendered view):
     submits is refused at submission instead.
   - Shared-state gated via ``refuse_if_shared_and_not_admin`` in
     ``agent_setup.gate``: edit_repo_form and remove_secret. Repo bindings and
-    env variables are per-agent attachments that never enter the agent spec, so
+    keys are per-agent attachments that never enter the agent spec, so
     they are exempt from the spec gate's absolutism about defaults-managed
     agents — an admin configuring the workspace's built-in agent is a supported
     first-run step. A non-admin is refused whenever the target is the built-in
@@ -241,7 +241,8 @@ def _render_mcp_config_ephemeral(*, agent_name: str, public_url: str, jwt: str) 
         "Add to your MCP config:\n"
         f"```json\n{mcp_json_block}\n```\n\n"
         f"_This token grants access to {agent_name} only. "
-        "Revoke it from /agent-setup → MCPs._"
+        "To disconnect, remove this MCP configuration from your coding tool. "
+        "Ask the operator to revoke the access token._"
     )
 
 
@@ -1211,8 +1212,8 @@ async def handle_agent_setup_action(runtime: SlackRuntime, payload: dict[str, An
                     channel=channel_id or user_id,
                     user=user_id,
                     text=(
-                        ":x: MCP URL / JWT secret not configured. "
-                        "Ask the operator to set DAIMON_MCP__PUBLIC_URL and DAIMON_MCP__JWT_SECRET."
+                        "This deployment is not finished being set up. Ask the operator to finish "
+                        "setup, then try again. Nothing was saved."
                     ),
                 )
                 return

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/gate.py
@@ -59,8 +59,8 @@ _SEEDED_AGENT_MESSAGE = (
 _SHARED_AGENT_MESSAGE = (
     ":lock: This agent is shared — it is either the workspace's built-in agent or the "
     "current default for this workspace or a channel — so changing its repo or its "
-    "environment variables needs workspace-admin permission. Fork it to get an "
-    "editable copy you own; the fork starts with no environment variables of its own."
+    "keys needs workspace-admin permission. Fork it to get an "
+    "editable copy you own; the fork starts with no keys of its own."
 )
 
 

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/submit.py
@@ -18,7 +18,7 @@ shape, same evaluate-then-spawn discipline, same boundary catch tuple.
 Threat register:
 - Creation (new agent, fork) is open to every workspace member — there is
   nothing an admin has approved for a brand-new agent.
-- Per-agent attachments (repo binding, inline token, env variables) never
+- Per-agent attachments (repo binding, inline token, keys) never
   enter the agent spec, so they are exempt from the spec gate's absolutism
   about defaults-managed agents — an admin configuring the workspace's
   built-in agent is a supported first-run step. They are NOT open to
@@ -547,7 +547,7 @@ def evaluate_paste_secrets_submission(payload: dict[str, Any]) -> SubmitDecision
     if len(parsed) > _SECRET_CAP:
         return _error_decision(
             "paste_secrets__content",
-            f"Too many secrets: {len(parsed)} provided, maximum is {_SECRET_CAP}.",
+            f"Too many keys: {len(parsed)} provided, maximum is {_SECRET_CAP}.",
             meta=meta,
             payload=payload,
         )
@@ -759,7 +759,10 @@ async def run_edit_agent_submission(
         await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
             channel=channel_id,
             user=user_id,
-            text=f":white_check_mark: Updated `{agent_name}`. Takes effect on the next session.",
+            text=(
+                f":white_check_mark: Updated `{agent_name}`. "
+                "Existing sessions may still use the previous setup."
+            ),
         )
     except (DaimonError, anthropic.APIError, SlackApiError, SQLAlchemyError) as exc:
         log.error(
@@ -984,7 +987,7 @@ async def run_edit_repo_submission(
         await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
             channel=channel_id,
             user=user_id,
-            text=f":white_check_mark: Saved repo + auth for `{agent_name}`.",
+            text=f":white_check_mark: Saved working repo access for `{agent_name}`.",
         )
     except (DaimonError, anthropic.APIError, SlackApiError, SQLAlchemyError) as exc:
         log.error(
@@ -1364,11 +1367,12 @@ async def run_paste_secrets_submission(
         if n == 1:
             confirm_text = (
                 f":white_check_mark: Added `{key_names_written[0]}`. "
-                "Takes effect on the next session."
+                "Existing sessions may still use the previous setup."
             )
         else:
             confirm_text = (
-                f":white_check_mark: Added {n} secrets. Takes effect on the next session."
+                f":white_check_mark: Added {n} keys. "
+                "Existing sessions may still use the previous setup."
             )
         await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
             channel=channel_id,
@@ -1387,7 +1391,10 @@ async def run_paste_secrets_submission(
         await web_client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]
             channel=channel_id,
             user=user_id,
-            text=":x: Failed to write secrets. Check operator logs.",
+            text=(
+                ":x: Keys could not be saved. "
+                "Ask the operator to check the failure, then try again."
+            ),
         )
 
 

--- a/packages/adapters/slack/daimon/adapters/slack/agent_setup/views.py
+++ b/packages/adapters/slack/daimon/adapters/slack/agent_setup/views.py
@@ -351,10 +351,10 @@ def build_l1_view(
 
 _SECTION_TABS: list[tuple[str, str]] = [
     ("Agent", "agent_setup__tab:agent"),
-    ("Repo+Auth", "agent_setup__tab:repo_auth"),
+    ("Working repo", "agent_setup__tab:repo_auth"),
     ("Skills", "agent_setup__tab:skills"),
-    ("MCPs", "agent_setup__tab:mcps"),
-    ("Secrets", "agent_setup__tab:secrets"),
+    ("MCP servers", "agent_setup__tab:mcps"),
+    ("Keys", "agent_setup__tab:secrets"),
 ]
 
 _ACTIVE_SECTION_TO_ACTION_ID: dict[str, str] = {
@@ -531,7 +531,7 @@ def build_repo_auth_section(
     repo: str | None,
     pat_last4: str | None,
 ) -> list[dict[str, Any]]:
-    """Build the Repo+Auth section blocks for the L2 editor.
+    """Build the Working repo section blocks for the L2 editor.
 
     The repo binding and its PAT are a per-agent attachment, not part of the
     agent spec an admin approves — the edit control renders for every
@@ -542,12 +542,12 @@ def build_repo_auth_section(
         pat_last4: Pre-masked PAT display string (e.g. ``****abcd``), or None.
 
     Returns:
-        List of Block Kit blocks for the Repo+Auth section.
+        List of Block Kit blocks for the Working repo section.
     """
     repo_text = (
-        f":file_folder: *Repo:* `{escape_mrkdwn(repo)}`"
+        f":file_folder: *Working repo:* `{escape_mrkdwn(repo)}`"
         if repo
-        else ":file_folder: *Repo:* _(none)_"
+        else ":file_folder: *Working repo:* _(none)_"
     )
     pat_text = (
         f":key: *PAT:* `{escape_mrkdwn(pat_last4)}`" if pat_last4 else ":key: *PAT:* _(none)_"
@@ -574,7 +574,7 @@ def build_repo_auth_section(
                 {
                     "type": "button",
                     "action_id": "agent_setup__edit_repo_form",
-                    "text": {"type": "plain_text", "text": "Edit repo + auth"},
+                    "text": {"type": "plain_text", "text": "Edit working repo"},
                 },
             ],
         }
@@ -678,7 +678,7 @@ def build_mcps_section(
     can_edit_spec: bool,
     is_admin: bool = False,
 ) -> list[dict[str, Any]]:
-    """Build the MCPs section blocks for the L2 editor.
+    """Build the MCP servers section blocks for the L2 editor.
 
     MCP servers are part of the agent spec an admin approves when the agent
     becomes reachable, so Add MCP server / Remove MCP follow
@@ -698,7 +698,7 @@ def build_mcps_section(
                        Gates Connect via MCP only.
 
     Returns:
-        List of Block Kit blocks for the MCPs section.
+        List of Block Kit blocks for the MCP servers section.
     """
     if mcps:
         mcps_text = "\n".join(
@@ -728,7 +728,7 @@ def build_mcps_section(
             {
                 "type": "static_select",
                 "action_id": "agent_setup__remove_mcp",
-                "placeholder": {"type": "plain_text", "text": "Remove MCP…"},
+                "placeholder": {"type": "plain_text", "text": "Remove MCP server…"},
                 "options": [
                     {
                         "text": {
@@ -774,9 +774,9 @@ def build_secrets_section(
     agent_name: str,
     secret_names: list[str],
 ) -> list[dict[str, Any]]:
-    """Build the Secrets section blocks for the L2 editor.
+    """Build the Keys section blocks for the L2 editor.
 
-    Env-variable credentials are a per-agent attachment, not part of the
+    Keys are a per-agent attachment, not part of the
     agent spec an admin approves — Add/Remove render for every
     member, on every agent, regardless of admin status or reachability.
 
@@ -790,12 +790,12 @@ def build_secrets_section(
         secret_names: List of secret KEY NAMES (values never passed here).
 
     Returns:
-        List of Block Kit blocks for the Secrets section.
+        List of Block Kit blocks for the Keys section.
     """
     if secret_names:
         keys_text = " · ".join(f"`{escape_mrkdwn(name)}`" for name in secret_names)
     else:
-        keys_text = "_-# + add your first secret_"
+        keys_text = "_Add your first key_"
 
     blocks: list[dict[str, Any]] = [
         {
@@ -823,14 +823,14 @@ def build_secrets_section(
                 {
                     "type": "button",
                     "action_id": "agent_setup__paste_secrets",
-                    "text": {"type": "plain_text", "text": "Add secrets"},
+                    "text": {"type": "plain_text", "text": "Add keys"},
                 },
                 {
                     "type": "static_select",
                     "action_id": "agent_setup__remove_secret",
                     "placeholder": {
                         "type": "plain_text",
-                        "text": "Remove secret…",
+                        "text": "Remove key…",
                     },
                     "options": [
                         {
@@ -1074,7 +1074,7 @@ def build_l3_edit_repo_form(
     agent_name: str,
     parent_section: str | None = "repo_auth",
 ) -> dict[str, Any]:
-    """Build the Edit Repo+Auth input form (L3 push).
+    """Build the Edit Working repo input form (L3 push).
 
     PAT field is always empty (write-only; blank = keep existing).
 
@@ -1096,7 +1096,7 @@ def build_l3_edit_repo_form(
             agent_name=agent_name,
             parent_section=parent_section,
         ),
-        "title": {"type": "plain_text", "text": "Repo + Auth"},
+        "title": {"type": "plain_text", "text": "Working repo"},
         "submit": {"type": "plain_text", "text": "Save"},
         "blocks": [
             {
@@ -1283,7 +1283,7 @@ def build_l3_paste_secrets_form(
     agent_name: str,
     parent_section: str | None = "secrets",
 ) -> dict[str, Any]:
-    """Build the Paste Secrets input form (L3 push).
+    """Build the Add keys input form (L3 push).
 
     Accepts KEY=VALUE lines (multiline). Values never appear in any block or
     block_id — they only exist in the user's textarea input and are parsed on
@@ -1307,7 +1307,7 @@ def build_l3_paste_secrets_form(
             agent_name=agent_name,
             parent_section=parent_section,
         ),
-        "title": {"type": "plain_text", "text": "Add secrets"},
+        "title": {"type": "plain_text", "text": "Add keys"},
         "submit": {"type": "plain_text", "text": "Save"},
         "blocks": [
             {

--- a/packages/adapters/slack/daimon/adapters/slack/app.py
+++ b/packages/adapters/slack/daimon/adapters/slack/app.py
@@ -24,6 +24,7 @@ import aiohttp
 import anthropic
 import structlog
 from cryptography.fernet import InvalidToken
+from daimon.adapters.slack.admin import resolve_admin_status
 from daimon.adapters.slack.agent_setup.actions import (
     handle_agent_setup_action,
     handle_agent_setup_command,
@@ -73,6 +74,7 @@ from daimon.adapters.slack.help import handle_help_command
 from daimon.adapters.slack.interactions import build_retry_handlers, resolve_web_client
 from daimon.adapters.slack.lifecycle import SlackTurnLifecycle
 from daimon.adapters.slack.memory import handle_memory_command
+from daimon.adapters.slack.mrkdwn import escape_mrkdwn
 from daimon.adapters.slack.output_delivery import deliver_session_outputs
 from daimon.adapters.slack.privacy_panel.actions import (
     handle_privacy_block_action,
@@ -91,7 +93,7 @@ from daimon.adapters.slack.routines_panel.submit import (
     run_routines_create_submission,
     run_routines_delete_submission,
 )
-from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.adapters.slack.runtime import SlackRuntime, resolve_bot_display_name
 from daimon.adapters.slack.vision import (
     SlackFile,
     download_as_image_blocks,
@@ -105,6 +107,8 @@ from daimon.core.ma_identity import derive_tenant_uuid
 from daimon.core.ma_resolver import MAResolverMissError
 from daimon.core.observability import capture_exception_with_scope
 from daimon.core.slack_oauth import build_slack_connect_url
+from daimon.core.stores.accounts import set_role
+from daimon.core.stores.domain import Role
 from daimon.core.stores.slack_bot_tokens import get_slack_bot_token
 from daimon.core.stores.slack_connect_prompts import mark_connect_prompted, was_connect_prompted
 from daimon.core.stores.slack_event_dedup import insert_if_new
@@ -868,7 +872,7 @@ class SlackApp:
             async with self.runtime.sessionmaker() as s:
                 row = await get_slack_bot_token(s, team_id=team_id)
             if row is None:
-                log.warning("slack.event_dropped.no_token", team_id=team_id)
+                log.error("slack.event_dropped.no_token", team_id=team_id)
                 return
 
             # (3) PER-EVENT CLIENT — decrypt and construct; NEVER cache on self/runtime.
@@ -976,9 +980,13 @@ class SlackApp:
             user=slack_user_id,
             thread_ts=thread_ts,
             text=(
-                "👋 Tip: connect your Slack account and daimon can read any channel "
+                "👋 Tip: connect your Slack account and "
+                f"{escape_mrkdwn(resolve_bot_display_name(self.runtime.settings))} "
+                "can read any channel "
                 "or DM *you* can see — no invites needed — plus search your messages "
-                f"(in a DM with daimon).\nConnect: {connect_url}\n"
+                "(in a DM with "
+                f"{escape_mrkdwn(resolve_bot_display_name(self.runtime.settings))}).\n"
+                f"Connect: {connect_url}\n"
                 "_The link is personal and expires in about an hour. If your "
                 "workspace requires admin approval for app permissions, an admin "
                 "may need to approve first. Disconnect any time via `/privacy`._"
@@ -1215,6 +1223,16 @@ class SlackApp:
         No try/except — errors propagate to the listener boundary in
         ``_handle_app_mention``.
         """
+        # --- Live admin lookup: one users.info per turn, before admit().
+        # admin_status distinguishes "not an admin" (False) from "lookup failed"
+        # (None) so the role write below can skip on failure rather than
+        # demoting a real admin on a transient Slack error. is_admin is the
+        # single local Task 2's context builders also consume — a second lookup
+        # would violate the one-call-per-turn constraint.
+        author_id = str(event.get("user") or "")
+        admin_status = await resolve_admin_status(web_client, user_id=author_id)
+        is_admin = bool(admin_status)
+
         # --- Stage one: admission (identity, config cascade, missing-config
         # bail, MA resolve/retrieve, balance gate, cap gate) -- D-01 admit(). ---
         try:
@@ -1222,7 +1240,7 @@ class SlackApp:
                 self.runtime.turn_deps,
                 tenant_id=tenant_id,
                 platform="slack",
-                external_user_id=str(event.get("user") or ""),
+                external_user_id=author_id,
                 channel_id=channel,
                 now=datetime.now(UTC),
             )
@@ -1236,14 +1254,10 @@ class SlackApp:
             hints: list[str] = []
             if "agent" in err.missing:
                 hints.append(
-                    "An admin can set the default agent in `/agent-setup` → "
-                    "*Set as default…* → [This channel] or [Whole workspace]."
+                    "Ask a workspace admin to choose who answers here with `/agent-setup`."
                 )
             if "environment" in err.missing:
-                hints.append(
-                    "Environment is operator-only — an operator can set it via the CLI "
-                    "(`daimon config set environment_name=...`)."
-                )
+                hints.append("Ask the operator to configure an environment for this channel.")
             await web_client.chat_postMessage(  # pyright: ignore[reportUnknownMemberType]
                 channel=channel,
                 thread_ts=thread_id,
@@ -1264,9 +1278,8 @@ class SlackApp:
                 thread_ts=thread_id,
                 text=(
                     "The configured agent or environment no longer exists. "
-                    "An admin can re-set the agent in `/agent-setup` → "
-                    "*Set as default…*; the environment is operator-only via the CLI "
-                    "(`daimon config set environment_name=...`)."
+                    "Ask a workspace admin to choose an existing agent with `/agent-setup`, "
+                    "or ask the operator to restore the environment."
                 ),
             )
             return
@@ -1283,7 +1296,9 @@ class SlackApp:
                     channel=channel,
                     thread_ts=thread_id,
                     text=(
-                        "This workspace's daimon credit is depleted. "
+                        f"This workspace's "
+                        f"{escape_mrkdwn(resolve_bot_display_name(self.runtime.settings))} "
+                        "credit is depleted. "
                         "An admin can top up with `/billing`."
                     ),
                 )
@@ -1309,6 +1324,19 @@ class SlackApp:
         agent = admission.agent
         _lc_agent_name: str = agent.name
         _lc_model_id: str = agent.model.id
+
+        # --- Per-turn role upsert: sync account.role from live Slack admin status
+        # Gated on the users.info lookup having succeeded above --
+        # on lookup failure admin_status is None and the stored role is left
+        # alone, never granted and never revoked on a transient Slack error.
+        if admin_status is not None:
+            async with self.runtime.sessionmaker() as _role_session:
+                await set_role(
+                    _role_session,
+                    admission.account_id,
+                    Role.ADMIN if is_admin else Role.USER,
+                )
+                await _role_session.commit()
 
         # lifecycle_holder tracks whichever SlackTurnLifecycle actually
         # completed the turn -- recovery_lifecycle rebuilds a fresh one against
@@ -1458,7 +1486,6 @@ class SlackApp:
             user_text = (
                 content_override if content_override is not None else str(event.get("text") or "")
             )
-            author_id = str(event.get("user") or "")
             if not reused:
                 # First turn: replay thread history (one Slack page from the root).
                 user_message = await build_context_xml(
@@ -1467,6 +1494,7 @@ class SlackApp:
                     thread_ts=thread_id,
                     user_query=user_text,
                     author_id=author_id,
+                    is_admin=is_admin,
                     proxy=proxy_ctx,
                 )
             elif watermark is not None:
@@ -1478,6 +1506,7 @@ class SlackApp:
                     watermark_ts=watermark,
                     user_query=user_text,
                     author_id=author_id,
+                    is_admin=is_admin,
                     proxy=proxy_ctx,
                 )
             else:
@@ -1541,6 +1570,7 @@ class SlackApp:
                     thread_ts=thread_id,
                     user_query=user_text,
                     author_id=author_id,
+                    is_admin=is_admin,
                     proxy=proxy_ctx,
                 )
                 if synthetic_prefix:

--- a/packages/adapters/slack/daimon/adapters/slack/context.py
+++ b/packages/adapters/slack/daimon/adapters/slack/context.py
@@ -77,11 +77,21 @@ def _render_message(msg: dict[str, Any], *, proxy: ProxyUrlContext | None) -> li
     return lines
 
 
-def _user_query_open_tag(author_id: str) -> str:
-    """Opening <user_query> tag, with a quoted author_id attribute when present."""
+def _user_query_open_tag(author_id: str, is_admin: bool) -> str:
+    """Opening <user_query> tag, with quoted author_id/is_admin attributes when present.
+
+    ``is_admin`` is rendered as the lowercase literal ``"true"``/``"false"``
+    (``is_admin="true|false"``, matching Discord's rendering
+    byte-for-byte), never Python's ``True``/``False``. When ``author_id`` is
+    empty the tag stays bare (back-compat) and ``is_admin`` is not rendered —
+    there is no caller identity to attach it to.
+    """
     if not author_id:
         return "<user_query>"
-    return f"<user_query author_id={quoteattr(author_id)}>"
+    return (
+        f"<user_query author_id={quoteattr(author_id)}"
+        f" is_admin={quoteattr('true' if is_admin else 'false')}>"
+    )
 
 
 async def build_context_xml(
@@ -91,6 +101,7 @@ async def build_context_xml(
     thread_ts: str,
     user_query: str,
     author_id: str = "",
+    is_admin: bool = False,
     proxy: ProxyUrlContext | None = None,
 ) -> str:
     """Build XML context from thread history for the first turn.
@@ -123,7 +134,7 @@ async def build_context_xml(
     lines.append("</thread_history>")
     lines.append("</context>")
     lines.append("")
-    lines.append(f"{_user_query_open_tag(author_id)}{escape(user_query)}</user_query>")
+    lines.append(f"{_user_query_open_tag(author_id, is_admin)}{escape(user_query)}</user_query>")
 
     return "\n".join(lines)
 
@@ -136,6 +147,7 @@ async def build_delta_xml(
     watermark_ts: str,
     user_query: str,
     author_id: str = "",
+    is_admin: bool = False,
     proxy: ProxyUrlContext | None = None,
 ) -> str:
     """Build XML context for a continuation turn (delta since watermark).
@@ -168,6 +180,6 @@ async def build_delta_xml(
     lines.append("</thread_delta>")
     lines.append("</context>")
     lines.append("")
-    lines.append(f"{_user_query_open_tag(author_id)}{escape(user_query)}</user_query>")
+    lines.append(f"{_user_query_open_tag(author_id, is_admin)}{escape(user_query)}</user_query>")
 
     return "\n".join(lines)

--- a/packages/adapters/slack/daimon/adapters/slack/credential_requests.py
+++ b/packages/adapters/slack/daimon/adapters/slack/credential_requests.py
@@ -116,23 +116,21 @@ _WRONG_WORKSPACE = (
 # re-derives the panel's decision from primitives, as Discord's
 # `credential_repo_bind` does.
 _SHARED_AGENT_MESSAGE = (
-    ":lock: This agent is shared — it is either the workspace's built-in agent or the "
-    "current default for this workspace or a channel — so changing its repo or its "
-    "environment variables needs workspace-admin permission. Fork it to get an "
-    "editable copy you own; the fork starts with no environment variables of its own."
+    ":lock: Changing this shared agent's working repo needs a workspace admin. "
+    "Ask an admin to request the working-repo change for this agent in this conversation."
 )
 
 _AGENT_GONE_MESSAGE = "That agent no longer exists — ask again and a fresh request will be posted."
 
 _MODAL_TITLE: Final[dict[CredentialRequestKind, str]] = {
-    "env": "Add secret",
-    "mcp": "Add MCP credential",
+    "env": "Add key",
+    "mcp": "Add MCP token",
     "skill_repo": "Import skills",
     "repo": "Bind repo",
 }
 
 _VALUE_LABEL: Final[dict[CredentialRequestKind, str]] = {
-    "env": "Secret value",
+    "env": "API key",
     "mcp": "Auth token",
     "skill_repo": "GitHub token",
 }
@@ -562,8 +560,8 @@ async def run_env_credential_submission(
         channel_id=channel_id,
         user_id=user_id,
         text=(
-            f"Added `{consumed.target}`. Takes effect on the next session — "
-            "anyone who talks to this agent can use it."
+            f"Saved `{consumed.target}` for shared use by this agent. "
+            "Existing sessions may still use the previous setup."
         ),
     )
 
@@ -595,8 +593,8 @@ async def run_mcp_credential_submission(
             channel_id=channel_id,
             user_id=user_id,
             text=(
-                "daimon-mcp is not configured (public_url / jwt_secret missing) — "
-                "credential not written."
+                "This deployment is not finished being set up. Ask the operator to finish "
+                "setup, then try again. Nothing was saved."
             ),
         )
         return
@@ -670,8 +668,8 @@ async def run_mcp_credential_submission(
             channel_id=channel_id,
             user_id=user_id,
             text=(
-                "Credential request consumed, but storing the auth token failed "
-                f"(`{type(err).__name__}`). Ask for a new request to retry."
+                "The request was used up, but storing the MCP token failed. "
+                "Ask for a new private form to retry."
             ),
         )
         return
@@ -715,8 +713,8 @@ async def run_mcp_credential_submission(
             user_id=user_id,
             text=(
                 f"Auth token stored, but attaching `{mcp_server_url}` to the agent "
-                f"failed (`{type(err).__name__}`). The server is not connected yet — "
-                "ask the agent to attach it, or request a new credential to retry."
+                "failed. The server is not connected yet — "
+                "ask the agent to attach it, or request a new private token form to retry."
             ),
         )
         return
@@ -726,7 +724,7 @@ async def run_mcp_credential_submission(
         channel_id=channel_id,
         user_id=user_id,
         text=(
-            f"MCP credential added for `{mcp_server_url}` and attached as "
+            f"MCP token added for `{mcp_server_url}` and attached as "
             f"`{consumed.target}`. Anyone who talks to this agent can use it."
         ),
     )
@@ -844,7 +842,7 @@ async def _attach_skills_to_requested_agent(
             agent_id=str(agent_id),
             err_type=type(err).__name__,
         )
-        return f"Imported, but attaching to `{agent.name}` failed ({type(err).__name__})."
+        return f"Imported, but attaching to `{agent.name}` failed. Ask again to retry attaching it."
     return f"Attached {len(skill_ids)} to `{agent.name}`."
 
 
@@ -895,6 +893,7 @@ async def run_skill_repo_credential_submission(
         pat_masked=mask_tail(value),
     )
 
+    is_token_stored = False
     try:
         # Verify BEFORE storing: a token that cannot read this repo is not a
         # credential for it, and storing it would shadow a working one on the
@@ -921,6 +920,7 @@ async def run_skill_repo_credential_submission(
             pasted_pat=value,
             now=now,
         )
+        is_token_stored = True
         async with runtime.sessionmaker.begin() as session:
             await set_binding(
                 session,
@@ -941,14 +941,17 @@ async def run_skill_repo_credential_submission(
             token=value,
         )
     except DaimonError as err:
-        # Written for the user by the raiser — surface verbatim.
+        # Keep upstream details in operator logs, never in the receipt.
+        log.warning("credential_request.skill_repo_sync_failed", err_type=type(err).__name__)
         await _post_ephemeral(
             client,
             channel_id=channel_id,
             user_id=user_id,
             text=(
-                f"Token stored, but the import failed: {err} The request was used up — "
-                "ask again to retry the import."
+                "Token stored, but skill setup did not finish. Ask again to retry."
+                if is_token_stored
+                else "Skill setup failed before token storage could be confirmed. "
+                "Ask again with a new private form to retry."
             ),
         )
         return
@@ -963,8 +966,10 @@ async def run_skill_repo_credential_submission(
             channel_id=channel_id,
             user_id=user_id,
             text=(
-                f"Token stored, but the import failed (`{type(err).__name__}`). "
-                "Ask again to retry the import."
+                "Token stored, but skill setup did not finish. Ask again to retry."
+                if is_token_stored
+                else "Skill setup failed before token storage could be confirmed. "
+                "Ask again with a new private form to retry."
             ),
         )
         return
@@ -1063,11 +1068,14 @@ async def run_repo_bind_credential_submission(
                 proof=proof,
             )
     except DaimonError as err:
+        log.warning("credential_request.repo_write_failed", err_type=type(err).__name__)
         await _post_ephemeral(
             client,
             channel_id=channel_id,
             user_id=user_id,
-            text=f"{err} The request was used up — ask again to retry.",
+            text=(
+                "Repository access could not be saved. Ask again to retry with a new private form."
+            ),
         )
         return
     except Exception as err:
@@ -1081,8 +1089,8 @@ async def run_repo_bind_credential_submission(
             channel_id=channel_id,
             user_id=user_id,
             text=(
-                "Credential request consumed, but binding the repo failed "
-                f"(`{type(err).__name__}`). Ask for a new request to retry."
+                "The request was used up, but binding the working repo failed. "
+                "Ask for a new private form to retry."
             ),
         )
         return
@@ -1091,5 +1099,8 @@ async def run_repo_bind_credential_submission(
         client,
         channel_id=channel_id,
         user_id=user_id,
-        text=f"Bound `{consumed.target}` on `{branch}`. Takes effect on the next session.",
+        text=(
+            f"Bound `{consumed.target}` on `{branch}`. "
+            "Existing sessions may still use the previous setup."
+        ),
     )

--- a/packages/adapters/slack/daimon/adapters/slack/errors.py
+++ b/packages/adapters/slack/daimon/adapters/slack/errors.py
@@ -61,7 +61,7 @@ def render_error(exc: Exception, *, request_id: str) -> str:
     if isinstance(exc, InvalidToken):
         # Fernet failures mean a stored bot token could not be decrypted; the
         # detail is operator-facing and belongs in the logs, not the channel.
-        return f"❌ *Credential error*: the workspace token could not be read.\n{rid}"
+        return f"❌ *Slack token error*: the workspace token could not be read.\n{rid}"
     if isinstance(exc, ValueError):
         return f"⚠️ *Invalid input*: {escape_mrkdwn(str(exc))}\n{rid}"
     return f"❌ *Unexpected error*: {escape_mrkdwn(str(exc))}\n{rid}"

--- a/packages/adapters/slack/daimon/adapters/slack/help.py
+++ b/packages/adapters/slack/daimon/adapters/slack/help.py
@@ -17,7 +17,8 @@ from typing import Any
 import structlog
 from daimon.adapters.slack.errors import generate_request_id, surface_command_error
 from daimon.adapters.slack.interactions import resolve_web_client
-from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.adapters.slack.mrkdwn import escape_mrkdwn
+from daimon.adapters.slack.runtime import SlackRuntime, resolve_bot_display_name
 from daimon.core.errors import DaimonError
 from slack_sdk.errors import SlackApiError
 
@@ -36,7 +37,7 @@ _BODY = """\
 /billing — Show your billing usage (admins see per-member breakdown)
 
 *Privacy*
-/privacy — See, export, or delete what daimon stores about you
+/privacy — See, export, or delete what {display_name} stores about you
 
 *Meta*
 /help — List commands and the @bot conversational entrypoint\
@@ -44,21 +45,33 @@ _BODY = """\
 
 _CONVERSATIONAL = """\
 💬 *Or just talk to your agent*
-@daimon help me set up
-@daimon make a routine that runs daily\
+@{display_name} help me set up
+@{display_name} make a routine that runs daily\
 """
 
 
-def build_help_blocks() -> list[dict[str, Any]]:
+def build_help_blocks(*, display_name: str = "daimon") -> list[dict[str, Any]]:
     """Build the static /help Block Kit blocks.
 
-    Pure — no I/O, zero args. Returns raw dicts (S4 convention; no
+    Pure — no I/O. Returns raw dicts (S4 convention; no
     slack_sdk.models.blocks types). Mirrors Discord's build_help_view().
     """
     return [
-        {"type": "section", "text": {"type": "mrkdwn", "text": _BODY}},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": _BODY.format(display_name=escape_mrkdwn(display_name)),
+            },
+        },
         {"type": "divider"},
-        {"type": "section", "text": {"type": "mrkdwn", "text": _CONVERSATIONAL}},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": _CONVERSATIONAL.format(display_name=escape_mrkdwn(display_name)),
+            },
+        },
     ]
 
 
@@ -89,8 +102,8 @@ async def handle_help_command(runtime: SlackRuntime, payload: dict[str, Any]) ->
         await client.chat_postEphemeral(  # pyright: ignore[reportUnknownMemberType]  # slack_sdk **kwargs: Unknown
             channel=channel_id,
             user=user_id,
-            text="daimon command reference",  # fallback for accessibility / notifications
-            blocks=build_help_blocks(),
+            text=f"{resolve_bot_display_name(runtime.settings)} command reference",
+            blocks=build_help_blocks(display_name=resolve_bot_display_name(runtime.settings)),
         )
     except (DaimonError, SlackApiError) as exc:
         request_id = generate_request_id()

--- a/packages/adapters/slack/daimon/adapters/slack/privacy_panel/actions.py
+++ b/packages/adapters/slack/daimon/adapters/slack/privacy_panel/actions.py
@@ -28,6 +28,7 @@ import structlog
 from cryptography.fernet import InvalidToken
 from daimon.adapters.slack.errors import generate_request_id, surface_command_error
 from daimon.adapters.slack.interactions import resolve_web_client
+from daimon.adapters.slack.mrkdwn import escape_mrkdwn
 from daimon.adapters.slack.privacy_panel.read import load_purge_preview, resolve_privacy_account
 from daimon.adapters.slack.privacy_panel.views import (
     build_delete_modal,
@@ -37,7 +38,7 @@ from daimon.adapters.slack.privacy_panel.views import (
     build_privacy_main_container,
     summary_line,
 )
-from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.adapters.slack.runtime import SlackRuntime, resolve_bot_display_name
 from daimon.core.errors import DaimonError
 from daimon.core.github_credentials import build_multifernet, decrypt_token
 from daimon.core.ma_identity import derive_tenant_uuid
@@ -50,20 +51,21 @@ from sqlalchemy.exc import SQLAlchemyError
 
 log = structlog.get_logger()
 
-# No-data-on-file view shown when the invoker has no account.
-_NO_DATA_BLOCKS: list[dict[str, Any]] = [
-    {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": (
-                "*🔒 Privacy*\n"
-                "You have no data on file with daimon.\n"
-                "Run any other slash command to start fresh."
-            ),
-        },
-    },
-]
+
+def _no_data_blocks(display_name: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    "*🔒 Privacy*\n"
+                    f"You have no data on file with {escape_mrkdwn(display_name)}.\n"
+                    "Run any other slash command to start fresh."
+                ),
+            },
+        }
+    ]
 
 
 def _mint_connect_url(runtime: SlackRuntime, *, team_id: str, slack_user_id: str) -> str | None:
@@ -131,7 +133,7 @@ async def handle_privacy_command(
                 view={
                     "type": "modal",
                     "title": {"type": "plain_text", "text": "Privacy"},
-                    "blocks": _NO_DATA_BLOCKS,
+                    "blocks": _no_data_blocks(resolve_bot_display_name(runtime.settings)),
                 },
             )
             return
@@ -152,6 +154,7 @@ async def handle_privacy_command(
                 is_slack_connected=is_slack_connected,
                 slack_connect_url=connect_url,
                 policy_url=str(runtime.settings.privacy_policy_url),
+                display_name=resolve_bot_display_name(runtime.settings),
             ),
         )
     except (DaimonError, anthropic.APIError, SlackApiError, InvalidToken, SQLAlchemyError) as exc:
@@ -236,13 +239,18 @@ async def handle_privacy_block_action(
             if account_id is None:
                 await web_client.views_push(  # pyright: ignore[reportUnknownMemberType]
                     trigger_id=trigger_id,
-                    view=build_export_result_view(summary=None),
+                    view=build_export_result_view(
+                        summary=None, display_name=resolve_bot_display_name(runtime.settings)
+                    ),
                 )
                 return
             preview = await load_purge_preview(sm=runtime.sessionmaker, account_id=account_id)
             await web_client.views_push(  # pyright: ignore[reportUnknownMemberType]
                 trigger_id=trigger_id,
-                view=build_export_result_view(summary=summary_line(preview)),
+                view=build_export_result_view(
+                    summary=summary_line(preview),
+                    display_name=resolve_bot_display_name(runtime.settings),
+                ),
             )
         elif action_id == "privacy_slack_disconnect":
             async with runtime.sessionmaker() as s:
@@ -272,6 +280,7 @@ async def handle_privacy_block_action(
                 view_id=current_view_id,
                 view=build_disconnect_result_view(
                     was_connected=token_row is not None,
+                    display_name=resolve_bot_display_name(runtime.settings),
                     reconnect_url=_mint_connect_url(
                         runtime, team_id=team_id, slack_user_id=user_id
                     ),

--- a/packages/adapters/slack/daimon/adapters/slack/privacy_panel/submit.py
+++ b/packages/adapters/slack/daimon/adapters/slack/privacy_panel/submit.py
@@ -29,7 +29,7 @@ import anthropic
 import structlog
 from daimon.adapters.slack.privacy_panel.read import resolve_privacy_account
 from daimon.adapters.slack.privacy_panel.views import build_deleting_view, build_post_delete_view
-from daimon.adapters.slack.runtime import SlackRuntime
+from daimon.adapters.slack.runtime import SlackRuntime, resolve_bot_display_name
 from daimon.core.errors import DaimonError
 from daimon.core.purge import purge_account
 from slack_sdk.errors import SlackApiError
@@ -204,7 +204,9 @@ async def run_purge_and_update(
         )
         await web_client.views_update(  # pyright: ignore[reportUnknownMemberType]
             view_id=view_id,
-            view=build_post_delete_view(result),
+            view=build_post_delete_view(
+                result, display_name=resolve_bot_display_name(runtime.settings)
+            ),
         )
     except (DaimonError, anthropic.APIError, SlackApiError) as exc:
         log.error(

--- a/packages/adapters/slack/daimon/adapters/slack/privacy_panel/views.py
+++ b/packages/adapters/slack/daimon/adapters/slack/privacy_panel/views.py
@@ -44,7 +44,7 @@ def summary_line(preview: PurgePreview) -> str:
     if preview.user_skills.count > 0:
         parts.append(f"{preview.user_skills.count} synced skill(s)")
     if preview.github_credentials.count > 0:
-        parts.append(f"{preview.github_credentials.count} GitHub credential(s)")
+        parts.append(f"{preview.github_credentials.count} GitHub token(s)")
     if preview.github_oauth_states.count > 0:
         parts.append(f"{preview.github_oauth_states.count} OAuth handshake record(s)")
     if preview.mcp_tokens.count > 0:
@@ -87,7 +87,7 @@ def _cascade_blocks(preview: PurgePreview) -> list[dict[str, Any]]:
     if preview.github_credentials.count > 0:
         ex = escape_mrkdwn(preview.github_credentials.example or "—")
         n = preview.github_credentials.count
-        will_happen_lines.append(f"• 🔑 Delete *{n}* stored GitHub credential(s) (`{ex}`)")
+        will_happen_lines.append(f"• 🔑 Delete *{n}* stored GitHub token(s) (`{ex}`)")
     if preview.github_oauth_states.count > 0:
         will_happen_lines.append(
             f"• 🤝 Remove *{preview.github_oauth_states.count}* GitHub OAuth handshake record(s)"
@@ -96,7 +96,7 @@ def _cascade_blocks(preview: PurgePreview) -> list[dict[str, Any]]:
         will_happen_lines.append(f"• 🎫 Revoke *{preview.mcp_tokens.count}* per-agent MCP token(s)")
     if preview.agent_github_binding.count > 0:
         n = preview.agent_github_binding.count
-        will_happen_lines.append(f"• 🤖 Remove *{n}* per-agent GitHub credential link(s)")
+        will_happen_lines.append(f"• 🤖 Remove *{n}* per-agent GitHub token link(s)")
     if preview.slack_user_tokens.count > 0:
         will_happen_lines.append(
             f"• 🔐 Remove *{preview.slack_user_tokens.count}* Slack user token(s)"
@@ -114,7 +114,7 @@ def _cascade_blocks(preview: PurgePreview) -> list[dict[str, Any]]:
 
     stays_text = (
         "🔐 *What stays in Managed Agents*\n"
-        "• Agent definitions, system prompts, MCP credentials\n"
+        "• Agent definitions, system prompts, MCP tokens\n"
         "• Session transcripts, turn message content\n"
         "• Skill repo references — the repos themselves stay on GitHub\n"
         "• Retention is governed by Anthropic's Managed Agents policy."
@@ -162,6 +162,7 @@ def build_privacy_main_container(
     is_slack_connected: bool,
     slack_connect_url: str | None,
     policy_url: str,
+    display_name: str = "daimon",
 ) -> dict[str, Any]:
     """Main privacy view: held-data summary + three trust-model groups + action buttons.
 
@@ -186,18 +187,18 @@ def build_privacy_main_container(
         "• Routines you scheduled\n"
         "• User config rows\n"
         "• Synced skill ledger rows\n"
-        "• Encrypted GitHub credentials (stored encrypted-at-rest)\n"
+        "• Encrypted GitHub tokens (stored encrypted-at-rest)\n"
         "• GitHub OAuth handshake records\n"
         "• The account row itself\n"
         "\n"
         "🔐 *What lives in Managed Agents*\n"
-        "• Agent definitions, system prompts, MCP credentials\n"
+        "• Agent definitions, system prompts, MCP tokens\n"
         "• Session transcripts, turn message content\n"
         "• Skill repo references (repos themselves stay on GitHub)\n"
         "• Retention governed by Anthropic's Managed Agents policy.\n"
         "\n"
         "🚫 *What we don't hold*\n"
-        "• Plaintext credentials (GitHub tokens are encrypted-at-rest)\n"
+        "• Plaintext keys or tokens (GitHub tokens are encrypted-at-rest)\n"
         "• Message content (we only log structural events)"
     )
 
@@ -236,7 +237,7 @@ def build_privacy_main_container(
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*🔒 Privacy*\ndaimon holds: {summary}",
+                "text": f"*🔒 Privacy*\n{escape_mrkdwn(display_name)} holds: {summary}",
             },
         },
         {"type": "divider"},
@@ -328,7 +329,9 @@ def build_deleting_view() -> dict[str, Any]:
     }
 
 
-def build_post_delete_view(result: AccountPurgeResult) -> dict[str, Any]:
+def build_post_delete_view(
+    result: AccountPurgeResult, *, display_name: str = "daimon"
+) -> dict[str, Any]:
     """Final status modal view enumerating what was removed.
 
     Port of privacy_panel/embeds.py:15-71 (Discord) adapted to Block Kit.
@@ -348,7 +351,7 @@ def build_post_delete_view(result: AccountPurgeResult) -> dict[str, Any]:
     if result.db.user_skills > 0:
         rows.append(f"• ✓ {result.db.user_skills} synced skill ledger row(s) removed")
     if result.db.github_credentials > 0:
-        rows.append(f"• ✓ {result.db.github_credentials} stored GitHub credential(s) deleted")
+        rows.append(f"• ✓ {result.db.github_credentials} stored GitHub token(s) deleted")
     if result.db.github_oauth_states > 0:
         rows.append(f"• ✓ {result.db.github_oauth_states} OAuth handshake record(s) removed")
     if result.db.accounts > 0:
@@ -384,7 +387,8 @@ def build_post_delete_view(result: AccountPurgeResult) -> dict[str, Any]:
                     "type": "mrkdwn",
                     "text": (
                         "*✅ Deleted*\n"
-                        "Your daimon data has been deleted. Re-onboarding starts from scratch."
+                        f"Your {escape_mrkdwn(display_name)} data has been deleted. "
+                        "Re-onboarding starts from scratch."
                     ),
                 },
             },
@@ -408,7 +412,9 @@ def _connect_button(connect_url: str) -> dict[str, Any]:
     }
 
 
-def build_export_result_view(*, summary: str | None) -> dict[str, Any]:
+def build_export_result_view(
+    *, summary: str | None, display_name: str = "daimon"
+) -> dict[str, Any]:
     """Modal pushed after the Export action.
 
     The privacy panel's buttons live in a modal, whose block_actions payloads
@@ -416,13 +422,13 @@ def build_export_result_view(*, summary: str | None) -> dict[str, Any]:
     posted as an ephemeral channel message. ``summary=None`` means no account.
     """
     if summary is None:
-        text = "📤 *Privacy export*\nYou have no data on file with daimon."
+        text = f"📤 *Privacy export*\nYou have no data on file with {escape_mrkdwn(display_name)}."
     else:
         text = (
             "📤 *Privacy export (summary)*\n"
-            f"daimon holds: {summary}\n\n"
+            f"{escape_mrkdwn(display_name)} holds: {summary}\n\n"
             "_Full JSON export is not yet implemented. When ready, it will produce "
-            "a download of every daimon-side row tied to your identity._"
+            f"a download of every row {escape_mrkdwn(display_name)} stores for your identity._"
         )
     return {
         "type": "modal",
@@ -432,7 +438,7 @@ def build_export_result_view(*, summary: str | None) -> dict[str, Any]:
 
 
 def build_disconnect_result_view(
-    *, was_connected: bool, reconnect_url: str | None
+    *, was_connected: bool, reconnect_url: str | None, display_name: str = "daimon"
 ) -> dict[str, Any]:
     """Modal shown after the Disconnect Slack action (both outcomes).
 
@@ -443,7 +449,8 @@ def build_disconnect_result_view(
     if was_connected:
         text = (
             "*🔌 Slack account disconnected.*\n"
-            "daimon no longer holds a token that reads Slack as you; reads fall "
+            f"{escape_mrkdwn(display_name)} no longer holds a token that reads Slack as you; "
+            "reads fall "
             "back to channels the bot is invited to."
         )
     else:

--- a/packages/adapters/slack/daimon/adapters/slack/runtime.py
+++ b/packages/adapters/slack/daimon/adapters/slack/runtime.py
@@ -35,6 +35,11 @@ class SlackRuntime:
     deployment_default: DeploymentDefault = field(default_factory=DeploymentDefault)
 
 
+def resolve_bot_display_name(settings: Settings) -> str:
+    """Use the configured Slack name, including when the Slack block is absent."""
+    return settings.slack.bot_display_name if settings.slack is not None else "daimon"
+
+
 def build_turn_deps(
     settings: Settings,
     anthropic: AsyncAnthropic,

--- a/packages/adapters/slack/pyproject.toml
+++ b/packages/adapters/slack/pyproject.toml
@@ -8,6 +8,7 @@ authors = [{ name = "PyMC Labs" }]
 dependencies = [
     "daimon-core",
     "slack-sdk>=3.42,<4",
+    "aiohttp>=3.9",
     "structlog>=24",
     "anthropic>=0.96",
     "sqlalchemy[asyncio]>=2",

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_submit.py
@@ -1708,7 +1708,7 @@ async def test_run_edit_repo_submission_blank_pat_binds_anon_when_repo_public(
     assert row.proof_at is not None, "proof_at must be recorded"
 
     texts = _ephemeral_texts_for(client_fake)
-    assert any("Saved repo + auth" in t for t in texts), (
+    assert any("Saved working repo access" in t for t in texts), (
         "user should see the plain save confirmation"
     )
     assert not any("App-covered" in t for t in texts), (

--- a/packages/adapters/slack/tests/agent_setup/test_agent_setup_views.py
+++ b/packages/adapters/slack/tests/agent_setup/test_agent_setup_views.py
@@ -458,8 +458,8 @@ def test_secrets_section_empty_names_renders_empty_state() -> None:
         secret_names=[],
     )
     serialized = json.dumps(blocks)
-    # The empty state copy is: "_-# + add your first secret_"
-    assert "add your first secret" in serialized, (
+    # The empty state copy is: "_Add your first key_"
+    assert "Add your first key" in serialized, (
         "empty secret_names must render the empty-state guidance copy"
     )
 

--- a/packages/adapters/slack/tests/test_admin.py
+++ b/packages/adapters/slack/tests/test_admin.py
@@ -4,7 +4,8 @@ Covers:
 - _is_admin_signal pure decision: each of is_admin / is_owner / is_primary_owner
   independently resolves to True; all-False resolves to False.
 - resolve_is_admin shell call: admin user → True; regular member → False;
-  users.info failure (SlackApiError) → False with no re-raise (fail-closed).
+  users.info failure → False with no re-raise (fail-closed), for BOTH an
+  API-level SlackApiError and a transport-level aiohttp error.
 
 Transport-level fakes only (aioresponses, via fresh contexts per test).
 No AsyncMock on client.* methods.
@@ -128,3 +129,48 @@ async def test_resolve_is_admin_returns_false_and_does_not_raise_on_slack_api_er
         result = await resolve_is_admin(client, user_id="U_TEST")
 
     assert result is False, "resolve_is_admin should return False (fail-closed) on SlackApiError"
+
+
+@pytest.mark.asyncio
+async def test_resolve_admin_status_returns_none_and_does_not_raise_on_transport_error() -> None:
+    """A connection failure degrades to None instead of killing the caller.
+
+    aiohttp's ClientConnectionError is NOT a SlackApiError subclass, so a catch
+    of SlackApiError alone lets it escape. Every Slack mention-turn calls this
+    once, so an escaping transport error takes the whole turn down on a
+    transient network blip.
+    """
+    import aiohttp
+    from daimon.adapters.slack.admin import resolve_admin_status
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            exception=aiohttp.ClientConnectionError("connection refused"),
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        result = await resolve_admin_status(client, user_id="U_TEST")
+
+    assert result is None, (
+        "resolve_admin_status should return None (lookup failed) on a transport error, not raise"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_is_admin_returns_false_and_does_not_raise_on_transport_error() -> None:
+    """The fail-closed wrapper collapses a transport failure to False."""
+    import aiohttp
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    with AioResponsesMock() as mock:
+        mock.get(  # pyright: ignore[reportUnknownMemberType]
+            _USERS_INFO_PATTERN,
+            exception=aiohttp.ClientConnectionError("connection refused"),
+        )
+        client = AsyncWebClient(token="xoxb-test")
+        result = await resolve_is_admin(client, user_id="U_TEST")
+
+    assert result is False, (
+        "resolve_is_admin should return False (fail-closed) on a transport error"
+    )

--- a/packages/adapters/slack/tests/test_app.py
+++ b/packages/adapters/slack/tests/test_app.py
@@ -496,12 +496,23 @@ async def test_handle_app_mention_no_token_when_no_token_row_drops(
         "text": "<@U_BOT> hello",
     }
 
-    await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
+    with structlog.testing.capture_logs() as captured:
+        await app._handle_app_mention(event, team_id=team_id)  # pyright: ignore[reportPrivateUsage]
 
     assert len(orchestrate_calls) == 0, (
         "event must be dropped when no token row exists — token-existence is the "
         "tenant liveness signal (STURN-03)"
     )
+
+    # The drop is the operator-visible failure surface — an app_mention
+    # carries no response_url and there is no client to post with, so the log
+    # line at error level is the only place this is visible.
+    dropped_logs = [c for c in captured if c.get("event") == "slack.event_dropped.no_token"]
+    assert len(dropped_logs) == 1, "exactly one slack.event_dropped.no_token log entry expected"
+    assert dropped_logs[0]["log_level"] == "error", (
+        "a tokenless-workspace drop must log at error, not warning"
+    )
+    assert dropped_logs[0]["team_id"] == team_id, "the dropped log must bind the team_id"
 
 
 async def test_handle_app_mention_slack_connect_external_when_external_user_posts_ephemeral(
@@ -736,6 +747,7 @@ def _make_orchestrate_app(
     settings = MagicMock()
     settings.crypto.keys = (SecretStr(crypto_key),) if crypto_key is not None else ()
     settings.slack.max_concurrent_turns_per_tenant = max_concurrent_turns_per_tenant
+    settings.slack.bot_display_name = "daimon"
     settings.mcp.public_url = None
     # app_root_url=None short-circuits _maybe_post_connect_nudge (Task 11) — these
     # orchestration tests don't exercise the connect-nudge flow.
@@ -2644,7 +2656,9 @@ async def test_orchestrate_first_turn_when_no_agent_configured_posts_guidance_an
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("display_name", ["daimon", "research-bot"])
 async def test_run_thread_turn_when_over_balance_blocks_before_session_create(
+    display_name: str,
     db_session: AsyncSession,
     db_session_factory: async_sessionmaker[AsyncSession],
     fake_slack_web_client: Any,
@@ -2661,6 +2675,8 @@ async def test_run_thread_turn_when_over_balance_blocks_before_session_create(
     await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
 
     app, _ = _make_orchestrate_app(db_session_factory)
+    assert app.runtime.settings.slack is not None
+    app.runtime.settings.slack.bot_display_name = display_name
 
     event: dict[str, Any] = {
         "type": "app_mention",
@@ -2715,7 +2731,7 @@ async def test_run_thread_turn_when_over_balance_blocks_before_session_create(
         b
         for b in post_bodies
         if str(b.get("text", ""))
-        == "This workspace's daimon credit is depleted. An admin can top up with `/billing`."
+        == f"This workspace's {display_name} credit is depleted. An admin can top up with `/billing`."
     ]
     assert depleted, (
         f"expected the exact D-10 over-balance copy via chat.postMessage, got: {post_bodies}"
@@ -4985,3 +5001,457 @@ async def test_ceiling_breach_releases_tenant_slot_and_thread_flag(
     )
     assert tenant_id not in app._inflight  # pyright: ignore[reportPrivateUsage]
     assert thread_ts_2 not in app._processing  # pyright: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# Per-turn admin lookup and role upsert
+# ---------------------------------------------------------------------------
+
+_USERS_INFO_PATTERN = re.compile(r"https://slack\.com/api/users\.info.*")
+
+
+def _fake_ma_session(session_id: str) -> BetaManagedAgentsSession:
+    """Build a real BetaManagedAgentsSession inline (no MagicMock shortcuts)."""
+    now = datetime.now(UTC)
+    agent_snapshot = BetaManagedAgentsSessionAgent(
+        id="agent_test_id",
+        mcp_servers=[],
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-4-6", speed="standard"),
+        name="test-agent",
+        skills=[],
+        tools=[],
+        type="agent",
+        version=1,
+    )
+    return BetaManagedAgentsSession(
+        outcome_evaluations=[],
+        id=session_id,
+        agent=agent_snapshot,
+        created_at=now,
+        environment_id="env_test_id",
+        metadata={},
+        resources=[],
+        stats=BetaManagedAgentsSessionStats(),
+        status="idle",
+        type="session",
+        updated_at=now,
+        usage=BetaManagedAgentsSessionUsage(),
+        vault_ids=[],
+    )
+
+
+def _users_info_request_count(fake_slack_web_client: Any) -> int:
+    """Count GET requests to users.info recorded by the aioresponses mock."""
+    return sum(
+        len(reqs)
+        for (method, url), reqs in fake_slack_web_client.mock.requests.items()
+        if method == "GET" and url.path == "/api/users.info"
+    )
+
+
+def _override_users_info(mock: Any, *, payload: dict[str, Any]) -> None:
+    """Replace the conftest non-admin users.info stub with the given payload.
+
+    aioresponses matches by insertion order and the conftest baseline is
+    registered with repeat=True, so a plain append never wins — the existing
+    users.info matchers have to be dropped first (mirrors
+    test_credential_requests.py's ``_override_users_info_admin``).
+    """
+    to_remove = [
+        k
+        for k, v in mock._matches.items()  # pyright: ignore[reportUnknownMemberType, reportPrivateUsage]
+        if getattr(v, "url_or_pattern", None) == _USERS_INFO_PATTERN
+    ]
+    for k in to_remove:
+        del mock._matches[k]  # pyright: ignore[reportUnknownMemberType, reportPrivateUsage]
+    mock.get(  # pyright: ignore[reportUnknownMemberType]
+        _USERS_INFO_PATTERN,
+        payload=payload,
+        repeat=True,
+    )
+
+
+class TestPerTurnRoleUpsert:
+    """Slack's per-turn account.role upsert from a live users.info admin lookup.
+
+    Mirrors Discord's TestPerTurnRoleUpsert. A users.info failure leaves the
+    stored role untouched rather than demoting a real admin.
+    """
+
+    async def test_admin_users_info_upserts_account_role_admin(
+        self,
+        db_session: AsyncSession,
+        db_session_factory: async_sessionmaker[AsyncSession],
+        fake_slack_web_client: Any,
+    ) -> None:
+        """users.info reporting admin -> account.role == Role.ADMIN after the turn,
+        and users.info is called exactly once."""
+        from daimon.core.stores.accounts import get_account
+        from daimon.core.stores.domain import Role
+        from daimon.core.stores.identity import get_or_create_platform_principal
+
+        team_id = "T_ROLE_ADMIN"
+        channel = "C_TEST"
+        thread_ts = "9100000001.000001"
+        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        await provision_tenant(
+            db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+        )
+        async with db_session_factory() as s:
+            principal = await get_or_create_platform_principal(
+                s, tenant_id=tenant_id, platform="slack", external_id="U_ROLE_ADMIN"
+            )
+            await s.commit()
+
+        _override_users_info(
+            fake_slack_web_client.mock,
+            payload={
+                "ok": True,
+                "user": {
+                    "id": "U_ROLE_ADMIN",
+                    "name": "admin_user",
+                    "is_admin": True,
+                    "is_owner": False,
+                    "is_primary_owner": False,
+                },
+            },
+        )
+
+        app, _ = _make_orchestrate_app(db_session_factory)
+
+        async def _fake_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+            state = TurnState(content=[TextBlock(kind="text", text="Hello!")])
+            await lifecycle.on_terminal_success(state)
+            return state
+
+        event: dict[str, Any] = {
+            "type": "app_mention",
+            "ts": thread_ts,
+            "event_ts": thread_ts,
+            "channel": channel,
+            "user": "U_ROLE_ADMIN",
+            "text": "<@U_BOT> hello",
+        }
+
+        with (
+            patch(
+                "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+            ) as mock_resolve_agent,
+            patch(
+                "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+            ) as mock_resolve_env,
+            patch(
+                "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+            ) as mock_create_session,
+            patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+            patch("daimon.adapters.slack.app.deliver_session_outputs", new_callable=AsyncMock),
+        ):
+            mock_resolve_agent.return_value = "agent_test_id"
+            mock_resolve_env.return_value = "env_test_id"
+            mock_create_session.return_value = _fake_ma_session("sess-role-admin")
+            mock_run_turn.side_effect = _fake_run_turn
+
+            await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+                event,
+                team_id=team_id,
+                channel=channel,
+                event_ts=thread_ts,
+                web_client=fake_slack_web_client.client,
+                tenant_id=tenant_id,
+            )
+
+            while app._bg_tasks:  # pyright: ignore[reportPrivateUsage]
+                await asyncio.gather(
+                    *list(app._bg_tasks),  # pyright: ignore[reportPrivateUsage]
+                    return_exceptions=True,
+                )
+                await asyncio.sleep(0)
+
+        assert _users_info_request_count(fake_slack_web_client) == 1, (
+            "exactly one users.info request must be issued per turn"
+        )
+
+        async with db_session_factory() as s:
+            account = await get_account(s, principal.account_id)
+        assert account is not None, "account must exist after turn"
+        assert account.role == Role.ADMIN, (
+            f"admin users.info signal must set account.role = Role.ADMIN; got: {account.role!r}"
+        )
+
+    async def test_member_users_info_upserts_account_role_user(
+        self,
+        db_session: AsyncSession,
+        db_session_factory: async_sessionmaker[AsyncSession],
+        fake_slack_web_client: Any,
+    ) -> None:
+        """users.info reporting a plain member -> account.role == Role.USER after the turn."""
+        from daimon.core.stores.accounts import get_account
+        from daimon.core.stores.domain import Role
+        from daimon.core.stores.identity import get_or_create_platform_principal
+
+        team_id = "T_ROLE_USER"
+        channel = "C_TEST"
+        thread_ts = "9100000002.000001"
+        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        await provision_tenant(
+            db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+        )
+        async with db_session_factory() as s:
+            principal = await get_or_create_platform_principal(
+                s, tenant_id=tenant_id, platform="slack", external_id="U_ROLE_USER"
+            )
+            await s.commit()
+
+        # conftest's default users.info payload (non-admin) is already registered
+        # by fake_slack_web_client; no override needed.
+
+        app, _ = _make_orchestrate_app(db_session_factory)
+
+        async def _fake_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+            state = TurnState(content=[TextBlock(kind="text", text="Hello!")])
+            await lifecycle.on_terminal_success(state)
+            return state
+
+        event: dict[str, Any] = {
+            "type": "app_mention",
+            "ts": thread_ts,
+            "event_ts": thread_ts,
+            "channel": channel,
+            "user": "U_ROLE_USER",
+            "text": "<@U_BOT> hello",
+        }
+
+        with (
+            patch(
+                "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+            ) as mock_resolve_agent,
+            patch(
+                "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+            ) as mock_resolve_env,
+            patch(
+                "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+            ) as mock_create_session,
+            patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+            patch("daimon.adapters.slack.app.deliver_session_outputs", new_callable=AsyncMock),
+        ):
+            mock_resolve_agent.return_value = "agent_test_id"
+            mock_resolve_env.return_value = "env_test_id"
+            mock_create_session.return_value = _fake_ma_session("sess-role-user")
+            mock_run_turn.side_effect = _fake_run_turn
+
+            await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+                event,
+                team_id=team_id,
+                channel=channel,
+                event_ts=thread_ts,
+                web_client=fake_slack_web_client.client,
+                tenant_id=tenant_id,
+            )
+
+            while app._bg_tasks:  # pyright: ignore[reportPrivateUsage]
+                await asyncio.gather(
+                    *list(app._bg_tasks),  # pyright: ignore[reportPrivateUsage]
+                    return_exceptions=True,
+                )
+                await asyncio.sleep(0)
+
+        async with db_session_factory() as s:
+            account = await get_account(s, principal.account_id)
+        assert account is not None, "account must exist after turn"
+        assert account.role == Role.USER, (
+            f"non-admin users.info signal must set account.role = Role.USER; got: {account.role!r}"
+        )
+
+    async def test_users_info_failure_leaves_role_unchanged(
+        self,
+        db_session: AsyncSession,
+        db_session_factory: async_sessionmaker[AsyncSession],
+        fake_slack_web_client: Any,
+    ) -> None:
+        """A users.info SlackApiError must leave a pre-existing ADMIN role
+        untouched -- never demoted by a transient lookup failure."""
+        from daimon.core.stores.accounts import get_account, set_role
+        from daimon.core.stores.domain import Role
+        from daimon.core.stores.identity import get_or_create_platform_principal
+
+        team_id = "T_ROLE_LOOKUP_FAIL"
+        channel = "C_TEST"
+        thread_ts = "9100000003.000001"
+        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        await provision_tenant(
+            db_session_factory, platform="slack", workspace_id=team_id, signup_credit=Decimal("10")
+        )
+        async with db_session_factory() as s:
+            principal = await get_or_create_platform_principal(
+                s, tenant_id=tenant_id, platform="slack", external_id="U_ROLE_LOOKUP_FAIL"
+            )
+            await set_role(s, principal.account_id, Role.ADMIN)
+            await s.commit()
+
+        # Override users.info with an ok=False body so the SDK raises SlackApiError
+        # (the SDK raises on ok=False regardless of HTTP status; see test_admin.py).
+        _override_users_info(
+            fake_slack_web_client.mock,
+            payload={"ok": False, "error": "internal_error"},
+        )
+
+        app, _ = _make_orchestrate_app(db_session_factory)
+
+        async def _fake_run_turn(*, lifecycle: Any, **kwargs: Any) -> TurnState:
+            state = TurnState(content=[TextBlock(kind="text", text="Hello!")])
+            await lifecycle.on_terminal_success(state)
+            return state
+
+        event: dict[str, Any] = {
+            "type": "app_mention",
+            "ts": thread_ts,
+            "event_ts": thread_ts,
+            "channel": channel,
+            "user": "U_ROLE_LOOKUP_FAIL",
+            "text": "<@U_BOT> hello",
+        }
+
+        with (
+            patch(
+                "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+            ) as mock_resolve_agent,
+            patch(
+                "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+            ) as mock_resolve_env,
+            patch(
+                "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+            ) as mock_create_session,
+            patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+            patch("daimon.adapters.slack.app.deliver_session_outputs", new_callable=AsyncMock),
+        ):
+            mock_resolve_agent.return_value = "agent_test_id"
+            mock_resolve_env.return_value = "env_test_id"
+            mock_create_session.return_value = _fake_ma_session("sess-role-lookup-fail")
+            mock_run_turn.side_effect = _fake_run_turn
+
+            await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+                event,
+                team_id=team_id,
+                channel=channel,
+                event_ts=thread_ts,
+                web_client=fake_slack_web_client.client,
+                tenant_id=tenant_id,
+            )
+
+            while app._bg_tasks:  # pyright: ignore[reportPrivateUsage]
+                await asyncio.gather(
+                    *list(app._bg_tasks),  # pyright: ignore[reportPrivateUsage]
+                    return_exceptions=True,
+                )
+                await asyncio.sleep(0)
+
+        assert _users_info_request_count(fake_slack_web_client) == 1, (
+            "exactly one users.info request must be issued per turn, whatever the outcome"
+        )
+
+        async with db_session_factory() as s:
+            account = await get_account(s, principal.account_id)
+        assert account is not None, "account must exist after turn"
+        assert account.role == Role.ADMIN, (
+            "a users.info lookup failure must leave the pre-existing role unchanged, "
+            f"not demote it; got: {account.role!r}"
+        )
+
+    async def test_admission_failure_performs_no_role_write(
+        self,
+        db_session: AsyncSession,
+        db_session_factory: async_sessionmaker[AsyncSession],
+        fake_slack_web_client: Any,
+    ) -> None:
+        """An admission-denied branch (over-balance) must not write account.role
+        even though the live admin lookup already ran before admit()."""
+        from daimon.core.stores.accounts import get_account, set_role
+        from daimon.core.stores.domain import Role
+        from daimon.core.stores.identity import get_or_create_platform_principal
+
+        team_id = "T_ROLE_ADMISSION_DENIED"
+        channel = "C_TEST"
+        thread_ts = "9100000004.000001"
+        tenant_id = derive_tenant_uuid(platform="slack", workspace_id=team_id)
+
+        await provision_tenant(db_session_factory, platform="slack", workspace_id=team_id)
+        async with db_session_factory() as s:
+            principal = await get_or_create_platform_principal(
+                s, tenant_id=tenant_id, platform="slack", external_id="U_ROLE_ADMISSION_DENIED"
+            )
+            await set_role(s, principal.account_id, Role.ADMIN)
+            await s.commit()
+
+        # Admin users.info payload -- if the write were unconditional (bug), this
+        # would already be ADMIN and the test would pass for the wrong reason;
+        # combined with the pre-seeded ADMIN role above it is neutral either way,
+        # so what actually proves "no write" is mock_over_balance being the sole
+        # reason admit() denies, with create_session/run_turn never called.
+        _override_users_info(
+            fake_slack_web_client.mock,
+            payload={
+                "ok": True,
+                "user": {
+                    "id": "U_ROLE_ADMISSION_DENIED",
+                    "name": "member",
+                    "is_admin": False,
+                    "is_owner": False,
+                    "is_primary_owner": False,
+                },
+            },
+        )
+
+        app, _ = _make_orchestrate_app(db_session_factory)
+
+        event: dict[str, Any] = {
+            "type": "app_mention",
+            "ts": thread_ts,
+            "event_ts": thread_ts,
+            "channel": channel,
+            "user": "U_ROLE_ADMISSION_DENIED",
+            "text": "<@U_BOT> hello",
+        }
+
+        with (
+            patch(
+                "daimon.core.turn.admission.resolve_agent", new_callable=AsyncMock
+            ) as mock_resolve_agent,
+            patch(
+                "daimon.core.turn.admission.resolve_environment", new_callable=AsyncMock
+            ) as mock_resolve_env,
+            patch(
+                "daimon.core.turn.admission.is_over_balance", new_callable=AsyncMock
+            ) as mock_over_balance,
+            patch(
+                "daimon.core.turn.prepare.create_session", new_callable=AsyncMock
+            ) as mock_create_session,
+            patch("daimon.core.turn.run.run_turn", new_callable=AsyncMock) as mock_run_turn,
+        ):
+            mock_resolve_agent.return_value = "agent_test_id"
+            mock_resolve_env.return_value = "env_test_id"
+            mock_over_balance.return_value = True
+
+            await app._orchestrate(  # pyright: ignore[reportPrivateUsage]
+                event,
+                team_id=team_id,
+                channel=channel,
+                event_ts=thread_ts,
+                web_client=fake_slack_web_client.client,
+                tenant_id=tenant_id,
+            )
+
+            mock_create_session.assert_not_called()  # pyright: ignore[reportUnknownMemberType]
+            mock_run_turn.assert_not_called()  # pyright: ignore[reportUnknownMemberType]
+
+        # The account was pre-seeded ADMIN and the incoming users.info signal was
+        # a plain member (False). If the role write ran despite the admission
+        # denial, it would have flipped to USER. It must still be ADMIN.
+        async with db_session_factory() as s:
+            account = await get_account(s, principal.account_id)
+        assert account is not None, "account must exist (identity resolution runs before the gate)"
+        assert account.role == Role.ADMIN, (
+            f"an admission-denied branch must perform no role write; got: {account.role!r}"
+        )

--- a/packages/adapters/slack/tests/test_context.py
+++ b/packages/adapters/slack/tests/test_context.py
@@ -13,7 +13,12 @@ import re
 
 from aioresponses import aioresponses as AioResponsesMock
 from daimon.adapters.slack.attachments import ProxyUrlContext
-from daimon.adapters.slack.context import _render_message, build_context_xml, build_delta_xml
+from daimon.adapters.slack.context import (
+    _render_message,
+    _user_query_open_tag,
+    build_context_xml,
+    build_delta_xml,
+)
 from daimon.core.slack_file_token import verify_file_token
 from slack_sdk.web.async_client import AsyncWebClient
 
@@ -283,7 +288,8 @@ def test_render_message_omits_attachments_when_no_proxy_configured() -> None:
 
 
 async def test_build_context_xml_renders_author_id_on_user_query() -> None:
-    """When author_id is given, it appears as an attribute on <user_query>."""
+    """When author_id is given, it appears as an attribute on <user_query>,
+    alongside is_admin (default False when unspecified)."""
     with AioResponsesMock() as mock:
         mock.get(
             _REPLIES_PATTERN,
@@ -294,8 +300,30 @@ async def test_build_context_xml_renders_author_id_on_user_query() -> None:
             client, channel="C1", thread_ts="100.0", user_query="hi", author_id="U0BDWSMCB26"
         )
 
-    assert '<user_query author_id="U0BDWSMCB26">' in xml, (
+    assert '<user_query author_id="U0BDWSMCB26" is_admin="false">' in xml, (
         "author_id must be rendered as a quoted attribute so the agent can mention the asker"
+    )
+
+
+async def test_build_context_xml_renders_is_admin_true_on_user_query() -> None:
+    """is_admin=True renders the lowercase literal "true", matching Discord's shape."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": [], "has_more": False},
+        )
+        client = _make_client()
+        xml = await build_context_xml(
+            client,
+            channel="C1",
+            thread_ts="100.0",
+            user_query="hi",
+            author_id="U0BDWSMCB26",
+            is_admin=True,
+        )
+
+    assert '<user_query author_id="U0BDWSMCB26" is_admin="true">' in xml, (
+        "is_admin=True must render the lowercase literal 'true' on <user_query>"
     )
 
 
@@ -314,7 +342,8 @@ async def test_build_context_xml_omits_author_id_attr_when_empty() -> None:
 
 
 async def test_build_delta_xml_renders_author_id_on_user_query() -> None:
-    """Delta builder also carries author_id onto <user_query>."""
+    """Delta builder also carries author_id onto <user_query>, with is_admin
+    defaulting to False when unspecified."""
     with AioResponsesMock() as mock:
         mock.get(
             _REPLIES_PATTERN,
@@ -330,4 +359,80 @@ async def test_build_delta_xml_renders_author_id_on_user_query() -> None:
             author_id="U123",
         )
 
-    assert '<user_query author_id="U123">' in xml, "delta user_query must carry author_id"
+    assert '<user_query author_id="U123" is_admin="false">' in xml, (
+        "delta user_query must carry author_id and is_admin"
+    )
+
+
+async def test_build_delta_xml_renders_is_admin_true_on_user_query() -> None:
+    """Delta builder propagates is_admin=True the same way build_context_xml does."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": [], "has_more": False},
+        )
+        client = _make_client()
+        xml = await build_delta_xml(
+            client,
+            channel="C1",
+            thread_ts="100.0",
+            watermark_ts="105.0",
+            user_query="more",
+            author_id="U123",
+            is_admin=True,
+        )
+
+    assert '<user_query author_id="U123" is_admin="true">' in xml, (
+        "delta user_query must carry is_admin=True"
+    )
+
+
+async def test_build_context_xml_reseed_shaped_call_carries_is_admin() -> None:
+    """The dead-session recovery reseed closure in app.py calls build_context_xml
+    with the same keyword shape as the ordinary first turn (author_id + is_admin);
+    this seam test drives that exact shape since test_app.py's orchestration
+    tests mock the builders wholesale and cannot see a missed keyword here."""
+    with AioResponsesMock() as mock:
+        mock.get(
+            _REPLIES_PATTERN,
+            payload={"ok": True, "messages": [], "has_more": False},
+        )
+        client = _make_client()
+        xml = await build_context_xml(
+            client,
+            channel="C1",
+            thread_ts="100.0",
+            user_query="reseed query",
+            author_id="U_RESEED",
+            is_admin=True,
+            proxy=None,
+        )
+
+    assert '<user_query author_id="U_RESEED" is_admin="true">' in xml, (
+        "the reseed-shaped call must carry is_admin the same as the ordinary first turn"
+    )
+
+
+def test_user_query_open_tag_renders_is_admin_true() -> None:
+    """_user_query_open_tag renders is_admin as the lowercase literal 'true'."""
+    assert _user_query_open_tag("U1", True) == '<user_query author_id="U1" is_admin="true">', (
+        "is_admin=True must render the lowercase literal 'true', not Python's True"
+    )
+
+
+def test_user_query_open_tag_renders_is_admin_false() -> None:
+    """_user_query_open_tag renders is_admin as the lowercase literal 'false'."""
+    assert _user_query_open_tag("U1", False) == '<user_query author_id="U1" is_admin="false">', (
+        "is_admin=False must render the lowercase literal 'false'"
+    )
+
+
+def test_user_query_open_tag_empty_author_id_stays_bare() -> None:
+    """Back-compat: an empty author_id renders the bare tag regardless of is_admin,
+    matching the pre-existing empty-author_id test's contract exactly."""
+    assert _user_query_open_tag("", True) == "<user_query>", (
+        "empty author_id must render the bare tag even when is_admin=True"
+    )
+    assert _user_query_open_tag("", False) == "<user_query>", (
+        "empty author_id must render the bare tag when is_admin=False"
+    )

--- a/packages/adapters/slack/tests/test_context_no_keys_element.py
+++ b/packages/adapters/slack/tests/test_context_no_keys_element.py
@@ -1,0 +1,105 @@
+"""Disabled-contract guard: Slack's built context carries no <keys> element.
+
+`daimon.core.turn_keys` defines the `<keys>` element contract but nothing
+wires it into any adapter yet (the reused-session refresh mechanism it would
+depend on does not exist). This file proves that on Slack, for a real built
+context, against an agent with stored keys:
+
+  - no `<keys` element appears,
+  - no stored value appears,
+  - no stored key *name* appears either, since nothing injects them,
+  - `context.py` carries no reference to the `turn_keys` module.
+
+When a later phase wires `render_keys_element` into a builder deliberately,
+every assertion here about key *names* being absent must be inverted (the
+value-absence assertions must stay, unchanged). Finding this test red is the
+signal that the wiring happened; go update the assertions here to match the
+new, intended behaviour instead of deleting them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from aioresponses import aioresponses as AioResponsesMock
+from daimon.adapters.slack.context import build_context_xml, build_delta_xml
+from daimon.core.stores.agent_files import put_agent_file
+from daimon.testing.factories import make_tenant
+from slack_sdk.web.async_client import AsyncWebClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+_REPLIES_PATTERN = re.compile(r"https://slack\.com/api/conversations\.replies.*")
+
+_STORED_KEY_ONE = "OPENAI_API_KEY"
+_STORED_VALUE_ONE = "sk-sentinel-slack-guard-7d2f0e"
+_STORED_KEY_TWO = "TOGGL_TOKEN"
+_STORED_VALUE_TWO = "toggl-sentinel-slack-guard-9a1c"
+
+
+def _make_client() -> AsyncWebClient:
+    return AsyncWebClient(token="xoxb-test")
+
+
+async def _seed_stored_keys(session: AsyncSession) -> None:
+    tenant = await make_tenant(session)
+    for key, value in (
+        (_STORED_KEY_ONE, _STORED_VALUE_ONE),
+        (_STORED_KEY_TWO, _STORED_VALUE_TWO),
+    ):
+        await put_agent_file(
+            session, tenant_id=tenant.id, agent_id=tenant.id, key=key, content=value
+        )
+
+
+def _assert_no_keys_element(xml: str, *, builder_name: str) -> None:
+    assert "<keys" not in xml, (
+        f"{builder_name} must not emit a <keys> element — nothing wires "
+        "render_keys_element into any adapter yet"
+    )
+    for value in (_STORED_VALUE_ONE, _STORED_VALUE_TWO):
+        assert value not in xml, (
+            f"{builder_name} must never leak a stored key's value, wiring or no wiring"
+        )
+    for name in (_STORED_KEY_ONE, _STORED_KEY_TWO):
+        assert name not in xml, (
+            f"{builder_name} must not mention a stored key's name today — nothing injects "
+            "key names into a turn yet. This expectation inverts once a later phase wires "
+            "render_keys_element into this builder; when it does, update this assertion to "
+            f"require the name instead of forbidding it."
+        )
+
+
+async def test_build_context_xml_carries_no_keys_element(db_session: AsyncSession) -> None:
+    await _seed_stored_keys(db_session)
+    with AioResponsesMock() as mock:
+        mock.get(_REPLIES_PATTERN, payload={"ok": True, "messages": [], "has_more": False})
+        client = _make_client()
+        xml = await build_context_xml(client, channel="C1", thread_ts="100.0", user_query="hi")
+
+    _assert_no_keys_element(xml, builder_name="build_context_xml")
+
+
+async def test_build_delta_xml_carries_no_keys_element(db_session: AsyncSession) -> None:
+    await _seed_stored_keys(db_session)
+    with AioResponsesMock() as mock:
+        mock.get(_REPLIES_PATTERN, payload={"ok": True, "messages": [], "has_more": False})
+        client = _make_client()
+        xml = await build_delta_xml(
+            client, channel="C1", thread_ts="100.0", watermark_ts="99.0", user_query="hi"
+        )
+
+    _assert_no_keys_element(xml, builder_name="build_delta_xml")
+
+
+def test_context_module_does_not_reference_turn_keys() -> None:
+    source = Path("packages/adapters/slack/daimon/adapters/slack/context.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "turn_keys" not in source, (
+        "slack/context.py must not reference daimon.core.turn_keys — the <keys> element "
+        "contract is intentionally unwired. If you are reading this because it failed, you "
+        "wired it: do so deliberately, then invert the name-absence assertions in "
+        "test_context_no_keys_element.py to match the new, intended behaviour."
+    )

--- a/packages/adapters/slack/tests/test_credential_requests.py
+++ b/packages/adapters/slack/tests/test_credential_requests.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import json
 import re
 import uuid
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -58,7 +59,7 @@ from daimon.adapters.slack.runtime import SlackRuntime
 from daimon.core.credential_requests import build_skill_repo_target, mint_request_token
 from daimon.core.defaults.provisioning import derive_guild_account_uuid
 from daimon.core.defaults.report import Action, ResourceOutcome
-from daimon.core.github_credentials import build_multifernet, encrypt_token
+from daimon.core.github_credentials import build_multifernet, encrypt_token, get_pat
 from daimon.core.ma_identity import derive_agent_uuid, derive_tenant_uuid
 from daimon.core.stores.agent_repo_binding import get_binding
 from daimon.core.stores.credential_requests import (
@@ -586,6 +587,13 @@ async def test_mcp_submission_with_unconfigured_mcp_refuses_before_the_consume(
         "a config refusal must land before the consume so the request survives"
     )
     assert ("POST", _EPHEMERAL_URL) in fake_slack_web_client.mock.requests
+    receipt = " ".join(_ephemeral_texts(fake_slack_web_client))
+    assert "Ask the operator" in receipt and "Nothing was saved" in receipt, (
+        "an unconfigured deployment should give an operator handoff and truthful save status"
+    )
+    assert "public_url" not in receipt and "jwt_secret" not in receipt, (
+        "the person should not receive internal deployment setting names"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -769,3 +777,60 @@ async def test_skill_repo_submission_binds_and_attaches_the_imported_skills(
     assert any("Attached 1 to `daimon`" in t for t in _ephemeral_texts(fake_slack_web_client)), (
         "the success ephemeral must report the attach half, not just the import"
     )
+
+
+@pytest.mark.parametrize("fails_after_storage", [False, True])
+async def test_skill_repo_failure_receipt_reflects_confirmed_token_storage(
+    fails_after_storage: bool,
+    db_session: AsyncSession,
+    db_session_factory: async_sessionmaker[AsyncSession],
+    fake_slack_web_client: Any,
+) -> None:
+    tenant_id, fernet_key = await _seed_team(db_session)
+    agent_id = uuid.uuid4()
+    token = await _seed_request(
+        db_session,
+        tenant_id=tenant_id,
+        kind="skill_repo",
+        agent_id=agent_id,
+        target=build_skill_repo_target("https://github.com/o/skills", "main", ""),
+    )
+    await db_session.commit()
+    checks = 0
+
+    def github_response(request: httpx.Request) -> httpx.Response:
+        nonlocal checks
+        checks += 1
+        if checks == 1 or (checks == 2 and fails_after_storage):
+            return httpx.Response(200, json={})
+        return httpx.Response(403, text="sensitive-upstream-detail")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(github_response)) as http_client:
+        runtime = replace(_build_runtime(fernet_key, db_session_factory), http_client=http_client)
+        await run_skill_repo_credential_submission(
+            runtime,
+            team_id=_TEAM_ID,
+            user_id=_USER_ID,
+            channel_id=_CHANNEL_ID,
+            message_ts=_MESSAGE_TS,
+            token=token,
+            value="ghp_test_private_value",
+        )
+    stored = await get_pat(
+        principal_id=derive_guild_account_uuid(tenant_id=tenant_id),
+        agent_id=agent_id,
+        sessionmaker=db_session_factory,
+        fernet=build_multifernet((fernet_key,)),
+    )
+    receipt = " ".join(_ephemeral_texts(fake_slack_web_client))
+    assert (stored is not None) == fails_after_storage, (
+        "fixture must fail at the intended write stage"
+    )
+    assert ("Token stored" in receipt) == fails_after_storage, (
+        "receipt must report only confirmed storage"
+    )
+    assert "retry" in receipt, "failed setup must offer a reachable retry"
+    assert "sensitive-upstream-detail" not in receipt, (
+        "upstream details must stay out of the receipt"
+    )
+    assert "ghp_test_private_value" not in receipt, "the private token must stay out of the receipt"

--- a/packages/adapters/slack/tests/test_errors.py
+++ b/packages/adapters/slack/tests/test_errors.py
@@ -115,7 +115,7 @@ class TestRenderError:
     def test_invalid_token_does_not_leak_ciphertext_detail(self) -> None:
         result = render_error(InvalidToken("gAAAA-ciphertext"), request_id=TEST_RID)
         assert "gAAAA" not in result, "Fernet detail stays in the logs"
-        assert "*Credential error*" in result
+        assert "*Slack token error*" in result
         assert TEST_RID in result
 
     def test_value_error(self) -> None:

--- a/packages/adapters/slack/tests/test_help.py
+++ b/packages/adapters/slack/tests/test_help.py
@@ -60,6 +60,8 @@ async def test_handle_help_command_posts_ephemeral_and_no_views_open(
     }
 
     runtime = MagicMock(spec=SlackRuntime)
+    runtime.settings = MagicMock()
+    runtime.settings.slack = None
 
     with patch(
         "daimon.adapters.slack.help.resolve_web_client",
@@ -108,6 +110,8 @@ async def test_handle_help_command_drops_silently_when_no_token(
     }
 
     runtime = MagicMock(spec=SlackRuntime)
+    runtime.settings = MagicMock()
+    runtime.settings.slack = None
 
     with patch(
         "daimon.adapters.slack.help.resolve_web_client",
@@ -142,6 +146,8 @@ async def test_handle_help_command_reports_failure_ephemerally() -> None:
         "channel_id": "C_HELP_TEST",
     }
     runtime = MagicMock(spec=SlackRuntime)
+    runtime.settings = MagicMock()
+    runtime.settings.slack = None
 
     with patch(
         "daimon.adapters.slack.help.resolve_web_client",
@@ -157,3 +163,12 @@ async def test_handle_help_command_reports_failure_ephemerally() -> None:
     assert notice["channel"] == "C_HELP_TEST"
     assert notice["user"] == "U_HELP_TEST"
     assert "rid:" in notice["text"], "the notice must carry a rid for log lookup"
+
+
+def test_help_uses_the_configured_bot_name() -> None:
+    from daimon.adapters.slack.help import build_help_blocks
+
+    text = str(build_help_blocks(display_name="research-bot"))
+    assert "@research-bot help me set up" in text, "help should mention the configured bot"
+    assert "what research-bot stores" in text, "privacy help should use the configured bot"
+    assert "daimon" not in text, "help should contain no hardcoded bot name"

--- a/packages/adapters/slack/tests/test_privacy_actions.py
+++ b/packages/adapters/slack/tests/test_privacy_actions.py
@@ -43,6 +43,7 @@ def _build_runtime(
     settings.crypto.keys = (SecretStr(fernet_key),)
     if mintable:
         settings.slack.signing_secret = SecretStr("shh-secret")
+        settings.slack.bot_display_name = "research-bot"
         settings.mcp.app_root_url = "https://mcp.example.com"
     else:
         settings.slack = None

--- a/packages/adapters/slack/tests/test_privacy_panel.py
+++ b/packages/adapters/slack/tests/test_privacy_panel.py
@@ -346,8 +346,8 @@ def test_cascade_blocks_render_agent_github_binding_row_when_nonzero() -> None:
     view = build_delete_modal(preview, account_id=uuid.uuid4(), user_name="alice", view_id="V2")
     joined = _extract_text(view)
     assert "2" in joined, "agent_github_binding count must appear in the cascade"
-    assert "per-agent GitHub credential link" in joined, (
-        "agent_github_binding row must mention the per-agent GitHub credential link"
+    assert "per-agent GitHub token link" in joined, (
+        "agent_github_binding row must mention the per-agent GitHub token link"
     )
 
 
@@ -376,8 +376,8 @@ def test_cascade_blocks_zero_count_categories_omit_new_rows() -> None:
     preview = _make_preview()
     view = build_delete_modal(preview, account_id=uuid.uuid4(), user_name="alice", view_id="V5")
     joined = _extract_text(view).lower()
-    assert "mcp token" not in joined, "zero-count mcp_tokens must NOT render a row"
-    assert "per-agent github credential link" not in joined, (
+    assert "mcp token(s)" not in joined, "zero-count mcp_tokens must NOT render a row"
+    assert "per-agent github token link" not in joined, (
         "zero-count agent_github_binding must NOT render a row"
     )
     assert "slack user token" not in joined, "zero-count slack_user_tokens must NOT render a row"
@@ -425,3 +425,27 @@ def _find_url_button(obj: Any, url: str) -> bool:  # noqa: ANN401 — test helpe
     if isinstance(obj, list):
         return any(_find_url_button(item, url) for item in obj)
     return False
+
+
+def test_privacy_views_use_the_configured_display_name() -> None:
+    from daimon.adapters.slack.privacy_panel.views import (
+        build_disconnect_result_view,
+        build_export_result_view,
+    )
+
+    views = [
+        build_privacy_main_container(
+            _make_preview(),
+            is_slack_connected=False,
+            slack_connect_url=None,
+            policy_url=_POLICY_URL,
+            display_name="research-bot",
+        ),
+        build_export_result_view(summary=None, display_name="research-bot"),
+        build_export_result_view(summary="one session", display_name="research-bot"),
+        build_disconnect_result_view(
+            was_connected=True, reconnect_url=None, display_name="research-bot"
+        ),
+    ]
+    for view in views:
+        assert "research-bot" in _extract_text(view), "privacy copy must use the configured name"

--- a/packages/adapters/slack/tests/test_privacy_submit.py
+++ b/packages/adapters/slack/tests/test_privacy_submit.py
@@ -197,6 +197,7 @@ async def test_run_purge_and_update_deletes_account_rows_and_calls_views_update(
     fake_anthropic = build_fake_anthropic(router.dispatch)
 
     settings = MagicMock()
+    settings.slack = None
     settings.crypto.keys = (SecretStr("placeholder"),)
     runtime = SlackRuntime(
         settings=settings,
@@ -253,6 +254,7 @@ async def test_run_purge_and_update_aborts_when_account_does_not_match_submitter
     await db_session.commit()
 
     settings = MagicMock()
+    settings.slack = None
     settings.crypto.keys = (SecretStr("placeholder"),)
     runtime = SlackRuntime(
         settings=settings,

--- a/packages/core/daimon/core/_models.py
+++ b/packages/core/daimon/core/_models.py
@@ -463,8 +463,8 @@ class SeededSkill(Base):
 
 class AgentGithubBinding(Base):
     """Per-agent GitHub credential overlay. Day-1 always empty; populated by
-    Discord agent-setup panel. Single credential per principal day-1,
-    so no github_login discriminator.
+    the working-repo binding path (`request_repo_binding`). Single credential
+    per principal day-1, so no github_login discriminator.
     """
 
     __tablename__ = "agent_github_binding"
@@ -476,9 +476,10 @@ class AgentGithubBinding(Base):
 class AgentGoogleBinding(Base):
     """Per-agent Google Workspace identity overlay.
 
-    Empty day-1; populated by the agent-setup panel. Holds the email
-    + scope set the token broker mints credentials for via domain-wide
-    delegation against the tenant service account.
+    Empty day-1; populated by an operator running `daimon agents bind-google
+    <agent> <email> --scopes <scope>...`. Holds the email + scope set the
+    token broker mints credentials for via domain-wide delegation against
+    the tenant service account.
     """
 
     __tablename__ = "agent_google_binding"

--- a/packages/core/daimon/core/agent_guidance.py
+++ b/packages/core/daimon/core/agent_guidance.py
@@ -23,20 +23,20 @@ _GUIDANCE_BODY = """\
 You have two separate credential systems. Know the difference or you'll
 look for keys that don't exist.
 
-1) SECRETS (API keys) — a file you must load.
-   Anything set for you in the agent panel (/agent-setup -> Secrets), e.g.
-   OPENAI_API_KEY, is mounted as a dotenv file at /mnt/session/uploads/.env.
-   Before using any skill/tool that needs an API key, load it:
-       set -a; source /mnt/session/uploads/.env; set +a
-   NEVER say a credential is missing without first reading that file.
+1) KEYS (API keys) — a file you must load.
+   Keys set for you are mounted as a dotenv file at
+   /mnt/session/uploads/.env. Before using any skill/tool that needs an API
+   key, load it: set -a; source /mnt/session/uploads/.env; set +a
+   NEVER say a credential is missing without first reading that file. Do not
+   assume a key is already loaded into this session — that file is the only
+   ground truth.
 
-2) MCP SERVERS — auth is handled for you; there is no key to find.
-   MCP servers attached to you (GitHub, Context7, daimon-mcp, ...) are
-   authenticated at the Anthropic Managed-Agents vault layer. Their creds
-   are NOT in /mnt/session/uploads/.env and NOT environment variables.
-   Just call the MCP tools — auth applies automatically. Never search for
-   an MCP server's API key, and never claim to have an MCP server unless
-   its tools actually appear when you list them.
+2) MCP SERVERS — a different system; do not look for their tokens here.
+   MCP servers attached to you (GitHub, Context7, daimon-mcp, ...) receive
+   authentication when required, supplied separately from
+   /mnt/session/uploads/.env. Never search that file or the environment for
+   an MCP server's token, and never claim to have an MCP server unless its
+   tools actually appear when you list them.
 
 INSPECTING CONFIG IS NOT LEAKING IT. The protected asset is a secret's
 VALUE, never its existence. Reading /mnt/session/uploads/.env, listing that

--- a/packages/core/daimon/core/broker/errors.py
+++ b/packages/core/daimon/core/broker/errors.py
@@ -17,13 +17,15 @@ class BrokerError(DaimonError):
 class NoBindingError(BrokerError):
     """Raised when no credential / binding exists for the requesting agent.
 
-    Operator-actionable: the resolution is to bind credentials via the
-    agent-setup repo-auth panel (inline PAT), or install the GitHub App on the repo.
+    Resolution: bind a working-repo token for the agent — `request_repo_binding`
+    is the chat path that collects one — or install the GitHub App on the
+    repository.
     """
 
 
 class ProviderConfigError(BrokerError):
     """Raised when provider configuration (settings) is missing or invalid.
 
-    Operator-actionable: the resolution is to set the missing env var.
+    Operator-actionable: the resolution is to set the missing deployment
+    configuration value.
     """

--- a/packages/core/daimon/core/broker/providers/gcloud.py
+++ b/packages/core/daimon/core/broker/providers/gcloud.py
@@ -52,7 +52,10 @@ class GcloudTokenProvider:
             binding = await get_agent_google_binding(session, agent_id=agent_id)
         if binding is None:
             raise NoBindingError(
-                "Agent not bound to a Google identity — operator must configure via agent-setup."
+                "This agent has no Google identity bound. Google access is "
+                "configured per deployment by the operator running it, not "
+                "from chat — tell them to run `daimon agents bind-google "
+                "<agent> <email> --scopes <scope>...` to bind one."
             )
         sa_json_text = settings.credentials.google_sa_json.get_secret_value()
         try:

--- a/packages/core/daimon/core/broker/providers/github.py
+++ b/packages/core/daimon/core/broker/providers/github.py
@@ -55,8 +55,15 @@ class GitHubTokenProvider:
             ),
         )
         if token is None:
+            if agent_id is None:
+                raise NoBindingError(
+                    "No GitHub token is bound to this caller's account. Ask the operator "
+                    "to configure CLI token access for this account. Binding a target "
+                    "agent's working repo does not supply an account-only call's token."
+                )
             raise NoBindingError(
-                "No GitHub credential bound to this account. Bind a PAT via the "
-                "agent-setup repo-auth panel, or install the GitHub App on the repo."
+                "No GitHub access is bound for this agent. Use request_repo_binding "
+                "to collect a token privately for the target agent. A GitHub App "
+                "installation alone does not supply this CLI token."
             )
         return token

--- a/packages/core/daimon/core/config.py
+++ b/packages/core/daimon/core/config.py
@@ -371,6 +371,15 @@ class SlackSettings(BaseModel):
     ``app_token`` for Socket Mode.
     """
 
+    bot_display_name: str = Field(
+        default="daimon",
+        # Keep surrounding Block Kit copy within Slack's limits and exclude
+        # mention, markdown, and emoji-shortcode metacharacters.
+        min_length=1,
+        max_length=32,
+        pattern=r"^[^\\`@#:]+$",
+        description="The bot's presented name in Slack setup, help, and privacy messages.",
+    )
     signing_secret: SecretStr = Field(
         description=(
             "Slack request-signing secret used to verify inbound HTTP "
@@ -408,7 +417,7 @@ class SlackSettings(BaseModel):
 
 
 class GithubSettings(BaseModel):
-    """GitHub repo-auth config (App-or-PAT; no OAuth flow). All fields are
+    """GitHub repository access config (App-or-PAT; no OAuth flow). All fields are
     optional so deployments without GitHub App or PAT config keep working.
 
     Cloning via the GitHub App requires only app_id + app_private_key.

--- a/packages/core/daimon/core/constants.py
+++ b/packages/core/daimon/core/constants.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 from daimon.core.pricing import AGENT_MODEL_PRICING
 
-# The Anthropic models the /agent-setup panel allows. Single source of truth:
+# The Anthropic models the product offers for Prompt & model. Single source of truth:
 # `pricing.AGENT_MODEL_PRICING.keys()` — when a model is added or repriced, both
 # surfaces update in lockstep. Tool-pinned models (`pricing.TOOL_MODEL_PRICING`)
 # are metered but never selectable here.
 #
-# UX-25-03: the Model TextInput is free-text because Discord modals cannot
-# contain Select components, so validation happens at submit time against this
-# tuple.
+# The model input is free-text, so submission validates against this tuple.
 ALLOWED_MODEL_IDS: tuple[str, ...] = tuple(AGENT_MODEL_PRICING.keys())
 
 # What a new agent gets when the creator does not name a model: every panel

--- a/packages/core/daimon/core/credential_requests.py
+++ b/packages/core/daimon/core/credential_requests.py
@@ -66,16 +66,13 @@ MAX_SLACK_BUTTON_LABEL_CHARS: Final[int] = 75
 # builders live here.
 SLACK_ACTION_ID: Final[str] = "credential_request"
 
-# The full label prefix for each kind. "env" and "mcp" reproduce the
-# pre-repo-kind wording byte-for-byte. "repo" cannot reuse the "Add {X}
-# credential: " interpolation — a repo binding is not a credential.
-# "skill_repo" is deliberately worded as an import, not a binding: it shares
-# "repo"'s PAT store but writes NO agent_repo_binding row, so a label saying
-# "bind" would promise a checkout the user never asked for.
+# Shared labels for newly posted buttons and rehydrated controls. Skill import
+# also stores a working-repo binding so later syncs can find its token; the
+# request description explains that side effect before the form is posted.
 _KIND_LABEL_PREFIX: Final[dict[CredentialRequestKind, str]] = {
-    "env": "Add env credential: ",
-    "mcp": "Add MCP credential: ",
-    "repo": "Bind repo: ",
+    "env": "Add key: ",
+    "mcp": "Add MCP token: ",
+    "repo": "Set working repo: ",
     "skill_repo": "Import skills from: ",
 }
 

--- a/packages/core/daimon/core/defaults/metadata.py
+++ b/packages/core/daimon/core/defaults/metadata.py
@@ -59,8 +59,8 @@ def build_metadata(
     `client.beta.environments.create` so LIST-by-client-filter can recover the
     daimon tenant and local name deterministically.
 
-    When `account_id` is provided, stamp `daimon_account=str(account_id)` so the
-    The `/agent-setup` panel can filter the roster to the invoking user.
+    When `account_id` is provided, stamp `daimon_account=str(account_id)` so
+    the roster can be filtered to the invoking user's own agents.
     When `account_id` is `None`, the `daimon_account` key is omitted entirely —
     this preserves the "tenant-scoped / no account" semantics of the seeded
     default agent (everyone's agent).

--- a/packages/core/daimon/core/defaults/sweep.py
+++ b/packages/core/daimon/core/defaults/sweep.py
@@ -35,8 +35,8 @@ _log = structlog.get_logger(__name__)
 def _is_defaults_managed(metadata: dict[str, str]) -> bool:
     """True when the resource was stamped by a defaults `reconcile_*` write.
 
-    User forks (created via `daimon agents fork`, Discord `/agent-setup`, etc.)
-    leave this marker unset so the sweep ignores them. Without this filter the
+    User forks (created via `daimon agents fork`, the chat `fork_agent` tool,
+    etc.) leave this marker unset so the sweep ignores them. Without this filter the
     sweep would archive every user-created resource on the next `defaults
     apply` (which runs on every scheduler boot).
     """

--- a/packages/core/daimon/core/github_credentials.py
+++ b/packages/core/daimon/core/github_credentials.py
@@ -133,7 +133,7 @@ async def get_github_login(
     """Display-only login resolver — the non-secret peer of `get_pat`.
 
     Returns `github_login` for the resolved credential without decrypting (or
-    even reading) the token, so the /agent-setup panel can show GitHub linkage
+    even reading) the token, so a Working repo view can show GitHub linkage
     for the selected agent. Same cascade shape as `get_pat`:
 
     agent_id given -> overlay-only -> None (no principal-default bleed).

--- a/packages/core/daimon/core/github_repo_auth.py
+++ b/packages/core/daimon/core/github_repo_auth.py
@@ -1,7 +1,7 @@
 """Clone-credential resolution for App-or-PAT repo auth.
 
 Owns the mode decisions (pure) and the token-resolution orchestrations
-(shell, injected httpx) for BOTH of daimon's independent GitHub-repo-auth
+(shell, injected httpx) for BOTH of daimon's independent GitHub-clone-auth
 callers: the per-agent clone path (`agent_repo_binding`, a bound repo with a
 recorded proof of access) and the skill-sync path (a bare repo URL that may
 have no binding row at all). No DB access, no module-level singletons —
@@ -324,7 +324,7 @@ async def resolve_clone_token(
         )
     raise DaimonError(
         f"No credential is authorized to clone {binding.repo_url}. Re-bind this repo "
-        "with a GitHub token that can read it, from the agent setup panel's GitHub option."
+        "with a GitHub token that can read it, using request_repo_binding."
     )
 
 

--- a/packages/core/daimon/core/stores/agent_google_binding.py
+++ b/packages/core/daimon/core/stores/agent_google_binding.py
@@ -1,15 +1,22 @@
-"""Read-only store for agent_google_binding.
+"""Store for agent_google_binding.
 
-Day-1 read-only: the agent-setup panel will add upsert/delete
-helpers. The GWS token-broker provider only needs to read the binding.
+Holds the operator-configured Google Workspace identity overlay for an
+agent: which email and scope set the token broker impersonates via
+domain-wide delegation against the tenant service account. Written by
+the admin CLI (`daimon agents bind-google`); read by the GWS token
+broker provider.
 """
 
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 
 from daimon.core._models import AgentGoogleBinding
+from daimon.core.errors import StoreError
 from daimon.core.stores.domain import AgentGoogleBindingRow
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -22,4 +29,43 @@ async def get_agent_google_binding(
     orm = await session.get(AgentGoogleBinding, agent_id)
     if orm is None:
         return None
+    return AgentGoogleBindingRow.model_validate(orm)
+
+
+async def upsert_agent_google_binding(
+    session: AsyncSession,
+    *,
+    agent_id: uuid.UUID,
+    email: str,
+    scopes: Sequence[str],
+) -> AgentGoogleBindingRow:
+    """Upsert the Google identity overlay for `agent_id`. Last-write-wins.
+
+    Returns the post-write row. Uses `.returning(...)` + `scalar_one()` so the
+    cursor — not the identity map — is the source of truth, mirroring
+    `agent_files.put_agent_file`.
+    """
+    if len(scopes) == 0:
+        raise StoreError("scopes must not be empty")
+
+    stmt = (
+        pg_insert(AgentGoogleBinding)
+        .values(
+            agent_id=agent_id,
+            email=email,
+            scopes=list(scopes),
+        )
+        .on_conflict_do_update(
+            constraint="agent_google_binding_pkey",
+            set_={
+                "email": email,
+                "scopes": list(scopes),
+                "updated_at": func.now(),
+            },
+        )
+        .returning(AgentGoogleBinding)
+    )
+    result = await session.execute(stmt)
+    orm = result.scalar_one()
+    await session.flush()
     return AgentGoogleBindingRow.model_validate(orm)

--- a/packages/core/daimon/core/turn_keys.py
+++ b/packages/core/daimon/core/turn_keys.py
@@ -1,0 +1,74 @@
+"""The names-only projection of an agent's stored keys, and its XML renderer.
+
+This module defines the contract for naming an agent's stored keys on a turn.
+**Nothing calls these functions today.** Enabling injection requires a
+mechanism that refreshes a reused session's mounted resources — re-syncing
+the `.env` a session reads from — which does not exist yet. Wiring either
+function into a turn today would tell the model a key is available when the
+answering session cannot actually read it.
+
+Stored key names are configuration metadata, never evidence that the
+answering session has those keys mounted. `list_turn_key_names` is not the
+tool that describes an arbitrary agent's stored keys to a person (that is
+the `list_agent_keys` chat tool, which resolves a target agent by name);
+this function takes only the answering session's own agent id, as a
+`uuid.UUID`, and resolves nothing.
+
+XML vocabulary (fixed here for a later phase to fill, not redefine): when
+there are names to render, `render_keys_element` emits a `<keys>` element
+containing one self-closing `<key name="..."/>` child per name, in the order
+given:
+
+    <keys><key name="TOGGL_TOKEN"/><key name="OPENAI_API_KEY"/></keys>
+
+A child element per name (not a delimited attribute) because a key name may
+legally contain punctuation that would need escaping twice under a delimiter
+scheme. An empty sequence renders as `""` — an agent with no keys contributes
+no element at all, matching the rest of the per-turn context vocabulary
+where an absent fact is an absent element.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from xml.sax.saxutils import quoteattr
+
+from daimon.core.stores.agent_files import list_agent_files
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def list_turn_key_names(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    agent_id: uuid.UUID,
+) -> tuple[str, ...]:
+    """Return the stored key names for this (tenant, agent), names only.
+
+    `agent_id` is the answering session's own agent — never an arbitrary
+    target resolved from a name. The store already returns rows ordered by
+    key, so the result is sorted for free; this function adds no sort of its
+    own and no deduplication (the store's primary key already guarantees
+    uniqueness).
+
+    The return type is `tuple[str, ...]`: no row, no mapping, no field
+    through which a stored value is reachable. That is what makes the
+    values-never-ride property a type guarantee rather than a convention.
+    """
+    rows = await list_agent_files(session, tenant_id=tenant_id, agent_id=agent_id)
+    return tuple(row.key for row in rows)
+
+
+def render_keys_element(names: Sequence[str]) -> str:
+    """Render the `<keys>` element for a turn, or `""` if there is nothing to say.
+
+    Pure and total: same input, same output, no I/O. Each name is rendered
+    inside a `<key name="..."/>` child with its attribute value XML-escaped,
+    so a name containing an XML metacharacter cannot close the element or
+    forge a sibling attribute.
+    """
+    if not names:
+        return ""
+    children = "".join(f"<key name={quoteattr(name)}/>" for name in names)
+    return f"<keys>{children}</keys>"

--- a/packages/core/tests/core/broker/test_broker.py
+++ b/packages/core/tests/core/broker/test_broker.py
@@ -127,7 +127,7 @@ async def test_github_passthrough_raises_no_binding_when_unbound(
 ) -> None:
     """Dispatch for service='github' with no credential row raises NoBindingError."""
     account_id = uuid.uuid4()
-    with pytest.raises(NoBindingError):
+    with pytest.raises(NoBindingError, match="operator.*account"):
         await dispatch_mint_token(
             service="github",
             account_id=account_id,
@@ -292,10 +292,10 @@ async def test_gcloud_raises_no_binding_when_no_agent_google_binding(
     gcloud_settings: Settings,
 ) -> None:
     """SA JSON configured but no agent_google_binding row → NoBindingError
-    with message naming the agent."""
+    naming the operator and the bind-google command."""
     account_id = uuid.uuid4()
     agent_id = uuid.uuid4()
-    with pytest.raises(NoBindingError, match="Agent not bound"):
+    with pytest.raises(NoBindingError, match="bind-google"):
         await dispatch_mint_token(
             service="gcloud",
             account_id=account_id,

--- a/packages/core/tests/defaults/test_defaults_dir.py
+++ b/packages/core/tests/defaults/test_defaults_dir.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from daimon.core.constants import DEFAULT_AGENT_MODEL
@@ -72,14 +73,7 @@ def test_defaults_skills_parse() -> None:
 
 
 def test_defaults_daimon_agent_guidance_routes_credentials_to_request_tools() -> None:
-    """The daimon agent's guidance — its system prompt plus its referenced
-    skills — must name both credential-request tools and no line anywhere in
-    that combined guidance may route credential *entry* to the /agent-setup
-    panel — replacing the setup-panel redirect was the whole point of the
-    request_env_credential / request_mcp_credential tools. The mechanism now
-    lives in the workspace-setup skill rather than the system prompt itself
-    (the prompt keeps only the no-plaintext rule), so this checks the union
-    of both, not the system prompt alone."""
+    """Seeded guidance names callable setup tools and avoids obsolete panel paths."""
     specs = load_agent_specs(DEFAULTS / "agents")
     daimon = next(s for s in specs if s.name == "daimon")
     skill_names = {ref.skill_id for ref in daimon.skills if ref.type == "custom"}
@@ -89,19 +83,34 @@ def test_defaults_daimon_agent_guidance_routes_credentials_to_request_tools() ->
         if load_skill_spec(d)[0].name in skill_names
     ]
     combined = "\n".join([daimon.system or "", *skill_bodies])
-    assert "request_env_credential" in combined, (
-        "guidance must name request_env_credential for ad hoc env secrets"
+    assert "request_agent_key" in combined, (
+        "guidance must name request_agent_key for ad hoc env secrets"
     )
-    assert "request_mcp_credential" in combined, (
-        "guidance must name request_mcp_credential for auth-required MCP servers"
+    assert "request_mcp_token" in combined, (
+        "guidance must name request_mcp_token for auth-required MCP servers"
     )
+    retired_tools = (
+        "request_env_credential",
+        "request_mcp_credential",
+        "request_skill_repo_credential",
+        "list_env_credential_keys",
+        "remove_env_credential",
+        "skills_sync",
+        "skills_list",
+        "skills_get",
+        "skills_delete",
+    )
+    for name in retired_tools:
+        assert name not in combined, f"seeded guidance names a retired tool: {name}"
     for line in combined.splitlines():
-        if "/agent-setup" not in line:
-            continue
         lowered = line.lower()
-        assert not any(
-            word in lowered for word in ("token", "secret", "credential", "mcps modal")
-        ), f"a line mentioning /agent-setup must not also route credential entry there: {line!r}"
+        assert not re.search(r"\bdoor\b|repo\+auth|repo-auth|mcps modal|\benv vars?\b", lowered), (
+            f"seeded guidance contains an obsolete setup label: {line!r}"
+        )
+        if "/agent-setup" in lowered:
+            assert not any(
+                word in lowered for word in ("token", "secret", "credential", "modal", "→", "->")
+            ), f"setup entry must not invent a nested path or route private input: {line!r}"
 
 
 def test_defaults_agent_skill_references_resolve() -> None:

--- a/packages/core/tests/stores/test_agent_google_binding.py
+++ b/packages/core/tests/stores/test_agent_google_binding.py
@@ -6,8 +6,13 @@ import uuid
 
 import pytest
 from daimon.core._models import AgentGoogleBinding
-from daimon.core.stores.agent_google_binding import get_agent_google_binding
+from daimon.core.errors import StoreError
+from daimon.core.stores.agent_google_binding import (
+    get_agent_google_binding,
+    upsert_agent_google_binding,
+)
 from daimon.core.stores.domain import AgentGoogleBindingRow
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -62,3 +67,90 @@ async def test_store_returns_pydantic_not_orm(db_session: AsyncSession) -> None:
     # Pydantic models are frozen; assignment should fail
     with pytest.raises((TypeError, ValueError)):
         result.email = "other@y.z"  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_upsert_agent_google_binding_inserts_row_when_unbound(
+    db_session: AsyncSession,
+) -> None:
+    agent_id = uuid.uuid4()
+
+    result = await upsert_agent_google_binding(
+        db_session,
+        agent_id=agent_id,
+        email="op@example.com",
+        scopes=["https://www.googleapis.com/auth/calendar"],
+    )
+
+    assert isinstance(result, AgentGoogleBindingRow), "store returns Pydantic, not ORM"
+    assert result.agent_id == agent_id, "agent_id round-trips"
+    assert result.email == "op@example.com", "email round-trips"
+    assert result.scopes == ("https://www.googleapis.com/auth/calendar",), (
+        "scopes round-trip as a tuple in declared order"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_agent_google_binding_replaces_existing_row_and_bumps_updated_at(
+    db_session: AsyncSession,
+) -> None:
+    agent_id = uuid.uuid4()
+
+    first = await upsert_agent_google_binding(
+        db_session,
+        agent_id=agent_id,
+        email="one@example.com",
+        scopes=["scope-a"],
+    )
+    # Commit so the second upsert runs in a fresh transaction: `func.now()` is
+    # transaction-scoped in Postgres, so without a commit both calls would
+    # see the same timestamp, as they do across two real CLI-driven sessions.
+    await db_session.commit()
+
+    second = await upsert_agent_google_binding(
+        db_session,
+        agent_id=agent_id,
+        email="two@example.com",
+        scopes=["scope-b", "scope-c"],
+    )
+
+    assert second.email == "two@example.com", "second upsert replaces email"
+    assert second.scopes == ("scope-b", "scope-c"), "second upsert replaces scopes"
+    assert second.created_at == first.created_at, "created_at is preserved across upsert"
+    assert second.updated_at > first.created_at, "updated_at is bumped past the original created_at"
+
+    row_count = await db_session.scalar(
+        select(func.count())
+        .select_from(AgentGoogleBinding)
+        .where(AgentGoogleBinding.agent_id == agent_id)
+    )
+    assert row_count == 1, "row count for the agent stays 1 after a second bind"
+
+
+@pytest.mark.asyncio
+async def test_upsert_agent_google_binding_round_trips_single_scope(
+    db_session: AsyncSession,
+) -> None:
+    agent_id = uuid.uuid4()
+
+    result = await upsert_agent_google_binding(
+        db_session,
+        agent_id=agent_id,
+        email="solo@example.com",
+        scopes=["scope-only"],
+    )
+
+    assert result.scopes == ("scope-only",), "single-element scope list round-trips as a tuple"
+
+
+@pytest.mark.asyncio
+async def test_upsert_agent_google_binding_rejects_empty_scopes(
+    db_session: AsyncSession,
+) -> None:
+    with pytest.raises(StoreError, match="scopes"):
+        await upsert_agent_google_binding(
+            db_session,
+            agent_id=uuid.uuid4(),
+            email="nobody@example.com",
+            scopes=[],
+        )

--- a/packages/core/tests/test_agent_guidance.py
+++ b/packages/core/tests/test_agent_guidance.py
@@ -25,6 +25,32 @@ def test_prepends_block_when_absent() -> None:
     assert "MCP" in out, "must explain MCP vault-bound auth"
 
 
+def test_block_names_no_setup_path() -> None:
+    # The preamble must not name a nested panel path.
+    assert "/agent-setup" not in CREDENTIAL_GUIDANCE_BLOCK, (
+        "block must not name a setup panel path — the preamble's reader is the agent"
+    )
+
+
+def test_replaces_old_style_block_not_stacks() -> None:
+    # A system carrying a stale sentinel-wrapped block (e.g. from before a
+    # preamble rewrite) must be replaced by the current block, never stacked
+    # alongside it — this is what makes a wording change safe to deploy over
+    # live agents.
+    old_block = (
+        "<!-- daimon:credential-guidance v1 -->\nSOME OLD STALE BODY\n"
+        "<!-- /daimon:credential-guidance -->"
+    )
+    system_with_old_block = f"{old_block}\n\nORIGINAL BODY"
+    out = apply_credential_guidance(system_with_old_block)
+    assert out.count("<!-- daimon:credential-guidance v1 -->") == 1, (
+        "must not stack an old-style block alongside the current one"
+    )
+    assert "SOME OLD STALE BODY" not in out, "stale body must be replaced, not preserved"
+    assert CREDENTIAL_GUIDANCE_BLOCK in out, "current block must be present"
+    assert out.endswith("ORIGINAL BODY"), "user's own body must survive the replacement"
+
+
 def test_idempotent_applied_twice_equals_once() -> None:
     once = apply_credential_guidance("base prompt")
     twice = apply_credential_guidance(once)

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -13,6 +13,7 @@ from daimon.core.config import (
     HubSettings,
     McpSettings,
     Settings,
+    SlackSettings,
     load_settings,
 )
 from pydantic import HttpUrl, PostgresDsn, SecretStr, ValidationError
@@ -682,3 +683,20 @@ def test_thread_naming_parsed_from_top_level_nested_env(monkeypatch: pytest.Monk
     assert settings.thread_naming.max_input_chars == 500, (
         "DAIMON_THREAD_NAMING__MAX_INPUT_CHARS must override the input bound"
     )
+
+
+def test_slack_display_name_defaults_to_daimon() -> None:
+    settings = SlackSettings(signing_secret=SecretStr("test"), app_token=SecretStr("xapp-test"))
+    assert settings.bot_display_name == "daimon", "unset display name must preserve existing copy"
+
+
+@pytest.mark.parametrize(
+    "name", ["", "a" * 33, "bot@name", "bot#name", "bot:name", "bot`name", "bot\\name"]
+)
+def test_slack_display_name_rejects_invalid_names(name: str) -> None:
+    with pytest.raises(ValidationError):
+        SlackSettings(
+            signing_secret=SecretStr("test"),
+            app_token=SecretStr("xapp-test"),
+            bot_display_name=name,
+        )

--- a/packages/core/tests/test_credential_requests.py
+++ b/packages/core/tests/test_credential_requests.py
@@ -57,26 +57,24 @@ def test_custom_id_pattern_rejects_wrong_prefix() -> None:
 
 
 def test_build_button_label_env() -> None:
-    assert build_button_label("env", "OPENAI_API_KEY") == "Add env credential: OPENAI_API_KEY"
+    assert build_button_label("env", "OPENAI_API_KEY") == "Add key: OPENAI_API_KEY"
 
 
 def test_build_button_label_mcp() -> None:
-    assert build_button_label("mcp", "linear") == "Add MCP credential: linear"
+    assert build_button_label("mcp", "linear") == "Add MCP token: linear"
 
 
 def test_build_button_label_truncates_long_target_within_discord_label_limit() -> None:
     label = build_button_label("mcp", "x" * 200)
 
     assert len(label) <= MAX_BUTTON_LABEL_CHARS, "label must fit Discord's 80-char button limit"
-    assert label.startswith("Add MCP credential: "), (
-        "truncation must not lose the human-readable prefix"
-    )
+    assert label.startswith("Add MCP token: "), "truncation must not lose the human-readable prefix"
 
 
 def test_build_button_label_repo() -> None:
     assert (
         build_button_label("repo", "clsandoval/daimon-qa-scratch")
-        == "Bind repo: clsandoval/daimon-qa-scratch"
+        == "Set working repo: clsandoval/daimon-qa-scratch"
     )
 
 
@@ -84,7 +82,9 @@ def test_build_button_label_truncates_long_repo_target_within_discord_label_limi
     label = build_button_label("repo", "https://github.com/" + "x" * 200)
 
     assert len(label) <= MAX_BUTTON_LABEL_CHARS, "label must fit Discord's 80-char button limit"
-    assert label.startswith("Bind repo: "), "truncation must not lose the human-readable prefix"
+    assert label.startswith("Set working repo: "), (
+        "truncation must not lose the human-readable prefix"
+    )
     assert label.endswith("…"), "truncation must append the single-character ellipsis"
 
 
@@ -136,7 +136,7 @@ def test_build_button_label_honours_slack_label_limit() -> None:
 
     label = build_button_label("mcp", "x" * 200, max_chars=MAX_SLACK_BUTTON_LABEL_CHARS)
     assert len(label) == MAX_SLACK_BUTTON_LABEL_CHARS == 75
-    assert label.startswith("Add MCP credential: ")
+    assert label.startswith("Add MCP token: ")
     assert label.endswith("…")
 
 

--- a/packages/core/tests/test_turn_keys.py
+++ b/packages/core/tests/test_turn_keys.py
@@ -1,0 +1,102 @@
+"""Tests for the names-only key projection and its `<keys>` element renderer."""
+
+from __future__ import annotations
+
+from daimon.core.stores.agent_files import put_agent_file
+from daimon.core.turn_keys import list_turn_key_names, render_keys_element
+from daimon.testing.factories import make_tenant
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def test_list_turn_key_names_returns_ascending_by_key(db_session: AsyncSession) -> None:
+    tenant = await make_tenant(db_session)
+    agent_id = tenant.id  # any stable uuid works; the store keys on (tenant_id, agent_id)
+
+    for key in ("ZED", "ALPHA", "mid"):
+        await put_agent_file(
+            db_session, tenant_id=tenant.id, agent_id=agent_id, key=key, content="secret-value"
+        )
+
+    names = await list_turn_key_names(db_session, tenant_id=tenant.id, agent_id=agent_id)
+
+    assert names == ("ALPHA", "ZED", "mid"), (
+        "names must come back in the store's ORDER BY key order, ascending by codepoint"
+    )
+
+
+async def test_list_turn_key_names_empty_for_agent_with_no_rows(db_session: AsyncSession) -> None:
+    tenant = await make_tenant(db_session)
+
+    names = await list_turn_key_names(db_session, tenant_id=tenant.id, agent_id=tenant.id)
+
+    assert names == (), "an agent with no stored keys must return an empty tuple, not None"
+
+
+async def test_list_turn_key_names_returns_a_plain_tuple_of_str(db_session: AsyncSession) -> None:
+    tenant = await make_tenant(db_session)
+    await put_agent_file(
+        db_session, tenant_id=tenant.id, agent_id=tenant.id, key="TOGGL_TOKEN", content="v"
+    )
+
+    names = await list_turn_key_names(db_session, tenant_id=tenant.id, agent_id=tenant.id)
+
+    assert isinstance(names, tuple), "the return type must be a tuple, not a list or row sequence"
+    assert all(isinstance(n, str) for n in names), (
+        "every element must be a plain str, with no field through which a value is reachable"
+    )
+
+
+async def test_list_turn_key_names_and_render_never_leak_a_stored_value(
+    db_session: AsyncSession,
+) -> None:
+    """The whole point of this module: a stored value must never be reachable
+    from the projection's repr or from the rendered element."""
+    tenant = await make_tenant(db_session)
+    sentinel_value = "sk-sentinel-do-not-leak-9f3a1c"
+    await put_agent_file(
+        db_session,
+        tenant_id=tenant.id,
+        agent_id=tenant.id,
+        key="OPENAI_API_KEY",
+        content=sentinel_value,
+    )
+
+    names = await list_turn_key_names(db_session, tenant_id=tenant.id, agent_id=tenant.id)
+    rendered = render_keys_element(names)
+
+    assert sentinel_value not in repr(names), (
+        "a stored value must not be reachable from the projection's repr"
+    )
+    assert sentinel_value not in rendered, (
+        "a stored value must not be reachable from the rendered <keys> element"
+    )
+    assert "OPENAI_API_KEY" in rendered, "the key name itself is the whole point of the element"
+
+
+def test_render_keys_element_empty_sequence_is_empty_string() -> None:
+    assert render_keys_element(()) == "", (
+        "an agent with no keys must contribute no element at all, not an empty <keys/>"
+    )
+
+
+def test_render_keys_element_non_empty_renders_a_single_keys_element() -> None:
+    rendered = render_keys_element(("ALPHA", "ZED"))
+
+    assert rendered.startswith("<keys>") and rendered.endswith("</keys>"), (
+        "a non-empty sequence must render as a single <keys>...</keys> element"
+    )
+    assert rendered.index("ALPHA") < rendered.index("ZED"), (
+        "names must render in the order given, not re-sorted by the renderer"
+    )
+    assert "\n" not in rendered, "the element must be single-line"
+
+
+def test_render_keys_element_escapes_xml_metacharacters() -> None:
+    rendered = render_keys_element(('WEIRD"NAME<>&',))
+
+    assert 'WEIRD"NAME<>&' not in rendered, (
+        "a name with XML metacharacters must not appear raw in the rendered element"
+    )
+    assert rendered.count("<key ") == 1, (
+        "an escaped metacharacter must not be interpreted as closing the element early"
+    )

--- a/scripts/lint_discord_modals.py
+++ b/scripts/lint_discord_modals.py
@@ -1,8 +1,8 @@
 """AST lint over discord.ui.Modal subclasses.
 
 Catches Discord-API violations before they reach send_modal: TextInput labels
-longer than 45 codepoints, Modals containing more than 5 components, Modals
-containing Select-style components, and TextInputs missing a label kwarg.
+longer than 45 codepoints, Modals containing more than 5 top-level components,
+and TextInputs missing a label kwarg.
 stdlib-only; CI-shaped (default path: packages/adapters/discord/daimon).
 """
 
@@ -41,6 +41,21 @@ _SELECT_NAMES = {
     "MentionableSelect",
 }
 
+# Every constructor Modal.add_item accepts as a top-level child. Matches
+# discord.ui.modal.Modal.add_item's flat `len(self._children) >= 5` check —
+# there is no separate cap per component type, and a bare top-level Select is
+# a legal child in discord.py 2.7.1 (Modal.to_components auto-wraps it in an
+# ActionRow exactly as it does a bare TextInput).
+_MODAL_CHILD_NAMES = {
+    "TextInput",
+    "Label",
+    "RadioGroup",
+    "CheckboxGroup",
+    "FileUpload",
+    "TextDisplay",
+    *_SELECT_NAMES,
+}
+
 
 def _is_modal_base(base: ast.expr) -> bool:
     """Match ``discord.ui.Modal`` or ``Modal`` in the bases tuple."""
@@ -59,14 +74,16 @@ def _is_text_input(node: ast.expr) -> bool:
     return isinstance(func, ast.Name) and func.id == "TextInput"
 
 
-def _is_select(node: ast.expr) -> bool:
-    """Match ``discord.ui.Select(...)`` or ``Select(...)`` call."""
+def _is_modal_child(node: ast.expr) -> bool:
+    """Match a call to any constructor ``Modal.add_item`` treats as a child:
+    ``discord.ui.X(...)`` or ``X(...)`` where ``X`` is in ``_MODAL_CHILD_NAMES``.
+    """
     if not isinstance(node, ast.Call):
         return False
     func = node.func
-    if isinstance(func, ast.Attribute) and func.attr in _SELECT_NAMES:
+    if isinstance(func, ast.Attribute) and func.attr in _MODAL_CHILD_NAMES:
         return True
-    return isinstance(func, ast.Name) and func.id in _SELECT_NAMES
+    return isinstance(func, ast.Name) and func.id in _MODAL_CHILD_NAMES
 
 
 def _label_kwarg(call: ast.Call) -> ast.expr | None:
@@ -124,39 +141,56 @@ def _module_int_constants(tree: ast.Module) -> dict[str, int]:
     return constants
 
 
+def _collect_modal_children(cls: ast.ClassDef) -> list[ast.Call]:
+    """Every top-level modal-child constructor call in the class body,
+    counted once each.
+
+    Matches ``Modal.add_item``'s flat ``len(self._children) >= 5`` check
+    (discord/ui/modal.py): the count is over top-level children only,
+    whatever their type. A candidate call nested inside another candidate's
+    arguments — e.g. the ``Select`` inside ``Label(component=Select(...))`` —
+    is *not* counted separately, because it is not a separate item passed to
+    ``add_item``; it is consumed by the outer ``Label``, which itself counts
+    as one child. ``ast.walk`` is depth-first and would find both calls with
+    no way to tell they nest, so this walks with explicit ancestor tracking
+    instead and skips any candidate whose nearest enclosing candidate has
+    already been recorded.
+    """
+    candidates: list[ast.Call] = []
+
+    def visit(node: ast.AST, ancestor_is_candidate: bool) -> None:
+        is_candidate = isinstance(node, ast.Call) and _is_modal_child(node)
+        if is_candidate and not ancestor_is_candidate:
+            assert isinstance(node, ast.Call)
+            candidates.append(node)
+        for child in ast.iter_child_nodes(node):
+            visit(child, ancestor_is_candidate or is_candidate)
+
+    visit(cls, False)
+    return candidates
+
+
 def _walk_modal_class(
     cls: ast.ClassDef, source_path: str, int_constants: dict[str, int]
 ) -> Iterator[Finding]:
-    """Yield findings for every TextInput / Select inside this Modal class.
-
-    Counts components as ``TextInput(...)`` constructor calls that appear
-    inside the class body (either bare or assigned to ``self.<name>``).
+    """Yield findings for every top-level child / TextInput inside this
+    Modal class.
     """
-    text_inputs: list[tuple[ast.Call, int]] = []
+    text_inputs: list[tuple[ast.Call, int]] = [
+        (node, getattr(node, "lineno", 0))
+        for node in ast.walk(cls)
+        if isinstance(node, ast.Call) and _is_text_input(node)
+    ]
 
-    for node in ast.walk(cls):
-        if isinstance(node, ast.Call):
-            if _is_text_input(node):
-                text_inputs.append((node, getattr(node, "lineno", 0)))
-            elif _is_select(node):
-                yield Finding(
-                    file=source_path,
-                    line=getattr(node, "lineno", 0),
-                    rule="discord/no-select-in-modal",
-                    message=(
-                        f"{cls.name}: Discord modals cannot contain Select-style "
-                        f"components — only TextInput. Use a follow-up View instead."
-                    ),
-                )
-
-    # Component count
-    if len(text_inputs) > MAX_COMPONENTS_PER_MODAL:
+    # Component count — every top-level child, matching Modal.add_item.
+    children = _collect_modal_children(cls)
+    if len(children) > MAX_COMPONENTS_PER_MODAL:
         yield Finding(
             file=source_path,
             line=cls.lineno,
             rule="discord/too-many-components",
             message=(
-                f"{cls.name}: has {len(text_inputs)} TextInputs — Discord limit is "
+                f"{cls.name}: has {len(children)} components — Discord limit is "
                 f"{MAX_COMPONENTS_PER_MODAL}."
             ),
         )
@@ -278,7 +312,6 @@ def main(argv: list[str] | None = None) -> int:
     failing_rules = {
         "discord/label-too-long",
         "discord/too-many-components",
-        "discord/no-select-in-modal",
         "discord/missing-label",
         "discord/max-length-too-large",
         "discord/non-literal-max-length",

--- a/tests/integration/test_seeded_prompt_tool_claims.py
+++ b/tests/integration/test_seeded_prompt_tool_claims.py
@@ -17,11 +17,9 @@ and in every skill it references (not just `workspace-setup`), is checked:
   call-syntax reference to a name that turns out not to exist at all fails
   as "unregistered".
 - If it is a real tool, it must be discoverable by a chat-turn-shaped
-  session (the same shape wave 2's `test_chat_session_tool_reachability.py`
-  built: an account subject, no `agent_id` claim, no `is_admin` claim, a
-  Discord-shaped platform claim) — unless it is in the short, commented
-  exception list below, for the handful of names the skill names *only* to
-  warn the model away from them.
+  session: an account subject, no `agent_id` claim, and a Discord platform
+  identity. Admin-only tools may be named for a handoff, but must remain
+  hidden from the member session and discoverable to the admin session.
 """
 
 from __future__ import annotations
@@ -41,6 +39,7 @@ from daimon.adapters.mcp.server import create_mcp_app
 from daimon.core.config import (
     AnthropicSettings,
     DatabaseSettings,
+    DiscordSettings,
     McpSettings,
     Settings,
 )
@@ -72,16 +71,15 @@ DEFAULTS = REPO_ROOT / "defaults"
 # network — plain English words in the surrounding prose never match it.
 _TOKEN_RE = re.compile(r"\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b")
 
-# Names the skill deliberately introduces ONLY to warn the model away from
-# them (a real, registered tool that is NOT reachable from a chat turn,
-# named on purpose to distinguish it from a chat-reachable sibling). Keep
-# this short — each entry needs a reason.
-_INTENTIONAL_NON_CHAT_MENTIONS: dict[str, str] = {
-    # named only to distinguish it from remove_skill, its chat-reachable sibling
-    "delete_skill": "tenant-wide destructive skill delete; admin-only, panel-only",
-    # admin-only, so an ADMIN chat turn does reach it — this test's chat
-    # session is deliberately non-admin, which is the only reason it is here
-    "archive_agent": "destructive agent delete; admin-gated, so absent from a non-admin chat turn",
+# Naming a gated operation lets a member hand the exact request to an admin.
+# These are still real tools: both their admin visibility and member hiding
+# are checked below, rather than exempting them from registry validation.
+_ADMIN_HANDOFF_TOOLS: set[str] = {
+    "delete_skill",
+    "archive_agent",
+    "sync_skills",
+    "set_agent_default",
+    "clear_agent_default",
 }
 
 
@@ -221,7 +219,7 @@ async def _search_text(
     result = await call("tools/call", {"name": "search_tools", "arguments": {"query": query}})
     payload = result.get("result", result)
     content = payload.get("content", [])  # type: ignore[union-attr]
-    return " ".join(item.get("text", "") for item in content if isinstance(item, dict))
+    return "\n".join(item.get("text", "") for item in content if isinstance(item, dict))
 
 
 def _make_app(sessionmaker: async_sessionmaker[AsyncSession]) -> ASGIApp:
@@ -229,6 +227,7 @@ def _make_app(sessionmaker: async_sessionmaker[AsyncSession]) -> ASGIApp:
         settings=Settings(
             database=DatabaseSettings(url=PostgresDsn("postgresql+asyncpg://u:p@h/d")),
             anthropic=AnthropicSettings(api_key=SecretStr("sk-test")),
+            discord=DiscordSettings(bot_token=SecretStr("test-discord-token")),
             mcp=McpSettings(jwt_secret=SecretStr(SECRET), public_url=HttpUrl("https://x/mcp")),
         ),
         sessionmaker=sessionmaker,
@@ -240,6 +239,13 @@ async def _seed_admin_token(sessionmaker: async_sessionmaker[AsyncSession]) -> s
     async with sessionmaker() as s, s.begin():
         tenant = await make_tenant(s, platform="discord", workspace_id="prompt-claims-admin")
         account = await make_account(s, tenant=tenant)
+        await make_platform_principal(
+            s,
+            platform="discord",
+            external_id="discord-admin-1",
+            tenant=tenant,
+            account=account,
+        )
         await accounts.set_role(s, account.id, Role.ADMIN)
         account_id = account.id
     return mint_jwt(account_id=account_id, secret=SECRET.encode(), now=_NOW)
@@ -248,7 +254,7 @@ async def _seed_admin_token(sessionmaker: async_sessionmaker[AsyncSession]) -> s
 async def _seed_chat_turn_token(sessionmaker: async_sessionmaker[AsyncSession]) -> str:
     """A token shaped exactly like a Discord chat turn: account subject, no
     `agent_id` claim, no `is_admin` claim, a Discord-bound platform identity —
-    the same shape wave 2's `test_chat_session_tool_reachability.py` built."""
+    the same identity shape used by the adapter."""
     async with sessionmaker() as s, s.begin():
         tenant = await make_tenant(s, platform="discord", workspace_id="prompt-claims-chat-turn")
         account = await make_account(s, tenant=tenant)
@@ -266,16 +272,7 @@ async def _seed_chat_turn_token(sessionmaker: async_sessionmaker[AsyncSession]) 
 async def test_seeded_prompt_and_skill_tool_claims_are_chat_turn_reachable(
     db_session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
-    """Every tool-name-shaped token the seeded prompt or its referenced
-    skills name must be one a chat-turn-shaped session can actually reach.
-
-    Regression coverage note (verified manually, not asserted here — the
-    check needs a live edit to prove): temporarily appending a fabricated
-    tool name, or a real admin-only tool name like `sync_skills`, to
-    `defaults/agents/daimon.yaml`'s system block makes this test fail and
-    names the offending token in the failure message. Both were confirmed
-    during development and reverted before this file was committed.
-    """
+    """Setup guidance names reachable tools and preserves role-specific discovery."""
     system_text, skill_bodies = _collect_texts()
 
     candidates: dict[str, str] = {}
@@ -302,14 +299,17 @@ async def test_seeded_prompt_and_skill_tool_claims_are_chat_turn_reachable(
     all_text = "\n".join([system_text, *skill_bodies.values()])
     offending: list[str] = []
     for token, source in sorted(candidates.items()):
-        if token in _INTENTIONAL_NON_CHAT_MENTIONS:
+        heading = rf"^### {re.escape(token)}\b"
+        is_registered = re.search(heading, admin_search_text[token], re.MULTILINE) is not None
+        is_chat_discoverable = re.search(heading, chat_search_text[token], re.MULTILINE) is not None
+        if token in _ADMIN_HANDOFF_TOOLS:
+            assert is_registered, f"admin handoff names an undiscoverable tool: {token}"
+            assert not is_chat_discoverable, f"admin-only tool is exposed to a member: {token}"
             continue
-        is_registered = token in admin_search_text[token]
         if not is_registered and not _is_call_syntax(token, all_text):
             # Not a real tool, and not written as a call — an ordinary
             # identifier-shaped word (a parameter name, a YAML key, ...).
             continue
-        is_chat_discoverable = token in chat_search_text[token]
         if not is_chat_discoverable:
             reason = (
                 "registered but not reachable from a chat turn"

--- a/tests/parity/drivers/slack_driver.py
+++ b/tests/parity/drivers/slack_driver.py
@@ -33,6 +33,7 @@ from cryptography.fernet import Fernet
 from daimon.adapters.slack.agent_setup import write as slack_write
 from daimon.adapters.slack.app import SlackApp
 from daimon.adapters.slack.runtime import SlackRuntime, build_turn_deps
+from daimon.core.config import SlackSettings
 from daimon.core.defaults.provisioning import teardown_slack_install
 from daimon.core.github_credentials import build_multifernet, encrypt_token
 from daimon.core.ma_resolver import new_resolver_cache
@@ -51,6 +52,7 @@ _POST_JSON_METHODS: tuple[str, ...] = (
     "chat.update",
     "chat.postEphemeral",
 )
+_USERS_INFO_PATTERN = re.compile(r"https://slack\.com/api/users\.info.*")
 _REACTIONS_ADD_PATTERN = re.compile(r"https://slack\.com/api/reactions\.add.*")
 _CONVERSATIONS_REPLIES_PATTERN = re.compile(r"https://slack\.com/api/conversations\.replies.*")
 
@@ -71,6 +73,14 @@ def _register_slack_defaults(mock: AioResponsesMock) -> None:
     that module lives under a package's `tests/` tree, not on the
     `daimon.testing` import path.
     """
+    mock.get(  # pyright: ignore[reportUnknownMemberType]  # aioresponses has no type stubs
+        _USERS_INFO_PATTERN,
+        payload={
+            "ok": True,
+            "user": {"is_admin": False, "is_owner": False, "is_primary_owner": False},
+        },
+        repeat=True,
+    )
     for method in _POST_JSON_METHODS:
         mock.post(  # pyright: ignore[reportUnknownMemberType]
             f"{_SLACK_API_BASE}/{method}",
@@ -152,7 +162,11 @@ class SlackDriver:
     ) -> SlackRuntime:
         settings = MagicMock()
         settings.crypto.keys = (SecretStr(fernet_key),)
-        settings.slack.max_concurrent_turns_per_tenant = 100
+        settings.slack = SlackSettings(
+            signing_secret=SecretStr("parity-signing-secret"),
+            app_token=SecretStr("xapp-parity-test"),
+            max_concurrent_turns_per_tenant=100,
+        )
         settings.mcp.public_url = None
         settings.mcp.app_root_url = None
         settings.mcp.jwt_secret = None

--- a/uv.lock
+++ b/uv.lock
@@ -972,6 +972,7 @@ name = "daimon-adapter-slack"
 version = "0.1.0"
 source = { editable = "packages/adapters/slack" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "anthropic" },
     { name = "asyncpg" },
     { name = "daimon-core" },
@@ -987,6 +988,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9" },
     { name = "anthropic", specifier = ">=0.96" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "daimon-core", editable = "packages/core" },
@@ -3796,8 +3798,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Setup responses could send people to obsolete panel paths, confuse API keys with MCP connections, or claim a change completed after only part of it saved. This change makes the Discord, Slack, MCP and seeded guidance describe reachable actions and actual results, with explicit target and permission handoffs.

It also refreshes Slack admin status on each turn, includes caller role in both chat contexts, suppresses Discord mass mentions, supports GitHub install-link cards on Slack, corrects modal component validation, and adds the operator `daimon agents bind-google` command. The names-only key projection is defined but remains disabled until session availability can be reported accurately.

Breaking tool changes are documented in CHANGELOG.md: five key/token operations have canonical new names, and the duplicate `skills_sync`, `skills_list`, `skills_get` and `skills_delete` aliases are removed.

Validation: broad local suites covered all adapters, core, CLI, scheduler, integration, parity and standalone apps; stale assertions found during integration were corrected and affected selections passed. All 54 exact retrieval queries, five authorization cases and schema snapshots passed. Project-wide Pyright, Ruff, import contracts, repository linters, generated environment example and pre-commit checks passed. Live staging conversations follow deployment; native controls still require human interaction.
