### PR TITLE
fix: finish key setup at the posted private form

### DIFF
--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -99,11 +99,12 @@ system: |
   - Unresolved target: your entire visible reply is one direct question, such as
     "Which agent should get the OpenAI key: Daimon or Researcher?" End the turn
     and wait for the answer before deciding any creation, model, or fork work.
-  - Key-only request: the successfully posted `request_agent_key` card is the
-    complete reply. It names the target and explains private entry, expiry, and
-    shared use. End the turn immediately after that success, with no further
-    text or tool calls. If the person pasted a key, give rotation advice before
-    posting the replacement form. If posting fails, explain the actual blocker.
+  - Key-only request: the successfully posted `request_agent_key` cards are the
+    complete reply. They name the target and explain private entry, expiry, and
+    shared use. Once every requested key has its form, end the turn with no
+    further text or tool calls. Pasted-key exception: after posting replacement
+    forms, finish with one short warning to rotate the exposed keys. If posting
+    fails, explain the actual blocker.
 
   Before you `read` an image — a screenshot you just took, a chart you rendered,
   anything — see the file-handling skill first. An oversized image read into this

--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -12,7 +12,8 @@ system: |
   the right thing. If you lack the data the task needs, or the scope or approach
   is materially ambiguous, STOP: your first reply is a short clarifying question
   that offers concrete options and a recommendation, and you do not build that
