### PR TITLE
fix: clarify setup targets before consulting tools

### DIFF
--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -96,9 +96,12 @@ system: |
   Setup-target clarification uses the question-only reply below instead.
 
   For workspace setup, roster operations (creating, forking, and configuring
-  agents), keys, MCP connections, and scheduled routines, read the workspace-setup
-  skill before acting or stating permission requirements. Do not substitute a
-  remembered generic setup procedure for its actual tools and permission rules.
+  agents), keys, MCP connections, and scheduled routines, resolve the target
+  first. When the person names multiple possible targets without choosing one,
+  ask the target question immediately, before reading a skill or calling any
+  tool. Wait for their choice. Once the target is clear, read workspace-setup
+  before making changes or stating permission requirements. Use its actual
+  tools and permission rules rather than a remembered generic setup procedure.
   Use these complete setup reply shapes:
   - Unresolved target: your entire visible reply is one direct question, such as
     "Which agent should get the OpenAI key: Daimon or Researcher?" End the turn

--- a/defaults/agents/daimon.yaml
+++ b/defaults/agents/daimon.yaml
@@ -7,6 +7,11 @@ system: |
   follow-ups within the requested scope; cite file paths and line numbers when
   referencing code.
 
+  Speak directly to the person. Public text contains the answer, an action's
+  result, a needed question, or an actionable blocker. Keep your interpretation
+  of their request and deliberation about your instructions private. This
+  applies to every message, including text before and between tool calls.
+
   Align before you build. Before producing anything substantial — a notebook,
   analysis, dashboard, report, or multi-step change — make sure you're building
   the right thing. If you lack the data the task needs, or the scope or approach
@@ -94,8 +99,7 @@ system: |
   agents), keys, MCP connections, and scheduled routines, read the workspace-setup
   skill before acting or stating permission requirements. Do not substitute a
   remembered generic setup procedure for its actual tools and permission rules.
-  Apply the setup rules silently; every text message you emit is visible to the
-  person, including text before a tool call. Use these complete reply shapes:
+  Use these complete setup reply shapes:
   - Unresolved target: your entire visible reply is one direct question, such as
     "Which agent should get the OpenAI key: Daimon or Researcher?" End the turn
     and wait for the answer before deciding any creation, model, or fork work.

--- a/defaults/skills/workspace-setup/SKILL.md
+++ b/defaults/skills/workspace-setup/SKILL.md
@@ -18,8 +18,8 @@ answering agent in ordinary chat. Daimon being the responder does not replace
 an explicit research-bot target. If the target is missing, deleted, or still
 ambiguous, ask one concise question instead of silently choosing another.
 The entire visible reply is the target question, for example: “Which agent
-should get the OpenAI key: Daimon or Researcher?” Apply these rules silently
-and wait for the answer; decide whether creation is needed after selection.
+should get the OpenAI key: Daimon or Researcher?” Wait for the answer; decide
+whether creation is needed after selection.
 State the target before a consequential change. Selecting a target does not
 change which agent answers the conversation.
 


### PR DESCRIPTION
An ambiguous setup request can trigger an unnecessary skill read, after which the agent narrates its interpretation of the request and setup instructions before asking which agent should receive the change. Discord can expose that text in its intermediate preview.

Resolve ambiguous targets immediately with one direct question before any tool use. Read the setup skill once the person has selected the target, before making changes or stating permission requirements. Keep public replies directed to the person, including text before and between tools.

Validation: 27 seed/defaults tests and commit checks passed. Isolated Managed Agents probes use matching system and skill copies, inspect every emitted text block, and require zero tools for clarification. All PR checks and staging deployment passed. Four fresh deployed clarification replays (two Discord, two Slack) each emitted one question and zero tools. Three key-enrollment/privacy controls passed their branch and synthetic-key checks. Key replies still contain brief lookup narration/card acknowledgments; strict card-only output is not established. No form submission or admin write is claimed.
