### PR TITLE
fix: clarify private token enrollment and replacement guidance

### DIFF
--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -61,6 +61,10 @@ system: |
   Keys and tokens never travel through chat as plaintext, during setup or at any
   other time. If a user pastes one anyway, acknowledge it, call no tool with
   it, and tell them to rotate it — never store or act on the value itself.
+  Still help them replace it: read workspace-setup and post the appropriate
+  private replacement form in that turn, using only non-secret arguments.
+  For an API key, use `request_agent_key`; do not replace that reachable action
+  with a vague secure-channel or admin-setup referral.
 
   If this workspace looks unconfigured — no repository bound, no MCP servers
   or skills attached beyond what you shipped with — lead your first reply
@@ -81,7 +85,9 @@ system: |
   block — that is when you resume, with the full history of having asked.
 
   For workspace setup, roster operations (creating, forking, and configuring
-  agents), keys, MCP connections, and scheduled routines, see the workspace-setup skill.
+  agents), keys, MCP connections, and scheduled routines, read the workspace-setup
+  skill before acting or stating permission requirements. Do not substitute a
+  remembered generic setup procedure for its actual tools and permission rules.
 
   Before you `read` an image — a screenshot you just took, a chart you rendered,
   anything — see the file-handling skill first. An oversized image read into this

--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -17,6 +17,8 @@ then a selected setup target if the context actually supplies one, then the
 answering agent in ordinary chat. Daimon being the responder does not replace
 an explicit research-bot target. If the target is missing, deleted, or still
 ambiguous, ask one concise question instead of silently choosing another.
+Ask only which agent should receive the change; defer creation, model, and fork
+choices until they are needed for that selected target.
 State the target before a consequential change. Selecting a target does not
 change which agent answers the conversation.
 
@@ -31,6 +33,8 @@ change which agent answers the conversation.
    design a variable name. A key can be added to Daimon itself without a fork,
    an MCP server, or a skill. Accept it before researching how to use the API;
    consult the service's documentation when a later task needs that knowledge.
+   For a key-only request, finish with the private form and shared-use notice.
+   Do not add a proposed skill, workflow, or API integration project.
 3. **Skills.** Use `list_skills` to find existing skills and `update_agent` to
    attach them to an editable agent. An admin can import a GitHub skill bundle
    from chat with `sync_skills`. If it needs a private token, use
@@ -38,7 +42,9 @@ change which agent answers the conversation.
    also binds the target's working repo so subsequent imports can find the
    token. Explain that repo change before requesting it.
 4. **MCP servers.** Use `attach_mcp_server` for a server needing no token, or
-   `request_mcp_token` for a supported connection that needs one. An API key
+   `request_mcp_token` for a supported connection that needs one. Members can
+   use that private form on Daimon or another default agent without an admin
+   handoff or a fork. An API key
    for code is not automatically an MCP connection token. Ask “API access for
    code or an MCP connection?” only when the request leaves that choice unclear.
    A token form does not complete an arbitrary browser OAuth login.
@@ -74,8 +80,13 @@ the replacement on a member's behalf.
 An agent answering in a channel or as the workspace default is admin-managed
 for direct prompt, model, skill, and MCP-spec edits. Direct edits to the built-in
 Daimon's spec require an editable copy even for admins. Offer `fork_agent` for
-those edits; keys, working-repo binding, and posted-token operations follow
-their own rules and must not get a blanket fork requirement.
+those direct edits. The posted forms `request_agent_key`, `request_mcp_token`,
+and `request_skill_repo_token` are available to members, including on shared
+agents and built-in Daimon. They do not inherit the direct-edit admin or fork
+gates: `request_mcp_token` can collect a bearer token and attach its server
+through the private form without an admin handoff. A shared agent's working-repo
+change through `request_repo_binding` does require an admin. Keep these paths
+distinct; an MCP token request is not a direct `attach_mcp_server` call.
 
 When the operation needs an admin and the caller is not one, do not attempt
 it. Give a reachable handoff carrying the target and action, for example:

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -353,8 +353,8 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
         an API key is not automatically an MCP token, and this does not complete OAuth.
 
         Use ``attach_mcp_server`` for public servers without tokens. Never accept
-        credentials in chat. This posted-token enrollment works on Daimon under its
-        own permission rules.
+        credentials in chat. Members can use this form on shared agents and built-in
+        Daimon; the admin and fork gates for direct spec edits do not apply.
 
         Posts a requester-only card in this channel, expiring in 30 minutes. The
         private form collects the token and attaches the server. Values never appear

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2825,8 +2825,8 @@
         an API key is not automatically an MCP token, and this does not complete OAuth.
         
         Use ``attach_mcp_server`` for public servers without tokens. Never accept
-        credentials in chat. This posted-token enrollment works on Daimon under its
-        own permission rules.
+        credentials in chat. Members can use this form on shared agents and built-in
+        Daimon; the admin and fork gates for direct spec edits do not apply.
         
         Posts a requester-only card in this channel, expiring in 30 minutes. The
         private form collects the token and attaches the server. Values never appear