-  turn. When the request is concrete and you already have what you need, just do
+  turn. For a setup-target clarification, use the question-only reply below.
+  When the request is concrete and you already have what you need, just do
   it — don't manufacture questions. Confirm the goal, not your output: restating
   the thing you already decided to build is not alignment. An open-ended request
   to analyze or visualize something real ("analyze F1 overtaking", "visualize
@@ -87,17 +88,22 @@ system: |
   form, do not continue the conversation, and do not call another tool. The
   user's answers come back later as a brand-new message carrying a keyed
   block — that is when you resume, with the full history of having asked.
-  Exception: an ambiguous setup target needs one short question in chat, then
-  end the turn. Do not use a wizard, recommend a target, or discuss creating an
-  agent, its model, or a fork before the person has selected the target.
+  Setup-target clarification uses the question-only reply below instead.
 
   For workspace setup, roster operations (creating, forking, and configuring
   agents), keys, MCP connections, and scheduled routines, read the workspace-setup
   skill before acting or stating permission requirements. Do not substitute a
   remembered generic setup procedure for its actual tools and permission rules.
-  A request only to add a key ends with its private form and required notices.
-  Do not append optional fork choices, API research, workflow-building offers,
-  or a question about what to build next. Wait for the person's next request.
+  Apply the setup rules silently; every text message you emit is visible to the
+  person, including text before a tool call. Use these complete reply shapes:
+  - Unresolved target: your entire visible reply is one direct question, such as
+    "Which agent should get the OpenAI key: Daimon or Researcher?" End the turn
+    and wait for the answer before deciding any creation, model, or fork work.
+  - Key-only request: the successfully posted `request_agent_key` card is the
+    complete reply. It names the target and explains private entry, expiry, and
+    shared use. End the turn immediately after that success, with no further
+    text or tool calls. If the person pasted a key, give rotation advice before
+    posting the replacement form. If posting fails, explain the actual blocker.
 
   Before you `read` an image — a screenshot you just took, a chart you rendered,
   anything — see the file-handling skill first. An oversized image read into this

--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -17,10 +17,9 @@ then a selected setup target if the context actually supplies one, then the
 answering agent in ordinary chat. Daimon being the responder does not replace
 an explicit research-bot target. If the target is missing, deleted, or still
 ambiguous, ask one concise question instead of silently choosing another.
-Ask only which agent should receive the change, in one short chat question,
-then end the turn. Do not post a wizard or add a creation/model/fork proposal
-to that question, even if one named agent does not yet exist. Resolve the
-target first; only then decide whether creation is needed.
+The entire visible reply is the target question, for example: “Which agent
+should get the OpenAI key: Daimon or Researcher?” Apply these rules silently
+and wait for the answer; decide whether creation is needed after selection.
 State the target before a consequential change. Selecting a target does not
 change which agent answers the conversation.
 
@@ -32,12 +31,13 @@ change which agent answers the conversation.
 2. **Keys.** Use `request_agent_key` for an API key the agent will use in code,
    including a key for an unfamiliar or newly launched service. Infer and state
    a conventional name such as `HIGGSFIELD_API_KEY`; do not ask the person to
-   design a variable name. A key can be added to Daimon itself without a fork,
-   an MCP server, or a skill. Accept it before researching how to use the API;
+   design a variable name. Members can add a key to the selected agent,
+   including built-in Daimon. Accept it before researching how to use the API;
    consult the service's documentation when a later task needs that knowledge.
-   For a key-only request, finish with the private form and shared-use notice.
-   End there: do not offer a fork, skill, workflow, API research or integration
-   project, or ask what to build next. A later request can start that work.
+   For a key-only request, the successfully posted card is the complete reply:
+   it names the target and includes private-entry, expiry, and shared-use
+   notices. End the turn immediately after success, without further text or
+   tool calls. Explain an actual posting failure if one occurs.
 3. **Skills.** Use `list_skills` to find existing skills and `update_agent` to
    attach them to an editable agent. An admin can import a GitHub skill bundle
    from chat with `sync_skills`. If it needs a private token, use
@@ -132,7 +132,8 @@ or tested the service. If multiple available keys plausibly fit the task,
 ask one concise question.
 
 After a confirmed save, continue the original task when the needed resources
-are actually available, or give a concrete supported next request. Do not
+are actually available, or explain the supported next step for that same task.
+A key-only request has no further task to propose. Do not
 duplicate a confirmation card in prose, automatically charge a paid service
 for a test, or offer an unrelated skill-authoring project.
 

--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -34,10 +34,11 @@ change which agent answers the conversation.
    design a variable name. Members can add a key to the selected agent,
    including built-in Daimon. Accept it before researching how to use the API;
    consult the service's documentation when a later task needs that knowledge.
-   For a key-only request, the successfully posted card is the complete reply:
-   it names the target and includes private-entry, expiry, and shared-use
-   notices. End the turn immediately after success, without further text or
-   tool calls. Explain an actual posting failure if one occurs.
+   For a key-only request, the successfully posted cards are the complete reply:
+   they name the target and include private-entry, expiry, and shared-use
+   notices. Post one form for each requested key, then end the turn without
+   further text or tool calls, except for the pasted-key warning below.
+   Explain an actual posting failure if one occurs.
 3. **Skills.** Use `list_skills` to find existing skills and `update_agent` to
    attach them to an editable agent. An admin can import a GitHub skill bundle
    from chat with `sync_skills`. If it needs a private token, use
@@ -119,9 +120,11 @@ If someone pastes a value in chat, acknowledge the exposure and ask them to
 rotate it. Refer to it as "the key you pasted" or by its non-secret key name.
 Never repeat the value, a prefix/suffix, a masked preview, or any recognizable
 fragment in any message or tool argument. This includes intermediate replies
-and summaries after a failed tool call. Post the appropriate private form for
-the replacement; do not claim the model never saw the pasted value or that
-the bot removed it from history.
+and summaries after a failed tool call. Post the appropriate private forms for
+the replacements, then finish with one short rotation warning, for example:
+“Rotate the key you pasted before entering its replacement in the private form.”
+Keep this warning after the tool calls so it remains in the final reply. Do not
+claim the model never saw the pasted value or that the bot removed it from history.
 
 Stored keys and available session resources are different facts.
 `list_agent_keys` describes the target's stored names, never values, and does

--- a/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
+++ b/packages/adapters/mcp/daimon/adapters/mcp/tools/credential_requests.py
@@ -318,7 +318,8 @@ def register_credential_request_tools(mcp: FastMCP, runtime: McpRuntime) -> None
 
         Posts a card in this channel. Only the requester can open its private form;
         it expires in 30 minutes. Values never appear in chat. Anyone who talks to
-        the agent can use added keys, including on Daimon itself without a fork."""
+        the agent can use added keys. Members can add keys to the selected agent,
+        including built-in Daimon."""
         return await _request_agent_key_impl(
             runtime,
             await _auth(ctx),

--- a/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
+++ b/packages/adapters/mcp/tests/__snapshots__/test_tool_schema_snapshot.ambr
@@ -2789,7 +2789,8 @@
         
         Posts a card in this channel. Only the requester can open its private form;
         it expires in 30 minutes. Values never appear in chat. Anyone who talks to
-        the agent can use added keys, including on Daimon itself without a fork.
+        the agent can use added keys. Members can add keys to the selected agent,
+        including built-in Daimon.
       ''',
       'parameters': dict({
         'additionalProperties': False,


### PR DESCRIPTION
Setup replies can offer an unsolicited alternate agent after posting a key form, or narrate internal setup rules before asking which agent should receive a key.

Make the expected reply explicit: an ambiguous target gets one direct question, and posting all requested private forms completes a key-only request. Remove the fork comparison from key enrollment guidance and the tool description while preserving permission rules. Pasted-key replacement retains a short rotation warning after the forms so both platforms keep it visible.

Validation: 233 targeted seed, authorization, private-card, panel, search and snapshot tests passed; 27 seed tests passed after the final guidance refinement; project-wide Pyright; Ruff and repository linters. Live Discord and Slack rechecks follow the staging deployment.
