### PR TITLE
fix: qualify tool availability after MCP enrollment

### DIFF
--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -48,6 +48,9 @@ change which agent answers the conversation.
    for code is not automatically an MCP connection token. Ask “API access for
    code or an MCP connection?” only when the request leaves that choice unclear.
    A token form does not complete an arbitrary browser OAuth login.
+   Successful submission attaches the server to the agent, but does not refresh
+   this conversation's toolset. Check actual tool availability before promising
+   to use the connection here; a new conversation can load the updated agent.
 5. **Confirm the result.** Explain what changed and what still needs doing.
    Read partial-success warnings: a saved token with a failed attachment is
    not a connected server, and an imported skill is not necessarily attached.

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -348,17 +348,18 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
             ),
         ],
     ) -> RequestCredentialResult:
-        """Connect an agent such as research-bot to Linear, Notion or GitHub through an
-        MCP endpoint with a bearer token. Match the endpoint's supported authentication;
-        an API key is not automatically an MCP token, and this does not complete OAuth.
+        """Connect an agent such as research-bot to Linear, Notion or GitHub through
+        an MCP endpoint with a bearer token, not browser OAuth.
+        Match supported authentication; an API key is not automatically an MCP token.
 
         Use ``attach_mcp_server`` for public servers without tokens. Never accept
         credentials in chat. Members can use this form on shared agents and built-in
         Daimon; the admin and fork gates for direct spec edits do not apply.
 
-        Posts a requester-only card in this channel, expiring in 30 minutes. The
-        private form collects the token and attaches the server. Values never appear
-        in chat; everyone talking to the agent can use the connection."""
+        Posts a requester-only card opening a private form, expiring in 30 minutes.
+        Submission attaches the server to the agent, not this session's toolset.
+        Check tool availability before promising use here. Values never appear in
+        chat; everyone talking to the agent can use the connection."""
         return await _request_mcp_token_impl(
             runtime,
             await _auth(ctx),

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2820,17 +2820,18 @@
     }),
     'request_mcp_token': dict({
       'description': '''
-        Connect an agent such as research-bot to Linear, Notion or GitHub through an
-        MCP endpoint with a bearer token. Match the endpoint's supported authentication;
-        an API key is not automatically an MCP token, and this does not complete OAuth.
+        Connect an agent such as research-bot to Linear, Notion or GitHub through
+        an MCP endpoint with a bearer token, not browser OAuth.
+        Match supported authentication; an API key is not automatically an MCP token.
         
         Use ``attach_mcp_server`` for public servers without tokens. Never accept
         credentials in chat. Members can use this form on shared agents and built-in
         Daimon; the admin and fork gates for direct spec edits do not apply.
         
-        Posts a requester-only card in this channel, expiring in 30 minutes. The
-        private form collects the token and attaches the server. Values never appear
-        in chat; everyone talking to the agent can use the connection.
+        Posts a requester-only card opening a private form, expiring in 30 minutes.
+        Submission attaches the server to the agent, not this session's toolset.
+        Check tool availability before promising use here. Values never appear in
+        chat; everyone talking to the agent can use the connection.
       ''',
       'parameters': dict({
         'additionalProperties': False,


### PR DESCRIPTION
A live Slack MCP enrollment reply promised that submitting the token would make the new tools available in the ongoing conversation. Submission updates the agent, while an existing session retains its tool definitions.

Clarify that boundary in the setup skill and MCP tool description, and require checking actual tool availability before promising use. The rendered schema snapshot reflects the wording change.

Validation: 69 retrieval, authorization, schema and seeded-default tests passed, including all 54 unchanged exact retrieval queries. Pyright, Ruff and all seven import contracts passed. Staging gets an exact-prompt live recheck after deployment.