--- a/packages/adapters/mcp/tests/test_tool_search_queries.py
+++ b/packages/adapters/mcp/tests/test_tool_search_queries.py
@@ -427,3 +427,120 @@ async def test_member_can_request_new_key_on_managed_agent(
     assert row.tenant_id == tenant.id and row.requester_platform_user_id == "U_TEST", (
         "request must stay tenant- and requester-bound"
     )
+
+
+async def test_member_can_request_mcp_token_on_managed_default_agent(
+    committing_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    key = SecretStr(Fernet.generate_key().decode())
+    fernet = build_multifernet((key.get_secret_value(),))
+    async with committing_sessionmaker.begin() as session:
+        tenant = await make_tenant(session, platform="slack", workspace_id="T_TEST")
+        account = await make_account(session, tenant=tenant)
+        await set_fields(
+            session,
+            scope=TenantScopeRef(tenant_id=tenant.id),
+            tenant_id=tenant.id,
+            agent_name="daimon",
+            mode="agent",
+        )
+        await upsert_slack_bot_token(
+            session, team_id="T_TEST", encrypted_token=encrypt_token(fernet, "xoxb-test")
+        )
+    agent = BetaManagedAgentsAgent(
+        id="ag_daimon",
+        name="daimon",
+        type="agent",
+        version=1,
+        model=BetaManagedAgentsModelConfig(id="claude-sonnet-5"),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        tools=[],
+        skills=[],
+        mcp_servers=[],
+        metadata={
+            "daimon_tenant": str(tenant.id),
+            "daimon_name": "daimon",
+            "daimon_managed": "true",
+        },
+    )
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET" and request.url.path == "/v1/agents", (
+            "request should only resolve its target upstream"
+        )
+        return list_response([agent.model_dump(mode="json")])
+
+    app = _make_app(
+        committing_sessionmaker,
+        platform="slack",
+        role="user",
+        tenant_id=tenant.id,
+        account_id=account.id,
+        client=build_fake_anthropic(transport),
+        crypto_keys=(key,),
+    )
+    found = await mcp_session(
+        app,
+        token="test-token",
+        method="tools/call",
+        params={
+            "name": "search_tools",
+            "arguments": {
+                "query": "Connect Daimon to Example Research MCP at https://mcp.example.com/research "
+                "using a bearer token. I need a private place to enter it."
+            },
+        },
+    )
+    assert "### request_mcp_token" in _result_text(found), (
+        "member must discover private MCP enrollment on the built-in default agent"
+    )
+    with aioresponses() as slack:
+        slack.get(
+            re.compile(r"https://slack\.com/api/conversations\.info.*"),
+            payload={"ok": True, "channel": {"id": "C_TEST", "is_private": False}},
+        )
+        slack.get(
+            re.compile(r"https://slack\.com/api/users\.info.*"),
+            payload={"ok": True, "user": {"id": "U_TEST", "is_restricted": False}},
+        )
+        slack.post("https://slack.com/api/chat.postMessage", payload={"ok": True, "ts": "123.456"})
+        called = await mcp_session(
+            app,
+            token="test-token",
+            method="tools/call",
+            params={
+                "name": "call_tool",
+                "arguments": {
+                    "name": "request_mcp_token",
+                    "arguments": {
+                        "agent_name": "daimon",
+                        "server_name": "Example Research MCP",
+                        "url": "https://mcp.example.com/research",
+                        "channel_id": "C_TEST",
+                    },
+                },
+            },
+        )
+        text = _result_text(called)
+        assert "123.456" in text and "Example Research MCP" in text, (
+            f"member enrollment must actually post: {text}"
+        )
+        payload = slack.requests[("POST", URL("https://slack.com/api/chat.postMessage"))][0].kwargs[
+            "json"
+        ]
+    token = next(block for block in payload["blocks"] if block["type"] == "actions")["elements"][0][
+        "value"
+    ]
+    async with committing_sessionmaker() as session:
+        row = await peek_credential_request(session, token=token)
+    assert row is not None and row.target == "Example Research MCP", (
+        "posted token must identify a persisted request"
+    )
+    assert row.tenant_id == tenant.id and row.requester_platform_user_id == "U_TEST", (
+        "request must stay tenant- and requester-bound"
+    )
+    assert row.kind == "mcp" and row.mcp_server_url == "https://mcp.example.com/research", (
+        "private enrollment must persist the requested MCP endpoint for token submission"
+    )
+    assert row.account_id == account.id, "the request must belong to the member who asked"


### PR DESCRIPTION
Live Slack setup conversations exposed a false admin refusal for a member requesting an MCP bearer-token form, a pasted-key reply that invented a generic admin setup process instead of posting a replacement form, and unnecessary follow-up questions or project suggestions.

Clarify that posted token enrollment remains available on shared and built-in agents under its existing requester-only rules. Require Daimon to read the setup skill before stating permissions, post a private replacement form after a pasted key, and keep key-only or ambiguous-target replies focused. Runtime authorization is unchanged.

Added a real HTTP regression proving a member can discover and post the MCP form for managed, workspace-default Daimon, with the request persisted for that tenant and requester. All 66 retrieval/authorization/defaults cases and ten prompt/schema checks passed, including the unchanged 54 exact retrieval queries. Pyright, Ruff, import contracts and pre-commit passed. Live rechecks follow staging deployment.
